### PR TITLE
Remove IceRpc::Context typealias

### DIFF
--- a/slice/IceRpc/Context.slice
+++ b/slice/IceRpc/Context.slice
@@ -1,7 +1,0 @@
-// Copyright (c) ZeroC, Inc. All rights reserved.
-
-module IceRpc
-{
-    /// A request context.
-    typealias Context = dictionary<string, string>;
-}

--- a/slice/IceRpc/Internal/IceDefinitions.slice
+++ b/slice/IceRpc/Internal/IceDefinitions.slice
@@ -55,7 +55,7 @@ compact struct IceRequestHeader
     fragment: Slice::Internal::Fragment,
     operation: string,
     operationMode: OperationMode,
-    context: Context,
+    context: dictionary<string, string>,
     encapsulationHeader: EncapsulationHeader,
 }
 

--- a/tests/IceRpc.Tests.Api/SliceDefinitions.slice
+++ b/tests/IceRpc.Tests.Api/SliceDefinitions.slice
@@ -9,7 +9,7 @@ interface Greeter
 
 interface InterceptorTest
 {
-    opContext() -> Context;
+    opContext() -> dictionary<string, string>;
     opInt(value: int) -> int;
 }
 


### PR DESCRIPTION
This tiny PR removes the Context typealias. It was used only twice: for an internal definition and a test.