### PR TITLE
Remove ConnectionPoolDisposedException

### DIFF
--- a/src/IceRpc/ConnectionPool.cs
+++ b/src/IceRpc/ConnectionPool.cs
@@ -51,7 +51,7 @@ namespace IceRpc
                 }
                 catch (ObjectDisposedException ex)
                 {
-                    throw new ConnectionPoolDisposedException(ex);
+                    throw new ObjectDisposedException($"{typeof(ConnectionPool).FullName}", ex);
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace IceRpc
                 {
                     if (_shutdownTask != null)
                     {
-                        throw new ConnectionPoolDisposedException();
+                        throw new ObjectDisposedException($"{typeof(ConnectionPool).FullName}");
                     }
 
                     // Check if there is an active connection that we can use according to the endpoint settings.

--- a/src/IceRpc/LocalException.cs
+++ b/src/IceRpc/LocalException.cs
@@ -4,24 +4,6 @@ using System;
 
 namespace IceRpc
 {
-    /// <summary>This exception reports an attempt to use a destroyed <see cref="ConnectionPool"/>.</summary>
-    public class ConnectionPoolDisposedException : ObjectDisposedException
-    {
-        /// <summary>Constructs a new instance of the <see cref="ConnectionPoolDisposedException"/> class.</summary>
-        public ConnectionPoolDisposedException()
-            : base(objectName: null, message: "communicator shutdown")
-        {
-        }
-
-        /// <summary>Constructs a new instance of the <see cref="ConnectionPoolDisposedException"/> class with a
-        /// reference to the inner exception that is the cause of this exception.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public ConnectionPoolDisposedException(Exception innerException)
-            : base($"{typeof(ConnectionPool).FullName}", innerException)
-        {
-        }
-    }
-
     /// <summary>This exception reports that a proxy has no endpoint or no usable endpoint.</summary>
     public class NoEndpointException : Exception
     {


### PR DESCRIPTION
I think this exception is not very useful we can directly throw `ObjectDisposedException`