### PR TITLE
Add Invocation.Response and Dispatch.Request

### DIFF
--- a/src/IceRpc/Slice/Dispatch.cs
+++ b/src/IceRpc/Slice/Dispatch.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Slice
     public sealed class Dispatch
     {
         /// <summary>The <see cref="Connection"/> over which the request was dispatched.</summary>
-        public Connection Connection => IncomingRequest.Connection;
+        public Connection Connection => Request.Connection;
 
         /// <summary>The deadline corresponds to the request's expiration time. Once the deadline is reached, the
         /// caller is no longer interested in the response and discards the request. The server-side runtime does not
@@ -21,7 +21,7 @@ namespace IceRpc.Slice
             {
                 if (_deadline == null)
                 {
-                    long value = IncomingRequest.Fields.DecodeValue(
+                    long value = Request.Fields.DecodeValue(
                         (int)FieldKey.Deadline,
                         (ref SliceDecoder decoder) => decoder.DecodeVarLong());
 
@@ -33,33 +33,33 @@ namespace IceRpc.Slice
         }
 
         /// <summary>The encoding used by the request.</summary>
-        public Encoding Encoding => IncomingRequest.PayloadEncoding;
+        public Encoding Encoding => Request.PayloadEncoding;
 
         /// <summary>The features associated with the request.</summary>
         public FeatureCollection Features
         {
-            get => IncomingRequest.Features;
-            set => IncomingRequest.Features = value;
+            get => Request.Features;
+            set => Request.Features = value;
         }
 
         /// <summary><c>True</c> for oneway requests, <c>False</c> otherwise.</summary>
-        public bool IsOneway => IncomingRequest.IsOneway;
+        public bool IsOneway => Request.IsOneway;
 
         /// <summary>The operation name.</summary>
-        public string Operation => IncomingRequest.Operation;
+        public string Operation => Request.Operation;
 
         /// <summary>The path (percent-escaped).</summary>
-        public string Path => IncomingRequest.Path;
+        public string Path => Request.Path;
 
         /// <summary>The protocol used by the request.</summary>
-        public Protocol Protocol => IncomingRequest.Protocol;
+        public Protocol Protocol => Request.Protocol;
 
-        /// <summary>The incoming request frame.</summary>
-        internal IncomingRequest IncomingRequest { get; }
+        /// <summary>The incoming request.</summary>
+        public IncomingRequest Request { get; }
 
         private DateTime? _deadline;
 
         /// <summary>Constructs a dispatch from an incoming request.</summary>
-        public Dispatch(IncomingRequest request) => IncomingRequest = request;
+        public Dispatch(IncomingRequest request) => Request = request;
     }
 }

--- a/src/IceRpc/Slice/DispatchExtensions.cs
+++ b/src/IceRpc/Slice/DispatchExtensions.cs
@@ -7,6 +7,6 @@ namespace IceRpc.Slice
     {
         /// <summary>Computes the Slice encoding to use when encoding a Slice-generated response.</summary>
         public static SliceEncoding GetSliceEncoding(this Dispatch dispatch) =>
-            dispatch.IncomingRequest.GetSliceEncoding();
+            dispatch.Request.GetSliceEncoding();
     }
 }

--- a/src/IceRpc/Slice/Invocation.cs
+++ b/src/IceRpc/Slice/Invocation.cs
@@ -12,13 +12,36 @@ namespace IceRpc.Slice
         public DateTime Deadline { get; set; } = DateTime.MaxValue;
 
         /// <summary>Gets or sets the features carried by the request.</summary>
-        public FeatureCollection Features { get; set; } = FeatureCollection.Empty;
+        public FeatureCollection Features
+        {
+            get => _response?.Request.Features ?? _features;
+
+            set
+            {
+                if (_response is IncomingResponse response)
+                {
+                    response.Request.Features = value;
+                }
+                else
+                {
+                    _features = value;
+                }
+            }
+        }
 
         /// <summary>Gets or sets whether a void-returning request is oneway. This property has no effect for operations
         /// defined in Slice that return a value.</summary>
         /// <value>When <c>true</c>, the request is sent as a oneway request. When <c>false</c>, the request is sent as
         /// a twoway request unless the operation is marked oneway in its Slice definition.</value>
         public bool IsOneway { get; set; }
+
+        /// <summary>Returns the response to this invocation.</summary>
+        /// <exception cref="InvalidOperationException">Thrown if the response was not received yet.</exception>
+        public IncomingResponse Response
+        {
+            get => _response ?? throw new InvalidOperationException("no response yet");
+            internal set => _response = value;
+        }
 
         /// <summary>Gets or sets the timeout of this invocation.</summary>
         /// <value>The timeout of this invocation. The default value is
@@ -31,6 +54,8 @@ namespace IceRpc.Slice
                 throw new ArgumentException($"{nameof(Timeout)} must be greater than 0", nameof(Timeout));
         }
 
+        private FeatureCollection _features = FeatureCollection.Empty;
+        private IncomingResponse? _response;
         private TimeSpan _timeout = System.Threading.Timeout.InfiniteTimeSpan;
     }
 }

--- a/src/IceRpc/Slice/ProxyExtensions.cs
+++ b/src/IceRpc/Slice/ProxyExtensions.cs
@@ -82,7 +82,7 @@ namespace IceRpc.Slice
 
                 if (invocation != null)
                 {
-                    invocation.Features = request.Features;
+                    invocation.Response = response;
                 }
 
                 return await responseDecodeFunc(response, cancel).ConfigureAwait(false);
@@ -143,7 +143,7 @@ namespace IceRpc.Slice
 
                 if (invocation != null)
                 {
-                    invocation.Features = request.Features;
+                    invocation.Response = response;
                 }
 
                 await response.CheckVoidReturnValueAsync(


### PR DESCRIPTION
This PR adds Invocation.Response and Dispatch.Request as proposed by #825.

It also reworks a little bit Invocation.Features to use _response.Request when available.

I think we should also simplify Dispatch and remove all the `Xxx => Request.Xxx` properties - what's the point now that Request is public? This means Dispatch would only keep 2 properties. Deadline and Request.