### PR TITLE
Change default for Server.Endpoint

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -34,9 +34,9 @@ namespace IceRpc
         public IDispatcher? Dispatcher { get; set; }
 
         /// <summary>Gets or sets the endpoint of this server.</summary>
-        /// <value>The endpoint of this server, for example <c>ice+tcp://[::0]</c>.The endpoint's host is usually an
+        /// <value>The endpoint of this server, by default <c>ice+tcp://[::0]</c>.The endpoint's host is usually an
         /// IP address, and it cannot be a DNS name.</value>
-        public Endpoint? Endpoint
+        public Endpoint Endpoint
         {
             get => _endpoint;
             set
@@ -76,7 +76,7 @@ namespace IceRpc
 
         private readonly HashSet<Connection> _connections = new();
 
-        private Endpoint? _endpoint;
+        private Endpoint _endpoint = "ice+tcp://[::0]";
 
         private IListener? _listener;
 
@@ -110,11 +110,6 @@ namespace IceRpc
                 if (_listening)
                 {
                     throw new InvalidOperationException($"server '{this}' is already listening");
-                }
-
-                if (_endpoint == null)
-                {
-                    throw new InvalidOperationException("server has no endpoint");
                 }
 
                 if (_shutdownTask != null)

--- a/tests/IceRpc.Tests.Api/ServerTests.cs
+++ b/tests/IceRpc.Tests.Api/ServerTests.cs
@@ -15,6 +15,11 @@ namespace IceRpc.Tests.Api
         public async Task Server_Exceptions()
         {
             {
+                await using var server = new Server();
+                Assert.AreEqual(Endpoint.FromString("ice+tcp://[::0]"), server.Endpoint);
+            }
+
+            {
                 await using var server = new Server
                 {
                     Endpoint = "tcp -h foo -p 10000"


### PR DESCRIPTION
This PR changes the default value for Server.Endpoint from null to `ice+tcp://[::0]`.