### PR TITLE
Add IsFixed to ServicePrxOptions

### DIFF
--- a/csharp/src/IceRpc/ByteBufferExtensions.cs
+++ b/csharp/src/IceRpc/ByteBufferExtensions.cs
@@ -247,13 +247,15 @@ namespace IceRpc
                 if (options != null)
                 {
                     options.Connection = connection;
+                    options.IsFixed = true;
                 }
                 else
                 {
                     options = new ServicePrxOptions()
                     {
                         Communicator = connection.Communicator,
-                        Connection = connection
+                        Connection = connection,
+                        IsFixed = true
                     };
                 }
             }

--- a/csharp/src/IceRpc/Ice1Parser.cs
+++ b/csharp/src/IceRpc/Ice1Parser.cs
@@ -306,13 +306,7 @@ namespace IceRpc
             if (beg == -1)
             {
                 // Well-known proxy
-                var endpoint = LocEndpoint.Create(new EndpointData(Transport.Loc,
-                                                                   host: result.Identity.Name,
-                                                                   port: 0,
-                                                                   options: new string[] { result.Identity.Category }),
-                                                  Protocol.Ice1);
-
-                result.Endpoints = ImmutableList.Create(endpoint);
+                result.Endpoints = ImmutableList.Create(LocEndpoint.Create(result.Identity));
                 return result;
             }
 
@@ -420,13 +414,7 @@ namespace IceRpc
                     throw new FormatException($"empty adapter ID in proxy `{s}'");
                 }
 
-                var endpoint = LocEndpoint.Create(new EndpointData(Transport.Loc,
-                                                                   host: adapterId,
-                                                                   port: 0,
-                                                                   options: Array.Empty<string>()),
-                                                  Protocol.Ice1);
-
-                result.Endpoints = ImmutableList.Create<Endpoint>(endpoint);
+                result.Endpoints = ImmutableList.Create<Endpoint>(LocEndpoint.Create(adapterId, Protocol.Ice1));
                 return result;
             }
 

--- a/csharp/src/IceRpc/IncomingRequestFrame.cs
+++ b/csharp/src/IceRpc/IncomingRequestFrame.cs
@@ -148,7 +148,8 @@ namespace IceRpc
                                        proxyOptions: new ServicePrxOptions()
                                                      {
                                                         Communicator = connection.Communicator!,
-                                                        Connection = connection
+                                                        Connection = connection,
+                                                        IsFixed = true
                                                      },
                                        startEncapsulation: true);
             T value = reader(istr, SocketStream);

--- a/csharp/src/IceRpc/LocEndpoint.cs
+++ b/csharp/src/IceRpc/LocEndpoint.cs
@@ -87,6 +87,13 @@ namespace IceRpc
             return new(data, protocol);
         }
 
+        internal static LocEndpoint Create(Interop.Identity identity) =>
+            new(new EndpointData(Transport.Loc, identity.Name, port: 0, new string[] { identity.Category }),
+                Protocol.Ice1);
+
+        internal static LocEndpoint Create(string location, Protocol protocol) =>
+            new(new EndpointData(Transport.Loc, location, port: 0, Array.Empty<string>()), protocol);
+
         // There is no ParseIce1Endpoint: in ice1 string format, loc is never represented as an endpoint.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/csharp/src/IceRpc/ServicePrx.cs
+++ b/csharp/src/IceRpc/ServicePrx.cs
@@ -540,9 +540,16 @@ namespace IceRpc
         {
             int endpointCount = options.Endpoints.Count;
 
-            if (options.Connection != null && endpointCount > 0)
+            if (options.IsFixed)
             {
-                throw new ArgumentException("a fixed proxy cannot specify endpoints", nameof(options));
+                if (endpointCount > 0)
+                {
+                    throw new ArgumentException("a fixed proxy cannot specify endpoints", nameof(options));
+                }
+                if (options.Connection == null)
+                {
+                    throw new ArgumentException("a fixed proxy requires a connection", nameof(options));
+                }
             }
 
             if (endpointCount > 0)
@@ -558,7 +565,7 @@ namespace IceRpc
                                                 nameof(options));
                 }
             }
-            else if (options.Connection == null && options.Protocol == Protocol.Ice1)
+            else if (!options.IsFixed && options.Protocol == Protocol.Ice1)
             {
                 throw new ArgumentException("a non-fixed ice1 proxy requires at least one endpoint",
                                             nameof(options));
@@ -576,7 +583,7 @@ namespace IceRpc
             Encoding = options.Encoding ?? options.Protocol.GetEncoding();
             Endpoints = options.Endpoints;
             InvocationInterceptors = options.InvocationInterceptors ?? ImmutableList<InvocationInterceptor>.Empty;
-            IsFixed = options.Connection != null; // auto-computed for now
+            IsFixed = options.IsFixed;
             IsOneway = options.IsOneway;
             Label = options.Label;
             LocationResolver = options.LocationResolver;
@@ -721,7 +728,7 @@ namespace IceRpc
                 {
                     CacheConnection = CacheConnection,
                     Communicator = Communicator,
-                    Connection = IsFixed ? _connection : null,
+                    Connection = _connection,
                     Context = Context,
                     Encoding = Encoding,
                     Endpoints = Endpoints,
@@ -729,6 +736,7 @@ namespace IceRpc
                     Identity = Identity,
                     InvocationInterceptors = InvocationInterceptors,
                     InvocationTimeoutOverride = _invocationTimeoutOverride,
+                    IsFixed = IsFixed,
                     IsOneway = IsOneway,
                     Label = Label,
                     LocationResolver = LocationResolver,
@@ -744,12 +752,13 @@ namespace IceRpc
                 {
                     CacheConnection = CacheConnection,
                     Communicator = Communicator,
-                    Connection = IsFixed ? _connection : null,
+                    Connection = _connection,
                     Context = Context,
                     Encoding = Encoding,
                     Endpoints = Endpoints,
                     InvocationInterceptors = InvocationInterceptors,
                     InvocationTimeoutOverride = _invocationTimeoutOverride,
+                    IsFixed = IsFixed,
                     IsOneway = IsOneway,
                     Label = Label,
                     LocationResolver = LocationResolver,

--- a/csharp/src/IceRpc/ServicePrxOptions.cs
+++ b/csharp/src/IceRpc/ServicePrxOptions.cs
@@ -23,6 +23,8 @@ namespace IceRpc
 
         public TimeSpan? InvocationTimeoutOverride { get; set; }
 
+        public bool IsFixed { get; set; }
+
         public bool IsOneway { get; set; }
 
         public object? Label { get; set; }

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -63,7 +63,7 @@ namespace IceRpc.Test.Binding
                 com.DeactivateServer(server);
 
                 var test3 = ITestIntfPrx.Factory.Copy(test1);
-                TestHelper.Assert(test3.GetCachedConnection() == null);
+                TestHelper.Assert(test3.GetCachedConnection() == test1.GetCachedConnection());
 
                 try
                 {

--- a/tests/IceRpc.Tests.Internal/SocketBaseTest.cs
+++ b/tests/IceRpc.Tests.Internal/SocketBaseTest.cs
@@ -175,6 +175,7 @@ namespace IceRpc.Tests.Internal
             {
                 Communicator = _clientCommunicator,
                 Connection = connection,
+                IsFixed = true,
                 Path = "dummy",
                 Protocol = ClientEndpoint.Protocol
             };


### PR DESCRIPTION
This PR adds the `IsFixed` property to ServicePrxOptions.

This allows Clone to preserve the cached connection in many situations.