### PR TITLE
Fixed incorrect input pipe writer completion

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
@@ -23,8 +23,8 @@ namespace IceRpc.Transports.Internal
         internal int PeerPauseWriterThreshold { get; private set; }
         internal int PauseWriterThreshold { get; }
         internal int ResumeWriterThreshold { get; }
-        public MemoryPool<byte> Pool { get; }
-        public int MinimumSegmentSize { get; }
+        internal MemoryPool<byte> Pool { get; }
+        internal int MinimumSegmentSize { get; }
 
         private readonly AsyncQueue<IMultiplexedStream> _acceptedStreamQueue = new();
         private int _bidirectionalStreamCount;


### PR DESCRIPTION
This PR fixes a Slic critical bug where the input pipe writer used to push data to the `SlicPipeReader` could be completed while data from the reading of a frame was written to it.
