### PR TITLE
Move options type validation to property setter

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -341,20 +341,14 @@ namespace IceRpc
                 {
                     _options ??= ClientConnectionOptions.Default;
                     var clientOptions =  (ClientConnectionOptions)_options;
-                    if (UnderlyingConnection == null)
-                    {
-                        if (_remoteEndpoint == null)
-                        {
-                            throw new InvalidOperationException("client connection has no remote endpoint set");
-                        }
-                        else if (_localEndpoint != null)
-                        {
-                            throw new InvalidOperationException("client connection has local endpoint set");
-                        }
+                    Debug.Assert(UnderlyingConnection == null);
 
-                        UnderlyingConnection =
-                            ClientTransport.CreateConnection(_remoteEndpoint, clientOptions, _logger);
+                    if (_remoteEndpoint == null)
+                    {
+                        throw new InvalidOperationException("client connection has no remote endpoint set");
                     }
+                    UnderlyingConnection =
+                        ClientTransport.CreateConnection(_remoteEndpoint, clientOptions, _logger);
 
                     // If the endpoint is secure, connect with the SSL client authentication options.
                     SslClientAuthenticationOptions? clientAuthenticationOptions = null;

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
This small PR moves the checking of ConnectionOptions type from `ConnectAsync` to the property setter, this way you get an error earlier when you set the bogus property, rather than later when you try to connect the connection.