### PR TITLE
encode_sequence cleanup

### DIFF
--- a/tools/slicec-cs/src/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/dispatch_visitor.rs
@@ -363,7 +363,11 @@ pub fn response_encode_action(operation: &Operation) -> CodeBlock {
         && returns.first().unwrap().tag.is_none();
 
     if use_default_encode_action {
-        encode_action(returns.first().unwrap().data_type(), namespace, true, true)
+        encode_action(
+            returns.first().unwrap().data_type(),
+            TypeContext::Outgoing,
+            namespace,
+        )
     } else {
         format!(
             "\
@@ -611,7 +615,8 @@ fn payload_source_stream(operation: &Operation, encoding: &str) -> CodeBlock {
                         stream_type.to_type_string(namespace, TypeContext::Outgoing, false),
                     stream_arg = stream_arg,
                     encoding = encoding,
-                    encode_action = encode_action(stream_type, namespace, false, false).indent(),
+                    encode_action =
+                        encode_action(stream_type, TypeContext::Outgoing, namespace).indent(),
                 )
                 .into(),
             }

--- a/tools/slicec-cs/src/proxy_visitor.rs
+++ b/tools/slicec-cs/src/proxy_visitor.rs
@@ -312,7 +312,8 @@ if ({invocation}?.RequestFeatures.Get<IceRpc.Features.CompressPayload>() == null
                 stream_type = stream_type.to_type_string(namespace, TypeContext::Outgoing, false),
                 stream_parameter = stream_parameter_name,
                 payload_encoding = payload_encoding,
-                encode_action = encode_action(stream_type, namespace, true, true).indent()
+                encode_action =
+                    encode_action(stream_type, TypeContext::Outgoing, namespace).indent()
             )),
         }
     } else {
@@ -600,7 +601,11 @@ fn request_encode_action(operation: &Operation) -> CodeBlock {
         && get_bit_sequence_size(&params) == 0
         && params.first().unwrap().tag.is_none()
     {
-        encode_action(params.first().unwrap().data_type(), &namespace, true, true)
+        encode_action(
+            params.first().unwrap().data_type(),
+            TypeContext::Outgoing,
+            &namespace,
+        )
     } else {
         format!(
             "\


### PR DESCRIPTION
This is a small simplification for `encode_sequence` and `encode_action` to use TypeContext instead of is_param/is_readonly bool parameters.