### PR TITLE
Fix for stream param test close timeout 

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -7,7 +7,6 @@ using IceRpc.Transports.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
-using System.Net.Security;
 
 namespace IceRpc
 {
@@ -202,7 +201,7 @@ namespace IceRpc
         private ILoggerFactory? _loggerFactory;
         // The mutex protects mutable data members and ensures the logic for some operations is performed atomically.
         private readonly object _mutex = new();
-        private ConnectionOptions _options;
+        private readonly ConnectionOptions _options;
         private RpcStream? _peerControlStream;
         private Endpoint? _remoteEndpoint;
         private Action<Connection>? _remove;

--- a/src/IceRpc/Transports/Internal/SignaledStream.cs
+++ b/src/IceRpc/Transports/Internal/SignaledStream.cs
@@ -262,9 +262,9 @@ namespace IceRpc.Transports.Internal
             return new ValueTask<T>(this, _source.Version);
         }
 
-        internal override async Task WaitForShutdownAsync(CancellationToken cancel) =>
+        internal override Task WaitForShutdownAsync(CancellationToken cancel) =>
             // Ignore the result, no result is expected when this is called, only an exception.
-            _ = await WaitAsync(cancel).ConfigureAwait(false);
+            WaitAsync(cancel).AsTask();
 
         private protected abstract Task SendResetFrameAsync(RpcStreamError errorCode);
 

--- a/tests/IceRpc.Tests.CodeGeneration/StreamParamTests.cs
+++ b/tests/IceRpc.Tests.CodeGeneration/StreamParamTests.cs
@@ -33,10 +33,15 @@ namespace IceRpc.Tests.CodeGeneration.Stream
                 Endpoint = transport == "coloc" ?
                     TestHelper.GetUniqueColocEndpoint(Protocol.Ice2) :
                     TestHelper.GetTestEndpoint(protocol: Protocol.Ice2),
+                LoggerFactory = LogAttributeLoggerFactory.Instance
             };
 
             _server.Listen();
-            _connection = new Connection { RemoteEndpoint = _server.Endpoint };
+            _connection = new Connection
+            {
+                RemoteEndpoint = _server.Endpoint,
+                LoggerFactory = LogAttributeLoggerFactory.Instance
+            };
             _prx = StreamParamOperationsPrx.FromConnection(_connection);
         }
 
@@ -413,6 +418,8 @@ namespace IceRpc.Tests.CodeGeneration.Stream
                 byte[] buffer = new byte[512];
                 Assert.That(p1.Read(buffer, 0, 512), Is.EqualTo(256));
                 Assert.That(buffer[..256], Is.EqualTo(_sendBuffer));
+                Assert.That(p1.ReadByte(), Is.EqualTo(-1));
+                p1.Dispose();
                 return default;
             }
 
@@ -425,6 +432,8 @@ namespace IceRpc.Tests.CodeGeneration.Stream
                 byte[] buffer = new byte[512];
                 Assert.That(p2.Read(buffer, 0, 512), Is.EqualTo(256));
                 Assert.That(buffer[..256], Is.EqualTo(_sendBuffer));
+                Assert.That(p2.ReadByte(), Is.EqualTo(-1));
+                p2.Dispose();
                 return default;
             }
 
@@ -438,6 +447,8 @@ namespace IceRpc.Tests.CodeGeneration.Stream
                 byte[] buffer = new byte[512];
                 Assert.That(p3.Read(buffer, 0, 512), Is.EqualTo(256));
                 Assert.That(buffer[..256], Is.EqualTo(_sendBuffer));
+                Assert.That(p3.ReadByte(), Is.EqualTo(-1));
+                p3.Dispose();
                 return default;
             }
 


### PR DESCRIPTION
The `StreamParam_Byte` test caused shutdown to hang until the close timeout kicked in. The hand was caused by the Rpc stream not being released on the server side because:
- the servant code was just reading 256 bytes but didn't call `Receive` again to actually receive the EOS
- it didn't `Dispose` the IO stream

One of these two needs to be performed to release the underlying Rpc stream (and disposing the IO stream is always required ... but the Rpc stream can be released before the IO stream is disposed when reaching EOS).

This PR also fixes two other minor code issues (missing readonly and use of AsTask).