### PR TITLE
Remove Server.Invoker usage in tests

### DIFF
--- a/tests/IceRpc.Tests.ClientServer/ColocTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ColocTests.cs
@@ -42,7 +42,6 @@ namespace IceRpc.Tests.ClientServer
             pipeline.Use(Interceptors.Coloc, Interceptors.Binder(pool));
             await using var server = new Server
             {
-                Invoker = pipeline,
                 Dispatcher = new Greeter(),
                 Endpoint = endpoint,
                 HasColocEndpoint = hasColocEndpoint,
@@ -51,6 +50,7 @@ namespace IceRpc.Tests.ClientServer
             server.Listen();
 
             var greeter = IGreeterPrx.FromServer(server, "/foo");
+            greeter.Invoker = pipeline;
             Assert.AreEqual(Transport.TCP, greeter.Endpoint!.Transport);
             Assert.DoesNotThrowAsync(async () => await greeter.IcePingAsync());
 

--- a/tests/IceRpc.Tests.ClientServer/LocationResolverTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/LocationResolverTests.cs
@@ -67,7 +67,6 @@ namespace IceRpc.Tests.ClientServer
         {
             _server = new Server
             {
-                Invoker = invoker,
                 HasColocEndpoint = false,
                 Dispatcher = new Greeter(),
                 Endpoint = protocol == Protocol.Ice2 ? "ice+tcp://127.0.0.1:0?tls=false" : "tcp -h 127.0.0.1 -p 0",
@@ -78,6 +77,7 @@ namespace IceRpc.Tests.ClientServer
 
             // Need to create proxy after calling Listen; otherwise, the port number is still 0.
             var greeter = IGreeterPrx.FromServer(_server, path);
+            greeter.Invoker = invoker;
             Assert.AreNotEqual(0, greeter.Endpoint!.Port);
             return greeter;
         }

--- a/tests/IceRpc.Tests.ClientServer/LocatorTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/LocatorTests.cs
@@ -30,7 +30,6 @@ namespace IceRpc.Tests.ClientServer
             router.Map(path, new Greeter());
             _server = new Server
             {
-                Invoker = _pipeline,
                 HasColocEndpoint = false,
                 Dispatcher = router,
                 Endpoint = "tcp -h 127.0.0.1 -p 0",
@@ -41,6 +40,7 @@ namespace IceRpc.Tests.ClientServer
 
             // Must be created after Listen to get the port number.
             _greeter = IGreeterPrx.FromServer(_server, path);
+            _greeter.Invoker = _pipeline;
         }
 
         [TestCase("adapt1", "foo:tcp -h host1 -p 10000")]
@@ -259,7 +259,10 @@ namespace IceRpc.Tests.ClientServer
         {
             string path = $"/{Guid.NewGuid()}";
             (_server.Dispatcher as Router)!.Map(path, new Locator());
-            return ISimpleLocatorTestPrx.FromServer(_server, path);
+
+            var locator = ISimpleLocatorTestPrx.FromServer(_server, path);
+            locator.Invoker = _pipeline;
+            return locator;
         }
 
         private class Locator : ISimpleLocatorTest

--- a/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
@@ -97,24 +97,25 @@ namespace IceRpc.Tests.ClientServer
             bool colocated,
             IInvoker invoker)
         {
-            _targetServer = CreateServer(targetProtocol, port: 0, colocated, invoker);
+            _targetServer = CreateServer(targetProtocol, port: 0, colocated);
 
             _router.Map("/target", new ProtocolBridgingTest());
             _targetServer.Dispatcher = _router;
             _targetServer.Listen();
             var targetService = IProtocolBridgingTestPrx.FromServer(_targetServer, "/target");
+            targetService.Invoker = invoker;
 
-            _forwarderServer = CreateServer(forwarderProtocol, port: 1, colocated, invoker);
+            _forwarderServer = CreateServer(forwarderProtocol, port: 1, colocated);
             _router.Map("/forward", new Forwarder(targetService));
             _forwarderServer.Dispatcher = _router;
             _forwarderServer.Listen();
             var forwardService = IProtocolBridgingTestPrx.FromServer(_forwarderServer, "/forward");
+            forwardService.Invoker = invoker;
             return forwardService;
 
-            Server CreateServer(Protocol protocol, int port, bool colocated, IInvoker invoker) =>
+            Server CreateServer(Protocol protocol, int port, bool colocated) =>
                 new Server
                 {
-                    Invoker = invoker,
                     Endpoint = colocated ?
                         TestHelper.GetUniqueColocEndpoint(protocol) :
                         GetTestEndpoint(port: port, protocol: protocol),

--- a/tests/IceRpc.Tests.ClientServer/RetryTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/RetryTests.cs
@@ -72,7 +72,6 @@ namespace IceRpc.Tests.ClientServer
 
             await using var server = new Server
             {
-                Invoker = pipeline,
                 HasColocEndpoint = false,
                 Dispatcher = new Bidir(),
                 Endpoint = GetTestEndpoint(),
@@ -81,6 +80,7 @@ namespace IceRpc.Tests.ClientServer
             server.Listen();
 
             var proxy = IRetryBidirTestPrx.FromServer(server, "/");
+            proxy.Invoker = pipeline;
             await proxy.IcePingAsync();
             proxy.Connection!.Dispatcher = server.Dispatcher;
             IRetryBidirTestPrx bidir = proxy.Clone(); // keeps Connection


### PR DESCRIPTION
This PR removes all use of Server.Invoker in tests. It replaces them by setting prx.Invoker on a few proxies created with FromServer and the server that had this invoker.

This shows that:
- what appears to be the primary function of Server.Invoker - setting the invoker on proxies received by a server in requests - is never used
- because we make same-process calls so much for testing, we fairly often call the proxy returned by FromServer, and occasionally need a special invoker on such proxies. It's likely that regular applications call FromServer proxies rarely. If we consider it's a fairly common use-case, we should add an invoker parameter to FromServer.