### PR TITLE
Fix for issue #753

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeReader.cs
@@ -66,7 +66,7 @@ namespace IceRpc.Transports.Internal
             if (!_isReaderCompleted)
             {
                 // If reads aren't marked as completed yet, abort stream reads. This will send a stream stop sending
-                // frame to the peer to notify it shouldn't send additional data (unless the connection has been lost).
+                // frame to the peer to notify it shouldn't send additional data.
                 if (!_stream.ReadsCompleted)
                 {
                     if (exception == null)
@@ -77,7 +77,7 @@ namespace IceRpc.Transports.Internal
                     {
                         _stream.AbortRead(abortedException.ToError());
                     }
-                    else if (exception is not ConnectionLostException)
+                    else
                     {
                         _stream.AbortRead(SlicStreamError.UnexpectedError.ToError());
                     }

--- a/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
@@ -39,7 +39,7 @@ namespace IceRpc.Transports.Internal
             if (!_isWriterCompleted)
             {
                 // If writes aren't marked as completed yet, abort stream writes. This will send a stream reset frame to
-                // the peer to notify it won't receive additional data (unless the connection has been lost).
+                // the peer to notify it won't receive additional data.
                 if (!_stream.WritesCompleted)
                 {
                     if (exception == null)
@@ -55,7 +55,7 @@ namespace IceRpc.Transports.Internal
                     {
                         _stream.AbortWrite(abortedException.ToError());
                     }
-                    else if (exception is not ConnectionLostException)
+                    else
                     {
                         _stream.AbortWrite(SlicStreamError.UnexpectedError.ToError());
                     }


### PR DESCRIPTION
This PR fixes #753. We keep the `Complete` implementation but throw if there's unflushed bytes on the `SlicPipeWriter` and `Complete(null)` is called.