### PR TITLE
ClassFactory & Service implementation simplications

### DIFF
--- a/src/IceRpc/Service.cs
+++ b/src/IceRpc/Service.cs
@@ -23,13 +23,13 @@ namespace IceRpc
             CancellationToken cancel);
 
         // A per type cache of dispatch methods and type IDs.
-        private static ConcurrentDictionary<Type, (Dictionary<string, IceDMethod> Methods, SortedSet<string> TypeIds)> _cache =
+        private static ConcurrentDictionary<Type, (IReadOnlyDictionary<string, IceDMethod> Methods, IReadOnlySet<string> TypeIds)> _cache =
            new();
 
         // A dictionary of operation name to IceDMethod used by DispatchAsync implementation.
-        private readonly Dictionary<string, IceDMethod> _dispatchMethods;
+        private readonly IReadOnlyDictionary<string, IceDMethod> _dispatchMethods;
         // The service type IDs.
-        private readonly SortedSet<string> _typeIds;
+        private readonly IReadOnlySet<string> _typeIds;
 
         /// <summary>Constructs a new service.</summary>
         public Service()


### PR DESCRIPTION
This PR simplifies the implementation of the cache in both `ClassFactory` & `Service`  classes:
* For `ClassFactory` replaced the immutable dictionary by a plain dictionary, as it should be faster/cheaper and all the writes happen in the constructor there is not sharing after.
* For `Service` the global static cache now uses a concurrent dictionary, prevents the race condition of the previous implementation if two types populate it concurrently, for the instance member replaced the immutable types for the non-mutable versions as we never write to them after they are initialized