### PR TITLE
Fix Locator interceptor implementation

### DIFF
--- a/src/IceRpc/Interceptors-Locator.cs
+++ b/src/IceRpc/Interceptors-Locator.cs
@@ -54,19 +54,10 @@ namespace IceRpc
         /// <returns>A new locator interceptor.</returns>
         public static Func<IInvoker, IInvoker> Locator(ILocatorPrx locator, LocatorOptions options)
         {
-            // We validate the arguments immediately, not when we construct LocatorInvoker.
-            if (locator.Endpoint == null || locator.Endpoint.Transport == Transport.Loc)
-            {
-                throw new ArgumentException($"{nameof(locator)} needs a non-loc endpoint", nameof(locator));
-            }
+            // Creates a locator client captured and shared by all invokers created from this Locator interceptor.
+            var locatorClient = new LocatorClient(locator, options);
 
-            if (options.Ttl != Timeout.InfiniteTimeSpan && options.JustRefreshedAge >= options.Ttl)
-            {
-                throw new ArgumentException(
-                    $"{nameof(options.JustRefreshedAge)} must be smaller than {nameof(options.Ttl)}", nameof(options));
-            }
-
-            return next => new LocatorInvoker(locator, options, next);
+            return next => new InlineInvoker((request, cancel) => locatorClient.InvokeAsync(request, next, cancel));
         }
     }
 }


### PR DESCRIPTION
This PR fixes this implementation of the Locator interceptor.

Before this PR, it was creating a LocatorInvoker object (with its cache) for each execution of the interceptor (= creation of an invoker pipeline). And an interceptor may get executed several times. For example, that what happens with the `With` addition from PR #343.

This PR fixes this bug by creating a single location client that is then captured and shared by executions of the interceptor. 