### PR TITLE
Cleanup definitions in "::Slice" module

### DIFF
--- a/slice/Ice/IdentityPath.slice
+++ b/slice/Ice/IdentityPath.slice
@@ -3,4 +3,4 @@
 [cs:namespace(IceRpc)]
 module Ice;
 
-typealias IdentityPath = Slice::IdentityPath;
+typealias IdentityPath = IceRpc::Slice::IdentityPath;

--- a/slice/IceRpc/Slice/IdentityPath.slice
+++ b/slice/IceRpc/Slice/IdentityPath.slice
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[cs:namespace("IceRpc.Slice")]
-module Slice;
+module IceRpc::Slice;
 
 /// The path of a service, encoded as an Ice identity.
 [cs:type("string")]

--- a/slice/IceRpc/Slice/SliceResultType.slice
+++ b/slice/IceRpc/Slice/SliceResultType.slice
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[cs:namespace("IceRpc.Slice")]
-module Slice;
+module IceRpc::Slice;
 
 /// The type of result carried by a response frame when using Slice generated code for the invocation and dispatch.
 enum SliceResultType : byte

--- a/slice/IceRpc/Slice/TagFormat.slice
+++ b/slice/IceRpc/Slice/TagFormat.slice
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[cs:namespace("IceRpc.Slice")]
-module Slice;
+module IceRpc::Slice;
 
 /// With encoding 1.1, each tagged parameter has a specific tag format. This tag format describes how the data is
 /// encoded and how it can be skipped by the decoding code if the tagged parameter is present in the buffer but is

--- a/src/IceRpc/IceRpc.csproj
+++ b/src/IceRpc/IceRpc.csproj
@@ -21,6 +21,7 @@
       <SliceCompile Include="../../slice/$(AssemblyName)/*.slice" OutputDir="$(MSBuildProjectDirectory)/generated" />
       <SliceCompile Include="../../slice/$(AssemblyName)/Internal/*.slice" OutputDir="$(MSBuildProjectDirectory)/generated/Internal" />
       <SliceCompile Include="../../slice/Slice/*.slice" OutputDir="$(MSBuildProjectDirectory)/Slice/generated" />
+      <SliceCompile Include="../../slice/$(AssemblyName)/Slice/*.slice" OutputDir="$(MSBuildProjectDirectory)/Slice/Internal/generated" />
       <SliceCompile Include="../../slice/$(AssemblyName)/Slice/Internal/*.slice" OutputDir="$(MSBuildProjectDirectory)/Slice/Internal/generated" />
       <SliceCompile Include="../../slice/$(AssemblyName)/Transports/*.slice" OutputDir="$(MSBuildProjectDirectory)/Transports/generated" />
       <SliceCompile Include="../../slice/$(AssemblyName)/Transports/Internal/*.slice" OutputDir="$(MSBuildProjectDirectory)/Transports/Internal/generated" />


### PR DESCRIPTION
Cleanup definitions in "::Slice" module

As suggested by Bernard the criteria for put definitions in "::Slice" module should be:
* is this a definition that other Slice files want to use fairly often, in particular Slice files that a future RPC could implement
* r does the type ID matter and must remain the same across multiple RPCs that use Slice