### PR TITLE
Fix implementation of isMutableAfterReturnType

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -85,16 +85,43 @@ namespace
             return isMutableAfterReturnType(optional->underlying());
         }
 
-        if (ClassDeclPtr::dynamicCast(type) || StructPtr::dynamicCast(type) || SequencePtr::dynamicCast(type)
-            || DictionaryPtr::dynamicCast(type))
+        if (ClassDeclPtr::dynamicCast(type) ||
+            InterfaceDeclPtr::dynamicCast(type) ||
+            SequencePtr::dynamicCast(type) ||
+            DictionaryPtr::dynamicCast(type))
         {
             return true;
         }
 
-        BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
-        if (builtin && builtin->usesClasses())
+        StructPtr st = StructPtr::dynamicCast(type);
+        if (st)
         {
-            return true;
+            MemberList members = st->dataMembers();
+            for (MemberList::const_iterator it = members.begin(); it != members.end(); it++)
+            {
+                if (isMutableAfterReturnType((*it)->type()))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
+        if (builtin)
+        {
+            switch(builtin->kind())
+            {
+                case Builtin::KindObject:
+                case Builtin::KindAnyClass:
+                {
+                    return true;
+                }
+                default:
+                {
+                    return false;
+                }
+            }
         }
 
         return false;

--- a/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
@@ -296,11 +296,15 @@ namespace IceRpc.Tests.CodeGeneration
             }
 
             {
-                MyStruct? r1 = await _prx.OpMyStructMarshaledResultAsync(null);
+                AnotherStruct? r1 = await _prx.OpAnotherStructMarshaledResultAsync(null);
                 Assert.IsNull(r1);
 
-                var p1 = new MyStruct(1, 1);
-                r1 = await _prx.OpMyStructMarshaledResultAsync(p1);
+                var p1 = new AnotherStruct(
+                    "hello",
+                    IOperationsPrx.Parse("ice+tcp://localhost/hello"),
+                    MyEnum.enum1,
+                    new MyStruct(1, 1));
+                r1 = await _prx.OpAnotherStructMarshaledResultAsync(p1);
                 Assert.AreEqual(p1, r1);
             }
 
@@ -753,11 +757,11 @@ namespace IceRpc.Tests.CodeGeneration
                 Dispatch dispatch,
                 CancellationToken cancel) => new((p1, p1));
 
-            public ValueTask<IOptionalOperations.OpMyStructMarshaledResultMarshaledReturnValue> OpMyStructMarshaledResultAsync(
-                MyStruct? p1,
+            public ValueTask<IOptionalOperations.OpAnotherStructMarshaledResultMarshaledReturnValue> OpAnotherStructMarshaledResultAsync(
+                AnotherStruct? p1,
                 Dispatch dispatch,
                 CancellationToken cancel) =>
-                new(new IOptionalOperations.OpMyStructMarshaledResultMarshaledReturnValue(p1, dispatch));
+                new(new IOptionalOperations.OpAnotherStructMarshaledResultMarshaledReturnValue(p1, dispatch));
 
             public ValueTask<(IEnumerable<MyStruct>? R1, IEnumerable<MyStruct>? R2)> OpMyStructSeqAsync(
                 MyStruct[]? p1,

--- a/tests/IceRpc.Tests.CodeGeneration/OptionalTests.ice
+++ b/tests/IceRpc.Tests.CodeGeneration/OptionalTests.ice
@@ -116,7 +116,7 @@ module IceRpc::Tests::CodeGeneration
         (IntDict? r1, IntDict? r2) opIntDict(IntDict? p1);
         (StringDict? r1, StringDict? r2) opStringDict(StringDict? p1);
 
-        [marshaled-result] MyStruct? opMyStructMarshaledResult(MyStruct? p1);
+        [marshaled-result] AnotherStruct? opAnotherStructMarshaledResult(AnotherStruct? p1);
         [marshaled-result] StringSeq? opStringSeqMarshaledResult(StringSeq? p1);
         [marshaled-result] IntDict? opIntDictMarshaledResult(IntDict? p1);
     }

--- a/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
@@ -321,11 +321,15 @@ namespace IceRpc.Tests.CodeGeneration
             }
 
             {
-                MyStruct? r1 = await _prx.OpMyStructMarshaledResultAsync(null);
+                AnotherStruct? r1 = await _prx.OpAnotherStructMarshaledResultAsync(null);
                 Assert.IsNull(r1);
 
-                var p1 = new MyStruct(1, 1);
-                r1 = await _prx.OpMyStructMarshaledResultAsync(p1);
+                var p1 = new AnotherStruct(
+                    "hello",
+                    IOperationsPrx.Parse("ice+tcp://localhost/hello"),
+                    MyEnum.enum1,
+                    new MyStruct(1, 1));
+                r1 = await _prx.OpAnotherStructMarshaledResultAsync(p1);
                 Assert.AreEqual(p1, r1);
             }
 
@@ -787,11 +791,11 @@ namespace IceRpc.Tests.CodeGeneration
             Dispatch dispatch,
             CancellationToken cancel) => new((p1, p1));
 
-        public ValueTask<ITaggedOperations.OpMyStructMarshaledResultMarshaledReturnValue> OpMyStructMarshaledResultAsync(
-            MyStruct? p1,
+        public ValueTask<ITaggedOperations.OpAnotherStructMarshaledResultMarshaledReturnValue> OpAnotherStructMarshaledResultAsync(
+            AnotherStruct? p1,
             Dispatch dispatch,
             CancellationToken cancel) =>
-            new(new ITaggedOperations.OpMyStructMarshaledResultMarshaledReturnValue(p1, dispatch));
+            new(new ITaggedOperations.OpAnotherStructMarshaledResultMarshaledReturnValue(p1, dispatch));
 
         public ValueTask<(IEnumerable<MyStruct>? R1, IEnumerable<MyStruct>? R2)> OpMyStructSeqAsync(
             MyStruct[]? p1,

--- a/tests/IceRpc.Tests.CodeGeneration/TaggedTests.ice
+++ b/tests/IceRpc.Tests.CodeGeneration/TaggedTests.ice
@@ -177,7 +177,7 @@ module IceRpc::Tests::CodeGeneration
 
         void opVoid();
 
-        [marshaled-result] tag(1) MyStruct? opMyStructMarshaledResult(tag(1) MyStruct? p1);
+        [marshaled-result] tag(1) AnotherStruct? opAnotherStructMarshaledResult(tag(1) AnotherStruct? p1);
         [marshaled-result] tag(1) StringSeq? opStringSeqMarshaledResult(tag(1) StringSeq? p1);
         [marshaled-result] tag(1) IntDict? opIntDictMarshaledResult(tag(1) IntDict? p1);
     }


### PR DESCRIPTION
This PR fixes the implementation of `isMutableAfterReturnType` to account for mutable proxies and immutable C# structs

see also https://github.com/zeroc-ice/icerpc-csharp/issues/31