### PR TITLE
Remove Invocation.ClassFormat

### DIFF
--- a/src/IceRpc/Invocation.cs
+++ b/src/IceRpc/Invocation.cs
@@ -10,9 +10,6 @@ namespace IceRpc
     /// </summary>
     public sealed class Invocation
     {
-        /// <summary>Gets or sets the marshaling format for classes.</summary>
-        public FormatType ClassFormat { get; set; }
-
         /// <summary>Gets or sets the value of the Context feature in <see cref="RequestFeatures"/>.</summary>
         public IDictionary<string, string> Context
         {


### PR DESCRIPTION
This PR removes the Invocation.ClassFormat property - it was not used.

I think it's fine for the class format to be settable only through attributes, without a way to override the attribute selection (or default) through an invocation property. 