### PR TITLE
Update endpoint record to NOT use positional syntax for its properties

### DIFF
--- a/src/IceRpc/Endpoint.cs
+++ b/src/IceRpc/Endpoint.cs
@@ -10,18 +10,23 @@ namespace IceRpc
 {
     /// <summary>An endpoint describes a server-side network sink for IceRPC requests: a server listens on an endpoint
     /// and a client establishes a connection to a given endpoint.</summary>
-    /// <param name="Protocol">The Ice protocol of this endpoint.</param>
-    /// <param name="Transport">The transport of this endpoint, for example "tcp" or "quic".</param>
-    /// <param name="Host">The host name or address.</param>
-    /// <param name="Port">The port number.</param>
-    /// <param name="Params">Transport-specific parameters.</param>
-    public sealed record Endpoint(
-        Protocol Protocol,
-        string Transport,
-        string Host,
-        ushort Port,
-        ImmutableList<EndpointParam> Params)
+    public sealed record class Endpoint
     {
+        /// <summary>The Ice protocol of this endpoint.</summary>
+        public Protocol Protocol { get; set; }
+
+        /// <summary>The transport of this endpoint, for example "tcp" or "quic".</summary>
+        public string Transport { get; set; }
+
+        /// <summary>The host name or address.</summary>
+        public string Host { get; set; }
+
+        /// <summary>The port number.</summary>
+        public ushort Port { get; set; }
+
+        /// <summary>Transport-specific parameters.</summary>
+        public ImmutableList<EndpointParam> Params { get; set; }
+
         /// <summary>Converts a string into an endpoint implicitly using <see cref="FromString"/>.</summary>
         /// <param name="s">The string representation of the endpoint.</param>
         /// <returns>The new endpoint.</returns>
@@ -36,6 +41,26 @@ namespace IceRpc
         /// </exception>
         public static Endpoint FromString(string s) =>
             IceUriParser.IsEndpointUri(s) ? IceUriParser.ParseEndpointUri(s) : Ice1Parser.ParseEndpointString(s);
+
+        /// <summary>Constructs a new endpoint.</summary>
+        /// <param name="protocol">The Ice protocol of this endpoint.</param>
+        /// <param name="transport">The transport of this endpoint, for example "tcp" or "quic".</param>
+        /// <param name="host">The host name or address.</param>
+        /// <param name="port">The port number.</param>
+        /// <param name="params">Transport-specific parameters.</param>
+        public Endpoint(
+            Protocol protocol,
+            string transport,
+            string host,
+            ushort port,
+            ImmutableList<EndpointParam> @params)
+        {
+            Protocol = protocol;
+            Transport = transport;
+            Host = host;
+            Port = port;
+            Params = @params;
+        }
 
         /// <summary>Checks if this endpoint is equal to another endpoint.</summary>
         /// <param name="other">The other endpoint.</param>

--- a/src/IceRpc/Internal/Ice1Parser.cs
+++ b/src/IceRpc/Internal/Ice1Parser.cs
@@ -447,8 +447,8 @@ namespace IceRpc.Internal
 
                 endpoint = new Endpoint(Protocol.Ice1,
                                         TransportNames.Loc,
-                                        Host: adapterId,
-                                        Port: 0,
+                                        host: adapterId,
+                                        port: 0,
                                         ImmutableList<EndpointParam>.Empty);
 
                 return new Proxy(new IdentityAndFacet(identity, facet).ToPath(), Protocol.Ice1)

--- a/src/IceRpc/Slice/Ice11Decoder.cs
+++ b/src/IceRpc/Slice/Ice11Decoder.cs
@@ -187,9 +187,9 @@ namespace IceRpc.Slice
                     {
                         endpoint = new Endpoint(Protocol.Ice1,
                                                 TransportNames.Loc,
-                                                Host: adapterId,
-                                                Port: Ice1Parser.DefaultPort,
-                                                Params: ImmutableList<EndpointParam>.Empty);
+                                                host: adapterId,
+                                                port: Ice1Parser.DefaultPort,
+                                                @params: ImmutableList<EndpointParam>.Empty);
                     }
                     else
                     {
@@ -534,8 +534,8 @@ namespace IceRpc.Slice
 
                             endpoint = new Endpoint(Protocol.Ice1,
                                                     TransportNames.Opaque,
-                                                    Host: "",
-                                                    Port: 0,
+                                                    host: "",
+                                                    port: 0,
                                                     endpointParams);
                             break;
                         }

--- a/tests/IceRpc.Tests.Internal/ConnectionBaseTest.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectionBaseTest.cs
@@ -79,8 +79,8 @@ namespace IceRpc.Tests.Internal
             {
                 ClientEndpoint = new Endpoint(Protocol.Ice2,
                                               transport,
-                                              Host: Guid.NewGuid().ToString(),
-                                              Port: 4062,
+                                              host: Guid.NewGuid().ToString(),
+                                              port: 4062,
                                               ImmutableList<EndpointParam>.Empty);
                 ServerEndpoint = ClientEndpoint;
             }

--- a/tests/IceRpc.Tests.Internal/ConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/ConnectionTests.cs
@@ -161,8 +161,8 @@ namespace IceRpc.Tests.Internal
                 {
                     Endpoint = new Endpoint(Protocol.Ice2,
                                             transport,
-                                            Host: Guid.NewGuid().ToString(),
-                                            Port: 4062,
+                                            host: Guid.NewGuid().ToString(),
+                                            port: 4062,
                                             ImmutableList<EndpointParam>.Empty);
                 }
                 else if (transport == "udp" || protocol == Protocol.Ice1)


### PR DESCRIPTION
This tiny PR updates Endpoint to not use the position syntax to define its properties. They are instead defined as regular get/set properties.

I find this syntax easier to document and it allows nicer param names for the no longer synthesized "one-shot" constructor.

`record class` is a new alias for `record` in C# 10.

Once `required` works, we may be able to drop the constructor and make most properties required.