### PR TITLE
Remove null check for non nullable parameter

### DIFF
--- a/src/IceRpc/Transports/Internal/AsyncSemaphore.cs
+++ b/src/IceRpc/Transports/Internal/AsyncSemaphore.cs
@@ -50,11 +50,6 @@ namespace IceRpc.Transports.Internal
         /// completion.</param>
         internal void Complete(Exception exception)
         {
-            if (exception == null)
-            {
-                throw new ArgumentOutOfRangeException("exception can't be null");
-            }
-
             lock (_mutex)
             {
                 if (_exception != null)

--- a/tests/IceRpc.Tests.Internal/AsyncSemaphoreTests.cs
+++ b/tests/IceRpc.Tests.Internal/AsyncSemaphoreTests.cs
@@ -85,13 +85,6 @@ namespace IceRpc.Tests.Internal
         }
 
         [Test]
-        public void AsyncSemaphore_Complete_Exception()
-        {
-            var semaphore = new AsyncSemaphore(1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => semaphore.Complete(null!));
-        }
-
-        [Test]
         public async Task AsyncSemaphore_Complete_ExceptionThrowing()
         {
             // Completing the semaphore should cause EnterAsync to throw the completion exception, other methods


### PR DESCRIPTION
I don't see the point of this check and test, the parameter is non nullable and the compiler will complain if you pass null.