### PR TITLE
Rework NormalizePath

### DIFF
--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -142,15 +142,18 @@ namespace ZeroC.Ice
             ServicePrx.InvokeAsync(proxy, request, oneway, progress);
 
         /// <summary>Normalizes a URI path: adds a leading slash (if the path does not start with a slash) and
-        /// percent-escapes all characters except the unreserved characters, slash and the characters already escaped.
-        /// </summary>
+        /// percent-escapes all characters except the unreserved characters, two reserved characters (/ and ?) and all
+        /// other characters such as %, \ and space.</summary>
         /// <param name="path">The input path, with slash separators. It can be already partially or fully percent-
         /// escaped.</param>
         /// <returns>The normalized path.</returns>
         public static string NormalizePath(string path)
         {
-            string[] segments = path.Split('/');
-            string normalized = string.Join('/', segments.Select(s => Uri.EscapeDataString(Uri.UnescapeDataString(s))));
+            string normalized = string.Join(
+                '/',
+                path.Split('/').Select(
+                    s => Uri.EscapeUriString(Uri.UnescapeDataString(s)).Replace("/", "%2F").Replace("?", "%3F")));
+
             if (normalized.StartsWith('/'))
             {
                 return normalized;

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -83,6 +83,7 @@ namespace ZeroC.Ice
             (Uri uri, IReadOnlyList<Endpoint> endpoints, ProxyOptions proxyOptions) =
                 Parse(uriString, serverEndpoints: false, communicator);
 
+            // We need to call NormalizePath for characters like # (escaped by Uri) and \ (not escaped by Uri).
             return (endpoints, Proxy.NormalizePath(uri.AbsolutePath), proxyOptions);
         }
 

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -173,7 +173,7 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(b1.Path == "/test");
 
             b1 = IServicePrx.Parse("ice:test#frag", communicator);
-            TestHelper.Assert(b1.Path == "/test%23frag");
+            TestHelper.Assert(b1.Path == "/test#frag");
 
             b1 = IServicePrx.Parse("ice:test ", communicator);
             TestHelper.Assert(b1.Path == "/test");
@@ -266,9 +266,9 @@ namespace ZeroC.Ice.Test.Proxy
             b1 = IServicePrx.Parse("ice:server/category/test", communicator);
             TestHelper.Assert(b1.Path == "/server/category/test");
             b1 = IServicePrx.Parse("ice:server:tcp/category/test", communicator);
-            TestHelper.Assert(b1.Path == "/server%3Atcp/category/test");
+            TestHelper.Assert(b1.Path == "/server:tcp/category/test");
 
-            // preferred syntax with escape:
+            // syntax with escape:
             TestHelper.Assert(b1.Equals(IServicePrx.Parse("ice:/server%3Atcp/category/test", communicator)));
 
             b1 = IServicePrx.Parse("category/test", communicator);
@@ -317,10 +317,10 @@ namespace ZeroC.Ice.Test.Proxy
             // End of ice1 format-only tests.
 
             b1 = IServicePrx.Parse("ice:id#facet", communicator);
-            TestHelper.Assert(b1.Path == "/id%23facet");
+            TestHelper.Assert(b1.Path == "/id#facet");
 
             b1 = IServicePrx.Parse("ice:id#facet%20x", communicator);
-            TestHelper.Assert(b1.Path == "/id%23facet%20x");
+            TestHelper.Assert(b1.Path == "/id#facet%20x");
 
             b1 = IServicePrx.Parse("id -f facet", communicator);
             TestHelper.Assert(b1.Identity.Name == "id" && b1.Identity.Category.Length == 0 && b1.Facet == "facet");

--- a/tests/IceRpc.Tests.Api/IdentityTests.cs
+++ b/tests/IceRpc.Tests.Api/IdentityTests.cs
@@ -14,7 +14,7 @@ namespace IceRpc.Tests.Api
         /// <param name="path">The path to check.</param>
         /// <param name="newPath">The new normalized path, if different than normalize(path).</param>
         [TestCase("foo/bar")]
-        [TestCase("foo/bar")]
+        [TestCase("/foo/bar")]
         [TestCase("/")]
         [TestCase("/foo/")]
         [TestCase("//foo", "/foo")]
@@ -83,11 +83,11 @@ namespace IceRpc.Tests.Api
         [TestCase("test", "\x7f€", "/%7F%E2%82%AC/test")]
         [TestCase("banana \x0E-\ud83c\udf4c\u20ac\u00a2\u0024",
                   "greek \ud800\udd6a",
-                  "/greek%20%F0%90%85%AA/banana%20%0E-%F0%9F%8D%8C%E2%82%AC%C2%A2%24")]
+                  "/greek%20%F0%90%85%AA/banana%20%0E-%F0%9F%8D%8C%E2%82%AC%C2%A2$")]
         [TestCase("/foo", "", "/%2Ffoo")]
         [TestCase("/foo", "bar", "/bar/%2Ffoo")]
         [TestCase("/foo", "/bar/", "/%2Fbar%2F/%2Ffoo")]
-        [TestCase("foo/// ///#@", "/bar/", "/%2Fbar%2F/foo%2F%2F%2F%20%2F%2F%2F%23%40")]
+        [TestCase("foo/// ///#@", "/bar/", "/%2Fbar%2F/foo%2F%2F%2F%20%2F%2F%2F#@")]
         [TestCase("", "", "/")] // empty identity
         [TestCase("", "cat/", "/cat%2F/")] // category with trailing slash and empty name
         public void Identity_ToPathFromPath(string name, string category, string path)


### PR DESCRIPTION
This updates the  Proxy.NormalizePath implementation to keep most reserved characters (such as #, ! etc) unescaped. Fixes #113.