### PR TITLE
Protocol bridging test

### DIFF
--- a/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Tests.ClientServer
     [Timeout(10000)]
     public class ProtocolBridgingTests : ClientServerBaseTest
     {
-        private Communicator _communicator;
+        private readonly Communicator _communicator;
         private Server _forwarderServer = null!;
         private Server _targetServer = null!;
         private SortedDictionary<string, string>? _forwardedContext;
@@ -27,7 +27,7 @@ namespace IceRpc.Tests.ClientServer
         [TearDown]
         public async Task TearDownAsync()
         {
-            await Task.WhenAll(_forwarderServer.DisposeAsync().AsTask(), _targetServer.DisposeAsync().AsTask());
+            await Task.WhenAll(_forwarderServer.ShutdownAsync(), _targetServer.ShutdownAsync());
             await _communicator.DisposeAsync();
         }
 
@@ -45,7 +45,6 @@ namespace IceRpc.Tests.ClientServer
             IProtocolBridgingServicePrx forwarderService =
                 await SetupForwarderServerAsync(forwarderProtocol, targetProtocol, colocated);
 
-            // testing forwarding with same protocol
             var newPrx = await TestProxyAsync(forwarderService, false);
             Assert.AreEqual(newPrx.Protocol, targetProtocol);
             _ = await TestProxyAsync(newPrx, true);


### PR DESCRIPTION
This PR reworks the protocol bridging test to create servers in a separate method as suggested in a previous PR, it also updates the test to run with colocated and non colocated setups.

Colocated setup fails for Ice1 currently disabled in https://github.com/pepone/icerpc-csharp/blob/e61b508f7dc2df1b69045230c1de57d245116b95/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs#L39-L40

This related to https://github.com/zeroc-ice/icerpc-csharp/issues/140