### PR TITLE
connection cleanup

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -30,13 +30,6 @@ namespace IceRpc
         Closed
     }
 
-    /// <summary>Error codes for connection errors.</summary>
-    public enum ConnectionErrorCode : byte
-    {
-        /// <summary>The connection has been shutdown.</summary>
-        Shutdown,
-    }
-
     /// <summary>Event arguments for the <see cref="Connection.Closed"/> event.</summary>
     public sealed class ClosedEventArgs : EventArgs
     {
@@ -235,20 +228,6 @@ namespace IceRpc
             }
         }
 
-        /// <summary>The connection transport.</summary>
-        /// <exception cref="InvalidOperationException">Thrown if there's no endpoint set.</exception>
-        public Transport Transport =>
-            (_localEndpoint ?? _remoteEndpoint)?.Transport ??
-            throw new InvalidOperationException(
-                $"{nameof(Transport)} is not available because there's no endpoint set");
-
-        /// <summary>The connection transport name.</summary>
-        /// <exception cref="InvalidOperationException">Thrown if there's no endpoint set.</exception>
-        public string TransportName =>
-            (_localEndpoint ?? _remoteEndpoint)?.TransportName ??
-            throw new InvalidOperationException(
-                $"{nameof(TransportName)} is not available because there's no endpoint set");
-
         /// <summary>The underlying multi-stream connection.</summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Usage",
@@ -444,8 +423,7 @@ namespace IceRpc
                     {
                         if (_state == ConnectionState.Closed)
                         {
-                            // This can occur if the communicator or server is disposed while the connection is being
-                            // initialized.
+                            // This can occur if the connection is disposed while the connection is being initialized.
                             throw new ConnectionClosedException();
                         }
 
@@ -486,8 +464,7 @@ namespace IceRpc
                 {
                     if (_state == ConnectionState.Closed)
                     {
-                        // This can occur if the communicator or server is disposed while the connection is being
-                        // initialized.
+                        // This can occur if the connection is disposed while the connection is being initialized.
                         throw new ConnectionClosedException();
                     }
 

--- a/src/IceRpc/Internal/OpaqueEndpoint.cs
+++ b/src/IceRpc/Internal/OpaqueEndpoint.cs
@@ -10,10 +10,10 @@ using System.Text;
 
 namespace IceRpc.Internal
 {
-    /// <summary>Describes an ice1 endpoint that the associated communicator cannot use, typically because it does not
-    /// implement the endpoint's transport. The communicator can marshal a proxy with such an endpoint and send it to
-    /// another Ice application that may know/decode this endpoint. This class is used only with the ice1 protocol.
-    /// </summary>
+    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC 
+    /// runtime. The IceRPC runtime cannot send a request to this endpoint; it can however marshal this endpoint
+    /// (within a proxy) and send this proxy to another application that may know this transport. This class is used
+    /// only with the ice1 protocol.</summary>
     internal sealed class OpaqueEndpoint : Endpoint
     {
         /// <inherit-doc/>

--- a/src/IceRpc/Internal/RetryInterceptor.cs
+++ b/src/IceRpc/Internal/RetryInterceptor.cs
@@ -130,8 +130,6 @@ namespace IceRpc.Internal
 
                         if (retryPolicy.Retryable == Retryable.AfterDelay && retryPolicy.Delay != TimeSpan.Zero)
                         {
-                            // The delay task can be canceled either by the user code using the provided cancellation
-                            // token or if the communicator is destroyed.
                             await Task.Delay(retryPolicy.Delay, cancel).ConfigureAwait(false);
                         }
 

--- a/src/IceRpc/Internal/UniversalEndpoint.cs
+++ b/src/IceRpc/Internal/UniversalEndpoint.cs
@@ -9,10 +9,10 @@ using System.Text;
 
 namespace IceRpc.Internal
 {
-    /// <summary>Describes an endpoint with a transport or protocol that the associated communicator does not implement.
-    /// The communicator cannot send a request to this endpoint; it can however marshal this endpoint (within a proxy)
-    /// and send this proxy to another application that may know this transport. This class is used only for protocol
-    /// ice2 or greater.</summary>
+    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC 
+    /// runtime. The IceRPC runtime cannot send a request to this endpoint; it can however marshal this endpoint
+    /// (within a proxy) and send this proxy to another application that may know this transport. This class is used
+    /// only for protocol ice2 or greater.</summary>
     internal sealed class UniversalEndpoint : Endpoint
     {
         /// <inherit-doc/>


### PR DESCRIPTION
This PR includes some minor cleanup:

- Remove Transport and TransportName from the connection those doesn't seem very useful for the users of the connection, and were not used by IceRpc runtime either
- Remove `ConnectionErrorCode ` unused enum
- Fixes a few comments that still refer to communicator