### PR TITLE
Remove IDisposable from ISlicFrameReader & Writer

### DIFF
--- a/src/IceRpc/Transports/Internal/ISlicFrameReader.cs
+++ b/src/IceRpc/Transports/Internal/ISlicFrameReader.cs
@@ -2,9 +2,8 @@
 
 namespace IceRpc.Transports.Internal
 {
-    /// <summary>A Slic frame reader is used by the Slic transport to read Slic frames. The reader is
-    /// disposable to allow implementations to rely on disposable resources.</summary>
-    internal interface ISlicFrameReader : IDisposable
+    /// <summary>A Slic frame reader is used by the Slic transport to read Slic frames.</summary>
+    internal interface ISlicFrameReader
     {
         /// <summary>Reads the data from a Slic frame into a buffer.</summary>
         ValueTask ReadFrameDataAsync(Memory<byte> buffer, CancellationToken cancel);

--- a/src/IceRpc/Transports/Internal/ISlicFrameWriter.cs
+++ b/src/IceRpc/Transports/Internal/ISlicFrameWriter.cs
@@ -2,9 +2,8 @@
 
 namespace IceRpc.Transports.Internal
 {
-    /// <summary>A Slic frame writer is used by the Slic transport to write Slic frames. The writer is
-    /// disposable to allow implementations to rely on disposable resources.</summary>
-    internal interface ISlicFrameWriter : IDisposable
+    /// <summary>A Slic frame writer is used by the Slic transport to write Slic frames.</summary>
+    internal interface ISlicFrameWriter
     {
         /// <summary>Writes a Slic frame.</summary>
         ValueTask WriteFrameAsync(

--- a/src/IceRpc/Transports/Internal/LogSlicFrameReaderDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogSlicFrameReaderDecorator.cs
@@ -18,8 +18,6 @@ namespace IceRpc.Transports.Internal
         private long? _frameStreamId;
         private readonly ILogger _logger;
 
-        public void Dispose() => _decoratee.Dispose();
-
         public async ValueTask ReadFrameDataAsync(Memory<byte> buffer, CancellationToken cancel)
         {
             await _decoratee.ReadFrameDataAsync(buffer, cancel).ConfigureAwait(false);

--- a/src/IceRpc/Transports/Internal/LogSlicFrameWriterDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogSlicFrameWriterDecorator.cs
@@ -15,8 +15,6 @@ namespace IceRpc.Transports.Internal
         private readonly ISlicFrameWriter _decoratee;
         private readonly ILogger _logger;
 
-        public void Dispose() => _decoratee.Dispose();
-
         public async ValueTask WriteFrameAsync(
             SlicMultiplexedStream? stream,
             ReadOnlyMemory<ReadOnlyMemory<byte>> buffers,

--- a/src/IceRpc/Transports/Internal/SlicListener.cs
+++ b/src/IceRpc/Transports/Internal/SlicListener.cs
@@ -5,7 +5,8 @@ namespace IceRpc.Transports.Internal
     internal class SlicListener : IListener<IMultiplexedNetworkConnection>
     {
         private readonly IListener<ISimpleNetworkConnection> _simpleListener;
-        private readonly Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> _slicFrameReaderWriterFactory;
+        private readonly Func<ISlicFrameReader, ISlicFrameReader> _slicFrameReaderDecorator;
+        private readonly Func<ISlicFrameWriter, ISlicFrameWriter> _slicFrameWriterDecorator;
         private readonly SlicOptions _slicOptions;
 
         public Endpoint Endpoint => _simpleListener.Endpoint;
@@ -14,18 +15,21 @@ namespace IceRpc.Transports.Internal
             new SlicNetworkConnection(
                 await _simpleListener.AcceptAsync().ConfigureAwait(false),
                 isServer: true,
-                _slicFrameReaderWriterFactory,
+                _slicFrameReaderDecorator,
+                _slicFrameWriterDecorator,
                 _slicOptions);
 
         public void Dispose() => _simpleListener.Dispose();
 
         internal SlicListener(
             IListener<ISimpleNetworkConnection> simpleListener,
-            Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> slicFrameReaderWriterFactory,
+            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator,
+            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator,
             SlicOptions slicOptions)
         {
             _simpleListener = simpleListener;
-            _slicFrameReaderWriterFactory = slicFrameReaderWriterFactory;
+            _slicFrameReaderDecorator = slicFrameReaderDecorator;
+            _slicFrameWriterDecorator = slicFrameWriterDecorator;
             _slicOptions = slicOptions;
         }
     }

--- a/src/IceRpc/Transports/Internal/StreamSlicFrameReader.cs
+++ b/src/IceRpc/Transports/Internal/StreamSlicFrameReader.cs
@@ -6,7 +6,7 @@ namespace IceRpc.Transports.Internal
 {
     /// <summary>The buffered receiver Slic frame reader class reads Slic frames from a buffered
     /// receiver.</summary>
-    internal class BufferedReceiverSlicFrameReader : ISlicFrameReader
+    internal class BufferedReceiverSlicFrameReader : ISlicFrameReader, IDisposable
     {
         private readonly BufferedReceiver _receiver;
 

--- a/src/IceRpc/Transports/Internal/StreamSlicFrameWriter.cs
+++ b/src/IceRpc/Transports/Internal/StreamSlicFrameWriter.cs
@@ -7,15 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace IceRpc.Transports.Internal
 {
-    /// <summary>The Slic frame writer class writes Slic frames and sends them over an <see
-    /// cref="ISimpleStream"/>.</summary>
+    /// <summary>The Slic frame writer class writes Slic frames and sends them over an <see cref="ISimpleStream"/>.
+    /// </summary>
     internal sealed class StreamSlicFrameWriter : ISlicFrameWriter
     {
         private readonly ISimpleStream _stream;
-
-        public void Dispose()
-        {
-        }
 
         public async ValueTask WriteFrameAsync(
             SlicMultiplexedStream? stream,

--- a/src/IceRpc/Transports/Internal/SynchronizedSlicFrameWriterDecorator.cs
+++ b/src/IceRpc/Transports/Internal/SynchronizedSlicFrameWriterDecorator.cs
@@ -7,18 +7,14 @@ namespace IceRpc.Transports.Internal
     /// <summary>The synchronized Slic frame writer decorator synchronizes concurrent calls to write Slic
     /// frames. It also ensures that Slic streams which are not started are started when the first stream data
     /// frame is written.</summary>
-    internal sealed class SynchronizedSlicFrameWriterDecorator : ISlicFrameWriter
+    internal sealed class SynchronizedSlicFrameWriterDecorator : ISlicFrameWriter, IDisposable
     {
         private readonly ISlicFrameWriter _decoratee;
         private long _nextBidirectionalId;
         private long _nextUnidirectionalId;
         private readonly AsyncSemaphore _sendSemaphore = new(1);
 
-        public void Dispose()
-        {
-            _decoratee.Dispose();
-            _sendSemaphore.Complete(new ConnectionClosedException());
-        }
+        public void Dispose() => _sendSemaphore.Complete(new ConnectionClosedException());
 
         public async ValueTask WriteFrameAsync(
             SlicMultiplexedStream? stream,

--- a/src/IceRpc/Transports/SlicClientTransport.cs
+++ b/src/IceRpc/Transports/SlicClientTransport.cs
@@ -10,7 +10,9 @@ namespace IceRpc.Transports
     public class SlicClientTransport : IClientTransport<IMultiplexedNetworkConnection>
     {
         private readonly IClientTransport<ISimpleNetworkConnection> _simpleClientTransport;
-        private readonly Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> _slicFrameReaderWriterFactory;
+        private readonly Func<ISlicFrameReader, ISlicFrameReader> _slicFrameReaderDecorator;
+        private readonly Func<ISlicFrameWriter, ISlicFrameWriter> _slicFrameWriterDecorator;
+
         private readonly SlicOptions _slicOptions;
 
         /// <summary>Constructs a Slic client transport.</summary>
@@ -25,8 +27,8 @@ namespace IceRpc.Transports
             SlicOptions slicOptions)
         {
             _simpleClientTransport = simpleClientTransport;
-            _slicFrameReaderWriterFactory =
-                simpleStream => (new StreamSlicFrameReader(simpleStream), new StreamSlicFrameWriter(simpleStream));
+            _slicFrameReaderDecorator = reader => reader;
+            _slicFrameWriterDecorator = writer => writer;
             _slicOptions = slicOptions;
         }
 
@@ -39,8 +41,9 @@ namespace IceRpc.Transports
 
             ISimpleNetworkConnection simpleNetworkConnection =
                 _simpleClientTransport.CreateConnection(remoteEndpoint, loggerFactory);
-            Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> slicFrameReaderWriterFactory =
-                _slicFrameReaderWriterFactory;
+
+            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _slicFrameReaderDecorator;
+            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _slicFrameWriterDecorator;
 
             if (loggerFactory.CreateLogger("IceRpc.Transports") is ILogger logger && logger.IsEnabled(LogLevel.Error))
             {
@@ -51,18 +54,14 @@ namespace IceRpc.Transports
                                                                                   remoteEndpoint,
                                                                                   logger);
 
-                slicFrameReaderWriterFactory = simpleStream =>
-                {
-                    (ISlicFrameReader reader, ISlicFrameWriter writer) = _slicFrameReaderWriterFactory(simpleStream);
-
-                    return (new LogSlicFrameReaderDecorator(reader, logger),
-                            new LogSlicFrameWriterDecorator(writer, logger));
-                };
+                slicFrameReaderDecorator = reader => new LogSlicFrameReaderDecorator(reader, logger);
+                slicFrameWriterDecorator = writer => new LogSlicFrameWriterDecorator(writer, logger);
             }
 
             return new SlicNetworkConnection(simpleNetworkConnection,
                                              isServer: false,
-                                             slicFrameReaderWriterFactory,
+                                             slicFrameReaderDecorator,
+                                             slicFrameWriterDecorator,
                                              _slicOptions);
         }
     }

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -11,7 +11,8 @@ namespace IceRpc.Transports
     {
         private readonly IServerTransport<ISimpleNetworkConnection> _simpleServerTransport;
 
-        private readonly Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> _slicFrameReaderWriterFactory;
+        private readonly Func<ISlicFrameReader, ISlicFrameReader> _slicFrameReaderDecorator;
+        private readonly Func<ISlicFrameWriter, ISlicFrameWriter> _slicFrameWriterDecorator;
         private readonly SlicOptions _slicOptions;
 
         /// <summary>Constructs a Slic server transport.</summary>
@@ -26,8 +27,8 @@ namespace IceRpc.Transports
             SlicOptions slicOptions)
         {
             _simpleServerTransport = simpleServerTransport;
-            _slicFrameReaderWriterFactory =
-                simpleStream => (new StreamSlicFrameReader(simpleStream), new StreamSlicFrameWriter(simpleStream));
+            _slicFrameReaderDecorator = reader => reader;
+            _slicFrameWriterDecorator = writer => writer;
             _slicOptions = slicOptions;
         }
 
@@ -40,8 +41,8 @@ namespace IceRpc.Transports
 
             IListener<ISimpleNetworkConnection> simpleListener = _simpleServerTransport.Listen(endpoint, loggerFactory);
 
-            Func<ISimpleStream, (ISlicFrameReader, ISlicFrameWriter)> slicFrameReaderWriterFactory =
-                _slicFrameReaderWriterFactory;
+            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _slicFrameReaderDecorator;
+            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _slicFrameWriterDecorator;
 
             if (loggerFactory.CreateLogger("IceRpc.Transports") is ILogger logger && logger.IsEnabled(LogLevel.Error))
             {
@@ -52,16 +53,11 @@ namespace IceRpc.Transports
                     logger,
                     LogSimpleNetworkConnectionDecorator.Decorate);
 
-                slicFrameReaderWriterFactory = simpleStream =>
-                {
-                    (ISlicFrameReader reader, ISlicFrameWriter writer) = _slicFrameReaderWriterFactory(simpleStream);
-
-                    return (new LogSlicFrameReaderDecorator(reader, logger),
-                            new LogSlicFrameWriterDecorator(writer, logger));
-                };
+                slicFrameReaderDecorator = reader => new LogSlicFrameReaderDecorator(reader, logger);
+                slicFrameWriterDecorator = writer => new LogSlicFrameWriterDecorator(writer, logger);
             }
 
-            return new SlicListener(simpleListener, slicFrameReaderWriterFactory, _slicOptions);
+            return new SlicListener(simpleListener, slicFrameReaderDecorator, slicFrameWriterDecorator, _slicOptions);
         }
     }
 }


### PR DESCRIPTION
This PR removes the disposable code smell from these two interfaces by moving IDisposable to the disposable implementations and reshuffling the decoration.