### PR TITLE
Fixed stream ID allocation bug

### DIFF
--- a/src/IceRpc/MultiStreamSocket.cs
+++ b/src/IceRpc/MultiStreamSocket.cs
@@ -251,7 +251,7 @@ namespace IceRpc
             return (largestBidirectionalStreamId, largestUnidirectionalStreamId);
         }
 
-        internal void AddStream(long id, SocketStream stream, bool control)
+        internal void AddStream(long id, SocketStream stream, bool control, ref long streamId)
         {
             lock (_mutex)
             {
@@ -262,6 +262,10 @@ namespace IceRpc
                     throw new ConnectionClosedException(isClosedByPeer: false, RetryPolicy.AfterDelay(TimeSpan.Zero));
                 }
                 _streams[id] = stream;
+
+                // Assign the stream ID within the mutex as well to ensure that the addition of the stream to
+                // the socket and the stream ID assignment are atomic.
+                streamId = id;
             }
 
             if (!control)

--- a/src/IceRpc/SocketStream.cs
+++ b/src/IceRpc/SocketStream.cs
@@ -38,10 +38,9 @@ namespace IceRpc
             {
                 Debug.Assert(_id == -1);
                 // First add the stream and then assign the ID. AddStream can throw if the socket is closed and
-                // in this case we want to make sure the id isn't assigned since the stream isn't considered if
-                // not added to the socket.
-                _socket.AddStream(value, this, IsControl);
-                _id = value;
+                // in this case we want to make sure the id isn't assigned since the stream isn't considered
+                // allocated if not added to the socket.
+                _socket.AddStream(value, this, IsControl, ref _id);
             }
         }
 
@@ -175,11 +174,9 @@ namespace IceRpc
         protected SocketStream(MultiStreamSocket socket, long streamId)
         {
             _socket = socket;
-            _id = streamId;
-            IsBidirectional = _id % 4 < 2;
-            IsControl = _id == 2 || _id == 3;
-
-            _socket.AddStream(_id, this, IsControl);
+            IsBidirectional = streamId % 4 < 2;
+            IsControl = streamId == 2 || streamId == 3;
+            _socket.AddStream(streamId, this, IsControl, ref _id);
         }
 
         /// <summary>Constructs an outgoing stream.</summary>


### PR DESCRIPTION
This PR fixes a race condition where the stream was added to the socket dictionary before its ID was assigned. The assignment of the ID and the addition to the dictionary are now atomic.