### PR TITLE
Replace Array.Empty<byte>() with ReadOnlyMemory<byte>.Empty

### DIFF
--- a/src/IceRpc/Internal/Ice1Definitions.cs
+++ b/src/IceRpc/Internal/Ice1Definitions.cs
@@ -61,8 +61,7 @@ namespace IceRpc.Internal
                 }
             };
 
-        // TODO: some tests fail on macOS when the value is ReadOnlyMemory<byte>.Empty. Need to figure out why.
-        private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload11 = Array.Empty<byte>();
+        private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload11 = ReadOnlyMemory<byte>.Empty;
 
         // The single byte corresponds to the compression format.
         private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload20 = new byte[] { 0 };

--- a/src/IceRpc/Internal/Ice2Definitions.cs
+++ b/src/IceRpc/Internal/Ice2Definitions.cs
@@ -10,8 +10,7 @@ namespace IceRpc.Internal
     {
         internal static readonly Encoding Encoding = Encoding.V20;
 
-        // TODO: some tests fail on macOS when the value is ReadOnlyMemory<byte>.Empty. Need to figure out why.
-        private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload11 = Array.Empty<byte>();
+        private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload11 = ReadOnlyMemory<byte>.Empty;
 
         // The only byte is for the compression format.
         private static readonly ReadOnlyMemory<byte> _voidReturnValuePayload20 = new byte[] { 0 };


### PR DESCRIPTION
Tested on macOS with .NET 6 preview 5 and no failures after the update