### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build Slice Compiler
       run: cd tools/slicec-cs && cargo build
     - name: Add github NuGet respository
-      run: dotnet nuget add source "https://nuget.pkg.github.com/zeroc-ice/index.json" -n GitHub -u pepone --store-password-in-clear-text -p ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget add source "https://nuget.pkg.github.com/zeroc-ice/index.json" -n GitHub -u ci --store-password-in-clear-text -p ${{ secrets.NUGET_API_TOKEN }}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
This PR updates the workflow to build slicec-cs compiler instead of the old C++ compiler

But there is a problem with checking out the private dependencies 
```
  env:
    DOTNET_ROOT: /home/runner/.dotnet
    Updating crates.io index
    Updating git repository `ssh://github.com/zeroc-ice/icerpc`
error: failed to get `slicec` as a dependency of package `slicec-cs v0.1.0 (/home/runner/work/icerpc-csharp/icerpc-csharp/tools/slicec-cs)`
```

Not sure how we can deal with this, specially for PR that don't have access to shared secrets