### PR TITLE
Rename ONE and OpNE to SNF and OpNF

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1756,7 +1756,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     // protected internal constructor used for unmarshaling (always generated).
     _out << sp;
-    _out << nl << "protected internal " << name << "(string? message, ZeroC.Ice.RemoteExceptionOrigin? origin)";
+    _out << nl << "protected internal " << name << "(string? message, ZeroC.Ice.RemoteExceptionOrigin origin)";
     // We call the base class constructor to initialize the base class fields.
     _out.inc();
     _out << nl << ": base(message, origin)";
@@ -2815,7 +2815,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
              << "Async(request, current, cancel),";
     }
 
-    _out << nl << "_ => throw new ZeroC.Ice.OperationNotExistException()";
+    _out << nl << "_ => throw new ZeroC.Ice.OperationNotFoundException()";
 
     _out << eb << ";"; // switch expression
     _out.dec(); // method
@@ -3410,7 +3410,7 @@ Slice::Gen::RemoteExceptionFactoryVisitor::visitExceptionStart(const ExceptionPt
     _out << nl << "public static class " << name;
     _out << sb;
     _out << nl << "public static " << prefix << "ZeroC.Ice.RemoteException Create(string? message, "
-         << prefix << "ZeroC.Ice.RemoteExceptionOrigin? origin) =>";
+         << prefix << "ZeroC.Ice.RemoteExceptionOrigin origin) =>";
     _out.inc();
     _out << nl << "new global::" << ns << "." << name << "(message, origin);";
     _out.dec();

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -206,7 +206,7 @@ namespace ZeroC.Ice
 
         private readonly object _mutex = new object();
 
-        private readonly ConcurrentDictionary<string, Func<string?, RemoteExceptionOrigin?, RemoteException>?> _remoteExceptionFactoryCache =
+        private readonly ConcurrentDictionary<string, Func<string?, RemoteExceptionOrigin, RemoteException>?> _remoteExceptionFactoryCache =
             new();
         private int _retryBufferSize;
 
@@ -697,7 +697,7 @@ namespace ZeroC.Ice
                return null;
            });
 
-        internal Func<string?, RemoteExceptionOrigin?, RemoteException>? FindRemoteExceptionFactory(string typeId) =>
+        internal Func<string?, RemoteExceptionOrigin, RemoteException>? FindRemoteExceptionFactory(string typeId) =>
             _remoteExceptionFactoryCache.GetOrAdd(typeId, typeId =>
             {
                 string className = TypeIdToClassName(typeId);
@@ -712,8 +712,8 @@ namespace ZeroC.Ice
                         new Type[] { typeof(string), typeof(RemoteExceptionOrigin) },
                         null);
                     Debug.Assert(method != null);
-                    return (Func<string?, RemoteExceptionOrigin?, RemoteException>)Delegate.CreateDelegate(
-                        typeof(Func<string?, RemoteExceptionOrigin?, RemoteException>), method);
+                    return (Func<string?, RemoteExceptionOrigin, RemoteException>)Delegate.CreateDelegate(
+                        typeof(Func<string?, RemoteExceptionOrigin, RemoteException>), method);
                 }
                 return null;
             });

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -525,7 +525,7 @@ namespace ZeroC.Ice
                 {
                     if (stream.IsBidirectional)
                     {
-                        response = new OutgoingResponseFrame(request, new ObjectNotExistException());
+                        response = new OutgoingResponseFrame(request, new ServiceNotFoundException());
                     }
                 }
                 else

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -132,7 +132,7 @@ namespace ZeroC.Ice
                     }
                 }
 
-                if (istr?.ReadIce1SystemException(replyStatus) is ObjectNotExistException one)
+                if (istr?.ReadIce1SystemException(replyStatus) is ServiceNotFoundException one)
                 {
                     // 1.1 System exceptions
                     if (proxy.IsIndirect)
@@ -185,14 +185,14 @@ namespace ZeroC.Ice
 
                     if (replyStatus == ReplyStatus.OperationNotExistException)
                     {
-                        systemException = new OperationNotExistException(
+                        systemException = new OperationNotFoundException(
                             message: null,
                             new RemoteExceptionOrigin(identity.ToPath(), operation))
                         { Facet = facet };
                     }
                     else
                     {
-                        systemException = new ObjectNotExistException(
+                        systemException = new ServiceNotFoundException(
                             message: null,
                             new RemoteExceptionOrigin(identity.ToPath(), operation))
                         { Facet = facet };

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -280,8 +280,8 @@ namespace ZeroC.Ice
             {
                 replyStatus = exception switch
                 {
-                    ObjectNotExistException _ => ReplyStatus.ObjectNotExistException,
-                    OperationNotExistException _ => ReplyStatus.OperationNotExistException,
+                    ServiceNotFoundException _ => ReplyStatus.ObjectNotExistException,
+                    OperationNotFoundException _ => ReplyStatus.OperationNotExistException,
                     UnhandledException _ => ReplyStatus.UnknownLocalException,
                     _ => ReplyStatus.UserException
                 };

--- a/csharp/src/Ice/Server.cs
+++ b/csharp/src/Ice/Server.cs
@@ -261,7 +261,7 @@ namespace ZeroC.Ice
                 IService? service = Find(current.Path, current.Facet);
                 if (service == null)
                 {
-                    throw new ObjectNotExistException(RetryPolicy.OtherReplica);
+                    throw new ServiceNotFoundException(RetryPolicy.OtherReplica);
                 }
 
                 return await service.DispatchAsync(request, current, cancel).ConfigureAwait(false);

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -487,7 +487,7 @@ namespace ZeroC.Ice.Test.AMI
                     // connection.
                     Task.Run(async () => await p.IcePingAsync()).Wait();
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                     // Expected with cross testing, this opXxxAsyncDispatch methods are C# only.
                 }
@@ -544,7 +544,7 @@ namespace ZeroC.Ice.Test.AMI
                         }
                     }
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                     output.WriteLine("not supported");
                 }
@@ -599,7 +599,7 @@ namespace ZeroC.Ice.Test.AMI
                         }
                     }
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                     output.WriteLine("not supported");
                 }

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -477,7 +477,7 @@ namespace ZeroC.Ice.Test.Binding
                         await prx.IcePingAsync();
                         TestHelper.Assert(false);
                     }
-                    catch (ObjectNotExistException)
+                    catch (ServiceNotFoundException)
                     {
                         // Expected. Server is reachable but there's no "dummy" object
                     }
@@ -511,7 +511,7 @@ namespace ZeroC.Ice.Test.Binding
                         var prx = IServicePrx.Parse(getProxy("dummy", "127.0.0.1"), clientCommunicator);
                         await prx.IcePingAsync();
                     }
-                    catch (ObjectNotExistException)
+                    catch (ServiceNotFoundException)
                     {
                         // Expected, no object registered.
                     }
@@ -577,7 +577,7 @@ namespace ZeroC.Ice.Test.Binding
                         var prx = IServicePrx.Parse(getProxy("dummy", "127.0.0.1"), clientCommunicator);
                         await prx.IcePingAsync();
                     }
-                    catch (ObjectNotExistException)
+                    catch (ServiceNotFoundException)
                     {
                         // Expected, no object registered.
                     }

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -60,7 +60,7 @@ namespace ZeroC.Ice.Test.DefaultServant
                 await prx.IcePingAsync();
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
                 // Expected
             }
@@ -70,7 +70,7 @@ namespace ZeroC.Ice.Test.DefaultServant
                 prx.GetName();
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
                 // Expected
             }
@@ -86,7 +86,7 @@ namespace ZeroC.Ice.Test.DefaultServant
                     await prx.IcePingAsync();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                     // Expected
                 }
@@ -96,7 +96,7 @@ namespace ZeroC.Ice.Test.DefaultServant
                     prx.GetName();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                     // Expected
                 }
@@ -112,7 +112,7 @@ namespace ZeroC.Ice.Test.DefaultServant
             {
                 await prx.IcePingAsync();
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
                 // Expected
             }

--- a/csharp/test/Ice/defaultServant/MyObjectI.cs
+++ b/csharp/test/Ice/defaultServant/MyObjectI.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.DefaultServant
 
             if (path == "/foo/ObjectNotExist")
             {
-                throw new ObjectNotExistException();
+                throw new ServiceNotFoundException();
             }
             return default;
         }
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.DefaultServant
 
             if (path == "/foo/ObjectNotExist")
             {
-                throw new ObjectNotExistException();
+                throw new ServiceNotFoundException();
             }
             return path;
         }

--- a/csharp/test/Ice/discovery/AllTests.cs
+++ b/csharp/test/Ice/discovery/AllTests.cs
@@ -81,7 +81,7 @@ namespace ZeroC.Ice.Test.Discovery
                     await IServicePrx.Parse("object @ oa1", communicator).IcePingAsync();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                 }
 
@@ -135,14 +135,14 @@ namespace ZeroC.Ice.Test.Discovery
                 {
                     await IServicePrx.Parse("object @ oa1", communicator).IcePingAsync();
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                 }
                 try
                 {
                     await IServicePrx.Parse("object @ oa2", communicator).IcePingAsync();
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                 }
 

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -381,9 +381,9 @@ namespace ZeroC.Ice.Test.Exceptions
                     await thrower2.IcePingAsync();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException ex)
+                catch (ServiceNotFoundException ex)
                 {
-                    TestHelper.Assert(ex.Origin!.Value.Path == "/does%20not%20exist");
+                    TestHelper.Assert(ex.Origin.Path == "/does%20not%20exist");
                     TestHelper.Assert(ex.Message.Contains("service")); // verify we don't get system message
                 }
                 catch
@@ -407,7 +407,7 @@ namespace ZeroC.Ice.Test.Exceptions
                         await thrower2.IcePingAsync();
                         TestHelper.Assert(false);
                     }
-                    catch (ObjectNotExistException ex)
+                    catch (ServiceNotFoundException ex)
                     {
                         TestHelper.Assert(ex.Facet == "no such facet");
                         TestHelper.Assert(ex.Message.Contains("with facet")); // verify we don't get system message
@@ -430,9 +430,9 @@ namespace ZeroC.Ice.Test.Exceptions
                 thrower2.NoSuchOperation();
                 TestHelper.Assert(false);
             }
-            catch (OperationNotExistException ex)
+            catch (OperationNotFoundException ex)
             {
-                TestHelper.Assert(ex.Origin!.Value.Operation == "noSuchOperation");
+                TestHelper.Assert(ex.Origin.Operation == "noSuchOperation");
                 TestHelper.Assert(ex.Message.Contains("could not find operation")); // verify we don't get system message
             }
             catch
@@ -457,12 +457,12 @@ namespace ZeroC.Ice.Test.Exceptions
                 // With ice1, the origin is not set; with ice2, it is.
                 if (ice1)
                 {
-                    TestHelper.Assert(ex.Origin == null);
+                    TestHelper.Assert(ex.Origin == RemoteExceptionOrigin.Unknown);
                 }
                 else
                 {
-                    TestHelper.Assert(ex.Origin!.Value.Path == thrower.Path &&
-                                      ex.Origin!.Value.Operation == "throwLocalException");
+                    TestHelper.Assert(ex.Origin.Path == thrower.Path &&
+                                      ex.Origin.Operation == "throwLocalException");
                 }
             }
             catch
@@ -764,9 +764,9 @@ namespace ZeroC.Ice.Test.Exceptions
                         TestHelper.Assert(exc.InnerException != null);
                         throw exc.InnerException;
                     }
-                    catch (ObjectNotExistException ex)
+                    catch (ServiceNotFoundException ex)
                     {
-                        TestHelper.Assert(ex.Origin!.Value.Path == "/does%20not%20exist");
+                        TestHelper.Assert(ex.Origin.Path == "/does%20not%20exist");
                     }
                     catch
                     {
@@ -796,7 +796,7 @@ namespace ZeroC.Ice.Test.Exceptions
                             TestHelper.Assert(exc.InnerException != null);
                             throw exc.InnerException;
                         }
-                        catch (ObjectNotExistException ex)
+                        catch (ServiceNotFoundException ex)
                         {
                             TestHelper.Assert(ex.Facet == "no such facet");
                         }
@@ -827,9 +827,9 @@ namespace ZeroC.Ice.Test.Exceptions
                         TestHelper.Assert(exc.InnerException != null);
                         throw exc.InnerException;
                     }
-                    catch (OperationNotExistException ex)
+                    catch (OperationNotFoundException ex)
                     {
-                        TestHelper.Assert(ex.Origin!.Value.Operation.Equals("noSuchOperation"));
+                        TestHelper.Assert(ex.Origin.Operation.Equals("noSuchOperation"));
                     }
                     catch
                     {
@@ -934,9 +934,9 @@ namespace ZeroC.Ice.Test.Exceptions
                     {
                         throw exc.InnerException;
                     }
-                    catch (ObjectNotExistException ex)
+                    catch (ServiceNotFoundException ex)
                     {
-                        TestHelper.Assert(ex.Origin!.Value.Path == "/does%20not%20exist");
+                        TestHelper.Assert(ex.Origin.Path == "/does%20not%20exist");
                     }
                     catch
                     {
@@ -966,7 +966,7 @@ namespace ZeroC.Ice.Test.Exceptions
                             TestHelper.Assert(exc.InnerException != null);
                             throw exc.InnerException;
                         }
-                        catch (ObjectNotExistException ex)
+                        catch (ServiceNotFoundException ex)
                         {
                             TestHelper.Assert(ex.Facet == "no such facet");
                         }
@@ -997,9 +997,9 @@ namespace ZeroC.Ice.Test.Exceptions
                         TestHelper.Assert(exc.InnerException != null);
                         throw exc.InnerException;
                     }
-                    catch (OperationNotExistException ex)
+                    catch (OperationNotFoundException ex)
                     {
-                        TestHelper.Assert(ex.Origin!.Value.Operation == "noSuchOperation");
+                        TestHelper.Assert(ex.Origin.Operation == "noSuchOperation");
                     }
                     catch
                     {

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -43,7 +43,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 prx.NotExistAdd(33, 12);
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
                 // expected
             }
@@ -74,7 +74,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 catch (InvalidInputException) when (kind == "invalidInput")
                 {
                 }
-                catch (ObjectNotExistException) when (kind == "notExist")
+                catch (ServiceNotFoundException) when (kind == "notExist")
                 {
                 }
             }

--- a/csharp/test/Ice/interceptor/DispatchInterceptors.cs
+++ b/csharp/test/Ice/interceptor/DispatchInterceptors.cs
@@ -30,7 +30,7 @@ namespace ZeroC.Ice.Test.Interceptor
                     }
                     else if (context == "notExist")
                     {
-                        throw new ObjectNotExistException();
+                        throw new ServiceNotFoundException();
                     }
                 }
 
@@ -44,7 +44,7 @@ namespace ZeroC.Ice.Test.Interceptor
                     }
                     else if (context == "notExist")
                     {
-                        throw new ObjectNotExistException();
+                        throw new ServiceNotFoundException();
                     }
                 }
 

--- a/csharp/test/Ice/interceptor/TestAMDI.cs
+++ b/csharp/test/Ice/interceptor/TestAMDI.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Interceptor
         public ValueTask<int> BadAddAsync(int x, int y, Current current, CancellationToken cancel) =>
             throw new InvalidInputException("badAdd");
         public ValueTask<int> NotExistAddAsync(int x, int y, Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ServiceNotFoundException();
         public ValueTask Op1Async(Current current, CancellationToken cancel) => new();
         public ValueTask OpWithBinaryContextAsync(Token token, Current current, CancellationToken cancel) => default;
 

--- a/csharp/test/Ice/interceptor/TestI.cs
+++ b/csharp/test/Ice/interceptor/TestI.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Interceptor
             throw new InvalidInputException("badAdd");
 
         public int NotExistAdd(int x, int y, Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ServiceNotFoundException();
 
         public void Op1(Current current, CancellationToken cancel) =>
             TestHelper.Assert(DispatchInterceptors.LocalContext.Value == int.Parse(current.Context["local-user"]));

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -62,7 +62,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
             else
             {
-                throw new OperationNotExistException();
+                throw new OperationNotFoundException();
             }
         }
     }

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -174,7 +174,7 @@ namespace ZeroC.Ice.Test.Objects
             {
                 initial.SetG(new G(new S("hello"), "g"));
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
             output.WriteLine("ok");
@@ -191,7 +191,7 @@ namespace ZeroC.Ice.Test.Objects
                 (retS, outS) = initial.OpBaseSeq(inS);
                 TestHelper.Assert(retS.Length == 1 && outS.Length == 1);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
             output.WriteLine("ok");
@@ -231,7 +231,7 @@ namespace ZeroC.Ice.Test.Objects
             {
                 TestHelper.Assert(initial.GetCompact() != null);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -280,7 +280,7 @@ namespace ZeroC.Ice.Test.Operations
                     c2.OpVoid();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                 }
 

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -76,10 +76,10 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
             try
             {
-                prx.OpObjectNotExistException();
+                prx.OpServiceNotFoundException();
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
             }
 

--- a/csharp/test/Ice/protocolBridging/Test.ice
+++ b/csharp/test/Ice/protocolBridging/Test.ice
@@ -28,9 +28,9 @@ module ZeroC::Ice::Test::ProtocolBridging
         // Operation that throws remote exception
         void opMyError();
 
-        // Operation that throws ObjectNotExistException (one of the special
+        // Operation that throws ServiceNotFoundException (one of the special
         // ice1 system exceptions)
-        void opObjectNotExistException();
+        void opServiceNotFoundException();
 
         // Operation that returns a new proxy
         TestIntf opNewProxy();

--- a/csharp/test/Ice/protocolBridging/TestI.cs
+++ b/csharp/test/Ice/protocolBridging/TestI.cs
@@ -85,11 +85,11 @@ namespace ZeroC.Ice.Test.ProtocolBridging
             throw new MyError(42);
         }
 
-        public void OpObjectNotExistException(Current current, CancellationToken cancel)
+        public void OpServiceNotFoundException(Current current, CancellationToken cancel)
         {
             TestHelper.Assert(current.Context.Count == 1);
             TestHelper.Assert(current.Context.ContainsKey("Intercepted") || current.Context.ContainsKey("Direct"));
-            throw new ObjectNotExistException();
+            throw new ServiceNotFoundException();
         }
 
         public ITestIntfPrx OpNewProxy(Current current, CancellationToken cancel)

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -825,7 +825,7 @@ namespace ZeroC.Ice.Test.Proxy
                     await IMyDerivedClassPrx.Factory.Clone(cl, facet: "facet").IcePingAsync();
                     TestHelper.Assert(false);
                 }
-                catch (ObjectNotExistException)
+                catch (ServiceNotFoundException)
                 {
                 }
             }

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -18,13 +18,13 @@ namespace ZeroC.Ice.Test.Retry
         {
             if (++_n < n)
             {
-                throw new ObjectNotExistException(RetryPolicy.AfterDelay(TimeSpan.FromMilliseconds(10)));
+                throw new ServiceNotFoundException(RetryPolicy.AfterDelay(TimeSpan.FromMilliseconds(10)));
             }
             _n = 0;
         }
 
         public void OtherReplica(Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException(RetryPolicy.OtherReplica);
+            throw new ServiceNotFoundException(RetryPolicy.OtherReplica);
     }
     public static class AllTests
     {

--- a/csharp/test/Ice/retry/RetryI.cs
+++ b/csharp/test/Ice/retry/RetryI.cs
@@ -48,7 +48,7 @@ namespace ZeroC.Ice.Test.Retry
                 bidir.OtherReplica(cancel: CancellationToken.None);
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
             }
 
@@ -59,7 +59,7 @@ namespace ZeroC.Ice.Test.Retry
                 bidir.AfterDelay(2, cancel: CancellationToken.None);
                 TestHelper.Assert(current.Protocol == Protocol.Ice2);
             }
-            catch (ObjectNotExistException)
+            catch (ServiceNotFoundException)
             {
                 TestHelper.Assert(current.Protocol == Protocol.Ice1);
             }

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -707,7 +707,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     // Exceptions are always marshaled in sliced format; format:compact applies only to in-parameters and
                     // return values.
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                 }
                 catch
@@ -784,7 +784,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(ex.Kp.Equals("preserved"));
                     TestHelper.Assert(ex.Kpd.Equals("derived"));
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                 }
                 catch
@@ -803,7 +803,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(ex.Kp.Equals("preserved"));
                     TestHelper.Assert(ex.Kpd.Equals("derived"));
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                 }
                 catch
@@ -827,7 +827,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(pc!.Pc.Equals("pc"));
                     TestHelper.Assert(ex.P2 == ex.P1);
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                 }
                 catch
@@ -851,7 +851,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(pc!.Pc.Equals("pc"));
                     TestHelper.Assert(ex.P2 == ex.P1);
                 }
-                catch (OperationNotExistException)
+                catch (OperationNotFoundException)
                 {
                 }
                 catch

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -1614,7 +1614,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(p2.Ps.Equals("preserved"));
                 TestHelper.Assert(p2.Pb == p2);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1630,7 +1630,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(!(r is PCUnknown));
                 TestHelper.Assert(r.Pi == 3);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1647,7 +1647,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(p2.Pi == 3);
                 TestHelper.Assert(p2.Pbs[0] == p2);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1664,7 +1664,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(p2.Pi == 3);
                 TestHelper.Assert(p2.Pbs[0] == p2);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1701,7 +1701,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(p3.Pcd2 == p3.Pi);
                 TestHelper.Assert(p3.Pcd3 == p3.Pbs[10]);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1716,7 +1716,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(slices.Count == 1);
                 TestHelper.Assert(slices[0].TypeId!.Equals("::ZeroC::Ice::Test::Slicing::Objects::PSUnknown"));
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1816,7 +1816,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 Preserved? p = testPrx.PBSUnknownAsPreserved();
                 testPrx.CheckPBSUnknown(p);
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 
@@ -1890,7 +1890,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                     TestHelper.Assert(false);
                 }
             }
-            catch (OperationNotExistException)
+            catch (OperationNotFoundException)
             {
             }
 

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -28,7 +28,7 @@ namespace ZeroC.IceSSL.Test.Configuration
             }
             else
             {
-                throw new OperationNotExistException();
+                throw new OperationNotFoundException();
             }
         }
     }

--- a/slice/Ice/Exceptions.ice
+++ b/slice/Ice/Exceptions.ice
@@ -10,8 +10,9 @@
 module Ice
 {
     /// Represents the origin of a remote exception. With the Ice 2.0 encoding, all remote exceptions have an implicit
-    /// origin data member set during marshaling. With the Ice 1.1 encoding, this origin data member is only set for
-    /// {@link ObjectNotExistException} and {@link OperationNotExistException}.
+    /// origin data member set during marshaling. With the Ice 1.1 encoding, this origin data member is set for
+    /// {@link ServiceNotFoundException} and {@link OperationNotFoundException}, and is otherwise set to an unknown
+    /// (all empty) value.
     [cs:readonly] struct RemoteExceptionOrigin
     {
         /// The path of the target service.
@@ -22,15 +23,13 @@ module Ice
     }
 
     /// The server could not find this service.
-    // TODO: rename to ServiceNotFoundException
-    exception ObjectNotExistException
+    exception ServiceNotFoundException
     {
     }
 
     /// The server found a service but this service does not implement the requested operation. This exception is
     /// typically thrown when a client with newer Slice definitions calls a server using older Slice definitions.
-    // TODO: rename to OperationNotFoundException
-    exception OperationNotExistException
+    exception OperationNotFoundException
     {
     }
 


### PR DESCRIPTION
This PR renames OperationNotExistException to ServiceNotFoundException and OperationNotExistException to OperationNotFoundException.

It also replaces the null RemoteExceptionOrigin by RemoteExceptionOrigin.Unknown, which is a cousin of Identity.Empty. Nullable value types are harder to use and in this case we have a natural all-empty / unknown instance.