### PR TITLE
Tag end marker cleanup

### DIFF
--- a/src/IceRpc/Internal/ProtocolExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolExtensions.cs
@@ -149,8 +149,12 @@ namespace IceRpc.Internal
                     string typeId = decoder.DecodeString();
                     if (typeId.IsIce1SystemExceptionTypeId())
                     {
+                        // We use the activator directly because we can't rewind to call decoder.DecodeException
                         var systemException = (RemoteException)_activator20.CreateInstance(typeId, decoder)!;
-                        decoder.CheckEndOfBuffer(skipTaggedParams: false);
+
+                        // skipTaggedParams is true to skip the remaining exception tagged members (most likely none);
+                        // see Ice20Decoder.DecodeException.
+                        decoder.CheckEndOfBuffer(skipTaggedParams: true);
                         return targetProtocol.CreateResponseFromRemoteException(systemException, Encoding.Ice11);
                     }
                 }

--- a/src/IceRpc/Slice/Ice11Decoder.cs
+++ b/src/IceRpc/Slice/Ice11Decoder.cs
@@ -370,18 +370,25 @@ namespace IceRpc.Slice
             _classGraphMaxDepth = classGraphMaxDepth;
         }
 
+        /// <summary>Skips the remaining tagged parameters, return value _or_ data members.</summary>
         private protected override void SkipTaggedParams()
         {
+            bool withTagEndMarker = (_current.InstanceType != InstanceType.None);
+
             while (true)
             {
-                if (_buffer.Length - Pos <= 0)
+                if (!withTagEndMarker && _buffer.Length - Pos <= 0)
                 {
+                    // When we don't use an end marker, the end of the buffer indicates the end of the tagged params /
+                    // members.
                     break;
                 }
 
                 int v = DecodeByte();
-                if (v == TagEndMarker)
+                if (withTagEndMarker && v == TagEndMarker)
                 {
+                    // When we use an end marker, the end marker (and only the end marker) indicates the end of the
+                    // tagged params / member.
                     break;
                 }
 
@@ -390,7 +397,7 @@ namespace IceRpc.Slice
                 {
                     SkipSize();
                 }
-                SkipTagged(format);
+                SkipTaggedValue(format);
             }
         }
 
@@ -760,26 +767,31 @@ namespace IceRpc.Slice
         /// <returns>True if the tagged parameter is present; otherwise, false.</returns>
         private bool DecodeTaggedParamHeader(int tag, TagFormat expectedFormat)
         {
-            // The current slice has no tagged parameter.
-            if (_current.InstanceType != InstanceType.None &&
-                (_current.SliceFlags & SliceFlags.HasTaggedMembers) == 0)
+            bool withTagEndMarker = false;
+
+            if (_current.InstanceType != InstanceType.None)
             {
-                return false;
+                if ((_current.SliceFlags & SliceFlags.HasTaggedMembers) == 0) // tagged member of a class or exception
+                {
+                    // The current slice has no tagged parameter.
+                    return false;
+                }
+                withTagEndMarker = true;
             }
 
             int requestedTag = tag;
 
             while (true)
             {
-                if (_buffer.Length - Pos <= 0)
+                if (!withTagEndMarker && _buffer.Length - Pos <= 0)
                 {
-                    return false; // End of buffer also indicates end of tagged parameters.
+                    return false; // End of buffer indicates end of tagged parameters.
                 }
 
                 int savedPos = Pos;
 
                 int v = DecodeByte();
-                if (v == TagEndMarker)
+                if (withTagEndMarker && v == TagEndMarker)
                 {
                     Pos = savedPos; // rewind
                     return false;
@@ -799,7 +811,7 @@ namespace IceRpc.Slice
                 }
                 else if (tag < requestedTag)
                 {
-                    SkipTagged(format);
+                    SkipTaggedValue(format);
                 }
                 else
                 {
@@ -1005,7 +1017,7 @@ namespace IceRpc.Slice
             return (_current.SliceFlags & SliceFlags.IsLastSlice) != 0;
         }
 
-        private void SkipTagged(TagFormat format)
+        private void SkipTaggedValue(TagFormat format)
         {
             switch (format)
             {


### PR DESCRIPTION
This small PR makes it clearer when we use TagEndMarker to detect the end of the tagged members, and when we use the end-of-buffer for this detection. The two criteria are actually mutually exclusive.