### PR TITLE
Fixed sporadic multiplexed stream test failure, fixes #693

### DIFF
--- a/src/IceRpc/Transports/SlicClientTransport.cs
+++ b/src/IceRpc/Transports/SlicClientTransport.cs
@@ -9,10 +9,11 @@ namespace IceRpc.Transports
     /// client transport.</summary>
     public class SlicClientTransport : IClientTransport<IMultiplexedNetworkConnection>
     {
+        private static readonly Func<ISlicFrameReader, ISlicFrameReader> _defaultSlicFrameReaderDecorator =
+            reader => reader;
+        private static readonly Func<ISlicFrameWriter, ISlicFrameWriter> _defaultSlicFrameWriterDecorator =
+            writer => writer;
         private readonly IClientTransport<ISimpleNetworkConnection> _simpleClientTransport;
-        private readonly Func<ISlicFrameReader, ISlicFrameReader> _slicFrameReaderDecorator;
-        private readonly Func<ISlicFrameWriter, ISlicFrameWriter> _slicFrameWriterDecorator;
-
         private readonly SlicOptions _slicOptions;
 
         /// <summary>Constructs a Slic client transport.</summary>
@@ -27,8 +28,6 @@ namespace IceRpc.Transports
             SlicOptions slicOptions)
         {
             _simpleClientTransport = simpleClientTransport;
-            _slicFrameReaderDecorator = reader => reader;
-            _slicFrameWriterDecorator = writer => writer;
             _slicOptions = slicOptions;
         }
 
@@ -42,8 +41,8 @@ namespace IceRpc.Transports
             ISimpleNetworkConnection simpleNetworkConnection =
                 _simpleClientTransport.CreateConnection(remoteEndpoint, logger);
 
-            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _slicFrameReaderDecorator;
-            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _slicFrameWriterDecorator;
+            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _defaultSlicFrameReaderDecorator;
+            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _defaultSlicFrameWriterDecorator;
 
             if (logger.IsEnabled(LogLevel.Error))
             {

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -12,10 +12,11 @@ namespace IceRpc.Transports
         /// <inheritdoc/>
         public Endpoint DefaultEndpoint => _simpleServerTransport.DefaultEndpoint;
 
+        private static readonly Func<ISlicFrameReader, ISlicFrameReader> _defaultSlicFrameReaderDecorator =
+            reader => reader;
+        private static readonly Func<ISlicFrameWriter, ISlicFrameWriter> _defaultSlicFrameWriterDecorator =
+            writer => writer;
         private readonly IServerTransport<ISimpleNetworkConnection> _simpleServerTransport;
-
-        private readonly Func<ISlicFrameReader, ISlicFrameReader> _slicFrameReaderDecorator;
-        private readonly Func<ISlicFrameWriter, ISlicFrameWriter> _slicFrameWriterDecorator;
         private readonly SlicOptions _slicOptions;
 
         /// <summary>Constructs a Slic server transport.</summary>
@@ -30,8 +31,6 @@ namespace IceRpc.Transports
             SlicOptions slicOptions)
         {
             _simpleServerTransport = simpleServerTransport;
-            _slicFrameReaderDecorator = reader => reader;
-            _slicFrameWriterDecorator = writer => writer;
             _slicOptions = slicOptions;
         }
 
@@ -44,8 +43,8 @@ namespace IceRpc.Transports
 
             IListener<ISimpleNetworkConnection> simpleListener = _simpleServerTransport.Listen(endpoint, logger);
 
-            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _slicFrameReaderDecorator;
-            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _slicFrameWriterDecorator;
+            Func<ISlicFrameReader, ISlicFrameReader> slicFrameReaderDecorator = _defaultSlicFrameReaderDecorator;
+            Func<ISlicFrameWriter, ISlicFrameWriter> slicFrameWriterDecorator = _defaultSlicFrameWriterDecorator;
 
             if (logger.IsEnabled(LogLevel.Error))
             {


### PR DESCRIPTION
This PR fixes #693. The `MultiplexedStream_StreamSendReceiveAsync` was too slow and triggered the 5s timeout. The allocations of multiple 1KB arrays for the comparison was the bottleneck. The test now directly compares the readonly memory content.

The PR also contains a minor fix for the default Slic reader/writer.