### PR TITLE
Add ProxyParams checking

### DIFF
--- a/src/IceRpc/Internal/IceProtocol.cs
+++ b/src/IceRpc/Internal/IceProtocol.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Slice;
 using IceRpc.Transports;
+using System.Collections.Immutable;
 
 namespace IceRpc.Internal
 {
@@ -22,7 +23,7 @@ namespace IceRpc.Internal
             new IceProtocolConnectionFactory();
 
         /// <summary>Checks if this absolute path holds a valid identity.</summary>
-        internal override void CheckUriPath(string uriPath)
+        internal override void CheckPath(string uriPath)
         {
             string workingPath = uriPath[1..]; // removes leading /.
             int firstSlash = workingPath.IndexOf('/', StringComparison.Ordinal);
@@ -45,6 +46,26 @@ namespace IceRpc.Internal
             if (escapedName.Length == 0)
             {
                 throw new FormatException($"invalid empty identity name in path '{uriPath}'");
+            }
+        }
+
+        /// <summary>Checks if the proxy parameters are valid. The only valid parameter is adapter-id with a non-empty
+        /// value.</summary>
+        internal override void CheckProxyParams(ImmutableDictionary<string, string> proxyParams)
+        {
+            foreach ((string name, string value) in proxyParams)
+            {
+                if (name == "adapter-id")
+                {
+                    if (value.Length == 0)
+                    {
+                        throw new FormatException("the value of the adapter-id parameter cannot be empty");
+                    }
+                }
+                else
+                {
+                    throw new FormatException($"'{name}' is not a valid ice proxy parameter");
+                }
             }
         }
 

--- a/src/IceRpc/Protocol.cs
+++ b/src/IceRpc/Protocol.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Internal;
 using IceRpc.Slice;
+using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace IceRpc
@@ -98,12 +99,21 @@ namespace IceRpc
             _ => throw new NotSupportedException($"cannot convert '{protocolMajor}.0' into a protocol")
         };
 
-        /// <summary>Checks if a URI absolute path is valid for this protocol.</summary>
+        /// <summary>Checks if a path is valid for this protocol.</summary>
         /// <param name="uriPath">The absolute path to check. The caller guarantees it's a valid URI absolute path.
         /// </param>
         /// <exception cref="FormatException">Thrown if the path is not valid.</exception>
-        internal virtual void CheckUriPath(string uriPath) =>
+        internal virtual void CheckPath(string uriPath) =>
             // by default, any URI absolute path is ok
+            Debug.Assert(IsSupported || this == Relative);
+
+        /// <summary>Checks if these proxy parameters are valid for this protocol.</summary>
+        /// <param name="proxyParams">The proxy parameters to check.</param>
+        /// <exception cref="FormatException">Thrown if the proxy parameters are not valid.</exception>
+        /// <remarks>This method does not and should not check if the parameter names and values are properly escaped;
+        /// it does not check for the invalid empty and alt-endpoint parameter names either.</remarks>
+        internal virtual void CheckProxyParams(ImmutableDictionary<string, string> proxyParams) =>
+            // by default, any dictionary is ok
             Debug.Assert(IsSupported || this == Relative);
 
         internal byte ToByte() => Name switch

--- a/src/IceRpc/Proxy.cs
+++ b/src/IceRpc/Proxy.cs
@@ -161,7 +161,7 @@ namespace IceRpc
                     try
                     {
                         CheckPath(value); // make sure it's properly escaped
-                        Protocol.CheckUriPath(value); // make sure the protocol is happy with this path
+                        Protocol.CheckPath(value); // make sure the protocol is happy with this path
                     }
                     catch (FormatException ex)
                     {
@@ -187,7 +187,8 @@ namespace IceRpc
 
                 try
                 {
-                    CheckParams(value);
+                    CheckParams(value); // general checking (properly escape, no empty name)
+                    Protocol.CheckProxyParams(value); // protocol-specific checking
                 }
                 catch (FormatException ex)
                 {
@@ -288,7 +289,7 @@ namespace IceRpc
 
                 if (Protocol.IsSupported)
                 {
-                    Protocol.CheckUriPath(_path);
+                    Protocol.CheckPath(_path);
                     if (!Protocol.HasFragment && _fragment.Length > 0)
                     {
                         throw new ArgumentException($"cannot create an {Protocol} proxy with a fragment", nameof(uri));
@@ -348,6 +349,7 @@ namespace IceRpc
                             throw new FormatException($"invalid alt-endpoint parameter in URI '{uri.OriginalString}'");
                         }
 
+                        Protocol.CheckProxyParams(queryParams);
                         Params = queryParams;
                     }
                 }

--- a/tests/IceRpc.Tests.Api/ProxyTests.cs
+++ b/tests/IceRpc.Tests.Api/ProxyTests.cs
@@ -151,10 +151,20 @@ namespace IceRpc.Tests.Api
                 proxy.Endpoint = new Endpoint(proxy.Protocol, "localhost");
 
                 proxy.Params = ImmutableDictionary<string, string>.Empty; // always ok
-                Assert.Throws<InvalidOperationException>(() => proxy.Params = proxy.Params.Add("name", "value"));
+                if (proxy.Protocol != Protocol.Ice)
+                {
+                    Assert.Throws<InvalidOperationException>(() => proxy.Params = proxy.Params.Add("name", "value"));
+                }
 
                 proxy.Endpoint = null;
-                proxy.Params = proxy.Params.Add("name", "value");
+
+                proxy.Params = proxy.Params.Add("adapter-id", "value");
+
+                if (proxy.Protocol == Protocol.Ice)
+                {
+                    Assert.Throws<ArgumentException>(() => proxy.Params = proxy.Params.SetItem("adapter-id", ""));
+                }
+
                 Assert.Throws<InvalidOperationException>(
                     () => proxy.Endpoint = new Endpoint(proxy.Protocol, "localhost"));
             }
@@ -256,6 +266,7 @@ namespace IceRpc.Tests.Api
         [TestCase("ice://host.zeroc.com/identity#%24%23f", "/identity", "%24%23f")]
         [TestCase("ice://host.zeroc.com/identity?tls=false")]
         [TestCase("ice://host.zeroc.com/identity?tls=true")]
+        [TestCase("ice:/path?adapter-id=foo")]
         [TestCase("icerpc://host.zeroc.com:1000/category/name")]
         [TestCase("icerpc://host.zeroc.com:1000/loc0/loc1/category/name")]
         [TestCase("icerpc://host.zeroc.com/category/name%20with%20space", "/category/name%20with%20space")]
@@ -325,13 +336,16 @@ namespace IceRpc.Tests.Api
         [TestCase("icerpc://host/path?alt-endpoint=")] // alt-endpoint authority cannot be empty
         [TestCase("icerpc://host/path?alt-endpoint=/foo")] // alt-endpoint cannot have a path
         [TestCase("icerpc://host/path?alt-endpoint=icerpc://host")] // alt-endpoint cannot have a scheme
-        [TestCase("icerpc:path")] // bad path
-        [TestCase("icerpc:/host/path#fragment")] // bad fragment
-        [TestCase("icerpc:/path#fragment")]      // bad fragment
-        [TestCase("icerpc://user@host/path")]    // bad user info
-        [TestCase("ice://host/s1/s2/s3")]        // too many slashes in path
-        [TestCase("ice://host/cat/")]            // empty identity name
-        [TestCase("ice://host/")]                // empty identity name
+        [TestCase("icerpc:path")]                  // bad path
+        [TestCase("icerpc:/host/path#fragment")]   // bad fragment
+        [TestCase("icerpc:/path#fragment")]        // bad fragment
+        [TestCase("icerpc://user@host/path")]      // bad user info
+        [TestCase("ice://host/s1/s2/s3")]          // too many slashes in path
+        [TestCase("ice://host/cat/")]              // empty identity name
+        [TestCase("ice://host/")]                  // empty identity name
+        [TestCase("ice:/path?alt-endpoint=foo")]   // alt-endpoint proxy parameter
+        [TestCase("ice:/path?adapter-id")]         // empty adapter-id
+        [TestCase("ice:/path?adapter-id=foo&foo")] // extra parameter
         public void Proxy_Parse_InvalidUriInput(string str)
         {
             Assert.Catch<FormatException>(() => Proxy.Parse(str));


### PR DESCRIPTION
This PR adds proxy parameter checks, that is, it makes sure that ice endpointless proxies have at most one parameter, `adapter-id`, with a non-empty value.