### PR TITLE
Simplify Endpoint hashing

### DIFF
--- a/csharp/src/IceRpc/LocEndpoint.cs
+++ b/csharp/src/IceRpc/LocEndpoint.cs
@@ -23,31 +23,10 @@ namespace IceRpc
 
         internal const ushort DefaultLocPort = 0;
 
-        private int _hashCode; // 0 is a special value that means not initialized.
-
         public override IAcceptor Acceptor(Server server) =>
             throw new InvalidOperationException();
 
         // There is no Equals as it's identical to the base.
-
-        // Only for caching, same value as base.
-        public override int GetHashCode()
-        {
-            if (_hashCode != 0)
-            {
-                return _hashCode;
-            }
-            else
-            {
-                int hashCode = base.GetHashCode();
-                if (hashCode == 0)
-                {
-                    hashCode = 1;
-                }
-                _hashCode = hashCode;
-                return _hashCode;
-            }
-        }
 
         // There is currently no support for server-side loc endpoints
         public override bool IsLocal(Endpoint endpoint) => false;

--- a/csharp/src/IceRpc/OpaqueEndpoint.cs
+++ b/csharp/src/IceRpc/OpaqueEndpoint.cs
@@ -37,8 +37,6 @@ namespace IceRpc
 
         internal Encoding ValueEncoding { get; }
 
-        private int _hashCode; // 0 is a special value that means not initialized.
-
         public override IAcceptor Acceptor(Server server) =>
             throw new InvalidOperationException();
 
@@ -52,28 +50,6 @@ namespace IceRpc
                 ValueEncoding == opaqueEndpoint.ValueEncoding &&
                 Value.Span.SequenceEqual(opaqueEndpoint.Value.Span) &&
                 base.Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            if (_hashCode != 0)
-            {
-                return _hashCode;
-            }
-            else
-            {
-                int hashCode = HashCode.Combine(
-                    base.GetHashCode(),
-                    ValueEncoding,
-                    MemoryMarshal.ToEnumerable(Value).GetSequenceHashCode());
-
-                if (hashCode == 0)
-                {
-                    hashCode = 1;
-                }
-                _hashCode = hashCode;
-                return _hashCode;
-            }
         }
 
         public override bool IsLocal(Endpoint endpoint) => false;

--- a/csharp/src/IceRpc/TcpEndpoint.cs
+++ b/csharp/src/IceRpc/TcpEndpoint.cs
@@ -35,9 +35,6 @@ namespace IceRpc
         /// <summary>The default timeout for ice1 endpoints.</summary>
         protected static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
 
-        private int _equivalentHashCode;
-        private int _hashCode;
-
         // TODO: should not be public
         public override IAcceptor Acceptor(Server server)
         {
@@ -92,35 +89,6 @@ namespace IceRpc
             }
         }
 
-        public override int GetHashCode()
-        {
-            // This code is thread safe because reading/writing _hashCode (an int) is atomic.
-            if (_hashCode != 0)
-            {
-                // Return cached value
-                return _hashCode;
-            }
-            else
-            {
-                int hashCode;
-                if (Protocol == Protocol.Ice1)
-                {
-                    hashCode = HashCode.Combine(base.GetHashCode(), HasCompressionFlag, Timeout);
-                }
-                else
-                {
-                    hashCode = base.GetHashCode();
-                }
-
-                if (hashCode == 0) // 0 is not a valid value as it means "not initialized".
-                {
-                    hashCode = 1;
-                }
-                _hashCode = hashCode;
-                return _hashCode;
-            }
-        }
-
         protected internal override void AppendOptions(StringBuilder sb, char optionSeparator)
         {
             base.AppendOptions(sb, optionSeparator);
@@ -134,26 +102,6 @@ namespace IceRpc
                 {
                     sb.Append(" -z");
                 }
-            }
-        }
-
-        protected internal override int GetEquivalentHashCode()
-        {
-            // This code is thread safe because reading/writing _hashCode (an int) is atomic.
-            if (_equivalentHashCode != 0)
-            {
-                // Return cached value
-                return _equivalentHashCode;
-            }
-            else
-            {
-                int hashCode = base.GetHashCode();
-                if (hashCode == 0) // 0 is not a valid value as it means "not initialized".
-                {
-                    hashCode = 1;
-                }
-                _equivalentHashCode = hashCode;
-                return _equivalentHashCode;
             }
         }
 

--- a/csharp/src/IceRpc/UdpEndpoint.cs
+++ b/csharp/src/IceRpc/UdpEndpoint.cs
@@ -37,8 +37,6 @@ namespace IceRpc
 
         private readonly bool _hasCompressionFlag;
 
-        private int _hashCode;
-
         public override IAcceptor Acceptor(Server server) =>
             throw new InvalidOperationException();
 
@@ -125,30 +123,6 @@ namespace IceRpc
                 base.Equals(udpEndpoint);
         }
 
-        public override int GetHashCode()
-        {
-            // This code is thread safe because reading/writing _hashCode (an int) is atomic.
-            if (_hashCode != 0)
-            {
-                // Return cached value
-                return _hashCode;
-            }
-            else
-            {
-                var hash = new HashCode();
-                hash.Add(base.GetHashCode());
-                hash.Add(_hasCompressionFlag);
-                hash.Add(MulticastInterface);
-                hash.Add(MulticastTtl);
-                int hashCode = hash.ToHashCode();
-                if (hashCode == 0) // 0 is not a valid value as it means "not initialized".
-                {
-                    hashCode = 1;
-                }
-                _hashCode = hashCode;
-                return _hashCode;
-            }
-        }
         protected internal override void AppendOptions(StringBuilder sb, char optionSeparator)
         {
             Debug.Assert(Protocol == Protocol.Ice1);

--- a/csharp/src/IceRpc/UniversalEndpoint.cs
+++ b/csharp/src/IceRpc/UniversalEndpoint.cs
@@ -33,31 +33,10 @@ namespace IceRpc
 
         internal const ushort DefaultUniversalPort = 0;
 
-        private int _hashCode; // 0 is a special value that means not initialized.
-
         public override IAcceptor Acceptor(Server server) =>
             throw new InvalidOperationException();
 
         // There is no Equals as it's identical to the base.
-
-        // Only for caching, same value as base.
-        public override int GetHashCode()
-        {
-            if (_hashCode != 0)
-            {
-                return _hashCode;
-            }
-            else
-            {
-                int hashCode = base.GetHashCode();
-                if (hashCode == 0)
-                {
-                    hashCode = 1;
-                }
-                _hashCode = hashCode;
-                return _hashCode;
-            }
-        }
 
         public override bool IsLocal(Endpoint endpoint) => false;
 


### PR DESCRIPTION
This PR removes most of the custom hashing from Endpoints, including endpoint caching.

It's based on the following principles:
 - better keep the code simple and write less code
 - nobody is ever going to use a dictionary of opaque endpoints or a dictionary of UDP endpoints with different "compress setting" or "multicast interface"
 - even if someone does, the dictionary still works - it's just a little slower because we'll get collisions in the dictionary

It's possible - even likely - we'll have dictionaries where the key is or contains endpoints (e.g. the endpoint resolver would maintain such a dictionary). However it's unlikely the non-cached hashing of endpoints is so slow it makes a difference, especially with proxies caching connections by default. 