### PR TITLE
Stack overflow during trait decoding

### DIFF
--- a/tests/IceRpc.Tests.Slice/TraitTests.cs
+++ b/tests/IceRpc.Tests.Slice/TraitTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using IceRpc.Slice;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using System.IO.Pipelines;
 
 namespace IceRpc.Tests.Slice
 {
@@ -59,6 +61,34 @@ namespace IceRpc.Tests.Slice
 
             Assert.That(await _prx.OpConvertToAAsync(tsb), Is.Null);
             Assert.That(await _prx.OpConvertToAAsync(tsab), Is.AssignableTo(typeof(IMyTraitA)));
+        }
+
+        [TestCase(3000)]
+        public async Task Trait_DecodeStackOverflow(int depth)
+        {
+            var request = new OutgoingRequest(_prx.Proxy, "opNestedTraitStruct")
+            {
+                PayloadSource = CreatePayload(),
+                PayloadEncoding = Encoding.Slice20
+            };
+
+            _ = await Proxy.DefaultInvoker.InvokeAsync(request);
+
+            // Constructs a payload that creates a stack overflow during decoding. We're targetting opNestedTraitStruct.
+            PipeReader CreatePayload()
+            {
+                string typeId = typeof(NestedTraitStruct).GetIceTypeId()!;
+
+                var pipe = new Pipe();
+                var encoder = new IceEncoder(pipe.Writer, Encoding.Slice20);
+                encoder.EncodeSize((typeId.Length + 1) * depth); // the payload size, in bytes
+                for (int i = 0; i < depth; ++i)
+                {
+                    encoder.EncodeString(typeId);
+                }
+                pipe.Writer.Complete();
+                return pipe.Reader;
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds a new test that shows that our trait decoding code is vulnerable: a sender can craft a malicious payload that creates a stack overflow during decoding. 

As this test demonstrates, the only things the attacker needs is:
 - a struct that holds a trait, and 
 - an operation that accepts this struct. 

The struct in question does not implement any trait in the server. This does not matter. The attacker crafts a message that pretends the struct implements the trait it holds. Our recursive decoding defers the type-checking until everything is read/decoded:
```
            string typeId = DecodeString();
            ITrait? trait = _activator?.CreateInstance(typeId, ref this) as ITrait; // full recursive decoding here
            if (trait is T result)
            {
                return result;
            }
```

which means the stack overflows before any type checking.

(on a side note, trait should be an `object?` not an `ITrait?` in the code above)

This shows that we should replace ClassContext.ClassGraphMaxDepth by a more generic property such as IceDecoder.MaxDepth, that limits the depth of any recursive decoding.

Running this test results in a process crash, not an exception:
```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
   at System.Buffers.SequenceReader`1[[System.Byte, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].get_CurrentSpan()
   at System.Buffers.SequenceReader`1[[System.Byte, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].TryPeek(Byte ByRef)
   at IceRpc.Slice.IceDecoder.PeekByte()
   at IceRpc.Slice.IceDecoder.DecodeVarULong()
   at IceRpc.Slice.IceDecoder.DecodeSize()
   at IceRpc.Slice.IceDecoder.DecodeString()
   at IceRpc.Slice.IceDecoder.DecodeTrait[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]()
   at IceRpc.Tests.Slice.NestedTraitStruct..ctor(IceRpc.Slice.IceDecoder ByRef)
   at DynamicClass.lambda_method45(System.Runtime.CompilerServices.Closure, IceRpc.Slice.IceDecoder ByRef)
   at IceRpc.Slice.Internal.Activator.IceRpc.Slice.IActivator.CreateInstance(System.String, IceRpc.Slice.IceDecoder ByRef)
   at IceRpc.Slice.IceDecoder.DecodeTrait[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]()
```