### PR TITLE
Allow empty operation names

### DIFF
--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -11,16 +11,16 @@ namespace IceRpc
         public FeatureCollection Features { get; set; } = FeatureCollection.Empty;
 
         /// <summary>The fragment of the target service. It's always empty with the icerpc protocol.</summary>
-        public string Fragment { get; init; }
+        public string Fragment { get; }
 
         /// <summary><c>True</c> for oneway requests, <c>false</c> otherwise.</summary>
         public bool IsOneway { get; init; }
 
         /// <summary>The operation called on the service.</summary>
-        public string Operation { get; init; }
+        public string Operation { get; }
 
         /// <summary>The path of the target service.</summary>
-        public string Path { get; init; }
+        public string Path { get; }
 
         /// <summary>Returns the encoding of the payload of this request.</summary>
         public Encoding PayloadEncoding { get; }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -129,11 +129,6 @@ namespace IceRpc.Internal
                 {
                     IceRequestHeader requestHeader = DecodeHeader(ref buffer);
 
-                    if (requestHeader.Operation.Length == 0)
-                    {
-                        throw new InvalidDataException("received request with empty operation name");
-                    }
-
                     // The payload size is the encapsulation size less the 6 bytes of the encapsulation header.
                     int payloadSize = requestHeader.EncapsulationHeader.EncapsulationSize - 6;
                     if (payloadSize != buffer.Length - 4)

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -118,11 +118,6 @@ namespace IceRpc.Internal
                     {
                         features = features.WithContext(context);
                     }
-
-                    if (header.Operation.Length == 0)
-                    {
-                        throw new InvalidDataException("received request with empty operation name");
-                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -23,7 +23,7 @@ namespace IceRpc
         public bool IsSent { get; set; }
 
         /// <summary>The operation called on the service.</summary>
-        public string Operation { get; }
+        public string Operation { get; init; } = "";
 
         /// <summary>Returns the encoding of the payload of this request.</summary>
         public Encoding PayloadEncoding { get; init; } = Encoding.Unknown;
@@ -41,14 +41,12 @@ namespace IceRpc
 
         /// <summary>Constructs an outgoing request.</summary>
         /// <param name="proxy">The <see cref="Proxy"/> used to send the request.</param>
-        /// <param name="operation">The operation of the request.</param>
-        public OutgoingRequest(Proxy proxy, string operation)
+        public OutgoingRequest(Proxy proxy)
             : base(proxy.Protocol, new DelayedPipeWriterDecorator())
         {
             Connection = proxy.Connection;
             // We keep it to initialize it later
             InitialPayloadSink = (DelayedPipeWriterDecorator)PayloadSink;
-            Operation = operation;
             Proxy = proxy;
         }
     }

--- a/src/IceRpc/Slice/ProxyExtensions.cs
+++ b/src/IceRpc/Slice/ProxyExtensions.cs
@@ -57,10 +57,11 @@ namespace IceRpc.Slice
                     nameof(invocation));
             }
 
-            var request = new OutgoingRequest(proxy, operation)
+            var request = new OutgoingRequest(proxy)
             {
                 Features = invocation?.Features ?? FeatureCollection.Empty,
                 Fields = idempotent ? _idempotentFields : ImmutableDictionary<int, ReadOnlyMemory<byte>>.Empty,
+                Operation = operation,
                 PayloadEncoding = payloadEncoding,
                 PayloadSource = payloadSource,
                 PayloadSourceStream = payloadSourceStream
@@ -117,11 +118,12 @@ namespace IceRpc.Slice
             bool oneway = false,
             CancellationToken cancel = default)
         {
-            var request = new OutgoingRequest(proxy, operation)
+            var request = new OutgoingRequest(proxy)
             {
                 Features = invocation?.Features ?? FeatureCollection.Empty,
                 Fields = idempotent ? _idempotentFields : ImmutableDictionary<int, ReadOnlyMemory<byte>>.Empty,
                 IsOneway = oneway || (invocation?.IsOneway ?? false),
+                Operation = operation,
                 PayloadEncoding = payloadEncoding,
                 PayloadSource = payloadSource,
                 PayloadSourceStream = payloadSourceStream

--- a/tests/IceRpc.Tests.Api/SliceFreeTests.cs
+++ b/tests/IceRpc.Tests.Api/SliceFreeTests.cs
@@ -25,7 +25,6 @@ namespace IceRpc.Tests.Api
         private const string _joe = "/joe";
         private const string _greeting = "how are you doing?";
         private const string _notGood = "feeling under the weather";
-        private const string _sayHelloOperation = "sayHello";
         private static readonly System.Text.UTF8Encoding _utf8 = new(false, true);
 
         private readonly ServiceProvider _serviceProvider;
@@ -54,7 +53,7 @@ namespace IceRpc.Tests.Api
             var payload = new ReadOnlySequence<byte>(_utf8.GetBytes(_greeting));
 
             var joeProxy = _proxy with { Path = _joe };
-            var request = new OutgoingRequest(joeProxy, _sayHelloOperation)
+            var request = new OutgoingRequest(joeProxy)
             {
                 PayloadEncoding = _customEncoding,
                 PayloadSource = PipeReader.Create(payload)
@@ -67,7 +66,7 @@ namespace IceRpc.Tests.Api
             Assert.That(greetingResponse, Is.EqualTo(_doingWell));
 
             var austinProxy = _proxy with { Path = _austin };
-            request = new OutgoingRequest(austinProxy, _sayHelloOperation)
+            request = new OutgoingRequest(austinProxy)
             {
                 PayloadEncoding = _customEncoding,
                 PayloadSource = PipeReader.Create(payload)
@@ -85,7 +84,7 @@ namespace IceRpc.Tests.Api
             var payload = new ReadOnlySequence<byte>(_utf8.GetBytes(_greeting));
 
             var badProxy = _proxy with { Path = "/bad" };
-            var request = new OutgoingRequest(badProxy, _sayHelloOperation)
+            var request = new OutgoingRequest(badProxy)
             {
                 PayloadEncoding = _customEncoding,
                 PayloadSource = PipeReader.Create(payload)
@@ -111,7 +110,7 @@ namespace IceRpc.Tests.Api
             var payload = new ReadOnlySequence<byte>(_utf8.GetBytes(_greeting));
             var joeProxy = _proxy with { Path = _joe };
 
-            var request = new OutgoingRequest(joeProxy, _sayHelloOperation)
+            var request = new OutgoingRequest(joeProxy)
             {
                 IsOneway = true,
                 PayloadEncoding = _customEncoding,
@@ -145,7 +144,7 @@ namespace IceRpc.Tests.Api
 
             public async ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancel)
             {
-                if (request.Operation != _sayHelloOperation)
+                if (request.Operation.Length > 0)
                 {
                     throw new Slice.DispatchException(Slice.DispatchErrorCode.OperationNotFound);
                 }

--- a/tests/IceRpc.Tests.ClientServer/CompressTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/CompressTests.cs
@@ -95,8 +95,9 @@ namespace IceRpc.Tests.ClientServer
                 .BuildServiceProvider();
 
             var proxy = Proxy.FromConnection(serviceProvider.GetRequiredService<Connection>(), "/");
-            var request = new OutgoingRequest(proxy, "compressRequestPayload")
+            var request = new OutgoingRequest(proxy)
             {
+                Operation = "compressRequestPayload",
                 PayloadSource = PipeReader.Create(new ReadOnlySequence<byte>(_mainPayload))
             };
             if (compressPayload)
@@ -176,7 +177,7 @@ namespace IceRpc.Tests.ClientServer
                 .BuildServiceProvider();
 
             var proxy = Proxy.FromConnection(serviceProvider.GetRequiredService<Connection>(), "/");
-            var request = new OutgoingRequest(proxy, "compressResponsePayload");
+            var request = new OutgoingRequest(proxy) { Operation = "compressResponsePayload" };
 
             bool called = false;
 

--- a/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/ProtocolBridgingTests.cs
@@ -164,11 +164,12 @@ namespace IceRpc.Tests.ClientServer
                     features = features.WithContext(incomingRequest.Features.GetContext());
                 }
 
-                var outgoingRequest = new OutgoingRequest(_target, incomingRequest.Operation)
+                var outgoingRequest = new OutgoingRequest(_target)
                 {
                     Features = features,
                     Fields = incomingRequest.Fields, // mostly ignored by ice, with the exception of Idempotent
                     IsOneway = incomingRequest.IsOneway,
+                    Operation = incomingRequest.Operation,
                     PayloadEncoding = incomingRequest.PayloadEncoding,
                     PayloadSource = incomingRequest.Payload
                 };

--- a/tests/IceRpc.Tests.Internal/LoggingTests.cs
+++ b/tests/IceRpc.Tests.Internal/LoggingTests.cs
@@ -274,10 +274,11 @@ namespace IceRpc.Tests.Internal
             PipeReader.Create(new ReadOnlySequence<byte>(new byte[10])));
 
         private static OutgoingRequest CreateOutgoingRequest(Connection connection, bool twoway) =>
-            new(new Proxy(connection.Protocol) { Path = "/dummy" }, operation: "foo")
+            new(new Proxy(connection.Protocol) { Path = "/dummy" })
             {
                 Connection = connection,
                 IsOneway = !twoway,
+                Operation = "foo",
                 PayloadSource = PipeReader.Create(new ReadOnlySequence<byte>(new byte[15])),
                 PayloadEncoding = Encoding.Slice20
             };

--- a/tests/IceRpc.Tests.Slice/OperationTagTests.cs
+++ b/tests/IceRpc.Tests.Slice/OperationTagTests.cs
@@ -476,8 +476,9 @@ namespace IceRpc.Tests.Slice
         public async Task OperationTag_DuplicateTag()
         {
             PipeReader requestPayload = CreatePayload();
-            var request = new OutgoingRequest(_prx.Proxy, "opVoid")
+            var request = new OutgoingRequest(_prx.Proxy)
             {
+                Operation = "opVoid",
                 PayloadEncoding = _prx.Proxy.Encoding,
                 PayloadSource = requestPayload
             };

--- a/tests/IceRpc.Tests.Slice/TraitTests.cs
+++ b/tests/IceRpc.Tests.Slice/TraitTests.cs
@@ -66,8 +66,9 @@ namespace IceRpc.Tests.Slice
         [TestCase(3000)]
         public async Task Trait_DecodeStackOverflow(int depth)
         {
-            var request = new OutgoingRequest(_prx.Proxy, "opNestedTraitStruct")
+            var request = new OutgoingRequest(_prx.Proxy)
             {
+                Operation = "opNestedTraitStruct",
                 PayloadSource = CreatePayload(),
                 PayloadEncoding = Encoding.Slice20
             };

--- a/tests/IceRpc.Tests/InvocationEventSourceTests.cs
+++ b/tests/IceRpc.Tests/InvocationEventSourceTests.cs
@@ -26,7 +26,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         eventListener.EnableEvents(_eventSource, EventLevel.Verbose);
 
         var proxy = new Proxy(Protocol.IceRpc) { Path = "/service" };
-        _eventSource.RequestStart(new OutgoingRequest(proxy, operation: "ice_id"));
+        _eventSource.RequestStart(new OutgoingRequest(proxy) { Operation = "ice_ping" });
 
         EventWrittenEventArgs? eventData = eventListener.EventData;
         Assert.That(eventData, Is.Not.Null);
@@ -35,7 +35,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         Assert.That(eventData.Level, Is.EqualTo(EventLevel.Informational));
         Assert.That(eventData.EventSource, Is.SameAs(_eventSource));
         Assert.That(eventData.Payload![0], Is.EqualTo("/service"));
-        Assert.That(eventData.Payload![1], Is.EqualTo("ice_id"));
+        Assert.That(eventData.Payload![1], Is.EqualTo("ice_ping"));
     }
 
     [Test]
@@ -46,7 +46,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         eventListener.EnableEvents(_eventSource, EventLevel.Verbose);
 
         var proxy = new Proxy(Protocol.IceRpc) { Path = "/service" };
-        _eventSource.RequestStop(new OutgoingRequest(proxy, operation: "ice_id"));
+        _eventSource.RequestStop(new OutgoingRequest(proxy) { Operation = "ice_ping" });
 
         EventWrittenEventArgs? eventData = eventListener.EventData;
         Assert.That(eventData, Is.Not.Null);
@@ -55,7 +55,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         Assert.That(eventData.Level, Is.EqualTo(EventLevel.Informational));
         Assert.That(eventData.EventSource, Is.SameAs(_eventSource));
         Assert.That(eventData.Payload![0], Is.EqualTo("/service"));
-        Assert.That(eventData.Payload![1], Is.EqualTo("ice_id"));
+        Assert.That(eventData.Payload![1], Is.EqualTo("ice_ping"));
     }
 
     [Test]
@@ -66,7 +66,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         eventListener.EnableEvents(_eventSource, EventLevel.Verbose);
 
         var proxy = new Proxy(Protocol.IceRpc) { Path = "/service" };
-        _eventSource.RequestCanceled(new OutgoingRequest(proxy, operation: "ice_id"));
+        _eventSource.RequestCanceled(new OutgoingRequest(proxy) { Operation = "ice_ping" });
 
         EventWrittenEventArgs? eventData = eventListener.EventData;
         Assert.That(eventData, Is.Not.Null);
@@ -75,7 +75,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         Assert.That(eventData.Level, Is.EqualTo(EventLevel.Informational));
         Assert.That(eventData.EventSource, Is.SameAs(_eventSource));
         Assert.That(eventData.Payload![0], Is.EqualTo("/service"));
-        Assert.That(eventData.Payload![1], Is.EqualTo("ice_id"));
+        Assert.That(eventData.Payload![1], Is.EqualTo("ice_ping"));
     }
 
     [Test]
@@ -87,7 +87,7 @@ public sealed class InvocationEventSourceTests : IDisposable
 
         var proxy = new Proxy(Protocol.IceRpc) { Path = "/service" };
         _eventSource.RequestFailed(
-            new OutgoingRequest(proxy, operation: "ice_id"),
+            new OutgoingRequest(proxy) { Operation = "ice_ping" },
             "IceRpc.RemoteException");
 
         EventWrittenEventArgs? eventData = eventListener.EventData;
@@ -97,7 +97,7 @@ public sealed class InvocationEventSourceTests : IDisposable
         Assert.That(eventData.Level, Is.EqualTo(EventLevel.Informational));
         Assert.That(eventData.EventSource, Is.SameAs(_eventSource));
         Assert.That(eventData.Payload![0], Is.EqualTo("/service"));
-        Assert.That(eventData.Payload![1], Is.EqualTo("ice_id"));
+        Assert.That(eventData.Payload![1], Is.EqualTo("ice_ping"));
         Assert.That(eventData.Payload![2], Is.EqualTo("IceRpc.RemoteException"));
     }
 


### PR DESCRIPTION
This PR allows operation names to be empty, and update the SliceFreeTest to use an empty operation name (empty operation name is the default for OutgoingRequest).

It also removes extra inits in IncomingRequest.