### PR TITLE
Add Name to Client and Server transports

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
@@ -11,6 +11,9 @@ namespace IceRpc.Transports
     /// <summary>Implements <see cref="IClientTransport{ISimpleNetworkConnection}"/> for the coloc transport.</summary>
     internal class ColocClientTransport : IClientTransport<ISimpleNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => ColocTransport.Name;
+
         private readonly ConcurrentDictionary<Endpoint, ColocListener> _listeners;
 
         /// <inheritdoc/>
@@ -24,7 +27,7 @@ namespace IceRpc.Transports
                 throw new NotSupportedException("cannot create a secure Coloc connection");
             }
 
-            remoteEndpoint = remoteEndpoint.WithTransport(ColocTransport.Name);
+            remoteEndpoint = remoteEndpoint.WithTransport(Name);
 
             if (remoteEndpoint.Params.Count > 1)
             {

--- a/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
@@ -27,11 +27,11 @@ namespace IceRpc.Transports.Internal
 
         internal ColocListener(Endpoint endpoint)
         {
-            Endpoint = endpoint.WithTransport(ColocTransport.Name);
-            if (Endpoint.Params.Count > 1)
+            if (endpoint.Params.Count > 1)
             {
                 throw new ArgumentException("unknown endpoint parameter", nameof(endpoint));
             }
+            Endpoint = endpoint;
         }
 
         internal (PipeReader, PipeWriter) NewClientConnection()

--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -10,6 +10,9 @@ namespace IceRpc.Transports
     /// <summary>Implements <see cref="IServerTransport{ISimpleNetworkConnection}"/> for the coloc transport.</summary>
     internal class ColocServerTransport : IServerTransport<ISimpleNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => ColocTransport.Name;
+
         private readonly ConcurrentDictionary<Endpoint, ColocListener> _listeners;
 
         /// <inheritdoc/>
@@ -23,7 +26,7 @@ namespace IceRpc.Transports
                 throw new NotSupportedException("cannot create secure Coloc server");
             }
 
-            var listener = new ColocListener(endpoint);
+            var listener = new ColocListener(endpoint.WithTransport(Name));
             if (!_listeners.TryAdd(listener.Endpoint, listener))
             {
                 throw new TransportException($"endpoint '{listener.Endpoint}' is already in use");

--- a/src/IceRpc/Configure/CompositeMultiplexedClientTransport.cs
+++ b/src/IceRpc/Configure/CompositeMultiplexedClientTransport.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
-using IceRpc.Transports.Internal;
 
 namespace IceRpc.Configure
 {
@@ -15,10 +14,18 @@ namespace IceRpc.Configure
     public static class CompositeMultiplexedClientTransportExtensions
     {
         /// <summary>Adds the Slic over TCP client transport to this composite client transport.</summary>
-        /// <param name="clientTransport">The transport being configured.</param>
-        /// <returns>The transport being configured.</returns>
+        /// <param name="clientTransport">The composite transport being configured.</param>
+        /// <returns>The composite transport being configured.</returns>
         public static CompositeClientTransport<IMultiplexedNetworkConnection> UseSlicOverTcp(
             this CompositeClientTransport<IMultiplexedNetworkConnection> clientTransport) =>
-            clientTransport.Add(TransportNames.Tcp, new SlicClientTransport(new TcpClientTransport()));
+            clientTransport.Add(new SlicClientTransport(new TcpClientTransport()));
+
+        /// <summary>Adds a Slic transport to this composite client transport.</summary>
+        /// <param name="clientTransport">The composite transport being configured.</param>
+        /// <param name="options">The Slic client transport options.</param>
+        /// <returns>The composite transport being configured.</returns>
+        public static CompositeClientTransport<IMultiplexedNetworkConnection> UseSlic(
+            this CompositeClientTransport<IMultiplexedNetworkConnection> clientTransport,
+            SlicClientTransportOptions options) => clientTransport.Add(new SlicClientTransport(options));
     }
 }

--- a/src/IceRpc/Configure/CompositeMultiplexedServerTransport.cs
+++ b/src/IceRpc/Configure/CompositeMultiplexedServerTransport.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
-using IceRpc.Transports.Internal;
 
 namespace IceRpc.Configure
 {
@@ -15,10 +14,18 @@ namespace IceRpc.Configure
     public static class CompositeMultiplexedServerTransportExtensions
     {
         /// <summary>Adds the Slic over TCP server transport to this composite server transport.</summary>
-        /// <param name="serverTransport">The transport being configured.</param>
-        /// <returns>The transport being configured.</returns>
+        /// <param name="serverTransport">The composite transport being configured.</param>
+        /// <returns>The composite transport being configured.</returns>
         public static CompositeServerTransport<IMultiplexedNetworkConnection> UseSlicOverTcp(
             this CompositeServerTransport<IMultiplexedNetworkConnection> serverTransport) =>
-            serverTransport.Add(TransportNames.Tcp, new SlicServerTransport(new TcpServerTransport()));
+            serverTransport.Add(new SlicServerTransport(new TcpServerTransport()));
+
+        /// <summary>Adds a Slic server transport to this composite server transport.</summary>
+        /// <param name="serverTransport">The composite transport being configured.</param>
+        /// <param name="options">The Slic server transport options.</param>
+        /// <returns>The composite transport being configured.</returns>
+        public static CompositeServerTransport<IMultiplexedNetworkConnection> UseSlic(
+            this CompositeServerTransport<IMultiplexedNetworkConnection> serverTransport,
+            SlicServerTransportOptions options) => serverTransport.Add(new SlicServerTransport(options));
     }
 }

--- a/src/IceRpc/Configure/CompositeSimpleClientTransport.cs
+++ b/src/IceRpc/Configure/CompositeSimpleClientTransport.cs
@@ -29,7 +29,7 @@ namespace IceRpc.Configure
             TcpClientTransportOptions options)
         {
             var transport = new TcpClientTransport(options);
-            return clientTransport.Add(TransportNames.Tcp, transport).Add(TransportNames.Ssl, transport);
+            return clientTransport.Add(transport).Add(TransportNames.Ssl, transport);
         }
 
         /// <summary>Adds the udp client transport to this composite client transport.</summary>
@@ -46,6 +46,6 @@ namespace IceRpc.Configure
         public static CompositeClientTransport<ISimpleNetworkConnection> UseUdp(
             this CompositeClientTransport<ISimpleNetworkConnection> clientTransport,
             UdpClientTransportOptions options) =>
-            clientTransport.Add(TransportNames.Udp, new UdpClientTransport(options));
+            clientTransport.Add(new UdpClientTransport(options));
     }
 }

--- a/src/IceRpc/Configure/CompositeSimpleServerTransport.cs
+++ b/src/IceRpc/Configure/CompositeSimpleServerTransport.cs
@@ -29,7 +29,7 @@ namespace IceRpc.Configure
             TcpServerTransportOptions options)
         {
             var transport = new TcpServerTransport(options);
-            return serverTransport.Add(TransportNames.Tcp, transport).Add(TransportNames.Ssl, transport);
+            return serverTransport.Add(transport).Add(TransportNames.Ssl, transport);
         }
 
         /// <summary>Adds the udp server transport to this composite server transport.</summary>
@@ -46,6 +46,6 @@ namespace IceRpc.Configure
         public static CompositeServerTransport<ISimpleNetworkConnection> UseUdp(
             this CompositeServerTransport<ISimpleNetworkConnection> serverTransport,
             UdpServerTransportOptions options) =>
-            serverTransport.Add(TransportNames.Udp, new UdpServerTransport(options));
+            serverTransport.Add(new UdpServerTransport(options));
     }
 }

--- a/src/IceRpc/Transports/IClientTransport.cs
+++ b/src/IceRpc/Transports/IClientTransport.cs
@@ -8,6 +8,9 @@ namespace IceRpc.Transports
     /// <summary>Gives Connection the ability to create outgoing transport connections.</summary>
     public interface IClientTransport<T> where T : INetworkConnection
     {
+        /// <summary>Returns the transport's name.</summary>
+        string Name { get; }
+
         /// <summary>Creates a new network connection to the remote endpoint.</summary>
         /// <param name="remoteEndpoint">The remote endpoint.</param>
         /// <param name="authenticationOptions">The SSL client authentication options.</param>

--- a/src/IceRpc/Transports/IServerTransport.cs
+++ b/src/IceRpc/Transports/IServerTransport.cs
@@ -8,6 +8,9 @@ namespace IceRpc.Transports
     /// <summary>Gives class <see cref="Server"/> the ability to create incoming transport connections.</summary>
     public interface IServerTransport<T> where T : INetworkConnection
     {
+        /// <summary>Returns the transport's name.</summary>
+        string Name { get; }
+
         /// <summary>Starts listening on an endpoint.</summary>
         /// <param name="endpoint">The endpoint.</param>
         /// <param name="authenticationOptions">The SSL server authentication options.</param>

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -58,25 +58,6 @@ namespace IceRpc.Transports.Internal
             TcpServerTransportOptions options,
             Func<TcpServerNetworkConnection, ISimpleNetworkConnection> serverConnectionDecorator)
         {
-            _ = endpoint.ParseTcpParams(); // sanity check
-
-            if (endpoint.Params.TryGetValue("transport", out string? endpointTransport))
-            {
-                if (endpointTransport == TransportNames.Ssl && authenticationOptions == null)
-                {
-                    throw new ArgumentNullException(
-                        nameof(authenticationOptions),
-                        $"{nameof(authenticationOptions)} cannot be null with the ssl transport");
-                }
-            }
-            else
-            {
-                endpoint = endpoint with
-                {
-                    Params = endpoint.Params.Add("transport", TransportNames.Tcp)
-                };
-            }
-
             if (!IPAddress.TryParse(endpoint.Host, out IPAddress? ipAddress))
             {
                 throw new NotSupportedException(

--- a/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
@@ -304,24 +304,6 @@ namespace IceRpc.Transports.Internal
             SslClientAuthenticationOptions? authenticationOptions,
             TcpClientTransportOptions options)
         {
-            _ = remoteEndpoint.ParseTcpParams(); // sanity check
-
-            if (remoteEndpoint.Params.TryGetValue("transport", out string? endpointTransport))
-            {
-                if (endpointTransport == TransportNames.Ssl)
-                {
-                    // With ssl, we always "turn on" SSL
-                    authenticationOptions ??= new SslClientAuthenticationOptions();
-                }
-            }
-            else
-            {
-                remoteEndpoint = remoteEndpoint with
-                {
-                    Params = remoteEndpoint.Params.Add("transport", TransportNames.Tcp)
-                };
-            }
-
             _remoteEndpoint = remoteEndpoint;
 
             _addr = IPAddress.TryParse(_remoteEndpoint.Host, out IPAddress? ipAddress) ?

--- a/src/IceRpc/Transports/Internal/TransportNames.cs
+++ b/src/IceRpc/Transports/Internal/TransportNames.cs
@@ -5,6 +5,7 @@ namespace IceRpc.Transports.Internal
     /// <summary>Transport names used by the IceRpc assembly.</summary>
     internal static class TransportNames
     {
+        internal const string Composite = "composite"; // pseudo transport
         internal const string Opaque = "opaque";  // ice only (i.e. no special handling with icerpc)
         internal const string Ssl = "ssl";
         internal const string Tcp = "tcp";

--- a/src/IceRpc/Transports/Internal/UdpNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/UdpNetworkConnection.cs
@@ -151,8 +151,7 @@ namespace IceRpc.Transports.Internal
 
         internal UdpClientNetworkConnection(Endpoint remoteEndpoint, UdpClientTransportOptions options)
         {
-            _remoteEndpoint = remoteEndpoint.WithTransport(TransportNames.Udp);
-
+            _remoteEndpoint = remoteEndpoint;
             (bool _, _ttl, _multicastInterface) = _remoteEndpoint.ParseUdpParams();
             _idleTimeout = options.IdleTimeout;
 
@@ -280,8 +279,6 @@ namespace IceRpc.Transports.Internal
 
         internal UdpServerNetworkConnection(Endpoint endpoint, UdpServerTransportOptions options)
         {
-            endpoint = endpoint.WithTransport(TransportNames.Udp);
-
             if (!IPAddress.TryParse(endpoint.Host, out IPAddress? ipAddress))
             {
                 throw new NotSupportedException(

--- a/src/IceRpc/Transports/SlicClientTransport.cs
+++ b/src/IceRpc/Transports/SlicClientTransport.cs
@@ -11,19 +11,22 @@ namespace IceRpc.Transports
     /// client transport.</summary>
     public class SlicClientTransport : IClientTransport<IMultiplexedNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => _simpleClientTransport.Name;
+
         private static readonly Func<ISlicFrameReader, ISlicFrameReader> _defaultSlicFrameReaderDecorator =
             reader => reader;
         private static readonly Func<ISlicFrameWriter, ISlicFrameWriter> _defaultSlicFrameWriterDecorator =
             writer => writer;
         private readonly IClientTransport<ISimpleNetworkConnection> _simpleClientTransport;
-        private readonly SlicTransportOptions _slicOptions;
+        private readonly SlicTransportOptions _slicTransportOptions;
 
         /// <summary>Constructs a Slic client transport.</summary>
         public SlicClientTransport(SlicClientTransportOptions options)
         {
             _simpleClientTransport = options.SimpleClientTransport ?? throw new ArgumentException(
                 $"{nameof(options.SimpleClientTransport)} is null", nameof(options));
-            _slicOptions = options;
+            _slicTransportOptions = options;
         }
 
         /// <summary>Constructs a Slic client transport.</summary>
@@ -61,7 +64,7 @@ namespace IceRpc.Transports
                                              isServer: false,
                                              slicFrameReaderDecorator,
                                              slicFrameWriterDecorator,
-                                             _slicOptions);
+                                             _slicTransportOptions);
         }
     }
 }

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -11,12 +11,15 @@ namespace IceRpc.Transports
     /// server transport.</summary>
     public class SlicServerTransport : IServerTransport<IMultiplexedNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => _simpleServerTransport.Name;
+
         private static readonly Func<ISlicFrameReader, ISlicFrameReader> _defaultSlicFrameReaderDecorator =
             reader => reader;
         private static readonly Func<ISlicFrameWriter, ISlicFrameWriter> _defaultSlicFrameWriterDecorator =
             writer => writer;
         private readonly IServerTransport<ISimpleNetworkConnection> _simpleServerTransport;
-        private readonly SlicTransportOptions _slicOptions;
+        private readonly SlicTransportOptions _slicTransportOptions;
 
         /// <summary>Constructs a Slic server transport.</summary>
         public SlicServerTransport(SlicServerTransportOptions options)
@@ -24,7 +27,7 @@ namespace IceRpc.Transports
             _simpleServerTransport = options.SimpleServerTransport ?? throw new ArgumentException(
                 $"{nameof(options.SimpleServerTransport)} is null",
                 nameof(options));
-            _slicOptions = options;
+            _slicTransportOptions = options;
         }
 
         /// <summary>Constructs a Slic server transport.</summary>
@@ -59,7 +62,7 @@ namespace IceRpc.Transports
                 slicFrameWriterDecorator = writer => new LogSlicFrameWriterDecorator(writer, logger);
             }
 
-            return new SlicListener(simpleListener, slicFrameReaderDecorator, slicFrameWriterDecorator, _slicOptions);
+            return new SlicListener(simpleListener, slicFrameReaderDecorator, slicFrameWriterDecorator, _slicTransportOptions);
         }
     }
 }

--- a/src/IceRpc/Transports/UdpClientTransport.cs
+++ b/src/IceRpc/Transports/UdpClientTransport.cs
@@ -10,6 +10,9 @@ namespace IceRpc.Transports
     /// <summary>Implements <see cref="IClientTransport{ISimpleNetworkConnection}"/> for the UDP transport.</summary>
     public class UdpClientTransport : IClientTransport<ISimpleNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => TransportNames.Udp;
+
         private readonly UdpClientTransportOptions _options;
 
         /// <summary>Constructs a <see cref="UdpClientTransport"/> with the default <see cref="UdpClientTransportOptions"/>.
@@ -28,14 +31,15 @@ namespace IceRpc.Transports
             SslClientAuthenticationOptions? authenticationOptions,
             ILogger logger)
         {
+            // This is the composition root of the udp client transport, where we install log decorators when logging
+            // is enabled.
+
             if (authenticationOptions != null)
             {
                 throw new NotSupportedException("cannot create a secure UDP connection");
             }
 
-            // This is the composition root of the udp client transport, where we install log decorators when logging
-            // is enabled.
-            var clientConnection = new UdpClientNetworkConnection(remoteEndpoint, _options);
+            var clientConnection = new UdpClientNetworkConnection(remoteEndpoint.WithTransport(Name), _options);
 
             return logger.IsEnabled(UdpLoggerExtensions.MaxLogLevel) ?
                 new LogUdpNetworkConnectionDecorator(clientConnection, logger) : clientConnection;

--- a/src/IceRpc/Transports/UdpServerTransport.cs
+++ b/src/IceRpc/Transports/UdpServerTransport.cs
@@ -10,6 +10,9 @@ namespace IceRpc.Transports
     /// <summary>Implements <see cref="IServerTransport{ISimpleNetworkConnection}"/> for the udp transport.</summary>
     public class UdpServerTransport : IServerTransport<ISimpleNetworkConnection>
     {
+        /// <inheritdoc/>
+        public string Name => TransportNames.Udp;
+
         private readonly UdpServerTransportOptions _options;
 
         /// <summary>Constructs a <see cref="UdpServerTransport"/> with the default <see cref="UdpServerTransportOptions"/>.
@@ -36,7 +39,7 @@ namespace IceRpc.Transports
             // This is the composition root of the tcp server transport, where we install log decorators when logging
             // is enabled.
 #pragma warning disable CA2000 // the caller will Dispose the connection
-            var udpServerConnection = new UdpServerNetworkConnection(endpoint, _options);
+            var udpServerConnection = new UdpServerNetworkConnection(endpoint.WithTransport(Name), _options);
 
             ISimpleNetworkConnection serverConnection =
                 logger.IsEnabled(UdpLoggerExtensions.MaxLogLevel) ?

--- a/tests/IceRpc.Tests.ClientServer/CustomTransportTests.cs
+++ b/tests/IceRpc.Tests.ClientServer/CustomTransportTests.cs
@@ -11,6 +11,8 @@ namespace IceRpc.Tests.ClientServer
 {
     public class CustomClientTransport : IClientTransport<IMultiplexedNetworkConnection>
     {
+        public string Name => "custom";
+
         private readonly IClientTransport<IMultiplexedNetworkConnection> _transport =
             new SlicClientTransport(new TcpClientTransport());
 
@@ -40,6 +42,8 @@ namespace IceRpc.Tests.ClientServer
 
     public class CustomServerTransport : IServerTransport<IMultiplexedNetworkConnection>
     {
+        public string Name => "custom";
+
         private readonly IServerTransport<IMultiplexedNetworkConnection> _transport =
             new SlicServerTransport(new TcpServerTransport());
 


### PR DESCRIPTION
This PR adds a Name property to IClientTransport and IServerTransport. This name is then used by default when adding such a transport to a composite transport.

For Slic, the Slic's transport name is the name of the underlying simple transport, e.g. tcp, coloc.

This PR also adds UseSlic extension methods (currently untested) to the composite multiplexed transports.