### PR TITLE
Fix tests with new ReadAllAsync pipe reader extension

### DIFF
--- a/tests/IceRpc.Tests.Api/IceRpc.Tests.Api.csproj
+++ b/tests/IceRpc.Tests.Api/IceRpc.Tests.Api.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\TestHelper.cs" Link="TestHelper.cs" />
     <Compile Include="..\Shared\LogAttribute.cs" Link="LogAttribute.cs" />
+    <Compile Include="..\Shared\PipeReaderExtensions.cs" Link="PipeReaderExtensions.cs" />
     <Compile Update="generated\SliceDefinitions.cs">
       <SliceCompileSource>SliceDefinitions.ice</SliceCompileSource>
     </Compile>

--- a/tests/IceRpc.Tests.Api/InterceptorTests.cs
+++ b/tests/IceRpc.Tests.Api/InterceptorTests.cs
@@ -111,8 +111,7 @@ namespace IceRpc.Tests.Api
                 {
                     response = await next.InvokeAsync(request, cancel);
 
-                    ReadResult readResult = await response.Payload.ReadAsync(cancel);
-                    Assert.That(readResult.IsCompleted);
+                    ReadResult readResult = await response.Payload.ReadAllAsync(cancel);;
                     savedPayload = new ReadOnlySequence<byte>(readResult.Buffer.ToArray());
                     response.Payload.AdvanceTo(readResult.Buffer.End);
                 }

--- a/tests/IceRpc.Tests.Api/SliceFreeTests.cs
+++ b/tests/IceRpc.Tests.Api/SliceFreeTests.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Configure;
-using IceRpc.Slice;
 using NUnit.Framework;
 using System.IO.Pipelines;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace IceRpc.Tests.Api
 {
@@ -128,12 +125,7 @@ namespace IceRpc.Tests.Api
             PipeReader reader,
             CancellationToken cancel = default)
         {
-            ReadResult readResult;
-            do
-            {
-                readResult = await reader.ReadAsync(cancel);
-            }
-            while (!readResult.IsCompleted);
+            ReadResult readResult = await reader.ReadAllAsync(cancel);
 
             Assert.That(readResult.Buffer.IsSingleSegment); // very likely; if not, fix test
             return readResult.Buffer.First;

--- a/tests/IceRpc.Tests.ClientServer/IceRpc.Tests.ClientServer.csproj
+++ b/tests/IceRpc.Tests.ClientServer/IceRpc.Tests.ClientServer.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\TestHelper.cs" Link="TestHelper.cs" />
     <Compile Include="..\Shared\LogAttribute.cs" Link="LogAttribute.cs" />
+    <Compile Include="..\Shared\PipeReaderExtensions.cs" Link="PipeReaderExtensions.cs" />
     <Compile Update="generated\RetryTests.cs">
       <SliceCompileSource>RetryTests.ice</SliceCompileSource>
     </Compile>

--- a/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
@@ -183,14 +183,8 @@ namespace IceRpc.Tests.ClientServer
                     features = features.WithContext(incomingRequest.Features.GetContext());
                 }
 
-                ReadResult readResult = await incomingRequest.Payload.ReadAsync(cancel);
-                while (!readResult.IsCompleted)
-                {
-                    incomingRequest.Payload.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-                    readResult = await incomingRequest.Payload.ReadAsync(cancel);
-                }
-                var payload = new byte[readResult.Buffer.Length];
-                readResult.Buffer.CopyTo(payload);
+                ReadResult readResult = await incomingRequest.Payload.ReadAllAsync(cancel);
+                var payload = readResult.Buffer.ToArray();
 
                 var outgoingRequest = new OutgoingRequest(
                     targetProtocol,
@@ -216,14 +210,8 @@ namespace IceRpc.Tests.ClientServer
 
                 // Then create an outgoing response from the incoming response
 
-                readResult = await incomingResponse.Payload.ReadAsync(cancel);
-                while (!readResult.IsCompleted)
-                {
-                    incomingResponse.Payload.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-                    readResult = await incomingResponse.Payload.ReadAsync(cancel);
-                }
-                payload = new byte[readResult.Buffer.Length];
-                readResult.Buffer.CopyTo(payload);
+                readResult = await incomingResponse.Payload.ReadAllAsync(cancel);
+                payload = readResult.Buffer.ToArray();
 
                 return new OutgoingResponse(_target.Protocol, incomingResponse.ResultType)
                 {

--- a/tests/IceRpc.Tests.SliceInternal/ClassTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/ClassTests.cs
@@ -76,8 +76,7 @@ namespace IceRpc.Tests.SliceInternal
 
                 IncomingResponse response = await next.InvokeAsync(request, cancel);
 
-                ReadResult readResult = await response.Payload.ReadAsync(cancel);
-                Assert.That(readResult.IsCompleted);
+                ReadResult readResult = await response.Payload.ReadAllAsync(cancel);
                 Assert.That(readResult.Buffer.IsSingleSegment);
 
                 decoder = new Ice11Decoder(readResult.Buffer.First);
@@ -113,8 +112,7 @@ namespace IceRpc.Tests.SliceInternal
                 Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
                 IncomingResponse response = await next.InvokeAsync(request, cancel);
 
-                ReadResult readResult = await response.Payload.ReadAsync(cancel);
-                Assert.That(readResult.IsCompleted);
+                ReadResult readResult = await response.Payload.ReadAllAsync(cancel);
                 Assert.That(readResult.Buffer.IsSingleSegment);
 
                 decoder = new Ice11Decoder(readResult.Buffer.First);
@@ -150,8 +148,7 @@ namespace IceRpc.Tests.SliceInternal
                 Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
                 IncomingResponse response = await next.InvokeAsync(request, cancel);
 
-                ReadResult readResult = await response.Payload.ReadAsync(cancel);
-                Assert.That(readResult.IsCompleted);
+                ReadResult readResult = await response.Payload.ReadAllAsync(cancel);
                 Assert.That(readResult.Buffer.IsSingleSegment);
 
                 decoder = new Ice11Decoder(readResult.Buffer.First);
@@ -186,8 +183,7 @@ namespace IceRpc.Tests.SliceInternal
                 Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize));
                 IncomingResponse response = await next.InvokeAsync(request, cancel);
 
-                ReadResult readResult = await response.Payload.ReadAsync(cancel);
-                Assert.That(readResult.IsCompleted);
+                ReadResult readResult = await response.Payload.ReadAllAsync(cancel);
                 Assert.That(readResult.Buffer.IsSingleSegment);
 
                 decoder = new Ice11Decoder(readResult.Buffer.First);

--- a/tests/IceRpc.Tests.SliceInternal/IceRpc.Tests.SliceInternal.csproj
+++ b/tests/IceRpc.Tests.SliceInternal/IceRpc.Tests.SliceInternal.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\LogAttribute.cs" Link="LogAttribute.cs" />
     <Compile Include="..\Shared\TestHelper.cs" Link="TestHelper.cs" />
+    <Compile Include="..\Shared\PipeReaderExtensions.cs" Link="PipeReaderExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Shared/PipeReaderExtensions.cs
+++ b/tests/Shared/PipeReaderExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using System.IO.Pipelines;
+
+namespace IceRpc.Tests
+{
+    public static class PipeReaderExtensions
+    {
+        /// <summary>Reads a reader until it's completed or canceled.</summary>
+        public static async ValueTask<ReadResult> ReadAllAsync(this PipeReader reader, CancellationToken cancel)
+        {
+            while (true)
+            {
+                ReadResult readResult = await reader.ReadAsync(cancel);
+
+                if (readResult.IsCompleted || readResult.IsCanceled)
+                {
+                    return readResult;
+                }
+                else
+                {
+                    reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes sporadic failures in various tests by adding a new ReadAllAsync pipe reader extension in IceRpc.Test.