### PR TITLE
Fixed shutdown race condition

### DIFF
--- a/src/IceRpc/Transports/Internal/ColocStream.cs
+++ b/src/IceRpc/Transports/Internal/ColocStream.cs
@@ -86,6 +86,7 @@ namespace IceRpc.Transports.Internal
                 (object frame, bool fin) = await WaitAsync(cancel).ConfigureAwait(false);
                 _streamReader = frame as ChannelReader<byte[]>;
                 Debug.Assert(_streamReader != null);
+                _connection.FinishedReceivedFrame();
             }
 
             int received = 0;
@@ -193,6 +194,7 @@ namespace IceRpc.Transports.Internal
             {
                 AbortRead(errorCode);
                 CancelDispatchSource?.Cancel();
+                _connection.FinishedReceivedFrame();
             }
             else
             {
@@ -202,37 +204,21 @@ namespace IceRpc.Transports.Internal
 
         internal override async ValueTask<IncomingRequest> ReceiveRequestFrameAsync(CancellationToken cancel)
         {
-            (object frameObject, bool fin) = await WaitAsync(cancel).ConfigureAwait(false);
-            if (ReadCompleted || (fin && !TrySetReadCompleted()))
-            {
-                throw AbortException ?? new InvalidOperationException("stream receive is completed");
-            }
-
-            Debug.Assert(frameObject is IncomingRequest);
-            var frame = (IncomingRequest)frameObject;
-            return frame;
+            (object frame, bool _) = await WaitFrameAsync(cancel).ConfigureAwait(false);
+            return (IncomingRequest)frame;
         }
 
         internal override async ValueTask<IncomingResponse> ReceiveResponseFrameAsync(CancellationToken cancel)
         {
-            (object frameObject, bool fin) = await WaitAsync(cancel).ConfigureAwait(false);
-            if (ReadCompleted || (fin && !TrySetReadCompleted()))
-            {
-                throw AbortException ?? new InvalidOperationException("stream receive is completed");
-            }
-            return (IncomingResponse)frameObject;
+            (object frame, bool _) = await WaitFrameAsync(cancel).ConfigureAwait(false);
+            return (IncomingResponse)frame;
         }
 
         private protected override async ValueTask<ReadOnlyMemory<byte>> ReceiveFrameAsync(
             byte expectedFrameType,
             CancellationToken cancel)
         {
-            (object frame, bool fin) = await WaitAsync(cancel).ConfigureAwait(false);
-            if (ReadCompleted || (fin && !TrySetReadCompleted()))
-            {
-                throw AbortException ?? new InvalidOperationException("stream receive is completed");
-            }
-
+            (object frame, bool fin) = await WaitFrameAsync(cancel).ConfigureAwait(false);
             if (frame is ReadOnlyMemory<ReadOnlyMemory<byte>> data)
             {
                 // Initialize or GoAway frame.
@@ -263,5 +249,21 @@ namespace IceRpc.Transports.Internal
                 frame.ToIncoming(),
                 fin: frame.StreamWriter == null,
                 cancel).ConfigureAwait(false);
+
+        private async ValueTask<(object frameObject, bool fin)> WaitFrameAsync(CancellationToken cancel)
+        {
+            (object frameObject, bool fin) = await WaitAsync(cancel).ConfigureAwait(false);
+            if (ReadCompleted || (fin && !TrySetReadCompleted()))
+            {
+                _connection.FinishedReceivedFrame();
+                throw AbortException ?? new InvalidOperationException("stream receive is completed");
+            }
+
+            // Notify the connection that the frame has been processed. This must be done after completing reads
+            // to ensure the stream is shutdown before. It's important to ensure the stream is removed from the
+            // connection before the connection is shutdown if the next frame is a close connection frame.
+            _connection.FinishedReceivedFrame();
+            return (frameObject, fin);
+        }
     }
 }

--- a/src/IceRpc/Transports/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Internal/SlicStream.cs
@@ -168,13 +168,6 @@ namespace IceRpc.Transports.Internal
                 // Read and append the received stream frame data into the given buffer.
                 using IDisposable? scope = StartScope();
                 await _connection.ReceiveDataAsync(buffer.Slice(0, size), CancellationToken.None).ConfigureAwait(false);
-
-                // If we've consumed the whole Slic frame, notify the connection that it can start receiving
-                // a new frame.
-                if (_receivedOffset == _receivedSize)
-                {
-                    _connection.FinishedReceivedStreamData(0);
-                }
             }
             else
             {
@@ -212,6 +205,16 @@ namespace IceRpc.Transports.Internal
             if (_receivedOffset == _receivedSize && _receivedEndStream)
             {
                 TrySetReadCompleted();
+            }
+
+            // Notify the connection that the frame has been processed. This must be done after completing reads
+            // to ensure the stream is shutdown before. It's important to ensure the stream is removed from the
+            // connection before the connection is shutdown if the next frame is a close frame.
+            if (_receiveBuffer == null && _receivedOffset == _receivedSize)
+            {
+                // If we've consumed the whole Slic frame, notify the connection that it can start receiving
+                // a new frame.
+                _connection.FinishedReceivedStreamData(0);
             }
 
             return size;


### PR DESCRIPTION
This PR fixes a race condition which could an invocation to fail with a `ConnectionLostException` if the connection was shutdown right after receiving the response. It also fixes some bogus renaming.