### PR TITLE
Check IncomingFrameMaxSize in frame decompress

### DIFF
--- a/src/IceRpc/Interceptors-Compressor.cs
+++ b/src/IceRpc/Interceptors-Compressor.cs
@@ -61,8 +61,8 @@ namespace IceRpc
 
                         if (payload.Length >= 1 && payload.Span[0] == (byte)CompressionFormat.Deflate)
                         {
-                            // TODO maxSize should come from the connection
-                            response.Payload = payload.Decompress(maxSize: 1024 * 1024);
+                            response.Payload = payload.Decompress(
+                                maxSize: request.Connection!.Options!.IncomingFrameMaxSize);
                         }
                     }
                     return response;

--- a/src/IceRpc/Middleware-Compressor.cs
+++ b/src/IceRpc/Middleware-Compressor.cs
@@ -43,8 +43,8 @@ namespace IceRpc
 
                         if (payload.Length >= 1 && payload.Span[0] == (byte)CompressionFormat.Deflate)
                         {
-                            // TODO maxSize should come from the connection
-                            request.Payload = payload.Decompress(maxSize: 1024 * 1024);
+                            request.Payload = payload.Decompress(
+                                maxSize: request.Connection.Options!.IncomingFrameMaxSize);
                         }
                     }
 


### PR DESCRIPTION
This PR fixes the compression middleware and interceptor to check IncomingFrameMaxSize 