### PR TITLE
Missing router tests

### DIFF
--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -119,7 +119,6 @@ namespace IceRpc
         /// <summary>Unregisters a route previously registered with <see cref="Map{T}(IDispatcher)"/>.</summary>
         /// <typeparam name="T">The service type used to get the default path.</typeparam>
         /// <returns>True when the route was found and unregistered; otherwise, false.</returns>
-        // TODO missing test
         public bool Unmap<T>() =>
             _exactMatchRoutes.Remove(typeof(T).GetDefaultPath());
 
@@ -127,10 +126,10 @@ namespace IceRpc
         /// <param name="prefix">The prefix of the route.</param>
         /// <returns>True when the route was found and unregistered; otherwise, false.</returns>
         /// <exception cref="ArgumentException">Raised if prefix does not start with a <c>/</c>.</exception>
-        // TODO missing test
         public bool Unmount(string prefix)
         {
             Internal.UriParser.CheckPath(prefix, nameof(prefix));
+            prefix = NormalizePrefix(prefix);
             return _prefixMatchRoutes.Remove(prefix);
         }
 

--- a/tests/IceRpc.Tests.Api/RouterTests.cs
+++ b/tests/IceRpc.Tests.Api/RouterTests.cs
@@ -75,9 +75,12 @@ namespace IceRpc.Tests.Api
             await greeter.IcePingAsync();
             Assert.AreEqual(1, value);
 
-            // Without exact match from Map, we hit the mounted route:
+            // If we unmap the route we get ServiceNotFoundException
             Assert.That(_router.Unmap(path), Is.True);
+            Assert.That(_router.Unmount(path), Is.True);
+            Assert.ThrowsAsync<ServiceNotFoundException>(async () => await greeter.IcePingAsync());
 
+            // Without exact match from Map, we hit the mounted route:
             _router.Mount(path, new InlineDispatcher(
                 async (current, cancel) =>
                 {
@@ -127,6 +130,9 @@ namespace IceRpc.Tests.Api
             var greeter = GreeterPrx.FromConnection(_connection, path);
             await greeter.IcePingAsync();
             Assert.That(called, Is.True);
+
+            Assert.That(_router.Unmount(prefix), Is.True);
+            Assert.ThrowsAsync<ServiceNotFoundException>(async () => await greeter.IcePingAsync());
         }
 
         [TestCase("/foo", "/foobar")]
@@ -225,15 +231,27 @@ namespace IceRpc.Tests.Api
             _router.Map<IGreeter>(new Greeter());
             await GreeterPrx.FromConnection(_connection).IcePingAsync();
 
+            _router.Unmap<IGreeter>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await GreeterPrx.FromConnection(_connection).IcePingAsync());
+
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await BaseAPrx.FromConnection(_connection).IcePingAsync());
             _router.Map<IBaseA>(new BaseA());
             await BaseAPrx.FromConnection(_connection).IcePingAsync();
 
+            _router.Unmap<IBaseA>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await BaseAPrx.FromConnection(_connection).IcePingAsync());
+
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await DerivedAPrx.FromConnection(_connection).IcePingAsync());
             _router.Map<IDerivedA>(new DerivedA());
             await DerivedAPrx.FromConnection(_connection).IcePingAsync();
+
+            _router.Unmap<IDerivedA>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await DerivedAPrx.FromConnection(_connection).IcePingAsync());
 
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await MostDerivedAPrx.FromConnection(_connection).IcePingAsync());
@@ -245,6 +263,10 @@ namespace IceRpc.Tests.Api
             _router.Map<IBaseB>(new BaseB());
             await BaseBPrx.FromConnection(_connection).IcePingAsync();
 
+            _router.Unmap<IBaseB>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await BaseBPrx.FromConnection(_connection).IcePingAsync());
+
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await DerivedBPrx.FromConnection(_connection).IcePingAsync());
             _router.Map<IDerivedB>(new DerivedB());
@@ -255,10 +277,18 @@ namespace IceRpc.Tests.Api
             _router.Map<IMostDerivedB>(new MostDerivedB());
             await MostDerivedBPrx.FromConnection(_connection).IcePingAsync();
 
+            _router.Unmap<IMostDerivedB>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await MostDerivedBPrx.FromConnection(_connection).IcePingAsync());
+
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await BaseCPrx.FromConnection(_connection).IcePingAsync());
             _router.Map<IBaseC>(new BaseC());
             await BaseCPrx.FromConnection(_connection).IcePingAsync();
+
+            _router.Unmap<IBaseC>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+             async () => await BaseCPrx.FromConnection(_connection).IcePingAsync());
 
             Assert.ThrowsAsync<ServiceNotFoundException>(
                 async () => await DerivedCPrx.FromConnection(_connection).IcePingAsync());
@@ -269,6 +299,10 @@ namespace IceRpc.Tests.Api
                 async () => await MostDerivedCPrx.FromConnection(_connection).IcePingAsync());
             _router.Map<IMostDerivedC>(new MostDerivedC());
             await MostDerivedCPrx.FromConnection(_connection).IcePingAsync();
+
+            _router.Unmap<IMostDerivedC>();
+            Assert.ThrowsAsync<ServiceNotFoundException>(
+                async () => await MostDerivedCPrx.FromConnection(_connection).IcePingAsync());
         }
 
         [TearDown]


### PR DESCRIPTION
This PR add missing tests for `Router.Unmount` and `Router.Unmap<T>`, there was a minor bug in `Ummount` it didn't normalize the prefix, so you cannot use the same prefix for mount and umount.