### PR TITLE
Remove progress callback

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -562,14 +562,6 @@ namespace IceRpc
 
                 using IDisposable? streamSocket = stream.StartScope();
 
-                // The request is sent, notify the progress callback.
-                // TODO: Get rid of the sentSynchronously parameter which is always false now?
-                if (request.Progress is IProgress<bool> progress)
-                {
-                    progress.Report(false);
-                    request.Progress = null; // Only call the progress callback once (TODO: revisit this?)
-                }
-
                 // Wait for the reception of the response.
                 IncomingResponse response = request.IsOneway ?
                     new IncomingResponse(this, request.PayloadEncoding) :

--- a/src/IceRpc/Invocation.cs
+++ b/src/IceRpc/Invocation.cs
@@ -29,9 +29,6 @@ namespace IceRpc
         /// a twoway request unless the operation is marked oneway in its Slice definition.</value>
         public bool IsOneway { get; set; }
 
-        /// <summary>Gets or sets the progress provider.</summary>
-        public IProgress<bool>? Progress { get; set; }
-
         /// <summary>Gets or sets the features carried by the request.</summary>
         public FeatureCollection RequestFeatures { get; set; } = FeatureCollection.Empty;
 

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -112,9 +112,6 @@ namespace IceRpc
             }
         }
 
-        /// <summary>The progress provider.</summary>
-        public IProgress<bool>? Progress { get; set; }
-
         /// <summary>The proxy that is sending this request.</summary>
         public IServicePrx Proxy { get; }
 
@@ -260,7 +257,6 @@ namespace IceRpc
             IsOneway = oneway || (invocation?.IsOneway ?? false);
             IsIdempotent = idempotent || (invocation?.IsIdempotent ?? false);
             Payload = args;
-            Progress = invocation?.Progress;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR removes the invocation and the request progress callbacks, the progress callback as it is doesn't have a clear use case, knowing that a request was sent when there can be additional retries isn't very interesting or worth reporting.

I also closed my proposal for a new progress callback https://github.com/zeroc-ice/icerpc-csharp/issues/229, as it wasn't very good, the proposed use case "flow control" can be implemented with an interceptor without the progress callback.

We can add a progress callback later if we have a good use case but as it is I don't think it is worth keeping it.