### PR TITLE
Move transport builders to IceRpc.Configure namespace

### DIFF
--- a/src/IceRpc/Configure/ClientTransportBuilder.cs
+++ b/src/IceRpc/Configure/ClientTransportBuilder.cs
@@ -45,7 +45,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the coloc client transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddColoc(this ClientTransportBuilder builder)
+        public static ClientTransportBuilder UseColoc(this ClientTransportBuilder builder)
         {
             builder.Add(TransportNames.Coloc, new ColocClientTransport());
             return builder;
@@ -54,7 +54,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the ssl client transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddSsl(this ClientTransportBuilder builder)
+        public static ClientTransportBuilder UseSsl(this ClientTransportBuilder builder)
         {
             builder.Add(TransportNames.Ssl, new TcpClientTransport());
             return builder;
@@ -64,7 +64,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddSsl(this ClientTransportBuilder builder, TcpOptions options)
+        public static ClientTransportBuilder UseSsl(this ClientTransportBuilder builder, TcpOptions options)
         {
             builder.Add(TransportNames.Ssl, new TcpClientTransport(options));
             return builder;
@@ -73,7 +73,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the tcp client transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddTcp(this ClientTransportBuilder builder)
+        public static ClientTransportBuilder UseTcp(this ClientTransportBuilder builder)
         {
             builder.Add(TransportNames.Tcp, new TcpClientTransport());
             return builder;
@@ -83,7 +83,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddTcp(this ClientTransportBuilder builder, TcpOptions options)
+        public static ClientTransportBuilder UseTcp(this ClientTransportBuilder builder, TcpOptions options)
         {
             builder.Add(TransportNames.Tcp, new TcpClientTransport(options));
             return builder;
@@ -92,7 +92,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the udp client transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddUdp(this ClientTransportBuilder builder)
+        public static ClientTransportBuilder UseUdp(this ClientTransportBuilder builder)
         {
             builder.Add(TransportNames.Udp, new UdpClientTransport());
             return builder;
@@ -102,7 +102,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ClientTransportBuilder AddUdp(this ClientTransportBuilder builder, UdpOptions options)
+        public static ClientTransportBuilder UseUdp(this ClientTransportBuilder builder, UdpOptions options)
         {
             builder.Add(TransportNames.Udp, new UdpClientTransport(options));
             return builder;

--- a/src/IceRpc/Configure/ServerTransportBuilder.cs
+++ b/src/IceRpc/Configure/ServerTransportBuilder.cs
@@ -45,7 +45,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the coloc server transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddColoc(this ServerTransportBuilder builder)
+        public static ServerTransportBuilder UseColoc(this ServerTransportBuilder builder)
         {
             builder.Add(TransportNames.Coloc, new ColocServerTransport());
             return builder;
@@ -54,7 +54,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the ssl server transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddSsl(this ServerTransportBuilder builder)
+        public static ServerTransportBuilder UseSsl(this ServerTransportBuilder builder)
         {
             builder.Add(TransportNames.Ssl, new TcpServerTransport());
             return builder;
@@ -64,7 +64,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddSsl(this ServerTransportBuilder builder, TcpOptions options)
+        public static ServerTransportBuilder UseSsl(this ServerTransportBuilder builder, TcpOptions options)
         {
             builder.Add(TransportNames.Ssl, new TcpServerTransport(options));
             return builder;
@@ -73,7 +73,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the tcp server transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddTcp(this ServerTransportBuilder builder)
+        public static ServerTransportBuilder UseTcp(this ServerTransportBuilder builder)
         {
             builder.Add(TransportNames.Tcp, new TcpServerTransport());
             return builder;
@@ -83,7 +83,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddTcp(this ServerTransportBuilder builder, TcpOptions options)
+        public static ServerTransportBuilder UseTcp(this ServerTransportBuilder builder, TcpOptions options)
         {
             builder.Add(TransportNames.Tcp, new TcpServerTransport(options));
             return builder;
@@ -92,7 +92,7 @@ namespace IceRpc.Configure
         /// <summary>Adds the udp server transport to this builder.</summary>
         /// <param name="builder">The builder being configured.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddUdp(this ServerTransportBuilder builder)
+        public static ServerTransportBuilder UseUdp(this ServerTransportBuilder builder)
         {
             builder.Add(TransportNames.Udp, new UdpServerTransport());
             return builder;
@@ -102,7 +102,7 @@ namespace IceRpc.Configure
         /// <param name="builder">The builder being configured.</param>
         /// <param name="options">The transport options.</param>
         /// <returns>The builder.</returns>
-        public static ServerTransportBuilder AddUdp(this ServerTransportBuilder builder, UdpOptions options)
+        public static ServerTransportBuilder UseUdp(this ServerTransportBuilder builder, UdpOptions options)
         {
             builder.Add(TransportNames.Udp, new UdpServerTransport(options));
             return builder;

--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -47,7 +47,7 @@ namespace IceRpc
     {
         /// <summary>The default value for <see cref="IClientTransport"/>.</summary>
         public static IClientTransport DefaultClientTransport { get; } =
-            new ClientTransportBuilder().AddTcp().AddSsl().AddColoc().AddUdp().Build();
+            new ClientTransportBuilder().UseTcp().UseSsl().UseColoc().UseUdp().Build();
 
         /// <summary>Gets the class factory used for instantiating classes decoded from requests or responses.
         /// </summary>

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -22,7 +22,7 @@ namespace IceRpc
     {
         /// <summary>The default value for <see cref="ServerTransport"/>.</summary>
         public static IServerTransport DefaultServerTransport { get; } =
-            new ServerTransportBuilder().AddTcp().AddSsl().AddColoc().AddUdp().Build();
+            new ServerTransportBuilder().UseTcp().UseSsl().UseColoc().UseUdp().Build();
 
         /// <summary>Gets or sets the options of server connections created by this server.</summary>
         public ServerConnectionOptions ConnectionOptions { get; set; } = new();


### PR DESCRIPTION
This PR moves the transport builders, to IceRpc.Configure namespace and replaces AddXxx with UseXxx for consistency with interceptor and middleware.