### PR TITLE
Remove fragment from icerpc requests

### DIFF
--- a/slice/IceRpc/Internal/IceRpcDefinitions.ice
+++ b/slice/IceRpc/Internal/IceRpcDefinitions.ice
@@ -40,7 +40,6 @@ module IceRpc::Internal
     struct IceRpcRequestHeader
     {
         path: string,
-        fragment: string,
         operation: string,
         \idempotent: bool,
         deadline: varlong,

--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -4,7 +4,7 @@ using System.IO.Pipelines;
 
 namespace IceRpc
 {
-    /// <summary>Represents a request protocol frame received by the application.</summary>
+    /// <summary>Represents a request frame received by the application.</summary>
     public sealed class IncomingRequest : IncomingFrame
     {
         /// <summary>The deadline corresponds to the request's expiration time. Once the deadline is reached, the
@@ -15,7 +15,7 @@ namespace IceRpc
         /// on the server-side even though the invocation timeout is usually not infinite.</summary>
         public DateTime Deadline { get; init; }
 
-        /// <summary>The fragment of the target service.</summary>
+        /// <summary>The fragment of the target service. It's always empty with the icerpc protocol.</summary>
         public string Fragment { get; init; }
 
         /// <summary>When <c>true</c>, the operation is idempotent.</summary>

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -152,7 +152,7 @@ namespace IceRpc.Internal
                 var request = new IncomingRequest(
                     Protocol.IceRpc,
                     path: header.Path,
-                    fragment: header.Fragment,
+                    fragment: "", // no fragment with icerpc
                     operation: header.Operation,
                     payload: reader,
                     payloadEncoding: header.PayloadEncoding.Length > 0 ?
@@ -290,6 +290,11 @@ namespace IceRpc.Internal
         /// <inheritdoc/>
         public async Task SendRequestAsync(OutgoingRequest request, CancellationToken cancel)
         {
+            if (request.Fragment.Length > 0)
+            {
+                throw new NotSupportedException("the icerpc protocol does not support fragments");
+            }
+
             IMultiplexedStream stream;
             MultiplexedStreamPipeWriter? requestWriter = null;
             try
@@ -360,7 +365,6 @@ namespace IceRpc.Internal
 
                 var header = new IceRpcRequestHeader(
                     request.Path,
-                    request.Fragment,
                     request.Operation,
                     request.IsIdempotent,
                     deadline,


### PR DESCRIPTION
This tiny PR removes fragments from icerpc requests.

I did not update the URI parsing as it depends on what we decide to do for URI parsing and the external representation of proxies. We currently use the same parsing for all URI schemes - there is no "if ice / if icerpc / if unknown-scheme".

The IceProxyFormat is not affected since it parses only protocol=ice proxies.