### PR TITLE
Add cs:internal attribute

### DIFF
--- a/tools/slicec-cs/src/class_visitor.rs
+++ b/tools/slicec-cs/src/class_visitor.rs
@@ -31,7 +31,7 @@ impl<'a> Visitor for ClassVisitor<'_> {
         } else {
             vec![]
         };
-        let access = class_def.get_access_modifier();
+        let access = class_def.access_modifier();
 
         let non_default_members = members
             .iter()

--- a/tools/slicec-cs/src/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/dispatch_visitor.rs
@@ -22,7 +22,7 @@ impl<'a> Visitor for DispatchVisitor<'_> {
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         let bases = interface_def.base_interfaces();
         let interface_name = interface_def.interface_name();
-        let access = interface_def.get_access_modifier();
+        let access = interface_def.access_modifier();
         let mut interface_builder =
             ContainerBuilder::new(&format!("{} partial interface", access), &interface_name);
 
@@ -76,7 +76,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
         return "".into();
     }
 
-    let access = interface_def.get_access_modifier();
+    let access = interface_def.access_modifier();
     let mut class_builder = ContainerBuilder::new(
         &if bases.is_empty() {
             format!("{} static class", access)
@@ -139,7 +139,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         return "".into();
     }
 
-    let access = interface_def.get_access_modifier();
+    let access = interface_def.access_modifier();
     let mut class_builder = ContainerBuilder::new(
         &if bases.is_empty() {
             format!("{} static class", access)
@@ -292,7 +292,7 @@ pub fn response_encode_action(operation: &Operation) -> CodeBlock {
 fn operation_declaration(operation: &Operation) -> CodeBlock {
     // TODO: operation obsolete deprecation
     FunctionBuilder::new(
-        &operation.parent().unwrap().get_access_modifier(),
+        &operation.parent().unwrap().access_modifier(),
         &operation.return_task(true),
         &(operation.escape_identifier_with_suffix("Async")),
         FunctionType::Declaration,

--- a/tools/slicec-cs/src/encoded_result.rs
+++ b/tools/slicec-cs/src/encoded_result.rs
@@ -21,7 +21,7 @@ pub fn encoded_result_struct(operation: &Operation) -> CodeBlock {
         return "".into();
     }
 
-    let access = operation.parent().unwrap().get_access_modifier();
+    let access = operation.parent().unwrap().access_modifier();
 
     let parameters = operation.return_members();
 

--- a/tools/slicec-cs/src/enum_visitor.rs
+++ b/tools/slicec-cs/src/enum_visitor.rs
@@ -24,7 +24,7 @@ impl<'a> Visitor for EnumVisitor<'a> {
 }
 
 fn enum_declaration(enum_def: &Enum) -> CodeBlock {
-    let access = enum_def.get_access_modifier();
+    let access = enum_def.access_modifier();
     let escaped_identifier = escape_keyword(enum_def.identifier());
     ContainerBuilder::new(&format!("{} enum", access), &escaped_identifier)
         .add_comment("summary", &doc_comment_message(enum_def))
@@ -50,7 +50,7 @@ fn enum_values(enum_def: &Enum) -> CodeBlock {
 }
 
 fn enum_helper(enum_def: &Enum) -> CodeBlock {
-    let access = enum_def.get_access_modifier();
+    let access = enum_def.access_modifier();
     let escaped_identifier = escape_keyword(enum_def.identifier());
     let namespace = &enum_def.namespace();
     let mut builder = ContainerBuilder::new(

--- a/tools/slicec-cs/src/exception_visitor.rs
+++ b/tools/slicec-cs/src/exception_visitor.rs
@@ -32,7 +32,7 @@ impl<'a> Visitor for ExceptionVisitor<'_> {
             .all_members()
             .iter()
             .all(|m| m.is_default_initialized());
-        let access = exception_def.get_access_modifier();
+        let access = exception_def.access_modifier();
 
         let mut exception_class_builder =
             ContainerBuilder::new(&format!("{} partial class", access), &exception_name);
@@ -200,7 +200,7 @@ fn one_shot_constructor(
     exception_def: &Exception,
     add_message_and_exception_parameters: bool,
 ) -> CodeBlock {
-    let access = exception_def.get_access_modifier();
+    let access = exception_def.access_modifier();
     let exception_name = exception_def.escape_identifier();
 
     let namespace = &exception_def.namespace();

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -40,7 +40,7 @@ pub fn data_member_declaration(
         prelude.writeln(&format!("[{}]", obsolete));
     }
 
-    let access = data_member.get_access_modifier();
+    let access = data_member.access_modifier();
 
     format!(
         "\

--- a/tools/slicec-cs/src/proxy_visitor.rs
+++ b/tools/slicec-cs/src/proxy_visitor.rs
@@ -23,7 +23,7 @@ impl<'a> Visitor for ProxyVisitor<'_> {
         let namespace = interface_def.namespace();
         let prx_interface = interface_def.proxy_name(); // IFooPrx
         let prx_impl: String = interface_def.proxy_implementation_name(); // FooPrx
-        let access = interface_def.get_access_modifier();
+        let access = interface_def.access_modifier();
         let all_bases: Vec<&Interface> = interface_def.all_base_interfaces();
         let bases: Vec<&Interface> = interface_def.base_interfaces();
 
@@ -157,7 +157,7 @@ private static readonly DefaultIceDecoderFactories _defaultIceDecoderFactories =
 }
 
 fn proxy_impl_static_methods(interface_def: &Interface) -> CodeBlock {
-    let access = interface_def.get_access_modifier();
+    let access = interface_def.access_modifier();
     format!(
         r#"/// <summary>Creates a new <see cref="{prx_impl}"/> from the give connection and path.</summary>
 /// <param name="connection">The connection. If it's an outgoing connection, the endpoint of the new proxy is
@@ -233,7 +233,7 @@ fn proxy_operation_impl(operation: &Operation) -> CodeBlock {
 
     let sends_classes = operation.sends_classes();
     let void_return = !operation.has_nonstreamed_return_members();
-    let access = operation.parent().unwrap().get_access_modifier();
+    let access = operation.parent().unwrap().access_modifier();
 
     let mut builder = FunctionBuilder::new(
         &access,
@@ -398,7 +398,7 @@ fn proxy_base_operation_impl(interface_def: &Interface, operation: &Operation) -
         .unwrap();
 
     let mut builder = FunctionBuilder::new(
-        &operation.parent().unwrap().get_access_modifier(),
+        &operation.parent().unwrap().access_modifier(),
         &return_task,
         &async_name,
         FunctionType::ExpressionBody,
@@ -456,7 +456,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
         return "".into();
     }
 
-    let access = interface_def.get_access_modifier();
+    let access = interface_def.access_modifier();
     let mut class_builder = ContainerBuilder::new(&format!("{} static class", access), "Request");
 
     class_builder.add_comment(
@@ -564,7 +564,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         return "".into();
     }
 
-    let access = interface_def.get_access_modifier();
+    let access = interface_def.access_modifier();
 
     let mut class_builder = ContainerBuilder::new(&format!("{} static class", access), "Response");
 

--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -30,7 +30,7 @@ pub trait EntityExt: Entity {
     fn type_id_attribute(&self) -> String;
 
     /// The C# access modifier to use
-    fn get_access_modifier(&self) -> String;
+    fn access_modifier(&self) -> String;
 }
 
 impl<T> EntityExt for T
@@ -113,7 +113,7 @@ where
         )
     }
 
-    fn get_access_modifier(&self) -> String {
+    fn access_modifier(&self) -> String {
         if self.has_attribute("cs:internal", self.kind() == "data member") {
             "internal".to_owned()
         } else {

--- a/tools/slicec-cs/src/struct_visitor.rs
+++ b/tools/slicec-cs/src/struct_visitor.rs
@@ -25,7 +25,7 @@ impl<'a> Visitor for StructVisitor<'a> {
         let escaped_identifier = struct_def.escape_identifier();
         let members = struct_def.members();
         let namespace = struct_def.namespace();
-        let access = struct_def.get_access_modifier();
+        let access = struct_def.access_modifier();
 
         let mut builder = ContainerBuilder::new(
             &format!(


### PR DESCRIPTION
This PR adds preliminary support for #544, there is a new EntityExt function `get_access_modifier` that returns the C# access modifier to use for a definition, currently, it just checks `cs:internal` and returns "internal" if set and otherwise returns "public".

The visitors have been updated to use this instead of hardcoding "public"