### PR TITLE
Simplify certificate validation callback

### DIFF
--- a/src/IceRpc/CertificateValidation.cs
+++ b/src/IceRpc/CertificateValidation.cs
@@ -74,7 +74,6 @@ namespace IceRpc
                     chain = new X509Chain(useMachineContext);
                     try
                     {
-                        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
                         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                         chain.ChainPolicy.DisableCertificateDownloads = true;
                         if (certificateAuthorities != null)


### PR DESCRIPTION
This PR simplifies the certificate validation callback by using the new `CustomTrustStore` chain property added in .NET 5