### PR TITLE
Updated tests to replace `Assert.AreEqual` to `Assert.That`

### DIFF
--- a/tests/IceRpc.Tests.SliceInternal/BuiltInTypesSequencesTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/BuiltInTypesSequencesTests.cs
@@ -34,8 +34,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             bool[] r1 = decoder.DecodeSequence<bool>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -48,8 +48,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             byte[] r1 = decoder.DecodeSequence<byte>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -62,8 +62,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             short[] r1 = decoder.DecodeSequence<short>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -76,8 +76,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             int[] r1 = decoder.DecodeSequence<int>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -90,8 +90,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeSequenceWithBitSequence(p1, (ref IceEncoder encoder, int v) => encoder.EncodeInt(v));
             int[] r1 = decoder.DecodeSequenceWithBitSequence((ref IceDecoder decoder) => decoder.DecodeInt());
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -104,8 +104,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             long[] r1 = decoder.DecodeSequence<long>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -118,8 +118,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             float[] r1 = decoder.DecodeSequence<float>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -132,8 +132,8 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeArray(p1);
             double[] r1 = decoder.DecodeSequence<double>();
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
 
         [TestCase(0)]
@@ -148,8 +148,8 @@ namespace IceRpc.Tests.SliceInternal
                 (ref IceEncoder encoder, string value) => encoder.EncodeString(value));
             IEnumerable<string> r1 = decoder.DecodeSequence(1, (ref IceDecoder decoder) => decoder.DecodeString());
 
-            CollectionAssert.AreEqual(p1, r1);
-            Assert.AreEqual(decoder.Consumed, _bufferWriter.WrittenBuffer.Length);
+            Assert.That(p1, Is.EqualTo(r1));
+            Assert.That(decoder.Consumed, Is.EqualTo(_bufferWriter.WrittenBuffer.Length));
         }
     }
 }

--- a/tests/IceRpc.Tests.SliceInternal/BuiltInTypesTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/BuiltInTypesTests.cs
@@ -34,9 +34,10 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeBool(p1);
             bool r1 = decoder.DecodeBool();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(bool)));
-            Assert.AreEqual(sizeof(bool), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(bool)));
+
         }
 
         [TestCase(byte.MinValue)]
@@ -49,9 +50,9 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeByte(p1);
             byte r1 = decoder.DecodeByte();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(byte)));
-            Assert.AreEqual(sizeof(byte), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(byte)));
         }
 
         [TestCase(short.MinValue)]
@@ -64,9 +65,9 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeShort(p1);
             short r1 = decoder.DecodeShort();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(short)));
-            Assert.AreEqual(sizeof(short), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(short)));
         }
 
         [TestCase(ushort.MinValue)]
@@ -78,9 +79,9 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeUShort(p1);
             ushort r1 = decoder.DecodeUShort();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(ushort)));
-            Assert.AreEqual(sizeof(ushort), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(ushort)));
         }
 
         [TestCase(int.MinValue)]
@@ -93,9 +94,9 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeInt(p1);
             int r1 = decoder.DecodeInt();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(int)));
-            Assert.AreEqual(sizeof(int), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(int)));
         }
 
         [TestCase(uint.MinValue)]
@@ -108,7 +109,7 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeUInt(p1);
             uint r1 = decoder.DecodeUInt();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(uint)));
         }
 
@@ -122,9 +123,9 @@ namespace IceRpc.Tests.SliceInternal
 
             long r1 = decoder.DecodeLong();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(long)));
-            Assert.AreEqual(sizeof(long), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(long)));
         }
 
         [TestCase(ulong.MinValue)]
@@ -136,7 +137,7 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeULong(p1);
             ulong r1 = decoder.DecodeULong();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(ulong)));
         }
 
@@ -149,7 +150,7 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeVarULong(p1);
             ulong r1 = decoder.DecodeVarULong();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
         }
 
         [TestCase(IceEncoder.VarLongMinValue)]
@@ -161,7 +162,7 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeVarLong(p1);
             long r1 = decoder.DecodeVarLong();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
         }
 
         [TestCase(float.MinValue)]
@@ -174,9 +175,9 @@ namespace IceRpc.Tests.SliceInternal
             encoder.EncodeFloat(p1);
             float r1 = decoder.DecodeFloat();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(float)));
-            Assert.AreEqual(sizeof(float), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(float)));
         }
 
         [TestCase(double.MinValue)]
@@ -190,9 +191,9 @@ namespace IceRpc.Tests.SliceInternal
 
             double r1 = decoder.DecodeDouble();
 
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
             Assert.That(_bufferWriter.WrittenBuffer.Length, Is.EqualTo(sizeof(double)));
-            Assert.AreEqual(sizeof(double), decoder.Consumed);
+            Assert.That(decoder.Consumed, Is.EqualTo(sizeof(double)));
         }
 
         [TestCase("")]
@@ -208,7 +209,7 @@ namespace IceRpc.Tests.SliceInternal
             // simple test
             encoder.EncodeString(p1);
             string r1 = decoder.DecodeString();
-            Assert.AreEqual(p1, r1);
+            Assert.That(p1, Is.EqualTo(r1));
 
             if (p1.Length > 0)
             {
@@ -232,7 +233,7 @@ namespace IceRpc.Tests.SliceInternal
                 for (int i = 0; i < 20; ++i)
                 {
                     r1 = decoder.DecodeString();
-                    Assert.AreEqual(p1, r1);
+                    Assert.That(p1, Is.EqualTo(r1));
                 }
                 pipe.Reader.AdvanceTo(readResult.Buffer.End);
             }

--- a/tests/IceRpc.Tests.SliceInternal/ClassTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/ClassTests.cs
@@ -70,10 +70,10 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice includes a size for the sliced format
-                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize));
+                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.True);
                 }
 
                 static void DecodeAfter(ReadOnlySequence<byte> data)
@@ -84,10 +84,10 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice includes a size for the sliced format
-                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize));
+                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.True);
                 }
             }));
             await prx1.OpMyClassAsync(new MyClassCustomFormat("foo"));
@@ -113,7 +113,7 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice does not include a size when using the compact format
                     Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
@@ -127,7 +127,7 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice does not include a size when using the compact format
                     Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
@@ -156,7 +156,7 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice does not include a size when using the compact format
                     Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
@@ -170,7 +170,7 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice does not include a size when using the compact format
                     Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.False);
@@ -200,10 +200,10 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice includes a size for the sliced format
-                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize));
+                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.True);
                 }
 
                 static void DecodeAfter(ReadOnlySequence<byte> data)
@@ -214,10 +214,10 @@ namespace IceRpc.Tests.SliceInternal
                     decoder.Skip(4);
 
                     // Read the instance marker
-                    Assert.AreEqual(1, decoder.DecodeSize());
+                    Assert.That(decoder.DecodeSize(), Is.EqualTo(1));
                     var sliceFlags = (SliceFlags)decoder.DecodeByte();
                     // The Slice includes a size for the sliced format
-                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize));
+                    Assert.That(sliceFlags.HasFlag(SliceFlags.HasSliceSize), Is.True);
                 }
             }));
             await prx3.OpMyClassSlicedFormatAsync(new MyClassCustomFormat("foo"));

--- a/tests/IceRpc.Tests.SliceInternal/ProxyTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/ProxyTests.cs
@@ -29,7 +29,7 @@ namespace IceRpc.Tests.SliceInternal
             await using var connection = new Connection();
 
             Proxy proxy2 = DecodeProxy();
-            Assert.AreEqual(proxy, proxy2);
+            Assert.That(proxy, Is.EqualTo(proxy2));
 
             void EncodeProxy()
             {
@@ -64,8 +64,8 @@ namespace IceRpc.Tests.SliceInternal
 
             Proxy proxy1 = DecodeProxy();
 
-            Assert.AreEqual(regular.Connection, proxy1.Connection);
-            Assert.AreEqual(proxy1.Endpoint, regular.Connection!.RemoteEndpoint);
+            Assert.That(regular.Connection, Is.EqualTo(proxy1.Connection));
+            Assert.That(proxy1.Endpoint, Is.EqualTo(regular.Connection!.RemoteEndpoint));
 
             void EncodeProxy()
             {

--- a/tests/IceRpc.Tests.SliceInternal/SlicingTests.cs
+++ b/tests/IceRpc.Tests.SliceInternal/SlicingTests.cs
@@ -50,9 +50,9 @@ namespace IceRpc.Tests.SliceInternal
             // First we unmarshal the class using the factory that know all the types, no Slicing should occur in this case.
             var decoder = new IceDecoder(buffer, Encoding.Slice11, activator: activator);
             MyMostDerivedClass r = decoder.DecodeClass<MyMostDerivedClass>();
-            Assert.AreEqual(p1.M1, r.M1);
-            Assert.AreEqual(p1.M2, r.M2);
-            Assert.AreEqual(p1.M3, r.M3);
+            Assert.That(p1.M1, Is.EqualTo(r.M1));
+            Assert.That(p1.M2, Is.EqualTo(r.M2));
+            Assert.That(p1.M3, Is.EqualTo(r.M3));
 
             // Create an activator that exclude 'MyMostDerivedClass' type ID and ensure that the class is unmarshaled as
             // 'MyDerivedClass' which is the base type.
@@ -69,8 +69,8 @@ namespace IceRpc.Tests.SliceInternal
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: slicingActivator);
             MyDerivedClass r1 = decoder.DecodeClass<MyDerivedClass>();
             Assert.That(r1.UnknownSlices, Is.Empty);
-            Assert.AreEqual(p1.M1, r1.M1);
-            Assert.AreEqual(p1.M2, r1.M2);
+            Assert.That(p1.M1, Is.EqualTo(r1.M1));
+            Assert.That(p1.M2, Is.EqualTo(r1.M2));
 
             // Repeat with an activator that also excludes 'MyDerivedClass' type ID
             slicingActivator = new SlicingActivator(
@@ -86,7 +86,7 @@ namespace IceRpc.Tests.SliceInternal
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: slicingActivator);
             MyBaseClass r2 = decoder.DecodeClass<MyBaseClass>();
             Assert.That(r2.UnknownSlices, Is.Empty);
-            Assert.AreEqual(p1.M1, r2.M1);
+            Assert.That(p1.M1, Is.EqualTo(r2.M1));
 
             // Repeat with an activator that also excludes 'MyBaseClass' type ID
             slicingActivator = new SlicingActivator(
@@ -131,9 +131,9 @@ namespace IceRpc.Tests.SliceInternal
             // First we unmarshal the class using the default factories, no Slicing should occur in this case.
             var decoder = new IceDecoder(buffer, Encoding.Slice11, activator: activator);
             MyCompactMostDerivedClass r = decoder.DecodeClass<MyCompactMostDerivedClass>();
-            Assert.AreEqual(p1.M1, r.M1);
-            Assert.AreEqual(p1.M2, r.M2);
-            Assert.AreEqual(p1.M3, r.M3);
+            Assert.That(p1.M1, Is.EqualTo(r.M1));
+            Assert.That(p1.M2, Is.EqualTo(r.M2));
+            Assert.That(p1.M3, Is.EqualTo(r.M3));
 
             // Create an activator that exclude 'MyCompactMostDerivedClass' compact type ID (3) and ensure that
             // the class is unmarshaled as 'MyCompactDerivedClass' which is the base type.
@@ -150,8 +150,8 @@ namespace IceRpc.Tests.SliceInternal
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: slicingActivator);
             MyCompactDerivedClass r1 = decoder.DecodeClass<MyCompactDerivedClass>();
             Assert.That(r1.UnknownSlices, Is.Empty);
-            Assert.AreEqual(p1.M1, r1.M1);
-            Assert.AreEqual(p1.M2, r1.M2);
+            Assert.That(p1.M1, Is.EqualTo(r1.M1));
+            Assert.That(p1.M2, Is.EqualTo(r1.M2));
 
             // Repeat with an activator that also excludes 'MyCompactDerivedClass' compact type ID (2)
             slicingActivator = slicingActivator = new SlicingActivator(
@@ -167,7 +167,7 @@ namespace IceRpc.Tests.SliceInternal
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: slicingActivator);
             MyCompactBaseClass r2 = decoder.DecodeClass<MyCompactBaseClass>();
             Assert.That(r2.UnknownSlices, Is.Empty);
-            Assert.AreEqual(p1.M1, r2.M1);
+            Assert.That(p1.M1, Is.EqualTo(r2.M1));
 
             // Repeat with an activator that also excludes 'MyCompactBaseClass' compact type ID (1)
             slicingActivator = slicingActivator = new SlicingActivator(
@@ -211,9 +211,9 @@ namespace IceRpc.Tests.SliceInternal
             RemoteException r = decoder.DecodeException();
             Assert.That(r, Is.InstanceOf<MyMostDerivedException>());
             var r1 = (MyMostDerivedException)r;
-            Assert.AreEqual(p1.M1, r1.M1);
-            Assert.AreEqual(p1.M2, r1.M2);
-            Assert.AreEqual(p1.M3, r1.M3);
+            Assert.That(p1.M1, Is.EqualTo(r1.M1));
+            Assert.That(p1.M2, Is.EqualTo(r1.M2));
+            Assert.That(p1.M3, Is.EqualTo(r1.M3));
 
             // Create an activator that exclude 'MyMostDerivedException' type ID and ensure that the class is unmarshaled
             // as 'MyDerivedException' which is the base type.
@@ -227,8 +227,8 @@ namespace IceRpc.Tests.SliceInternal
             Assert.That(r, Is.InstanceOf<MyDerivedException>());
             Assert.That(r, Is.Not.InstanceOf<MyMostDerivedException>());
             var r2 = (MyDerivedException)r;
-            Assert.AreEqual(p1.M1, r2.M1);
-            Assert.AreEqual(p1.M2, r2.M2);
+            Assert.That(p1.M1, Is.EqualTo(r2.M1));
+            Assert.That(p1.M2, Is.EqualTo(r2.M2));
 
             // Repeat with an activator that also excludes 'MyDerivedException' type ID
             slicingActivator = new SlicingActivator(
@@ -242,7 +242,7 @@ namespace IceRpc.Tests.SliceInternal
             Assert.That(r, Is.Not.InstanceOf<MyDerivedException>());
             Assert.That(r, Is.InstanceOf<MyBaseException>());
             var r3 = (MyBaseException)r;
-            Assert.AreEqual(p1.M1, r3.M1);
+            Assert.That(p1.M1, Is.EqualTo(r3.M1));
 
             // Repeat with an activator that also excludes 'MyBaseException' type ID
             slicingActivator = new SlicingActivator(
@@ -256,8 +256,7 @@ namespace IceRpc.Tests.SliceInternal
             r = decoder.DecodeException();
             Assert.That(r, Is.Not.InstanceOf<MyBaseException>());
             Assert.That(r, Is.InstanceOf<UnknownSlicedRemoteException>());
-            Assert.AreEqual("::IceRpc::Tests::SliceInternal::MyMostDerivedException",
-                            ((UnknownSlicedRemoteException)r).TypeId);
+            Assert.That(((UnknownSlicedRemoteException)r).TypeId, Is.EqualTo("::IceRpc::Tests::SliceInternal::MyMostDerivedException"));
 
             // Marshal the exception again -- there is no Slice preservation for exceptions
             buffer = new byte[1024 * 1024];
@@ -314,13 +313,13 @@ namespace IceRpc.Tests.SliceInternal
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: activator);
             MyPreservedDerivedClass1 r2 = decoder.DecodeClass<MyPreservedDerivedClass1>();
             Assert.That(r2.UnknownSlices, Is.Empty);
-            Assert.AreEqual("p1-m1", r2.M1);
-            Assert.AreEqual("p1-m2", r2.M2);
+            Assert.That(r2.M1, Is.EqualTo("p1-m1"));
+            Assert.That(r2.M2, Is.EqualTo("p1-m2"));
             Assert.That(r2.M3, Is.InstanceOf<MyPreservedDerivedClass1>());
             var r3 = (MyPreservedDerivedClass1)r2.M3;
-            Assert.AreEqual("p2-m1", r3.M1);
-            Assert.AreEqual("p2-m2", r3.M2);
-            Assert.AreEqual("base", r3.M3.M1);
+            Assert.That(r3.M1, Is.EqualTo("p2-m1"));
+            Assert.That(r3.M2, Is.EqualTo("p2-m2"));
+            Assert.That(r3.M3.M1, Is.EqualTo("base"));
         }
 
         [Test]
@@ -363,13 +362,13 @@ namespace IceRpc.Tests.SliceInternal
             // unmarshal again using the default factory, the unmarshaled class should contain the preserved Slices.
             decoder = new IceDecoder(buffer, Encoding.Slice11, activator: activator);
             MyPreservedDerivedClass2 r2 = decoder.DecodeClass<MyPreservedDerivedClass2>();
-            Assert.AreEqual("p1-m1", r2.M1);
-            Assert.AreEqual("p1-m2", r2.M2);
+            Assert.That(r2.M1, Is.EqualTo("p1-m1"));
+            Assert.That(r2.M2, Is.EqualTo("p1-m2"));
             Assert.That(r2.M3, Is.InstanceOf<MyPreservedDerivedClass2>());
             var r3 = (MyPreservedDerivedClass2)r2.M3;
-            Assert.AreEqual("p2-m1", r3.M1);
-            Assert.AreEqual("p2-m2", r3.M2);
-            Assert.AreEqual("base", r3.M3.M1);
+            Assert.That(r3.M1, Is.EqualTo("p2-m1"));
+            Assert.That(r3.M2, Is.EqualTo("p2-m2"));
+            Assert.That(r3.M3.M1, Is.EqualTo("base"));
         }
     }
 }


### PR DESCRIPTION
Updated the encoding and decoding tests to use `Assert.That` in place of `Assert.AreEqual`. 