### PR TITLE
Adjust default path for plain Service

### DIFF
--- a/src/IceRpc/TypeIdAttribute.cs
+++ b/src/IceRpc/TypeIdAttribute.cs
@@ -111,8 +111,16 @@ namespace IceRpc
         {
             if (type.GetIceTypeId() is string typeId)
             {
-                Debug.Assert(typeId.StartsWith("::", StringComparison.InvariantCulture));
-                return "/" + typeId[2..].Replace("::", ".");
+                Debug.Assert(typeId.StartsWith("::", StringComparison.Ordinal));
+
+                if (typeId == "::Ice::Object")
+                {
+                    return "/IceRpc.Service";
+                }
+                else
+                {
+                    return "/" + typeId[2..].Replace("::", ".");
+                }
             }
             else
             {

--- a/tests/IceRpc.Tests.Api/ProxyTests.cs
+++ b/tests/IceRpc.Tests.Api/ProxyTests.cs
@@ -422,7 +422,7 @@ namespace IceRpc.Tests.Api
         [Test]
         public async Task Proxy_FactoryMethodsAsync()
         {
-            Assert.AreEqual("/Ice.Object", IServicePrx.DefaultPath);
+            Assert.AreEqual("/IceRpc.Service", IServicePrx.DefaultPath);
 
             var service = IServicePrx.FromPath("/test");
             Assert.AreEqual("/test", service.Path);


### PR DESCRIPTION
This tiny PR changes the default path for a plain service to `IceRpc.Service`. It's now much easier since the default path computation is performed in a single spot.