### PR TITLE
Remove implicit uses

### DIFF
--- a/src/IceRpc.Interop/Configure/LocatorOptions.cs
+++ b/src/IceRpc.Interop/Configure/LocatorOptions.cs
@@ -2,8 +2,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
-using System.Threading;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc.Interop/Internal/EndpointCache.cs
+++ b/src/IceRpc.Interop/Internal/EndpointCache.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace IceRpc.Internal

--- a/src/IceRpc.Interop/Internal/EndpointFinder.cs
+++ b/src/IceRpc.Interop/Internal/EndpointFinder.cs
@@ -2,10 +2,7 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc.Interop/Internal/LocationResolver.cs
+++ b/src/IceRpc.Interop/Internal/LocationResolver.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc.Interop/LocatorInterceptor.cs
+++ b/src/IceRpc.Interop/LocatorInterceptor.cs
@@ -3,10 +3,7 @@
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc.Interop/Transports/UdpClientTransport.cs
+++ b/src/IceRpc.Interop/Transports/UdpClientTransport.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;

--- a/src/IceRpc.Interop/Transports/UdpOptions.cs
+++ b/src/IceRpc.Interop/Transports/UdpOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Net;
 
 namespace IceRpc.Transports

--- a/src/IceRpc.Interop/Transports/UdpServerTransport.cs
+++ b/src/IceRpc.Interop/Transports/UdpServerTransport.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/IceRpc/AsyncEnumerableStreamParamSender.cs
+++ b/src/IceRpc/AsyncEnumerableStreamParamSender.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/BinderInterceptor.cs
+++ b/src/IceRpc/BinderInterceptor.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>A binder interceptor is responsible for providing connections to requests using an

--- a/src/IceRpc/BitSequence.cs
+++ b/src/IceRpc/BitSequence.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Text;
 
 namespace IceRpc

--- a/src/IceRpc/ByteStreamParamSender.cs
+++ b/src/IceRpc/ByteStreamParamSender.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
-using System;
 using System.Buffers;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/CertificateValidation.cs
+++ b/src/IceRpc/CertificateValidation.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System.Collections.Generic;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 

--- a/src/IceRpc/ClassAttribute.cs
+++ b/src/IceRpc/ClassAttribute.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/IceRpc/ClassFactory.cs
+++ b/src/IceRpc/ClassFactory.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 
 namespace IceRpc

--- a/src/IceRpc/CompressorInterceptor.cs
+++ b/src/IceRpc/CompressorInterceptor.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/CompressorMiddleware.cs
+++ b/src/IceRpc/CompressorMiddleware.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/Configure/Pipeline.cs
+++ b/src/IceRpc/Configure/Pipeline.cs
@@ -1,11 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc/Configure/PipelineExtensions.cs
+++ b/src/IceRpc/Configure/PipelineExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc/Configure/RetryOptions.cs
+++ b/src/IceRpc/Configure/RetryOptions.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc/Configure/Router.cs
+++ b/src/IceRpc/Configure/Router.cs
@@ -1,13 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc/Configure/ServerTransport.cs
+++ b/src/IceRpc/Configure/ServerTransport.cs
@@ -3,8 +3,6 @@
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-using System;
 
 namespace IceRpc.Configure
 {

--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -6,12 +6,8 @@ using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
-using System;
 using System.Net.Security;
 
 namespace IceRpc

--- a/src/IceRpc/ConnectionPool.cs
+++ b/src/IceRpc/ConnectionPool.cs
@@ -4,12 +4,7 @@ using IceRpc.Internal;
 using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/DefaultTimeoutInterceptor.cs
+++ b/src/IceRpc/DefaultTimeoutInterceptor.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>An interceptor that sets the invocation timeout, the interceptor sets the

--- a/src/IceRpc/Dispatch.cs
+++ b/src/IceRpc/Dispatch.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Features;
-using System;
-using System.Collections.Generic;
 
 namespace IceRpc
 {

--- a/src/IceRpc/DispatchEventSource.cs
+++ b/src/IceRpc/DispatchEventSource.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace IceRpc
 {

--- a/src/IceRpc/Encoding.cs
+++ b/src/IceRpc/Encoding.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc
 {
     /// <summary>Encoding identifies the format (a.k.a. encoding) used to encode data into bytes. With IceRPC, it is

--- a/src/IceRpc/Endpoint.cs
+++ b/src/IceRpc/Endpoint.cs
@@ -2,11 +2,8 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 
 namespace IceRpc

--- a/src/IceRpc/FeatureCollection.cs
+++ b/src/IceRpc/FeatureCollection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace IceRpc

--- a/src/IceRpc/Features/Context.cs
+++ b/src/IceRpc/Features/Context.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace IceRpc.Features

--- a/src/IceRpc/Fields.cs
+++ b/src/IceRpc/Fields.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/Gen/ProxyExtensions.cs
+++ b/src/IceRpc/Gen/ProxyExtensions.cs
@@ -1,9 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc.Gen
 {
     /// <summary>A function that decodes the return value from an Ice-encoded response payload.</summary>

--- a/src/IceRpc/IConnectionProvider.cs
+++ b/src/IceRpc/IConnectionProvider.cs
@@ -1,10 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>Provides connections to the <see cref="BinderInterceptor"/> interceptor.</summary>

--- a/src/IceRpc/IDispatcher.cs
+++ b/src/IceRpc/IDispatcher.cs
@@ -1,9 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>A dispatcher handles (dispatches) incoming requests and returns outgoing responses.</summary>

--- a/src/IceRpc/IInvoker.cs
+++ b/src/IceRpc/IInvoker.cs
@@ -1,9 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>An invoker sends outgoing requests and returns incoming responses.</summary>

--- a/src/IceRpc/IPrx.cs
+++ b/src/IceRpc/IPrx.cs
@@ -1,8 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>The common interface of all concrete typed proxies. It gives access to an untyped proxy object that can

--- a/src/IceRpc/IStreamParamSender.cs
+++ b/src/IceRpc/IStreamParamSender.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
-using System;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/IceDecoder-Class.cs
+++ b/src/IceRpc/IceDecoder-Class.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/IceRpc/IceDecoder.cs
+++ b/src/IceRpc/IceDecoder.cs
@@ -2,13 +2,10 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/IceRpc/IceEncoder-Class.cs
+++ b/src/IceRpc/IceEncoder-Class.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 

--- a/src/IceRpc/IceEncoder.cs
+++ b/src/IceRpc/IceEncoder.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/IceRpc/Identity.cs
+++ b/src/IceRpc/Identity.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/IncomingFrame.cs
+++ b/src/IceRpc/IncomingFrame.cs
@@ -1,10 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>Base class for incoming frames.</summary>

--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -3,8 +3,6 @@
 using IceRpc.Features;
 using IceRpc.Internal;
 using IceRpc.Transports;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace IceRpc

--- a/src/IceRpc/IncomingResponse.cs
+++ b/src/IceRpc/IncomingResponse.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/Internal/ByteBuffer.cs
+++ b/src/IceRpc/Internal/ByteBuffer.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 

--- a/src/IceRpc/Internal/CompressionExtensions.cs
+++ b/src/IceRpc/Internal/CompressionExtensions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.IO;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
 

--- a/src/IceRpc/Internal/ConnectionLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ConnectionLoggerExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc/Internal/EncodingDefinitions.cs
+++ b/src/IceRpc/Internal/EncodingDefinitions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Internal
 {
     internal static class EncodingDefinitions

--- a/src/IceRpc/Internal/EncodingExtensions.cs
+++ b/src/IceRpc/Internal/EncodingExtensions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Internal
 {
     internal static class EncodingExtensions

--- a/src/IceRpc/Internal/EndpointExtensions.cs
+++ b/src/IceRpc/Internal/EndpointExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/IceRpc/Internal/EnumerableExtensions.cs
+++ b/src/IceRpc/Internal/EnumerableExtensions.cs
@@ -1,8 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-
 namespace IceRpc.Internal
 {
     /// <summary>This class contains extensions methods to compute sequences hash code.</summary>

--- a/src/IceRpc/Internal/ExceptionUtil.cs
+++ b/src/IceRpc/Internal/ExceptionUtil.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 

--- a/src/IceRpc/Internal/Ice1Definitions.cs
+++ b/src/IceRpc/Internal/Ice1Definitions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
 
 namespace IceRpc.Internal

--- a/src/IceRpc/Internal/Ice1Parser.cs
+++ b/src/IceRpc/Internal/Ice1Parser.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc/Internal/Ice2Definitions.cs
+++ b/src/IceRpc/Internal/Ice2Definitions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Internal
 {
     // Definitions for the ice2 protocol.

--- a/src/IceRpc/Internal/IceUriParser.cs
+++ b/src/IceRpc/Internal/IceUriParser.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/Internal/ProtocolExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolExtensions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Internal
 {
     /// <summary>Parser that creates protocol instances.</summary>

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc/Internal/StringUtil.cs
+++ b/src/IceRpc/Internal/StringUtil.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 

--- a/src/IceRpc/Internal/Time.cs
+++ b/src/IceRpc/Internal/Time.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
 
 namespace IceRpc.Internal

--- a/src/IceRpc/Internal/TimeSpanExtensions.cs
+++ b/src/IceRpc/Internal/TimeSpanExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Globalization;
-using System.Threading;
 
 namespace IceRpc.Internal
 {

--- a/src/IceRpc/Invocation.cs
+++ b/src/IceRpc/Invocation.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Features;
-using System;
-using System.Collections.Generic;
 
 namespace IceRpc
 {

--- a/src/IceRpc/InvocationEventSource.cs
+++ b/src/IceRpc/InvocationEventSource.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace IceRpc
 {

--- a/src/IceRpc/LocalException.cs
+++ b/src/IceRpc/LocalException.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc
 {
     /// <summary>This exception reports that a proxy has no endpoint or no usable endpoint.</summary>

--- a/src/IceRpc/LoggerInterceptor.cs
+++ b/src/IceRpc/LoggerInterceptor.cs
@@ -1,8 +1,5 @@
 ﻿using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/LoggerMiddleware.cs
+++ b/src/IceRpc/LoggerMiddleware.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/MetricsInterceptor.cs
+++ b/src/IceRpc/MetricsInterceptor.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>An interceptor that publishes invocation metrics.</summary>

--- a/src/IceRpc/MetricsMiddleware.cs
+++ b/src/IceRpc/MetricsMiddleware.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>A middleware that publishes dispatch metrics using a dispatch event source.</summary>

--- a/src/IceRpc/OperationAttribute.cs
+++ b/src/IceRpc/OperationAttribute.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc
 {
     /// <summary>This attribute class is used by the generated code to mark operations that can be called from

--- a/src/IceRpc/OutgoingFrame.cs
+++ b/src/IceRpc/OutgoingFrame.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -3,8 +3,6 @@
 using IceRpc.Features;
 using IceRpc.Internal;
 using IceRpc.Transports;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/OutgoingResponse.cs
+++ b/src/IceRpc/OutgoingResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/IceRpc/Payload.cs
+++ b/src/IceRpc/Payload.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Diagnostics;
 
 namespace IceRpc

--- a/src/IceRpc/Proxy.cs
+++ b/src/IceRpc/Proxy.cs
@@ -4,15 +4,10 @@ using IceRpc.Features;
 using IceRpc.Internal;
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/ProxyInvokerMiddleware.cs
+++ b/src/IceRpc/ProxyInvokerMiddleware.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace IceRpc
 {
     /// <summary>A middleware that sets <see cref="IncomingRequest.ProxyInvoker"/> and indirectly

--- a/src/IceRpc/RemoteException.cs
+++ b/src/IceRpc/RemoteException.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Diagnostics;
 using System.Text;
 

--- a/src/IceRpc/RetryInterceptor.cs
+++ b/src/IceRpc/RetryInterceptor.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -6,12 +6,7 @@ using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/Service.cs
+++ b/src/IceRpc/Service.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/SlicedData.cs
+++ b/src/IceRpc/SlicedData.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace IceRpc

--- a/src/IceRpc/StreamParamReceiver.cs
+++ b/src/IceRpc/StreamParamReceiver.cs
@@ -2,12 +2,8 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/TelemetryInterceptor.cs
+++ b/src/IceRpc/TelemetryInterceptor.cs
@@ -2,10 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/TelemetryMiddleware.cs
+++ b/src/IceRpc/TelemetryMiddleware.cs
@@ -2,12 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc
 {

--- a/src/IceRpc/Transports/ColocClientTransport.cs
+++ b/src/IceRpc/Transports/ColocClientTransport.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using ColocChannelReader = System.Threading.Channels.ChannelReader<(long StreamId, object Frame, bool Fin)>;
 using ColocChannelWriter = System.Threading.Channels.ChannelWriter<(long StreamId, object Frame, bool Fin)>;
 

--- a/src/IceRpc/Transports/EndpointCodex.cs
+++ b/src/IceRpc/Transports/EndpointCodex.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 
 namespace IceRpc.Transports
 {

--- a/src/IceRpc/Transports/IListener.cs
+++ b/src/IceRpc/Transports/IListener.cs
@@ -1,8 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading.Tasks;
-
 namespace IceRpc.Transports
 {
     /// <summary>A listener listens for connection requests from clients. It creates a server connection when it accepts

--- a/src/IceRpc/Transports/Internal/AsyncSemaphore.cs
+++ b/src/IceRpc/Transports/Internal/AsyncSemaphore.cs
@@ -1,10 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/BufferedReceiveOverNetworkSocket.cs
+++ b/src/IceRpc/Transports/Internal/BufferedReceiveOverNetworkSocket.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
 using System.Net.Security;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/CircularBuffer.cs
+++ b/src/IceRpc/Transports/Internal/CircularBuffer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
-using System.Threading;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/ColocConnection.cs
+++ b/src/IceRpc/Transports/Internal/ColocConnection.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics;
 using System.Net.Security;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/ColocListener.cs
+++ b/src/IceRpc/Transports/Internal/ColocListener.cs
@@ -1,13 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using ColocChannelReader = System.Threading.Channels.ChannelReader<(long StreamId, object Frame, bool Fin)>;
 using ColocChannelWriter = System.Threading.Channels.ChannelWriter<(long StreamId, object Frame, bool Fin)>;
 

--- a/src/IceRpc/Transports/Internal/ColocStream.cs
+++ b/src/IceRpc/Transports/Internal/ColocStream.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/EndpointParseExtensions.cs
+++ b/src/IceRpc/Transports/Internal/EndpointParseExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Globalization;
 using System.Net;
 

--- a/src/IceRpc/Transports/Internal/ExceptionExtensions.cs
+++ b/src/IceRpc/Transports/Internal/ExceptionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Net.Sockets;
-using System.Threading;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/IPEndPointExtensions.cs
+++ b/src/IceRpc/Transports/Internal/IPEndPointExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 

--- a/src/IceRpc/Transports/Internal/Ice1Connection.cs
+++ b/src/IceRpc/Transports/Internal/Ice1Connection.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/Ice1Stream.cs
+++ b/src/IceRpc/Transports/Internal/Ice1Stream.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Internal;
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/ManualResetValueTaskCompletionSource.cs
+++ b/src/IceRpc/Transports/Internal/ManualResetValueTaskCompletionSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace IceRpc.Transports.Internal

--- a/src/IceRpc/Transports/Internal/SignaledStream.cs
+++ b/src/IceRpc/Transports/Internal/SignaledStream.cs
@@ -1,10 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace IceRpc.Transports.Internal

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -2,13 +2,9 @@
 
 using IceRpc.Internal;
 using IceRpc.Slic;
-using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/SlicDefinitions.cs
+++ b/src/IceRpc/Transports/Internal/SlicDefinitions.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Transports.Internal
 {
     internal static class SlicDefinitions

--- a/src/IceRpc/Transports/Internal/SlicLoggerExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SlicLoggerExtensions.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Slic;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Internal/SlicStream.cs
@@ -2,12 +2,7 @@
 
 using IceRpc.Internal;
 using IceRpc.Slic;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -2,9 +2,7 @@
 
 using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Net.Sockets;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/TcpSocket.cs
+++ b/src/IceRpc/Transports/Internal/TcpSocket.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Buffers;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -11,8 +10,6 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/TlsLoggerExtensions.cs
+++ b/src/IceRpc/Transports/Internal/TlsLoggerExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/TransportLoggerExtensions.cs
+++ b/src/IceRpc/Transports/Internal/TransportLoggerExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/UdpSocket.cs
+++ b/src/IceRpc/Transports/Internal/UdpSocket.cs
@@ -2,15 +2,12 @@
 
 using IceRpc.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports.Internal
 {

--- a/src/IceRpc/Transports/Internal/UdpUtils.cs
+++ b/src/IceRpc/Transports/Internal/UdpUtils.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;

--- a/src/IceRpc/Transports/MultiStreamConnection.cs
+++ b/src/IceRpc/Transports/MultiStreamConnection.cs
@@ -3,14 +3,11 @@
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports
 {

--- a/src/IceRpc/Transports/NetworkSocket.cs
+++ b/src/IceRpc/Transports/NetworkSocket.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using System;
 using System.Net.Security;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports
 {

--- a/src/IceRpc/Transports/NetworkSocketConnection.cs
+++ b/src/IceRpc/Transports/NetworkSocketConnection.cs
@@ -3,8 +3,6 @@
 using IceRpc.Transports.Internal;
 using System.Diagnostics;
 using System.Net.Security;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports
 {

--- a/src/IceRpc/Transports/RpcStream.cs
+++ b/src/IceRpc/Transports/RpcStream.cs
@@ -2,10 +2,7 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Transports
 {

--- a/src/IceRpc/Transports/SlicOptions.cs
+++ b/src/IceRpc/Transports/SlicOptions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Transports
 {
     /// <summary>An options class for configuring Slic based transports.</summary>

--- a/src/IceRpc/Transports/TcpOptions.cs
+++ b/src/IceRpc/Transports/TcpOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
 using System.Net;
 
 namespace IceRpc.Transports

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/IceRpc/Transports/UnknownTransportException.cs
+++ b/src/IceRpc/Transports/UnknownTransportException.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc.Transports
 {
     /// <summary>This exception reports that the provided transport is unknown or unregistered.</summary>

--- a/src/IceRpc/TypeIdAttribute.cs
+++ b/src/IceRpc/TypeIdAttribute.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace IceRpc

--- a/src/IceRpc/UnknownSlicedClass.cs
+++ b/src/IceRpc/UnknownSlicedClass.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-
 namespace IceRpc
 {
     /// <summary>UnknownSlicedClass represents a fully sliced class instance. The local Ice runtime does not known this

--- a/tests/IceRpc.Tests.Api/ConnectionTests.cs
+++ b/tests/IceRpc.Tests.Api/ConnectionTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/EndpointTests.cs
+++ b/tests/IceRpc.Tests.Api/EndpointTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/FeatureTests.cs
+++ b/tests/IceRpc.Tests.Api/FeatureTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Multiplier = System.Int32;
 
 namespace IceRpc.Tests.Api

--- a/tests/IceRpc.Tests.Api/IdentityTests.cs
+++ b/tests/IceRpc.Tests.Api/IdentityTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/InterceptorTests.cs
+++ b/tests/IceRpc.Tests.Api/InterceptorTests.cs
@@ -3,10 +3,6 @@
 using IceRpc.Configure;
 using IceRpc.Features;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/InvocationTimeoutTests.cs
+++ b/tests/IceRpc.Tests.Api/InvocationTimeoutTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/MiddlewareTests.cs
+++ b/tests/IceRpc.Tests.Api/MiddlewareTests.cs
@@ -2,10 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/PipelineTests.cs
+++ b/tests/IceRpc.Tests.Api/PipelineTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/ProxyTests.cs
+++ b/tests/IceRpc.Tests.Api/ProxyTests.cs
@@ -3,10 +3,6 @@
 using IceRpc.Configure;
 using IceRpc.Features;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/RouterTests.cs
+++ b/tests/IceRpc.Tests.Api/RouterTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.Api/ServerTests.cs
+++ b/tests/IceRpc.Tests.Api/ServerTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Api
 {

--- a/tests/IceRpc.Tests.ClientServer/ClientServerBaseTest.cs
+++ b/tests/IceRpc.Tests.ClientServer/ClientServerBaseTest.cs
@@ -2,7 +2,6 @@
 
 using NUnit.Framework;
 using System.Globalization;
-using System.Threading;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/CompressTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/CompressTests.cs
@@ -2,12 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/CustomTransportTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/CustomTransportTests.cs
@@ -3,8 +3,6 @@
 using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/HeaderTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/HeaderTests.cs
@@ -2,10 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/LocationResolverTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/LocationResolverTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/LocatorTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/LocatorTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/LoggingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/LoggingTests.cs
@@ -4,13 +4,7 @@ using IceRpc.Configure;
 using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/MetricsTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/MetricsTests.cs
@@ -2,12 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/RetryTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/RetryTests.cs
@@ -2,13 +2,8 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/StressTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/StressTests.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/TelemetryTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/TelemetryTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.ClientServer/TlsConfigurationTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/TlsConfigurationTests.cs
@@ -2,14 +2,9 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.IO;
-using System.Linq;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.ClientServer
 {

--- a/tests/IceRpc.Tests.CodeGeneration/AliasTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/AliasTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Reflection;
 
 namespace IceRpc.Tests.CodeGeneration

--- a/tests/IceRpc.Tests.CodeGeneration/ClassTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/ClassTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/Custom.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/Custom.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/DictionaryTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/DictionaryTests.cs
@@ -1,11 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/EnumTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/EnumTests.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/ExceptionTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/ExceptionTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/InterfaceInheritanceTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/InterfaceInheritanceTests.cs
@@ -3,9 +3,6 @@
 using IceRpc.Configure;
 using IceRpc.Tests.CodeGeneration.InterfaceInheritance;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/MarshaledResultTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/MarshaledResultTests.cs
@@ -1,11 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/NamespaceMetadataTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/NamespaceMetadataTests.cs
@@ -4,10 +4,7 @@ using IceRpc.Tests.CodeGeneration.NamespaceMD.M1.M2.M3;
 using IceRpc.Tests.CodeGeneration.NamespaceMD.WithNamespace;
 using IceRpc.Tests.CodeGeneration.NamespaceMD.WithNamespace.N1.N2;
 using NUnit.Framework;
-using System;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/OperationsTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/OperationsTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/OptionalTests.cs
@@ -1,11 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/ScopeTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/ScopeTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Configure;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/SequenceTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/SequenceTests.cs
@@ -1,11 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/StreamParamTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/StreamParamTests.cs
@@ -1,14 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 #pragma warning disable CA2000 // TODO Dispose MemoryStream used for Stream params
 

--- a/tests/IceRpc.Tests.CodeGeneration/StructTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/StructTests.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/TaggedTests.cs
@@ -1,11 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.CodeGeneration
 {

--- a/tests/IceRpc.Tests.Encoding/BuiltInTypesSequencesTests.cs
+++ b/tests/IceRpc.Tests.Encoding/BuiltInTypesSequencesTests.cs
@@ -2,8 +2,6 @@
 
 using NUnit.Framework;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace IceRpc.Tests.Encoding
 {

--- a/tests/IceRpc.Tests.Encoding/BuiltInTypesTests.cs
+++ b/tests/IceRpc.Tests.Encoding/BuiltInTypesTests.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Internal;
 using NUnit.Framework;
-using System;
 
 namespace IceRpc.Tests.Encoding
 {

--- a/tests/IceRpc.Tests.Encoding/ClassTests.cs
+++ b/tests/IceRpc.Tests.Encoding/ClassTests.cs
@@ -3,10 +3,7 @@
 using IceRpc.Configure;
 using IceRpc.Internal;
 using NUnit.Framework;
-using System;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Encoding
 {

--- a/tests/IceRpc.Tests.Encoding/ProxyTests.cs
+++ b/tests/IceRpc.Tests.Encoding/ProxyTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Encoding
 {

--- a/tests/IceRpc.Tests.Encoding/SlicingTests.cs
+++ b/tests/IceRpc.Tests.Encoding/SlicingTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Collections.Immutable;
 using System.Reflection;
 

--- a/tests/IceRpc.Tests.Internal/AcceptNetworkSocketConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/AcceptNetworkSocketConnectionTests.cs
@@ -3,11 +3,8 @@
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using NUnit.Framework;
-using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/AsyncSemaphoreTests.cs
+++ b/tests/IceRpc.Tests.Internal/AsyncSemaphoreTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/CircularBufferTests.cs
+++ b/tests/IceRpc.Tests.Internal/CircularBufferTests.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports.Internal;
 using NUnit.Framework;
-using System;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/ConnectNetworkSocketConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectNetworkSocketConnectionTests.cs
@@ -2,10 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/ConnectionBaseTest.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectionBaseTest.cs
@@ -4,15 +4,12 @@ using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/ConnectionOptionsTests.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectionOptionsTests.cs
@@ -2,12 +2,8 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/ConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectionTests.cs
@@ -3,14 +3,11 @@
 using IceRpc.Configure;
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
 using System.Collections.Immutable;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/DatagramMulticastTests.cs
+++ b/tests/IceRpc.Tests.Internal/DatagramMulticastTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/DatagramTests.cs
+++ b/tests/IceRpc.Tests.Internal/DatagramTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/DispatchEventSourceTests.cs
+++ b/tests/IceRpc.Tests.Internal/DispatchEventSourceTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Diagnostics.Tracing;
 
 namespace IceRpc.Tests.Internal

--- a/tests/IceRpc.Tests.Internal/EndpointFinderTests.cs
+++ b/tests/IceRpc.Tests.Internal/EndpointFinderTests.cs
@@ -2,9 +2,6 @@
 
 using IceRpc.Internal;
 using NUnit.Framework;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/InvocationEventSourceTests.cs
+++ b/tests/IceRpc.Tests.Internal/InvocationEventSourceTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Diagnostics.Tracing;
 
 namespace IceRpc.Tests.Internal

--- a/tests/IceRpc.Tests.Internal/LocationResolverTests.cs
+++ b/tests/IceRpc.Tests.Internal/LocationResolverTests.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Internal;
 using NUnit.Framework;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/MultiStreamConnectionBaseTest.cs
+++ b/tests/IceRpc.Tests.Internal/MultiStreamConnectionBaseTest.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/MultiStreamConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/MultiStreamConnectionTests.cs
@@ -2,11 +2,6 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/NetworkSocketConnectionBaseTest.cs
+++ b/tests/IceRpc.Tests.Internal/NetworkSocketConnectionBaseTest.cs
@@ -3,7 +3,6 @@
 using IceRpc.Transports;
 using NUnit.Framework;
 using System.Net.Sockets;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/NetworkSocketConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/NetworkSocketConnectionTests.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System.Threading;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/NonDatagramTests.cs
+++ b/tests/IceRpc.Tests.Internal/NonDatagramTests.cs
@@ -2,10 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/StreamParamTests.cs
+++ b/tests/IceRpc.Tests.Internal/StreamParamTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.IO;
 using System.IO.Compression;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/IceRpc.Tests.Internal/StreamTests.cs
+++ b/tests/IceRpc.Tests.Internal/StreamTests.cs
@@ -2,11 +2,7 @@
 
 using IceRpc.Transports;
 using NUnit.Framework;
-using System;
-using System.IO;
 using System.IO.Compression;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IceRpc.Tests.Internal
 {

--- a/tests/Shared/LogAttribute.cs
+++ b/tests/Shared/LogAttribute.cs
@@ -5,8 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using System;
-using System.Collections.Generic;
 
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 

--- a/tests/Shared/TestHelper.cs
+++ b/tests/Shared/TestHelper.cs
@@ -1,8 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using System;
-using System.Threading;
-
 namespace IceRpc.Tests
 {
     public static class TestHelper

--- a/tests/Shared/TestLogger.cs
+++ b/tests/Shared/TestLogger.cs
@@ -2,10 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 


### PR DESCRIPTION
This PR removes the implicit using directives, with the new `Global using directives` in 
 .NET 6 preview 7https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#net-sdk-c-project-templates-modernized

Alternatively, we can disable the implicit using directives with `DisableImplicitNamespaceImports`, what style do you prefer?