### PR TITLE
Use ActivitySource.CreateActivity to create activities

### DIFF
--- a/src/IceRpc/Internal/TelemetryDispatcher.cs
+++ b/src/IceRpc/Internal/TelemetryDispatcher.cs
@@ -23,17 +23,12 @@ namespace IceRpc.Internal
         {
             if (request.Protocol == Protocol.Ice2)
             {
-                // TODO Use CreateActivity from ActivitySource once we move to .NET 6, to avoid starting the activity
-                // before we restore its context.
-                Activity? activity = _options.ActivitySource?.StartActivity(
+                Activity? activity = _options.ActivitySource?.CreateActivity(
                     $"{request.Path}/{request.Operation}",
                     ActivityKind.Server);
                 if (activity == null && (_logger.IsEnabled(LogLevel.Critical) || Activity.Current != null))
                 {
                     activity = new Activity($"{request.Path}/{request.Operation}");
-                    // TODO we should start the activity after restoring its context, we should update this once
-                    // we move to CreateActivity in .NET 6
-                    activity.Start();
                 }
 
                 if (activity != null)
@@ -44,6 +39,7 @@ namespace IceRpc.Internal
                     // TODO add additional attributes
                     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#common-remote-procedure-call-conventions
                     RestoreActivityContext(request, activity);
+                    activity.Start();
                 }
 
                 try

--- a/src/IceRpc/Internal/TelemetryInvoker.cs
+++ b/src/IceRpc/Internal/TelemetryInvoker.cs
@@ -21,13 +21,12 @@ namespace IceRpc.Internal
         {
             if (request.Protocol == Protocol.Ice2)
             {
-                Activity? activity = _options.ActivitySource?.StartActivity(
+                Activity? activity = _options.ActivitySource?.CreateActivity(
                     $"{request.Path}/{request.Operation}",
                     ActivityKind.Client);
                 if (activity == null && (_logger.IsEnabled(LogLevel.Critical) || Activity.Current != null))
                 {
                     activity = new Activity($"{request.Path}/{request.Operation}");
-                    activity.Start();
                 }
 
                 if (activity != null)
@@ -37,6 +36,7 @@ namespace IceRpc.Internal
                     activity.AddTag("rpc.method", request.Operation);
                     // TODO add additional attributes
                     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#common-remote-procedure-call-conventions
+                    activity.Start();
                 }
 
                 WriteActivityContext(request);


### PR DESCRIPTION
This tiny PR just update the creation of activity objects to use the new .NET 6 API `ActivitySource.CreateActivity` so that the activity is always started after the context has been restored