### PR TITLE
Validate cs:attributes

### DIFF
--- a/tools/slicec-cs/src/cs_validator.rs
+++ b/tools/slicec-cs/src/cs_validator.rs
@@ -62,6 +62,13 @@ fn validate_collection_attributes<T: Attributable>(attributable: &T) {
     }
 }
 
+fn validate_data_type_attributes(data_type: &TypeRef) {
+    match data_type.concrete_type() {
+        Types::Sequence(_) | Types::Dictionary(_) => validate_collection_attributes(data_type),
+        _ => report_typeref_unexpected_attributes(data_type),
+    }
+}
+
 fn report_typeref_unexpected_attributes<T: Attributable>(attributable: &T) {
     for attribute in &cs_attributes(attributable.attributes()) {
         report_unexpected_attribute(attribute);
@@ -159,38 +166,18 @@ impl Visitor for CsValidator {
     }
 
     fn visit_type_alias(&mut self, type_alias: &TypeAlias) {
-        match type_alias.underlying.concrete_type() {
-            Types::Sequence(_) | Types::Dictionary(_) => {
-                validate_collection_attributes(&type_alias.underlying)
-            }
-            _ => report_typeref_unexpected_attributes(&type_alias.underlying),
-        }
+        validate_data_type_attributes(&type_alias.underlying);
     }
 
     fn visit_data_member(&mut self, data_member: &DataMember) {
-        match data_member.data_type.concrete_type() {
-            Types::Sequence(_) | Types::Dictionary(_) => {
-                validate_collection_attributes(&data_member.data_type)
-            }
-            _ => report_typeref_unexpected_attributes(&data_member.data_type),
-        }
+        validate_data_type_attributes(&data_member.data_type);
     }
 
     fn visit_parameter(&mut self, parameter: &Parameter) {
-        match parameter.data_type.concrete_type() {
-            Types::Sequence(_) | Types::Dictionary(_) => {
-                validate_collection_attributes(&parameter.data_type)
-            }
-            _ => report_typeref_unexpected_attributes(&parameter.data_type),
-        }
+        validate_data_type_attributes(&parameter.data_type);
     }
 
     fn visit_return_member(&mut self, parameter: &Parameter) {
-        match parameter.data_type.concrete_type() {
-            Types::Sequence(_) | Types::Dictionary(_) => {
-                validate_collection_attributes(&parameter.data_type)
-            }
-            _ => report_typeref_unexpected_attributes(&parameter.data_type),
-        }
+        validate_data_type_attributes(&parameter.data_type);
     }
 }


### PR DESCRIPTION
This PR implements the CsValidator to handle the validation of attributes with `cs:` prefix, the attributes without prefix should be validated by `slicec` library in a separate validator.

There is a minor issue with the logic for validating `cs:generic` attributes, we validate those in the visitor methods for data members, type alias, arguments and return. This results in duplicate messages when the type alias is used. Not clear to me how to distinguish between collections defined as an alias and anonymous types.

