### PR TITLE
Move generated code to Proxy.Create methods

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2301,15 +2301,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "public static new "
          << name << " FromConnection(IceRpc.Connection connection, string? path = null) =>";
     _out.inc();
-    _out << nl << "new " << impl << "(path ?? DefaultPath, connection.Protocol)";
-    _out << sb;
-    _out << nl << "Identity = connection.Protocol == IceRpc.Protocol.Ice1 ?";
-    _out.inc();
-    _out << nl << "IceRpc.Interop.Identity.FromPath(path ?? DefaultPath) : IceRpc.Interop.Identity.Empty,";
-    _out.dec();
-    _out << nl << "Endpoint = connection.IsIncoming ? null : connection.RemoteEndpoint,";
-    _out << nl << "Connection = connection";
-    _out << eb << ";";
+    _out << nl << "IceRpc.Proxy.Create(Factory, connection, path ?? DefaultPath);";
     _out.dec();
 
     _out << sp;
@@ -2323,13 +2315,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "public static new "
          << name << " FromPath(string? path = null, IceRpc.Protocol protocol = IceRpc.Protocol.Ice2) =>";
     _out.inc();
-    _out << nl << "new " << impl << "(path ?? DefaultPath, protocol)";
-    _out << sb;
-    _out << nl << "Identity = protocol == IceRpc.Protocol.Ice1 ?";
-    _out.inc();
-    _out << nl << "IceRpc.Interop.Identity.FromPath(path ?? DefaultPath) : IceRpc.Interop.Identity.Empty,";
-    _out.dec();
-    _out << eb << ";";
+    _out << nl << "IceRpc.Proxy.Create(Factory, path ?? DefaultPath, protocol);";
     _out.dec();
 
     _out << sp;
@@ -2342,24 +2328,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
          << "is used.";
     _out << nl << "/// </param>";
     _out << nl << "/// <returns>The new proxy.</returns>";
-    _out << nl << "public static new " << name << " FromServer(IceRpc.Server server, string? path = null)";
-    _out << sb;
-    _out << nl << "if (server.ProxyEndpoint == null)";
-    _out << sb;
-    _out << nl << "throw new global::System.InvalidOperationException("
-         << "\"cannot create a proxy using a server with no endpoint\");";
-    _out << eb;
-
-    _out << nl << "return new " << impl << "(path ?? DefaultPath, server.Protocol)";
-    _out << sb;
-    _out << nl << "Identity = server.Protocol == IceRpc.Protocol.Ice1 ?";
+    _out << nl << "public static new " << name << " FromServer(IceRpc.Server server, string? path = null) =>";
     _out.inc();
-    _out << nl << "IceRpc.Interop.Identity.FromPath(path ?? DefaultPath) : IceRpc.Interop.Identity.Empty,";
+    _out << nl << "IceRpc.Proxy.Create(Factory, server, path ?? DefaultPath);";
     _out.dec();
-    _out << nl << "Endpoint = server.ProxyEndpoint,";
-    _out << nl << "Invoker = server.Invoker";
-    _out << eb << ";";
-    _out << eb;
 
     _out << sp;
     _out << nl << "// <summary>An <see cref=\"InputStreamReader{T}\"/> used to read <see cref=\"" << name

--- a/src/IceRpc/IServicePrx.cs
+++ b/src/IceRpc/IServicePrx.cs
@@ -83,14 +83,7 @@ namespace IceRpc
         /// </param>
         /// <returns>The new proxy.</returns>
         public static IServicePrx FromConnection(Connection connection, string? path = null) =>
-            new ServicePrx(path ?? DefaultPath, connection.Protocol)
-            {
-                Identity = connection.Protocol == Protocol.Ice1 ?
-                    Identity.FromPath(path ?? DefaultPath) : Identity.Empty,
-                Endpoint = connection.IsIncoming ? null : connection.RemoteEndpoint,
-                Connection = connection,
-                // TODO set the Invoker
-            };
+            Factory.Create(connection, path ?? DefaultPath);
 
         /// <summary>Creates an <see cref="IServicePrx"/> endpointless proxy with the given path and protocol.</summary>
         /// <param name="path">The optional path for the proxy, if null the <see cref="DefaultPath"/> is used.
@@ -98,10 +91,7 @@ namespace IceRpc
         /// <param name="protocol">The proxy protocol.</param>
         /// <returns>The new proxy.</returns>
         public static IServicePrx FromPath(string? path = null, Protocol protocol = Protocol.Ice2) =>
-            new ServicePrx(path ?? DefaultPath, protocol)
-            {
-                Identity = protocol == Protocol.Ice1 ? Identity.FromPath(path ?? DefaultPath) : Identity.Empty
-            };
+           Factory.Create(path ?? DefaultPath, protocol);
 
         /// <summary>Creates an <see cref="IServicePrx"/> proxy from the given server and path.</summary>
         /// <param name="server">The created proxy uses the <see cref="Server.ProxyEndpoint"/> as its
@@ -109,20 +99,8 @@ namespace IceRpc
         /// <param name="path">The optional path for the proxy, if null the <see cref="DefaultPath"/> is used.
         /// </param>
         /// <returns>The new proxy.</returns>
-        public static IServicePrx FromServer(Server server, string? path = null)
-        {
-            if (server.ProxyEndpoint == null)
-            {
-                throw new InvalidOperationException("cannot create a proxy using a server with no endpoint");
-            }
-
-            return new ServicePrx(path ?? DefaultPath, server.Protocol)
-            {
-                Identity = server.Protocol == Protocol.Ice1 ? Identity.FromPath(path ?? DefaultPath) : Identity.Empty,
-                Endpoint = server.ProxyEndpoint,
-                Invoker = server.Invoker
-            };
-        }
+        public static IServicePrx FromServer(Server server, string? path = null) =>
+            Factory.Create(server, path ?? DefaultPath);
 
         /// <summary>An <see cref="InputStreamReader{T}"/> used to read <see cref="IServicePrx"/> nullable proxies.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/IceRpc/ServicePrx.cs
+++ b/src/IceRpc/ServicePrx.cs
@@ -103,22 +103,6 @@ namespace IceRpc
             }
         }
 
-        /// <summary>The identity of this proxy. Used only with the ice1 protocol.</summary>
-        public Identity Identity
-        {
-            get => _identity;
-            set
-            {
-                Debug.Assert(Protocol == Protocol.Ice1 || value == Identity.Empty);
-                if (Protocol == Protocol.Ice1 && value.Name.Length == 0)
-                {
-                    throw new ArgumentException("identity name of ice1 service cannot be empty",
-                                                nameof(Identity));
-                }
-                _identity = value;
-            }
-        }
-
         /// <inheritdoc/>
         public IInvoker? Invoker
         {
@@ -139,6 +123,22 @@ namespace IceRpc
         {
             get => FacetPath.Count == 0 ? "" : FacetPath[0];
             set => FacetPath = value.Length > 0 ? ImmutableList.Create(value) : ImmutableList<string>.Empty;
+        }
+
+        /// <summary>The identity of this proxy. Used only with the ice1 protocol.</summary>
+        internal Identity Identity
+        {
+            get => _identity;
+            set
+            {
+                Debug.Assert(Protocol == Protocol.Ice1 || value == Identity.Empty);
+                if (Protocol == Protocol.Ice1 && value.Name.Length == 0)
+                {
+                    throw new ArgumentException("identity name of ice1 service cannot be empty",
+                                                nameof(Identity));
+                }
+                _identity = value;
+            }
         }
 
         /// <summary>The facet path that holds the facet. Used only during marshaling/unmarshaling of ice1 proxies.


### PR DESCRIPTION
This tiny PR moves proxy creation logic from the generated code to `Proxy.Create` helper methods.

The only new behavior introduced by this PR is:
```
  impl.Invoker = connection.Server?.Invoker;
```

in the Create(connection) extension.