### PR TITLE
Remove per thread current context

### DIFF
--- a/csharp/src/IceRpc/Communicator.cs
+++ b/csharp/src/IceRpc/Communicator.cs
@@ -21,43 +21,6 @@ namespace IceRpc
         /// <summary>The connection options.</summary>
         public OutgoingConnectionOptions ConnectionOptions;
 
-        /// <summary>Each time you send a request without an explicit context parameter, Ice sends automatically the
-        /// per-thread CurrentContext combined with the proxy's context.</summary>
-        public SortedDictionary<string, string> CurrentContext
-        {
-            get
-            {
-                try
-                {
-                    if (_currentContext.IsValueCreated)
-                    {
-                        Debug.Assert(_currentContext.Value != null);
-                        return _currentContext.Value;
-                    }
-                    else
-                    {
-                        _currentContext.Value = new SortedDictionary<string, string>();
-                        return _currentContext.Value;
-                    }
-                }
-                catch (ObjectDisposedException)
-                {
-                    return new SortedDictionary<string, string>();
-                }
-            }
-            set
-            {
-                try
-                {
-                    _currentContext.Value = value;
-                }
-                catch (ObjectDisposedException ex)
-                {
-                    throw new CommunicatorDisposedException(ex);
-                }
-            }
-        }
-
         /// <summary>Gets the communicator observer used by the Ice run-time or null if a communicator observer
         /// was not set during communicator construction.</summary>
         public Instrumentation.ICommunicatorObserver? Observer { get; }
@@ -100,7 +63,6 @@ namespace IceRpc
         private static readonly object _staticMutex = new();
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-        private readonly ThreadLocal<SortedDictionary<string, string>> _currentContext = new();
         private Task? _shutdownTask;
 
         private readonly object _mutex = new();
@@ -318,7 +280,6 @@ namespace IceRpc
 
                 // Ensure all the outgoing connections were removed
                 Debug.Assert(_outgoingConnections.Count == 0);
-                _currentContext.Dispose();
                 _cancellationTokenSource.Dispose();
             }
         }

--- a/csharp/src/IceRpc/OutgoingRequestFrame.cs
+++ b/csharp/src/IceRpc/OutgoingRequestFrame.cs
@@ -377,36 +377,8 @@ namespace IceRpc
                 proxy.Communicator.CancellationToken,
                 cancel);
 
-            if (context != null)
-            {
-                // This makes a copy if context is not immutable.
-                _initialContext = context.ToImmutableSortedDictionary();
-            }
-            else
-            {
-                IReadOnlyDictionary<string, string> currentContext = proxy.Communicator.CurrentContext;
-
-                if (proxy.Context.Count == 0)
-                {
-                    _initialContext = currentContext;
-                }
-                else if (currentContext.Count == 0)
-                {
-                    _initialContext = proxy.Context;
-                }
-                else
-                {
-                    var combinedContext = new SortedDictionary<string, string>(
-                        (IDictionary<string, string>)currentContext);
-
-                    foreach ((string key, string value) in proxy.Context)
-                    {
-                        combinedContext[key] = value; // the proxy Context entry prevails.
-                    }
-                    _initialContext = combinedContext;
-                    _writableContext = combinedContext;
-                }
-            }
+            // This makes a copy if context is not immutable.
+            _initialContext = context?.ToImmutableSortedDictionary() ?? proxy.Context;
         }
     }
 }


### PR DESCRIPTION
This PR removes the per-thread current context, I think this feature can be easily provided using an interceptor and it is not widely used to be built-in. I think we can go one step further and remove the per proxy context, which can also be easily implemented using interceptors.