### PR TITLE
Remove most Communicator.Default properties

### DIFF
--- a/csharp/src/IceRpc/ByteBufferExtensions.cs
+++ b/csharp/src/IceRpc/ByteBufferExtensions.cs
@@ -33,7 +33,7 @@ namespace IceRpc
             Connection? connection = null,
             IServicePrx? proxy = null)
         {
-            var istr = new InputStream(buffer, encoding, communicator, connection, proxy?.Impl);
+            var istr = new InputStream(buffer, encoding, communicator, ComputeOptions(connection, proxy));
             T result = reader(istr);
             istr.CheckEndOfBuffer(skipTaggedParams: false);
             return result;
@@ -103,8 +103,7 @@ namespace IceRpc
             var istr = new InputStream(buffer,
                                        encoding,
                                        communicator,
-                                       connection,
-                                       proxy?.Impl,
+                                       ComputeOptions(connection, proxy),
                                        startEncapsulation: true);
             T result = payloadReader(istr);
             istr.CheckEndOfBuffer(skipTaggedParams: true);
@@ -240,5 +239,26 @@ namespace IceRpc
         }
 
         internal static void WriteInt(this Span<byte> buffer, int v) => MemoryMarshal.Write(buffer, ref v);
+
+        private static ServicePrxOptions? ComputeOptions(Connection? connection, IServicePrx? proxy)
+        {
+            ServicePrxOptions? options = proxy?.Impl?.CloneOptions();
+            if (connection != null)
+            {
+                if (options != null)
+                {
+                    options.Connection = connection;
+                }
+                else
+                {
+                    options = new ServicePrxOptions()
+                    {
+                        Communicator = connection.Communicator,
+                        Connection = connection
+                    };
+                }
+            }
+            return options;
+        }
     }
 }

--- a/csharp/src/IceRpc/Communicator.cs
+++ b/csharp/src/IceRpc/Communicator.cs
@@ -64,42 +64,8 @@ namespace IceRpc
             }
         }
 
-        /// <summary>The default context for proxies created using this communicator. Changing the value of
-        /// DefaultContext does not change the context of previously created proxies.</summary>
-        public IReadOnlyDictionary<string, string> DefaultContext
-        {
-            get => _defaultContext;
-            set => _defaultContext = value.ToImmutableSortedDictionary();
-        }
-
-        /// <summary>The default invocation interceptors for proxies created using this communicator. Changing the value
-        /// of DefaultInvocationInterceptors does not change the invocation interceptors of previously created proxies.
-        /// </summary>
-        public ImmutableList<InvocationInterceptor> DefaultInvocationInterceptors
-        {
-            get => _defaultInvocationInterceptors;
-            set => _defaultInvocationInterceptors = value;
-        }
-
-        /// <summary>The default location resolver for this communicator.</summary>
-        public ILocationResolver? DefaultLocationResolver
-        {
-            get => _defaultLocationResolver;
-            set => _defaultLocationResolver = value;
-        }
-
-        /// <summary>Gets the communicator's preference for reusing existing connections.</summary>
-        public bool DefaultPreferExistingConnection { get; }
-
-        /// <summary>Gets the communicator's preference for establishing non-secure connections.</summary>
-        public NonSecure DefaultPreferNonSecure { get; }
-
         /// <summary>Gets the default source address value used by proxies created with this communicator.</summary>
         public IPAddress? DefaultSourceAddress { get; }
-
-        /// <summary>Gets the default invocation timeout value used by proxies created with this communicator.
-        /// </summary>
-        public TimeSpan DefaultInvocationTimeout { get; }
 
         /// <summary>Gets the communicator observer used by the Ice run-time or null if a communicator observer
         /// was not set during communicator construction.</summary>
@@ -173,11 +139,6 @@ namespace IceRpc
         private readonly ConcurrentDictionary<string, Func<AnyClass>?> _classFactoryCache = new();
         private readonly ConcurrentDictionary<int, Func<AnyClass>?> _compactIdCache = new();
         private readonly ThreadLocal<SortedDictionary<string, string>> _currentContext = new();
-        private volatile ImmutableSortedDictionary<string, string> _defaultContext =
-            ImmutableSortedDictionary<string, string>.Empty;
-        private volatile ImmutableList<InvocationInterceptor> _defaultInvocationInterceptors =
-            ImmutableList<InvocationInterceptor>.Empty;
-        private volatile ILocationResolver? _defaultLocationResolver;
         private Task? _shutdownTask;
 
         private readonly object _mutex = new object();
@@ -321,20 +282,6 @@ namespace IceRpc
                     _oneOffDone = true;
                 }
             }
-
-            DefaultInvocationTimeout =
-                this.GetPropertyAsTimeSpan("Ice.Default.InvocationTimeout") ?? TimeSpan.FromSeconds(60);
-            if (DefaultInvocationTimeout == TimeSpan.Zero)
-            {
-                throw new InvalidConfigurationException("0 is not a valid value for Ice.Default.InvocationTimeout");
-            }
-
-            DefaultPreferExistingConnection =
-                this.GetPropertyAsBool("Ice.Default.PreferExistingConnection") ?? true;
-
-            // TODO: switch to NonSecure.Never default
-            DefaultPreferNonSecure =
-                this.GetPropertyAsEnum<NonSecure>("Ice.Default.PreferNonSecure") ?? NonSecure.Always;
 
             if (GetProperty("Ice.Default.SourceAddress") is string address)
             {

--- a/csharp/src/IceRpc/Ice1Definitions.cs
+++ b/csharp/src/IceRpc/Ice1Definitions.cs
@@ -123,7 +123,6 @@ namespace IceRpc
                 {
                     istr = new InputStream(response.Payload.Slice(1),
                                            Ice2Definitions.Encoding,
-                                           sourceProxy: proxy,
                                            startEncapsulation: true);
 
                     replyStatus = istr.ReadReplyStatus();

--- a/csharp/src/IceRpc/IncomingRequestFrame.cs
+++ b/csharp/src/IceRpc/IncomingRequestFrame.cs
@@ -141,7 +141,11 @@ namespace IceRpc
 
             var istr = new InputStream(Payload.AsReadOnlyMemory(),
                                        Protocol.GetEncoding(),
-                                       connection: connection,
+                                       proxyOptions: new ServicePrxOptions()
+                                                     {
+                                                        Communicator = connection.Communicator,
+                                                        Connection = connection
+                                                     },
                                        startEncapsulation: true);
             T value = reader(istr, SocketStream);
             // Clear the socket stream to ensure it's not disposed with the request frame. It's now the

--- a/csharp/src/IceRpc/IncomingResponseFrame.cs
+++ b/csharp/src/IceRpc/IncomingResponseFrame.cs
@@ -94,7 +94,7 @@ namespace IceRpc
 
                 var istr = new InputStream(Payload.AsReadOnlyMemory(1),
                                            Protocol.GetEncoding(),
-                                           sourceProxy: proxy.Impl,
+                                           proxyOptions: proxy.Impl.CloneOptions(),
                                            startEncapsulation: true);
                 T value = reader(istr, SocketStream);
                 // Clear the socket stream to ensure it's not disposed with the response frame. It's now the
@@ -294,7 +294,7 @@ namespace IceRpc
             {
                 istr = new InputStream(Payload.Slice(1),
                                        Protocol.GetEncoding(),
-                                       sourceProxy: proxy.Impl,
+                                       proxyOptions: proxy.Impl.CloneOptions(),
                                        startEncapsulation: true);
 
                 if (Protocol == Protocol.Ice2 && PayloadEncoding == Encoding.V11)

--- a/csharp/src/IceRpc/InputStream.cs
+++ b/csharp/src/IceRpc/InputStream.cs
@@ -107,10 +107,6 @@ namespace IceRpc
         /// exception.</summary>
         public Communicator? Communicator { get; }
 
-        /// <summary>The Connection used to read relative proxies. When not null, a relative proxy is unmarshaled into
-        /// a fixed proxy bound to this connection.</summary>
-        public Connection? Connection { get; }
-
         /// <summary>The Ice encoding used by this stream when reading its byte buffer.</summary>
         /// <value>The encoding.</value>
         public Encoding Encoding { get; }
@@ -118,10 +114,8 @@ namespace IceRpc
         /// <summary>The 0-based position (index) in the underlying buffer.</summary>
         internal int Pos { get; private set; }
 
-        /// <summary>The proxy used to read relative proxies. When not null, a relative proxy is unmarshaled into a
-        /// clone of this proxy (with various updates). SourceProxy and Connection are mutually exclusive: only one of
-        /// them can be non-null.</summary>
-        internal ServicePrx? SourceProxy { get; }
+        /// <summary>Proxy options used when unmarshaling proxies.</summary>
+        internal ServicePrxOptions? ProxyOptions { get; }
 
         /// <summary>The sliced-off slices held by the current instance, if any.</summary>
         internal SlicedData? SlicedData
@@ -958,24 +952,18 @@ namespace IceRpc
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="encoding">The encoding of the buffer.</param>
         /// <param name="communicator">The communicator (optional).</param>
-        /// <param name="connection">The connection (optional).</param>
-        /// <param name="sourceProxy">The source proxy (optional).</param>
+        /// <param name="proxyOptions">Options used when unmarshaling proxies (optional).</param>
         /// <param name="startEncapsulation">When true, start reading an encapsulation in this byte buffer, and
         /// <c>encoding</c> represents the encoding of the header.</param>
         internal InputStream(
             ReadOnlyMemory<byte> buffer,
             Encoding encoding,
             Communicator? communicator = null,
-            Connection? connection = null,
-            ServicePrx? sourceProxy = null,
+            ServicePrxOptions? proxyOptions = null,
             bool startEncapsulation = false)
         {
-            // Connection and sourceProxy are mutually exclusive - it's either one or the other.
-            Debug.Assert(connection == null || sourceProxy == null);
-
-            Communicator = communicator ?? connection?.Communicator ?? sourceProxy?.Communicator;
-            Connection = connection;
-            SourceProxy = sourceProxy;
+            Communicator = communicator ?? proxyOptions?.Communicator;
+            ProxyOptions = proxyOptions;
 
             Pos = 0;
             _buffer = buffer;

--- a/csharp/src/IceRpc/ServicePrx.cs
+++ b/csharp/src/IceRpc/ServicePrx.cs
@@ -20,13 +20,12 @@ namespace IceRpc
     {
         public bool CacheConnection { get; } = true;
         public Communicator Communicator { get; }
-        public IReadOnlyDictionary<string, string> Context { get; } = ImmutableDictionary<string, string>.Empty;
+        public IReadOnlyDictionary<string, string> Context { get; }
         public Encoding Encoding { get; }
         public IReadOnlyList<Endpoint> Endpoints { get; } = ImmutableList<Endpoint>.Empty;
-        public IReadOnlyList<InvocationInterceptor> InvocationInterceptors { get; } =
-            ImmutableList<InvocationInterceptor>.Empty;
+        public IReadOnlyList<InvocationInterceptor> InvocationInterceptors { get; }
 
-        public TimeSpan InvocationTimeout => _invocationTimeoutOverride ?? Communicator.DefaultInvocationTimeout;
+        public TimeSpan InvocationTimeout => _invocationTimeoutOverride ?? TimeSpan.FromSeconds(60);
         public bool IsFixed { get; }
 
         public bool IsOneway { get; }
@@ -35,9 +34,8 @@ namespace IceRpc
 
         public string Path { get; } = "";
 
-        public bool PreferExistingConnection =>
-            _preferExistingConnectionOverride ?? Communicator.DefaultPreferExistingConnection;
-        public NonSecure PreferNonSecure => _preferNonSecureOverride ?? Communicator.DefaultPreferNonSecure;
+        public bool PreferExistingConnection => _preferExistingConnectionOverride ?? true;
+        public NonSecure PreferNonSecure => _preferNonSecureOverride ?? NonSecure.Always; // TODO: fix default
         public Protocol Protocol { get; }
 
         ServicePrx IServicePrx.Impl => this;
@@ -574,10 +572,10 @@ namespace IceRpc
 
             CacheConnection = options.CacheConnection;
             Communicator = options.Communicator!;
-            Context = options.Context ?? Communicator.DefaultContext;
+            Context = options.Context ?? ImmutableDictionary<string, string>.Empty;
             Encoding = options.Encoding ?? options.Protocol.GetEncoding();
             Endpoints = options.Endpoints;
-            InvocationInterceptors = options.InvocationInterceptors ?? Communicator.DefaultInvocationInterceptors;
+            InvocationInterceptors = options.InvocationInterceptors ?? ImmutableList<InvocationInterceptor>.Empty;
             IsFixed = options.Connection != null; // auto-computed for now
             IsOneway = options.IsOneway;
             Label = options.Label;

--- a/csharp/src/IceRpc/UriParser.cs
+++ b/csharp/src/IceRpc/UriParser.cs
@@ -116,7 +116,6 @@ namespace IceRpc
                 InvocationTimeoutOverride = parsedOptions.InvocationTimeout,
                 IsOneway = parsedOptions.IsOneway ?? false,
                 Label = parsedOptions.Label,
-                LocationResolver = communicator.DefaultLocationResolver,
                 Path = uri.AbsolutePath,
                 PreferExistingConnectionOverride = parsedOptions.PreferExistingConnection,
                 PreferNonSecureOverride = parsedOptions.PreferNonSecure,

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1705,23 +1705,8 @@ namespace IceRpc.Test.Operations
                 }
                 TestHelper.Assert(combined["one"].Equals("UN"));
 
-                TestHelper.Assert(communicator.DefaultContext.Count == 0);
-                communicator.DefaultContext = prxContext;
-                TestHelper.Assert(communicator.DefaultContext != prxContext); // it's a copy
-                TestHelper.Assert(communicator.DefaultContext.DictionaryEqual(prxContext));
-
-                p3 = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
-                var ctx = new SortedDictionary<string, string>(communicator.CurrentContext);
-
-                communicator.CurrentContext.Clear();
-                TestHelper.Assert(p3.OpContext().DictionaryEqual(prxContext));
-
-                communicator.CurrentContext = ctx;
-                TestHelper.Assert(p3.OpContext().DictionaryEqual(combined));
-
                 // Cleanup
                 communicator.CurrentContext.Clear();
-                communicator.DefaultContext = new SortedDictionary<string, string>();
             }
 
             p.OpIdempotent();

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -1291,23 +1291,8 @@ namespace IceRpc.Test.Operations
                 }
                 TestHelper.Assert(combined["one"].Equals("UN"));
 
-                TestHelper.Assert(communicator.DefaultContext.Count == 0);
-                communicator.DefaultContext = prxContext;
-                TestHelper.Assert(communicator.DefaultContext != prxContext); // it's a copy
-                TestHelper.Assert(communicator.DefaultContext.DictionaryEqual(prxContext));
-
-                p3 = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
-
-                var ctx = new SortedDictionary<string, string>(communicator.CurrentContext);
-                communicator.CurrentContext.Clear();
-                TestHelper.Assert(p3.OpContextAsync().Result.DictionaryEqual(prxContext));
-
-                communicator.CurrentContext = ctx;
-                TestHelper.Assert(p3.OpContextAsync().Result.DictionaryEqual(combined));
-
                 // Cleanup
                 communicator.CurrentContext.Clear();
-                communicator.DefaultContext = new SortedDictionary<string, string>();
             }
 
             p.OpIdempotentAsync().Wait();

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -266,29 +266,13 @@ namespace IceRpc.Test.Proxy
             output.Write("testing communicator default invocation timeout... ");
             output.Flush();
             {
-                await using var comm1 = new Communicator(new Dictionary<string, string>()
-                    {
-                        { "Ice.Default.InvocationTimeout", "120s" }
-                    });
-
-                await using var comm2 = new Communicator();
-
-                TestHelper.Assert(IServicePrx.Parse("ice+tcp://localhost/identity", comm1).InvocationTimeout ==
-                                  TimeSpan.FromSeconds(120));
-
-                TestHelper.Assert(IServicePrx.Parse("ice+tcp://localhost/identity", comm2).InvocationTimeout ==
+                TestHelper.Assert(IServicePrx.Parse("ice+tcp://localhost/identity", communicator).InvocationTimeout ==
                                   TimeSpan.FromSeconds(60));
 
                 TestHelper.Assert(IServicePrx.Parse("ice+tcp://localhost/identity?invocation-timeout=10s",
-                                                   comm1).InvocationTimeout == TimeSpan.FromSeconds(10));
+                                                   communicator).InvocationTimeout == TimeSpan.FromSeconds(10));
 
-                TestHelper.Assert(IServicePrx.Parse("ice+tcp://localhost/identity?invocation-timeout=10s",
-                                                   comm2).InvocationTimeout == TimeSpan.FromSeconds(10));
-
-                TestHelper.Assert(IServicePrx.Parse("identity -t:tcp -h localhost", comm1).InvocationTimeout ==
-                                 TimeSpan.FromSeconds(120));
-
-                TestHelper.Assert(IServicePrx.Parse("identity -t:tcp -h localhost", comm2).InvocationTimeout ==
+                TestHelper.Assert(IServicePrx.Parse("identity -t:tcp -h localhost", communicator).InvocationTimeout ==
                                   TimeSpan.FromSeconds(60));
             }
             output.WriteLine("ok");
@@ -296,18 +280,6 @@ namespace IceRpc.Test.Proxy
             output.Write("testing invalid invocation timeout... ");
             output.Flush();
             {
-                try
-                {
-                    await using var comm1 = new Communicator(new Dictionary<string, string>()
-                    {
-                        { "Ice.Default.InvocationTimeout", "0s" }
-                    });
-                    TestHelper.Assert(false);
-                }
-                catch (InvalidConfigurationException)
-                {
-                }
-
                 try
                 {
                     IServicePrx.Parse("ice+tcp://localhost/identity", communicator).Clone(

--- a/tests/IceRpc.Tests.Api/ProxyTests.cs
+++ b/tests/IceRpc.Tests.Api/ProxyTests.cs
@@ -282,23 +282,6 @@ namespace IceRpc.Tests.Api
             Assert.AreEqual("", prx.GetFacet());
         }
 
-        /// <summary>Test that the communicator default invocation interceptors are used when the
-        /// proxy doesn't specify its own interceptors.</summary>
-        [Test]
-        public void Proxy_DefaultInvocationInterceptors()
-        {
-            var communicator = new Communicator
-            {
-                DefaultInvocationInterceptors = ImmutableList.Create<InvocationInterceptor>(
-                    (target, request, next, cancel) => throw new NotImplementedException(),
-                    (target, request, next, cancel) => throw new NotImplementedException())
-            };
-
-            var prx = IServicePrx.Parse("test", communicator);
-
-            CollectionAssert.AreEqual(communicator.DefaultInvocationInterceptors, prx.InvocationInterceptors);
-        }
-
         [Test]
         public void Proxy_Equals()
         {
@@ -448,12 +431,6 @@ namespace IceRpc.Tests.Api
             prx = communicator.GetPropertyAsProxy(propertyPrefix, IServicePrx.Factory)!;
             communicator.SetProperty($"{propertyPrefix}.InvocationTimeout", "");
             Assert.AreEqual(prx.InvocationTimeout, TimeSpan.FromSeconds(1));
-
-            Assert.AreEqual(prx.PreferNonSecure, communicator.DefaultPreferNonSecure);
-            communicator.SetProperty($"{propertyPrefix}.PreferNonSecure", "SameHost");
-            prx = communicator.GetPropertyAsProxy(propertyPrefix, IServicePrx.Factory)!;
-            communicator.RemoveProperty($"{propertyPrefix}.PreferNonSecure");
-            Assert.AreNotEqual(prx.PreferNonSecure, communicator.DefaultPreferNonSecure);
         }
 
         [Test]
@@ -519,10 +496,6 @@ namespace IceRpc.Tests.Api
             Assert.AreEqual(prx.InvocationTimeout, TimeSpan.FromSeconds(60));
             prx = IServicePrx.Parse($"{proxyString}?invocation-timeout=1s", communicator);
             Assert.AreEqual(prx.InvocationTimeout, TimeSpan.FromSeconds(1));
-
-            Assert.AreEqual(prx.PreferNonSecure, communicator.DefaultPreferNonSecure);
-            prx = IServicePrx.Parse($"{proxyString}?prefer-non-secure=SameHost", communicator);
-            Assert.AreNotEqual(prx.PreferNonSecure, communicator.DefaultPreferNonSecure);
 
             string complicated = $"{proxyString}?invocation-timeout=10s&context=c%201=some%20value" +
                 "&label=myLabel&oneway=true" +


### PR DESCRIPTION
This PR removes most Communicator.Default properties.

They are replaced by:
- when parsing a proxy, nothing (i.e. the global default)
- when unmarshaling a proxy in an IncomingResponseFrame, by the "source proxy" options (similar to what we already did for relative proxies)
- when unmarshaling a proxy ing an IncomingRequestFrame by currently nothing. A future PR should add proxy options to ServerOptions to set these options. Note that relative proxies in IncomingRequestFrame still work - they are unmarshaled as fixed proxies.