### PR TITLE
Add clippy to rust workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,7 +31,7 @@ jobs:
       run: cargo build
     - uses: actions-rs/clippy@master
       with:
-        args: --all-features --all-targets -p tools/slicec-cs
+        args: --all-features --all-targets --manifest-path tools/slicec-cs/Cargo.toml
     - name: Add github NuGet respository
       run: dotnet nuget add source "https://nuget.pkg.github.com/zeroc-ice/index.json" -n GitHub -u ci --store-password-in-clear-text -p ${{ secrets.NUGET_API_TOKEN }}
     - name: Restore dependencies


### PR DESCRIPTION
This PR updates the GitHub workflow to run `cargo clippy` action in the `tools/slicec-cs` compiler target.