### PR TITLE
Change mapping for read-only dictionaries

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -451,15 +451,17 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
     DictionaryPtr d = DictionaryPtr::dynamicCast(type);
     if (d)
     {
-        string typeName;
         if (readOnly)
         {
-            typeName = "IReadOnlyDictionary";
+            return "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<" +
+                typeToString(d->keyType(), package) + ", " +
+                typeToString(d->valueType(), package) + ">>";
         }
         else
         {
             string prefix = "cs:generic:";
             string meta;
+            string typeName;
 
             if (d->findMetadata(prefix, meta))
             {
@@ -469,11 +471,11 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
             {
                 typeName = "Dictionary";
             }
-        }
 
-        return "global::System.Collections.Generic." + typeName + "<" +
-            typeToString(d->keyType(), package) + ", " +
-            typeToString(d->valueType(), package) + ">";
+            return "global::System.Collections.Generic." + typeName + "<" +
+                typeToString(d->keyType(), package) + ", " +
+                typeToString(d->valueType(), package) + ">";
+        }
     }
 
     ContainedPtr contained = ContainedPtr::dynamicCast(type);

--- a/src/IceRpc/OutputStream.cs
+++ b/src/IceRpc/OutputStream.cs
@@ -345,12 +345,12 @@ namespace IceRpc
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
         public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue> v,
+            IEnumerable<KeyValuePair<TKey, TValue>> v,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
         {
-            WriteSize(v.Count);
+            WriteSize(v.Count());
             foreach ((TKey key, TValue value) in v)
             {
                 keyWriter(this, key);
@@ -365,7 +365,7 @@ namespace IceRpc
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
         public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue?> v,
+            IEnumerable<KeyValuePair<TKey, TValue?>> v,
             bool withBitSequence,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
@@ -374,7 +374,7 @@ namespace IceRpc
         {
             if (withBitSequence)
             {
-                int count = v.Count;
+                int count = v.Count();
                 WriteSize(count);
                 BitSequence bitSequence = WriteBitSequence(count);
                 int index = 0;
@@ -394,7 +394,7 @@ namespace IceRpc
             }
             else
             {
-                WriteDictionary((IReadOnlyDictionary<TKey, TValue>)v, keyWriter, valueWriter);
+                WriteDictionary((IEnumerable<KeyValuePair<TKey, TValue>>)v, keyWriter, valueWriter);
             }
         }
 
@@ -404,13 +404,13 @@ namespace IceRpc
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
         public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue?> v,
+            IEnumerable<KeyValuePair<TKey, TValue?>> v,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
             where TValue : struct
         {
-            int count = v.Count;
+            int count = v.Count();
             WriteSize(count);
             BitSequence bitSequence = WriteBitSequence(count);
             int index = 0;
@@ -755,17 +755,17 @@ namespace IceRpc
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
         public void WriteTaggedDictionary<TKey, TValue>(
             int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
+            IEnumerable<KeyValuePair<TKey, TValue>>? v,
             int entrySize,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
         {
             Debug.Assert(entrySize > 1);
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
+            if (v is IEnumerable<KeyValuePair<TKey, TValue>> dict)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-                int count = dict.Count;
+                int count = dict.Count();
                 WriteSize(count == 0 ? 1 : (count * entrySize) + GetSizeLength(count));
                 WriteDictionary(dict, keyWriter, valueWriter);
             }
@@ -778,12 +778,12 @@ namespace IceRpc
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
         public void WriteTaggedDictionary<TKey, TValue>(
             int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
+            IEnumerable<KeyValuePair<TKey, TValue>>? v,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
         {
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
+            if (v is IEnumerable<KeyValuePair<TKey, TValue>> dict)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
@@ -801,14 +801,14 @@ namespace IceRpc
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
         public void WriteTaggedDictionary<TKey, TValue>(
             int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v,
+            IEnumerable<KeyValuePair<TKey, TValue?>>? v,
             bool withBitSequence,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
             where TValue : class
         {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            if (v is IEnumerable<KeyValuePair<TKey, TValue?>> dict)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
@@ -825,13 +825,13 @@ namespace IceRpc
         /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
         public void WriteTaggedDictionary<TKey, TValue>(
             int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v,
+            IEnumerable<KeyValuePair<TKey, TValue?>>? v,
             OutputStreamWriter<TKey> keyWriter,
             OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
             where TValue : struct
         {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            if (v is IEnumerable<KeyValuePair<TKey, TValue?>> dict)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();

--- a/tests/IceRpc.Tests.Api/InvocationInterceptorTests.cs
+++ b/tests/IceRpc.Tests.Api/InvocationInterceptorTests.cs
@@ -132,7 +132,7 @@ namespace IceRpc.Tests.Api
 
         internal class TestService : IInvocationInterceptorTestService
         {
-            public ValueTask<IReadOnlyDictionary<string, string>> OpContextAsync(Dispatch dispatch, CancellationToken cancel) =>
+            public ValueTask<IEnumerable<KeyValuePair<string, string>>> OpContextAsync(Dispatch dispatch, CancellationToken cancel) =>
                 new(dispatch.Context);
             public ValueTask<int> OpIntAsync(int value, Dispatch dispatch, CancellationToken cancel) => new(value);
         }

--- a/tests/IceRpc.Tests.CodeGeneration/ClassTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/ClassTests.cs
@@ -328,7 +328,7 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));
 
-            public ValueTask<(IReadOnlyDictionary<string, AnyClass?> R1, IReadOnlyDictionary<string, AnyClass?> R2)> OpClassMapAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, AnyClass?>> R1, IEnumerable<KeyValuePair<string, AnyClass?>> R2)> OpClassMapAsync(
                 Dictionary<string, AnyClass?> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));

--- a/tests/IceRpc.Tests.CodeGeneration/DictionaryTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/DictionaryTests.cs
@@ -280,208 +280,208 @@ namespace IceRpc.Tests.CodeGeneration
         public class DictionaryOperations : IDictionaryOperations
         {
             // Builtin types dictionaries
-            public ValueTask<(IReadOnlyDictionary<byte, byte> R1, IReadOnlyDictionary<byte, byte> R2)> OpByteDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<byte, byte>> R1, IEnumerable<KeyValuePair<byte, byte>> R2)> OpByteDictAsync(
                 Dictionary<byte, byte> p1,
                 Dictionary<byte, byte> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<bool, bool> R1, IReadOnlyDictionary<bool, bool> R2)> OpBoolDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<bool, bool>> R1, IEnumerable<KeyValuePair<bool, bool>> R2)> OpBoolDictAsync(
                 Dictionary<bool, bool> p1,
                 Dictionary<bool, bool> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<short, short> R1, IReadOnlyDictionary<short, short> R2)> OpShortDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<short, short>> R1, IEnumerable<KeyValuePair<short, short>> R2)> OpShortDictAsync(
                 Dictionary<short, short> p1,
                 Dictionary<short, short> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ushort, ushort> R1, IReadOnlyDictionary<ushort, ushort> R2)> OpUShortDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ushort, ushort>> R1, IEnumerable<KeyValuePair<ushort, ushort>> R2)> OpUShortDictAsync(
                 Dictionary<ushort, ushort> p1,
                 Dictionary<ushort, ushort> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<int, int> R1, IReadOnlyDictionary<int, int> R2)> OpIntDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<int, int>> R1, IEnumerable<KeyValuePair<int, int>> R2)> OpIntDictAsync(
                 Dictionary<int, int> p1,
                 Dictionary<int, int> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<int, int> R1, IReadOnlyDictionary<int, int> R2)> OpVarIntDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<int, int>> R1, IEnumerable<KeyValuePair<int, int>> R2)> OpVarIntDictAsync(
                 Dictionary<int, int> p1,
                 Dictionary<int, int> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<uint, uint> R1, IReadOnlyDictionary<uint, uint> R2)> OpUIntDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<uint, uint>> R1, IEnumerable<KeyValuePair<uint, uint>> R2)> OpUIntDictAsync(
                 Dictionary<uint, uint> p1,
                 Dictionary<uint, uint> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<uint, uint> R1, IReadOnlyDictionary<uint, uint> R2)> OpVarUIntDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<uint, uint>> R1, IEnumerable<KeyValuePair<uint, uint>> R2)> OpVarUIntDictAsync(
                 Dictionary<uint, uint> p1,
                 Dictionary<uint, uint> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<long, long> R1, IReadOnlyDictionary<long, long> R2)> OpLongDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<long, long>> R1, IEnumerable<KeyValuePair<long, long>> R2)> OpLongDictAsync(
                 Dictionary<long, long> p1,
                 Dictionary<long, long> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<long, long> R1, IReadOnlyDictionary<long, long> R2)> OpVarLongDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<long, long>> R1, IEnumerable<KeyValuePair<long, long>> R2)> OpVarLongDictAsync(
                 Dictionary<long, long> p1,
                 Dictionary<long, long> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ulong, ulong> R1, IReadOnlyDictionary<ulong, ulong> R2)> OpULongDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ulong, ulong>> R1, IEnumerable<KeyValuePair<ulong, ulong>> R2)> OpULongDictAsync(
                 Dictionary<ulong, ulong> p1,
                 Dictionary<ulong, ulong> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ulong, ulong> R1, IReadOnlyDictionary<ulong, ulong> R2)> OpVarULongDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ulong, ulong>> R1, IEnumerable<KeyValuePair<ulong, ulong>> R2)> OpVarULongDictAsync(
                 Dictionary<ulong, ulong> p1,
                 Dictionary<ulong, ulong> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<string, string> R1, IReadOnlyDictionary<string, string> R2)> OpStringDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, string>> R1, IEnumerable<KeyValuePair<string, string>> R2)> OpStringDictAsync(
                 Dictionary<string, string> p1,
                 Dictionary<string, string> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyEnum, MyEnum> R1, IReadOnlyDictionary<MyEnum, MyEnum> R2)> OpMyEnumDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyEnum, MyEnum>> R1, IEnumerable<KeyValuePair<MyEnum, MyEnum>> R2)> OpMyEnumDictAsync(
                 Dictionary<MyEnum, MyEnum> p1,
                 Dictionary<MyEnum, MyEnum> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyFixedLengthEnum, MyFixedLengthEnum> R1, IReadOnlyDictionary<MyFixedLengthEnum, MyFixedLengthEnum> R2)> OpMyFixedLengthEnumDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyFixedLengthEnum, MyFixedLengthEnum>> R1, IEnumerable<KeyValuePair<MyFixedLengthEnum, MyFixedLengthEnum>> R2)> OpMyFixedLengthEnumDictAsync(
                 Dictionary<MyFixedLengthEnum, MyFixedLengthEnum> p1,
                 Dictionary<MyFixedLengthEnum, MyFixedLengthEnum> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyUncheckedEnum, MyUncheckedEnum> R1, IReadOnlyDictionary<MyUncheckedEnum, MyUncheckedEnum> R2)> OpMyUncheckedEnumDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyUncheckedEnum, MyUncheckedEnum>> R1, IEnumerable<KeyValuePair<MyUncheckedEnum, MyUncheckedEnum>> R2)> OpMyUncheckedEnumDictAsync(
                 Dictionary<MyUncheckedEnum, MyUncheckedEnum> p1,
                 Dictionary<MyUncheckedEnum, MyUncheckedEnum> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyStruct, MyStruct> R1, IReadOnlyDictionary<MyStruct, MyStruct> R2)> OpMyStructDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyStruct, MyStruct>> R1, IEnumerable<KeyValuePair<MyStruct, MyStruct>> R2)> OpMyStructDictAsync(
                 Dictionary<MyStruct, MyStruct> p1,
                 Dictionary<MyStruct, MyStruct> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<string, IOperationsPrx> R1, IReadOnlyDictionary<string, IOperationsPrx> R2)> OpOperationsDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, IOperationsPrx>> R1, IEnumerable<KeyValuePair<string, IOperationsPrx>> R2)> OpOperationsDictAsync(
                 Dictionary<string, IOperationsPrx> p1,
                 Dictionary<string, IOperationsPrx> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<string, AnotherStruct> R1, IReadOnlyDictionary<string, AnotherStruct> R2)> OpAnotherStructDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, AnotherStruct>> R1, IEnumerable<KeyValuePair<string, AnotherStruct>> R2)> OpAnotherStructDictAsync(
                 Dictionary<string, AnotherStruct> p1,
                 Dictionary<string, AnotherStruct> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<byte, byte> R1, IReadOnlyDictionary<byte, byte> R2)> OpByteSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<byte, byte>> R1, IEnumerable<KeyValuePair<byte, byte>> R2)> OpByteSortedDictAsync(
                 SortedDictionary<byte, byte> p1,
                 SortedDictionary<byte, byte> p2,
                 Dispatch dispatch, CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<bool, bool> R1, IReadOnlyDictionary<bool, bool> R2)> OpBoolSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<bool, bool>> R1, IEnumerable<KeyValuePair<bool, bool>> R2)> OpBoolSortedDictAsync(
                 SortedDictionary<bool, bool> p1,
                 SortedDictionary<bool, bool> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<short, short> R1, IReadOnlyDictionary<short, short> R2)> OpShortSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<short, short>> R1, IEnumerable<KeyValuePair<short, short>> R2)> OpShortSortedDictAsync(
                 SortedDictionary<short, short> p1,
                 SortedDictionary<short, short> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ushort, ushort> R1, IReadOnlyDictionary<ushort, ushort> R2)> OpUShortSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ushort, ushort>> R1, IEnumerable<KeyValuePair<ushort, ushort>> R2)> OpUShortSortedDictAsync(
                 SortedDictionary<ushort, ushort> p1,
                 SortedDictionary<ushort, ushort> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<int, int> R1, IReadOnlyDictionary<int, int> R2)> OpIntSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<int, int>> R1, IEnumerable<KeyValuePair<int, int>> R2)> OpIntSortedDictAsync(
                 SortedDictionary<int, int> p1,
                 SortedDictionary<int, int> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
-            public ValueTask<(IReadOnlyDictionary<int, int> R1, IReadOnlyDictionary<int, int> R2)> OpVarIntSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<int, int>> R1, IEnumerable<KeyValuePair<int, int>> R2)> OpVarIntSortedDictAsync(
                 SortedDictionary<int, int> p1,
                 SortedDictionary<int, int> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
-            public ValueTask<(IReadOnlyDictionary<uint, uint> R1, IReadOnlyDictionary<uint, uint> R2)> OpUIntSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<uint, uint>> R1, IEnumerable<KeyValuePair<uint, uint>> R2)> OpUIntSortedDictAsync(
                 SortedDictionary<uint, uint> p1,
                 SortedDictionary<uint, uint> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<uint, uint> R1, IReadOnlyDictionary<uint, uint> R2)> OpVarUIntSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<uint, uint>> R1, IEnumerable<KeyValuePair<uint, uint>> R2)> OpVarUIntSortedDictAsync(
                 SortedDictionary<uint, uint> p1,
                 SortedDictionary<uint, uint> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<long, long> R1, IReadOnlyDictionary<long, long> R2)> OpLongSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<long, long>> R1, IEnumerable<KeyValuePair<long, long>> R2)> OpLongSortedDictAsync(
                 SortedDictionary<long, long> p1,
                 SortedDictionary<long, long> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<long, long> R1, IReadOnlyDictionary<long, long> R2)> OpVarLongSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<long, long>> R1, IEnumerable<KeyValuePair<long, long>> R2)> OpVarLongSortedDictAsync(
                 SortedDictionary<long, long> p1,
                 SortedDictionary<long, long> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ulong, ulong> R1, IReadOnlyDictionary<ulong, ulong> R2)> OpULongSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ulong, ulong>> R1, IEnumerable<KeyValuePair<ulong, ulong>> R2)> OpULongSortedDictAsync(
                 SortedDictionary<ulong, ulong> p1,
                 SortedDictionary<ulong, ulong> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<ulong, ulong> R1, IReadOnlyDictionary<ulong, ulong> R2)> OpVarULongSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<ulong, ulong>> R1, IEnumerable<KeyValuePair<ulong, ulong>> R2)> OpVarULongSortedDictAsync(
                 SortedDictionary<ulong, ulong> p1,
                 SortedDictionary<ulong, ulong> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<string, string> R1, IReadOnlyDictionary<string, string> R2)> OpStringSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, string>> R1, IEnumerable<KeyValuePair<string, string>> R2)> OpStringSortedDictAsync(
                 SortedDictionary<string, string> p1,
                 SortedDictionary<string, string> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyEnum, MyEnum> R1, IReadOnlyDictionary<MyEnum, MyEnum> R2)> OpMyEnumSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyEnum, MyEnum>> R1, IEnumerable<KeyValuePair<MyEnum, MyEnum>> R2)> OpMyEnumSortedDictAsync(
                 SortedDictionary<MyEnum, MyEnum> p1,
                 SortedDictionary<MyEnum, MyEnum> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyFixedLengthEnum, MyFixedLengthEnum> R1, IReadOnlyDictionary<MyFixedLengthEnum, MyFixedLengthEnum> R2)> OpMyFixedLengthEnumSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyFixedLengthEnum, MyFixedLengthEnum>> R1, IEnumerable<KeyValuePair<MyFixedLengthEnum, MyFixedLengthEnum>> R2)> OpMyFixedLengthEnumSortedDictAsync(
                 SortedDictionary<MyFixedLengthEnum, MyFixedLengthEnum> p1,
                 SortedDictionary<MyFixedLengthEnum, MyFixedLengthEnum> p2,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p2));
 
-            public ValueTask<(IReadOnlyDictionary<MyUncheckedEnum, MyUncheckedEnum> R1, IReadOnlyDictionary<MyUncheckedEnum, MyUncheckedEnum> R2)> OpMyUncheckedEnumSortedDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<MyUncheckedEnum, MyUncheckedEnum>> R1, IEnumerable<KeyValuePair<MyUncheckedEnum, MyUncheckedEnum>> R2)> OpMyUncheckedEnumSortedDictAsync(
                 SortedDictionary<MyUncheckedEnum, MyUncheckedEnum> p1,
                 SortedDictionary<MyUncheckedEnum, MyUncheckedEnum> p2,
                 Dispatch dispatch,

--- a/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
@@ -701,7 +701,7 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));
 
-            public ValueTask<(IReadOnlyDictionary<int, int>? R1, IReadOnlyDictionary<int, int>? R2)> OpIntDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<int, int>>? R1, IEnumerable<KeyValuePair<int, int>>? R2)> OpIntDictAsync(
                 Dictionary<int, int>? p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));
@@ -783,7 +783,7 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));
 
-            public ValueTask<(IReadOnlyDictionary<string, string>? R1, IReadOnlyDictionary<string, string>? R2)> OpStringDictAsync(
+            public ValueTask<(IEnumerable<KeyValuePair<string, string>>? R1, IEnumerable<KeyValuePair<string, string>>? R2)> OpStringDictAsync(
                 Dictionary<string, string>? p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));

--- a/tests/IceRpc.Tests.CodeGeneration/ScopeTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/ScopeTests.cs
@@ -169,7 +169,7 @@ namespace IceRpc.Tests.CodeGeneration
 
             public ValueTask<C> OpCAsync(C p1, Dispatch dispatch, CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, C>> OpCMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, C>>> OpCMapAsync(
                 Dictionary<string, C> p1,
                 Dispatch dispatch, CancellationToken cancel) => new(p1);
 
@@ -184,7 +184,7 @@ namespace IceRpc.Tests.CodeGeneration
 
             public ValueTask<S> OpSAsync(S p1, Dispatch dispatch, CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, S>> OpSMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, S>>> OpSMapAsync(
                 Dictionary<string, S> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -202,7 +202,7 @@ namespace IceRpc.Tests.CodeGeneration
         {
             public ValueTask<Inner2.C> OpCAsync(Inner2.C p1, Dispatch dispatch, CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, Inner2.C>> OpCMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, Inner2.C>>> OpCMapAsync(
                 Dictionary<string, Inner2.C> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -214,7 +214,7 @@ namespace IceRpc.Tests.CodeGeneration
 
             public ValueTask<Inner2.S> OpSAsync(Inner2.S p1, Dispatch dispatch, CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, Inner2.S>> OpSMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, Inner2.S>>> OpSMapAsync(
                 Dictionary<string, Inner2.S> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -232,7 +232,7 @@ namespace IceRpc.Tests.CodeGeneration
         {
             public ValueTask<C> OpCAsync(C c1, Dispatch dispatch, CancellationToken cancel) => new(c1);
 
-            public ValueTask<IReadOnlyDictionary<string, C>> OpCMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, C>>> OpCMapAsync(
                 Dictionary<string, C> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -244,7 +244,7 @@ namespace IceRpc.Tests.CodeGeneration
 
             public ValueTask<S> OpSAsync(S p1, Dispatch dispatch, CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, S>> OpSMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, S>>> OpSMapAsync(
                 Dictionary<string, S> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -265,7 +265,7 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, Scope.C>> OpCMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, Scope.C>>> OpCMapAsync(
                 Dictionary<string, Scope.C> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
@@ -280,7 +280,7 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);
 
-            public ValueTask<IReadOnlyDictionary<string, Scope.S>> OpSMapAsync(
+            public ValueTask<IEnumerable<KeyValuePair<string, Scope.S>>> OpSMapAsync(
                 Dictionary<string, Scope.S> p1,
                 Dispatch dispatch,
                 CancellationToken cancel) => new(p1);

--- a/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
@@ -736,7 +736,7 @@ namespace IceRpc.Tests.CodeGeneration
             Dispatch dispatch,
             CancellationToken cancel) => new((p1, p1));
 
-        public ValueTask<(IReadOnlyDictionary<int, int>? R1, IReadOnlyDictionary<int, int>? R2)> OpIntDictAsync(
+        public ValueTask<(IEnumerable<KeyValuePair<int, int>>? R1, IEnumerable<KeyValuePair<int, int>>? R2)> OpIntDictAsync(
             Dictionary<int, int>? p1,
             Dispatch dispatch,
             CancellationToken cancel) => new((p1, p1));
@@ -825,7 +825,7 @@ namespace IceRpc.Tests.CodeGeneration
             Dispatch dispatch,
             CancellationToken cancel) => new((p1, p1));
 
-        public ValueTask<(IReadOnlyDictionary<string, string>? R1, IReadOnlyDictionary<string, string>? R2)> OpStringDictAsync(
+        public ValueTask<(IEnumerable<KeyValuePair<string, string>>? R1, IEnumerable<KeyValuePair<string, string>>? R2)> OpStringDictAsync(
             Dictionary<string, string>? p1,
             Dispatch dispatch,
             CancellationToken cancel) => new((p1, p1));


### PR DESCRIPTION
This PR changes the mapping for read-only dictionaries.

Before: `IReadOnlyDictionary<T, V>`
After: `IEnumerable<KeyValuePair<T, V>>`

The rationale is some dictionaries, such as `IDictionary`, is not an `IReadOnlyDictionary`, so switching to an `IEnumerable<KVP>` is more flexible. It's also more Linq friendly and consistent with our sequence mapping.

Nevertheless, `IEnumerable<KVP>` does not provide unique keys guarantee so you can abuse this mapping to send a "dictionary" without unique keys. I don't see this as big issue: if you want to avoid this problem, simply use any dictionary class (they all derive from `IEnumerable<KVP>`).