### PR TITLE
New slice free tests

### DIFF
--- a/tests/IceRpc.Tests.Api/SliceFreeTests.cs
+++ b/tests/IceRpc.Tests.Api/SliceFreeTests.cs
@@ -14,6 +14,7 @@ namespace IceRpc.Tests.Api
     [Parallelizable(scope: ParallelScope.All)]
     [Timeout(5000)]
     [Log(LogAttributeLevel.Information)]
+    [FixtureLifeCycle(LifeCycle.SingleInstance)]
     public sealed class SliceFreeTests : IAsyncDisposable
     {
         private const string _austin = "/austin";
@@ -52,7 +53,7 @@ namespace IceRpc.Tests.Api
             };
         }
 
-        // TODO: never called, what's the fix?
+        [OneTimeTearDown]
         public async ValueTask DisposeAsync()
         {
             await _connection.DisposeAsync();


### PR DESCRIPTION
This PR adds Slice-free tests to the API test category, i.e. a bunch of tests where the payload is not encoded using Slice.

Naturally more tests are needed, but the few tests in there show some shortcomings of our API.

Invocation and Proxy.InvokeAsync make be useful as opposed to creating an IncomingRequest directly (direct incoming request test missing).

Dispatch does not appear useful at all in a Slice-free context. It also can't be used since its constructor is internal.