### PR TITLE
Remove ActivitySource leftover

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -20,10 +20,6 @@ namespace IceRpc
     /// <see cref="Listen"/> and finally shut down with <see cref="ShutdownAsync"/>.</summary>
     public sealed class Server : IAsyncDisposable
     {
-        /// <summary>When set to a non null value it is used as the source to create <see cref="Activity"/>
-        /// instances for dispatches.</summary>
-        public ActivitySource? ActivitySource { get; set; }
-
         /// <summary>Gets or sets the options of server connections created by this server.</summary>
         public ServerConnectionOptions ConnectionOptions { get; set; } = new();
 

--- a/tests/IceRpc.Tests.ClientServer/TelemetryTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/TelemetryTests.cs
@@ -142,7 +142,6 @@ namespace IceRpc.Tests.ClientServer
                 {
                     Endpoint = TestHelper.GetUniqueColocEndpoint(),
                     Dispatcher = router,
-                    ActivitySource = activitySource,
                 };
                 server.Listen();
                 await using var connection = new Connection { RemoteEndpoint = server.ProxyEndpoint };
@@ -203,7 +202,6 @@ namespace IceRpc.Tests.ClientServer
             {
                 Endpoint = TestHelper.GetTestEndpoint(),
                 Dispatcher = router,
-                ActivitySource = activitySource,
                 // TODO use localhost see https://github.com/dotnet/runtime/issues/53447
                 HostName = "127.0.0.1"
             };


### PR DESCRIPTION
This tiny PR just removes `Server.ActivitySource` which is not longer used since we move telemetry to interceptor/middleware.