### PR TITLE
Add IgnoreUnreachableDestinationPort property and tests

### DIFF
--- a/src/IceRpc/Configure/UdpOptions.cs
+++ b/src/IceRpc/Configure/UdpOptions.cs
@@ -18,6 +18,14 @@ namespace IceRpc.Transports
                 throw new ArgumentException($"0 is not a valid value for {nameof(IdleTimeout)}", nameof(value));
         }
 
+        /// <summary>When sending datagrams to a server, the server host can return an ICMP packet to notify the sender
+        /// that the destination port is unreachable. The sender can either ignore this notification or close the
+        /// connection.</summary>
+        /// <value>When true, the sender ignores the port unreachable ICMP packet. When false (the default), the sender
+        /// closes its connection when it receives such an ICMP packet, and subsequent sends on that connection will
+        /// fail.</value>
+        public bool IgnoreUnreachableDestinationPort { get; set; }
+
         /// <summary>Configures an IPv6 socket to only support IPv6. The socket won't support IPv4 mapped addresses
         /// when this property is set to true. The default value is false.</summary>
         /// <value>The boolean value to enable or disable IPv6-only support.</value>

--- a/tests/IceRpc.Tests.ClientServer/UdpTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/UdpTests.cs
@@ -12,7 +12,6 @@ namespace IceRpc.Tests.ClientServer
     [Parallelizable(ParallelScope.All)]
     public class UdpTests : ClientServerBaseTest
     {
-
         [Test]
         public async Task Udp_Invoke()
         {
@@ -46,21 +45,42 @@ namespace IceRpc.Tests.ClientServer
         {
             await using var connection = new Connection
             {
-                RemoteEndpoint = GetTestEndpoint(protocol: Protocol.Ice1, port: 4061, transport: "udp"),
+                RemoteEndpoint = "udp -h 127.0.0.1 -p 4061"
             };
             await connection.ConnectAsync();
 
             var proxy = ServicePrx.FromConnection(connection);
-            Assert.CatchAsync<TransportException>(async () =>
+            // We're sending a UDP request to an unreachable port. We get back a "destination port unreachable"
+            // ICMP packet and close the connection, which results in the second ping failing with a Connection
+            // closed exception.
+            await proxy.IcePingAsync(new Invocation { IsOneway = true });
+            await Task.Delay(500);
+
+            Assert.CatchAsync<ConnectionClosedException>(async () =>
+                await proxy.IcePingAsync(new Invocation { IsOneway = true }));
+        }
+
+        [Test]
+        public async Task Udp_ConnectUnreachableSuccess()
+        {
+            await using var connection = new Connection
             {
-                // Depending on the system, the first send on the UDP socket will often succeed and the second will
-                // fail because the error that results from the absence of a listening UDP server socket is received
-                // asynchronously after the first send. We insert a small delay to ensure the error is received by
-                // the UDP socket before the second send.
-                await proxy.IcePingAsync(new Invocation { IsOneway = true });
-                await Task.Delay(500);
-                await proxy.IcePingAsync(new Invocation { IsOneway = true });
-            });
+                RemoteEndpoint = "udp -h 127.0.0.1 -p 4061",
+                SimpleClientTransport = new UdpClientTransport
+                    (new UdpOptions { IgnoreUnreachableDestinationPort = true })
+            };
+            await connection.ConnectAsync();
+
+            var proxy = ServicePrx.FromConnection(connection);
+
+            // When IgnoreUnreachableDestinationPort is true, the connection is not closed by the ICMP "destination
+            // port unreachable" packet.
+
+            await proxy.IcePingAsync(new Invocation { IsOneway = true });
+            await Task.Delay(500);
+            await proxy.IcePingAsync(new Invocation { IsOneway = true });
+            await proxy.IcePingAsync(new Invocation { IsOneway = true });
+            await proxy.IcePingAsync(new Invocation { IsOneway = true });
         }
 
         [Test]


### PR DESCRIPTION
This PR adds a new UdpOptions, IgnoreUnreacheableDestinationPort, which controls how a UDP client handles the ICMP port unreachable error. It also adds the corresponding tests.