### PR TITLE
Remove Connection.NullDispatcher

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -831,8 +831,9 @@ namespace IceRpc
             OutgoingResponse? response = null;
             try
             {
-                IDispatcher dispatcher = Dispatcher ?? throw new ServiceNotFoundException(RetryPolicy.OtherReplica);
-                response = await dispatcher.DispatchAsync(request, cancel).ConfigureAwait(false);
+                response = await (Dispatcher ?? NullDispatcher.Instance).DispatchAsync(
+                    request,
+                    cancel).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/IceRpc/Internal/NullDispatcher.cs
+++ b/src/IceRpc/Internal/NullDispatcher.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ZeroC, Inc. All rights reserved.
+
+namespace IceRpc.Internal
+{
+    /// <summary>A dispatcher that always throws <see cref="ServiceNotFoundException"/> and can be used
+    /// as a local default when there isn't a dispatcher.</summary>
+    internal static class NullDispatcher
+    {
+        /// <summary>The dispatcher instance.</summary>
+        internal static IDispatcher Instance { get; } =
+            new InlineDispatcher((request, cancel) => throw new ServiceNotFoundException(RetryPolicy.OtherReplica));
+    }
+}

--- a/src/IceRpc/Internal/OpaqueEndpoint.cs
+++ b/src/IceRpc/Internal/OpaqueEndpoint.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace IceRpc.Internal
 {
-    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC 
+    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC
     /// runtime. The IceRPC runtime cannot send a request to this endpoint; it can however marshal this endpoint
     /// (within a proxy) and send this proxy to another application that may know this transport. This class is used
     /// only with the ice1 protocol.</summary>

--- a/src/IceRpc/Internal/UniversalEndpoint.cs
+++ b/src/IceRpc/Internal/UniversalEndpoint.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace IceRpc.Internal
 {
-    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC 
+    /// <summary>Describes an endpoint with a transport or protocol that has not been registered with the IceRPC
     /// runtime. The IceRPC runtime cannot send a request to this endpoint; it can however marshal this endpoint
     /// (within a proxy) and send this proxy to another application that may know this transport. This class is used
     /// only for protocol ice2 or greater.</summary>

--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using IceRpc.Internal;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -181,7 +182,7 @@ namespace IceRpc
                             if (path.Length == AbsolutePrefix.Length)
                             {
                                 // We consume everything so there is nothing left to match.
-                                throw new ServiceNotFoundException(RetryPolicy.OtherReplica);
+                                return NullDispatcher.Instance.DispatchAsync(request, cancel);
                             }
                             else
                             {
@@ -217,7 +218,7 @@ namespace IceRpc
 
                             if (prefix == "/")
                             {
-                                throw new ServiceNotFoundException(RetryPolicy.OtherReplica);
+                                return NullDispatcher.Instance.DispatchAsync(request, cancel);
                             }
 
                             // Cut last segment


### PR DESCRIPTION
This tiny PR removes the internal `Connection.NullDispatcher` the code now directly throw `ServiceNotFoundException`