### PR TITLE
remove unused code in EndpointParseExceptions

### DIFF
--- a/src/IceRpc/Transports/Internal/EndpointParseExtensions.cs
+++ b/src/IceRpc/Transports/Internal/EndpointParseExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using IceRpc.Slice.Internal;
 using System.Globalization;
 using System.Net;
 
@@ -10,96 +9,6 @@ namespace IceRpc.Transports.Internal
     internal static class EndpointParseExtensions
     {
         internal const int DefaultTcpTimeout = 60_000; // 60s
-
-        internal static (TransportCode TransportCode, ReadOnlyMemory<byte> Bytes) ParseOpaqueParams(
-           this Endpoint endpoint)
-        {
-            if (endpoint.Protocol != Protocol.Ice1)
-            {
-                throw new FormatException($"endpoint '{endpoint}': protocol/transport mismatch");
-            }
-
-            TransportCode? transportCode = null;
-            ReadOnlyMemory<byte> bytes = default;
-            bool encodingFound = false;
-
-            foreach ((string name, string value) in endpoint.Params)
-            {
-                switch (name)
-                {
-                    case "-e":
-                        if (encodingFound)
-                        {
-                            throw new FormatException($"multiple -e parameters in endpoint '{endpoint}'");
-                        }
-                        if (value == "1.0" || value == "1.1")
-                        {
-                            encodingFound = true;
-                        }
-                        else
-                        {
-                            throw new FormatException($"invalid value for -e parameter in endpoint '{endpoint}'");
-                        }
-                        break;
-
-                    case "-t":
-                        if (transportCode != null)
-                        {
-                            throw new FormatException($"multiple -t parameters in endpoint '{endpoint}'");
-                        }
-
-                        short t;
-                        try
-                        {
-                            t = short.Parse(value, CultureInfo.InvariantCulture);
-                        }
-                        catch (FormatException ex)
-                        {
-                            throw new FormatException(
-                                $"invalid value for parameter -t in endpoint '{endpoint}'", ex);
-                        }
-
-                        if (t < 0)
-                        {
-                            throw new FormatException(
-                                $"value for -t parameter out of range in endpoint '{endpoint}'");
-                        }
-
-                        transportCode = (TransportCode)t;
-                        break;
-
-                    case "-v":
-                        if (bytes.Length > 0)
-                        {
-                            throw new FormatException($"multiple -v parameters in endpoint '{endpoint}'");
-                        }
-
-                        try
-                        {
-                            bytes = Convert.FromBase64String(value);
-                        }
-                        catch (FormatException ex)
-                        {
-                            throw new FormatException($"invalid Base64 value in endpoint '{endpoint}'", ex);
-                        }
-                        break;
-
-                    default:
-                        throw new FormatException($"unknown parameter '{name}' in endpoint '{endpoint}'");
-                }
-            }
-
-            if (transportCode == null)
-            {
-                throw new FormatException($"missing -t parameter in endpoint '{endpoint}'");
-            }
-            else if (bytes.Length == 0)
-            {
-                throw new FormatException($"missing -v parameter in endpoint '{endpoint}'");
-            }
-
-            return (transportCode.Value, bytes);
-        }
 
         internal static (bool Compress, int Timeout, bool? Tls) ParseTcpParams(this Endpoint endpoint)
         {


### PR DESCRIPTION
This method is no longer used,  seems this is now handled by Ice11Encoder after https://github.com/zeroc-ice/icerpc-csharp/commit/ac02207d8e498216529177b818528e98254cfff6#diff-4b350854fcbc6559786b742e2b5461c5c0639fb73c15678a8e2fce6fede47213