### PR TITLE
Fixed missing LogSlicFrameWriterDecorator exception rethrow

### DIFF
--- a/src/IceRpc/Transports/Internal/LogSlicFrameWriterDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogSlicFrameWriterDecorator.cs
@@ -27,6 +27,7 @@ namespace IceRpc.Transports.Internal
             catch (Exception exception)
             {
                 _logger.LogSendSlicFrameFailure((FrameType)buffers.Span[0].Span[0], exception);
+                throw;
             }
             LogSentFrame(buffers);
         }
@@ -47,6 +48,7 @@ namespace IceRpc.Transports.Internal
             catch (Exception exception)
             {
                 _logger.LogSendSlicFrameFailure(endStream ? FrameType.StreamLast : FrameType.Stream, exception);
+                throw;
             }
         }
 


### PR DESCRIPTION
This PR fixes missing throw clauses in the in the `LogSlicFrameWriterDecorator` implementation.