### PR TITLE
Updated Options to use get/set

### DIFF
--- a/src/IceRpc/Configure/CompressOptions.cs
+++ b/src/IceRpc/Configure/CompressOptions.cs
@@ -12,14 +12,15 @@ namespace IceRpc.Configure
         /// <value> The default value is <see cref="CompressionLevel.Fastest"/>. </value>
         public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Fastest;
 
-        /// <summary>Gets or sets whether or not to apply compression to the 2.0 encoded payload of a request or response when
-        /// <see cref="Features.CompressPayload.Yes"/> is present in the request features or response features
-        /// respectively.</summary>
-        /// <value>The default value is <c>true</c>.</value>
+        /// <summary>Gets or sets whether or not to compress the request or response payload.</summary>
+        /// <value>When <c>true</c>, compress the payload if it is not compressed yet. When <c>false</c>, do not
+        /// compress the payload. The default value is <c>true</c>.</value>
         public bool CompressPayload { get; set; } = true;
 
-        /// <summary>Whether or not to decompress the compressed request or response payload. The default value is
-        /// <c>true</c>.</summary>
+        /// <summary>Gets or sets whether or not to decompress the compressed request or response payload.
+        /// The default value is <c>true</c>.</summary>
+        /// <value>When <c>true</c>, decompress the payload if it is not decompressed yet. When <c>false</c>, do not
+        /// decompress the payload. The default value is <c>true</c>.</value>
         public bool DecompressPayload { get; set; } = true;
     }
 }

--- a/src/IceRpc/Configure/CompressOptions.cs
+++ b/src/IceRpc/Configure/CompressOptions.cs
@@ -17,9 +17,8 @@ namespace IceRpc.Configure
         /// compress the payload. The default value is <c>true</c>.</value>
         public bool CompressPayload { get; set; } = true;
 
-        /// <summary>Gets or sets whether or not to decompress the compressed request or response payload.
-        /// The default value is <c>true</c>.</summary>
-        /// <value>When <c>true</c>, decompress the payload if it is not decompressed yet. When <c>false</c>, do not
+        /// <summary>Gets or sets whether or not to decompress the compressed request or response payload. </summary>
+        /// <value>When <c>true</c>, decompress the payload if it is compressed. When <c>false</c>, do not
         /// decompress the payload. The default value is <c>true</c>.</value>
         public bool DecompressPayload { get; set; } = true;
     }

--- a/src/IceRpc/Configure/CompressOptions.cs
+++ b/src/IceRpc/Configure/CompressOptions.cs
@@ -10,15 +10,15 @@ namespace IceRpc.Configure
     {
         /// <summary>The compression level for the compress operation, the default value is
         /// <see cref="CompressionLevel.Fastest"/>.</summary>
-        public CompressionLevel CompressionLevel { get; init; } = CompressionLevel.Fastest;
+        public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Fastest;
 
         /// <summary>Whether or not to apply compression to the 2.0 encoded payload of a request or response when
         /// <see cref="Features.CompressPayload.Yes"/> is present in the request features or response features
         /// respectively. The default value is <c>true</c>.</summary>
-        public bool CompressPayload { get; init; } = true;
+        public bool CompressPayload { get; set; } = true;
 
         /// <summary>Whether or not to decompress the compressed request or response payload. The default value is
         /// <c>true</c>.</summary>
-        public bool DecompressPayload { get; init; } = true;
+        public bool DecompressPayload { get; set; } = true;
     }
 }

--- a/src/IceRpc/Configure/CompressOptions.cs
+++ b/src/IceRpc/Configure/CompressOptions.cs
@@ -8,13 +8,14 @@ namespace IceRpc.Configure
     /// <see cref="CompressorMiddleware"/>.</summary>
     public sealed record class CompressOptions
     {
-        /// <summary>The compression level for the compress operation, the default value is
-        /// <see cref="CompressionLevel.Fastest"/>.</summary>
+        /// <summary>Gets or sets the compression level for the compress operation.</summary>
+        /// <value> The default value is <see cref="CompressionLevel.Fastest"/>. </value>
         public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Fastest;
 
-        /// <summary>Whether or not to apply compression to the 2.0 encoded payload of a request or response when
+        /// <summary>Gets or sets whether or not to apply compression to the 2.0 encoded payload of a request or response when
         /// <see cref="Features.CompressPayload.Yes"/> is present in the request features or response features
-        /// respectively. The default value is <c>true</c>.</summary>
+        /// respectively.</summary>
+        /// <value>The default value is <c>true</c>.</value>
         public bool CompressPayload { get; set; } = true;
 
         /// <summary>Whether or not to decompress the compressed request or response payload. The default value is

--- a/src/IceRpc/Configure/RetryOptions.cs
+++ b/src/IceRpc/Configure/RetryOptions.cs
@@ -8,9 +8,10 @@ namespace IceRpc.Configure
     /// <summary>Options class to configure <see cref="RetryInterceptor"/>.</summary>
     public sealed record class RetryOptions
     {
-        /// <summary>The maximum amount of memory in bytes used to hold all retryable requests. Once this limit is
-        /// reached new requests are not retried and their memory is released after being sent. The default value is
-        /// 100 MB.</summary>
+        /// <summary>Gets or sets the maximum amount of memory in bytes used to hold all retryable requests.
+        /// Once this limit is reached new requests are not retried and their memory is released after being sent.
+        /// </summary>
+        /// <value>The buffer maximum size in bytes. The default value is 100 MB.</value>
         public int BufferMaxSize
         {
             get => _bufferMaxSize;
@@ -28,7 +29,8 @@ namespace IceRpc.Configure
         /// <summary>A logger factory used to create the retry interceptor logger.</summary>
         public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
-        /// <summary>The maximum number of attempts for retrying a request.</summary>
+        /// <summary>Gets or sets the maximum number of attempts for retrying a request.</summary>
+        /// <value>The maximum number of attempts for retrying a request. The default value is 1 attempt.</value>
         public int MaxAttempts
         {
             get => _maxAttempts;
@@ -43,8 +45,9 @@ namespace IceRpc.Configure
             }
         }
 
-        /// <summary>The maximum payload size in bytes for a request to be retryable, requests with a bigger payload
-        /// size are released after sent and cannot be retried. The default value is 1 MB.</summary>
+        /// <summary>Gets or sets the maximum payload size in bytes for a request to be retryable. Requests with a
+        /// bigger payload size are released after sent and cannot be retried.</summary>
+        /// <value>The maximum payload size in bytes. The default value is 1 MB.</value>
         public int RequestMaxSize
         {
             get => _requestMaxSize;

--- a/src/IceRpc/Configure/RetryOptions.cs
+++ b/src/IceRpc/Configure/RetryOptions.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Configure
     {
         /// <summary>The maximum amount of memory in bytes used to hold all retryable requests. Once this limit is
         /// reached new requests are not retried and their memory is released after being sent. The default value is
-        /// 100 MB</summary>
+        /// 100 MB.</summary>
         public int BufferMaxSize
         {
             get => _bufferMaxSize;

--- a/src/IceRpc/Configure/RetryOptions.cs
+++ b/src/IceRpc/Configure/RetryOptions.cs
@@ -14,7 +14,7 @@ namespace IceRpc.Configure
         public int BufferMaxSize
         {
             get => _bufferMaxSize;
-            init
+            set
             {
                 if (value < 1)
                 {
@@ -26,13 +26,13 @@ namespace IceRpc.Configure
         }
 
         /// <summary>A logger factory used to create the retry interceptor logger.</summary>
-        public ILoggerFactory LoggerFactory { get; init; } = NullLoggerFactory.Instance;
+        public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
         /// <summary>The maximum number of attempts for retrying a request.</summary>
         public int MaxAttempts
         {
             get => _maxAttempts;
-            init
+            set
             {
                 if (value < 1)
                 {
@@ -48,7 +48,7 @@ namespace IceRpc.Configure
         public int RequestMaxSize
         {
             get => _requestMaxSize;
-            init
+            set
             {
                 if (value < 1)
                 {

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -12,9 +12,9 @@ namespace IceRpc.Configure
         /// bidirectional streams opened on a connection. When this limit is reached, trying to open a new
         /// bidirectional stream will be delayed until a bidirectional stream is closed. Since an
         /// bidirectional stream is opened for each two-way proxy invocation, the sending of the two-way
-        /// invocation will be delayed until another two-way invocation on the connection completes. It can't
-        /// be less than 1 and the default value is 100.</summary>
-        /// <value>The bidirectional stream maximum count.</value>
+        /// invocation will be delayed until another two-way invocation on the connection completes.</summary>
+        /// <value>The bidirectional stream maximum count. It can't
+        /// be less than 1 and the default value is 100.</value>
         public int BidirectionalStreamMaxCount
         {
             get => _bidirectionalStreamMaxCount;
@@ -24,11 +24,11 @@ namespace IceRpc.Configure
                     nameof(value));
         }
 
-        /// <summary>Gets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
+        /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
         /// <value>A pool of memory blocks used for buffer management.</value>
         public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
-        /// <summary>Gets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
+        /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
         /// <value>The minimum size of the segment requested from the <see cref="Pool" />.</value>
         public int MinimumSegmentSize
         {
@@ -37,9 +37,9 @@ namespace IceRpc.Configure
                 throw new ArgumentException($"{nameof(MinimumSegmentSize)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>The packet maximum size in bytes. It can't be less than 1KB and the default value is
-        /// 32KB.</summary>
-        /// <value>The packet maximum size in bytes.</value>
+        /// <summary>The packet maximum size in bytes.</summary>
+        /// <value>The packet maximum size in bytes. It can't be less than 1KB and the default value is
+        /// 32KB.</value>
         public int PacketMaxSize
         {
             get => _packetMaxSize;
@@ -47,7 +47,7 @@ namespace IceRpc.Configure
                 throw new ArgumentException($"{nameof(PacketMaxSize)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>Gets the number of bytes when writes on a Slic stream starts blocking.</summary>
+        /// <summary>Gets or setsthe number of bytes when writes on a Slic stream starts blocking.</summary>
         /// <value>The pause writer threshold.</value>
         public int PauseWriterThreshold
         {
@@ -56,7 +56,7 @@ namespace IceRpc.Configure
                 throw new ArgumentException($"{nameof(PauseWriterThreshold)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>Gets the number of bytes when writes on a Slic stream stops blocking.</summary>
+        /// <summary>Gets or sets the number of bytes when writes on a Slic stream stops blocking.</summary>
         /// <value>The resume writer threshold.</value>
         public int ResumeWriterThreshold
         {
@@ -74,9 +74,9 @@ namespace IceRpc.Configure
         /// unidirectional streams opened on a connection. When this limit is reached, trying to open a new
         /// unidirectional stream will be delayed until an unidirectional stream is closed. Since an
         /// unidirectional stream is opened for each one-way proxy invocation, the sending of the one-way
-        /// invocation will be delayed until another one-way invocation on the connection completes. It can't
-        /// be less than 1 and the default value is 100.</summary>
-        /// <value>The unidirectional stream maximum count.</value>
+        /// invocation will be delayed until another one-way invocation on the connection completes.</summary>
+        /// <value>The unidirectional stream maximum count. It can't
+        /// be less than 1 and the default value is 100.</value>
         public int UnidirectionalStreamMaxCount
         {
             get => _unidirectionalStreamMaxCount;

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -46,7 +46,7 @@ namespace IceRpc.Configure
                 throw new ArgumentException($"{nameof(PacketMaxSize)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>Gets or setsthe number of bytes when writes on a Slic stream starts blocking.</summary>
+        /// <summary>Gets or sets the number of bytes when writes on a Slic stream starts blocking.</summary>
         /// <value>The pause writer threshold.</value>
         public int PauseWriterThreshold
         {

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -36,8 +36,8 @@ namespace IceRpc.Configure
                 throw new ArgumentException($"{nameof(MinimumSegmentSize)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>The packet maximum size in bytes.</summary>
-        /// <value>The packet maximum size in bytes. It can't be less than 1KB and the default value is
+        /// <summary>The maximum packet size in bytes.</summary>
+        /// <value>The maximum packet size in bytes. It can't be less than 1KB and the default value is
         /// 32KB.</value>
         public int PacketMaxSize
         {

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -18,7 +18,7 @@ namespace IceRpc.Configure
         public int BidirectionalStreamMaxCount
         {
             get => _bidirectionalStreamMaxCount;
-            init => _bidirectionalStreamMaxCount = value > 0 ? value :
+            set => _bidirectionalStreamMaxCount = value > 0 ? value :
                 throw new ArgumentException(
                     $"{nameof(BidirectionalStreamMaxCount)} can't be less than 1",
                     nameof(value));
@@ -26,14 +26,14 @@ namespace IceRpc.Configure
 
         /// <summary>Gets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
         /// <value>A pool of memory blocks used for buffer management.</value>
-        public MemoryPool<byte> Pool { get; init; } = MemoryPool<byte>.Shared;
+        public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
         /// <summary>Gets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
         /// <value>The minimum size of the segment requested from the <see cref="Pool" />.</value>
         public int MinimumSegmentSize
         {
             get => _minimumSegmentSize;
-            init => _minimumSegmentSize = value >= 1024 ? value :
+            set => _minimumSegmentSize = value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(MinimumSegmentSize)} can't be less than 1KB", nameof(value));
         }
 
@@ -43,7 +43,7 @@ namespace IceRpc.Configure
         public int PacketMaxSize
         {
             get => _packetMaxSize;
-            init => _packetMaxSize = value >= 1024 ? value :
+            set => _packetMaxSize = value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(PacketMaxSize)} can't be less than 1KB", nameof(value));
         }
 
@@ -52,7 +52,7 @@ namespace IceRpc.Configure
         public int PauseWriterThreshold
         {
             get => _pauseWriterThreshold;
-            init => _pauseWriterThreshold = value >= 1024 ? value :
+            set => _pauseWriterThreshold = value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(PauseWriterThreshold)} can't be less than 1KB", nameof(value));
         }
 
@@ -61,7 +61,7 @@ namespace IceRpc.Configure
         public int ResumeWriterThreshold
         {
             get => _resumeWriterThreshold;
-            init => _resumeWriterThreshold =
+            set => _resumeWriterThreshold =
                 value < 1024 ? throw new ArgumentException(
                     @$"{nameof(ResumeWriterThreshold)} can't be less than 1KB", nameof(value)) :
                 value > _pauseWriterThreshold ? throw new ArgumentException(
@@ -80,7 +80,7 @@ namespace IceRpc.Configure
         public int UnidirectionalStreamMaxCount
         {
             get => _unidirectionalStreamMaxCount;
-            init => _unidirectionalStreamMaxCount = value > 0 ? value :
+            set => _unidirectionalStreamMaxCount = value > 0 ? value :
                 throw new ArgumentException(
                     $"{nameof(UnidirectionalStreamMaxCount)} can't be less than 1",
                     nameof(value));
@@ -99,14 +99,14 @@ namespace IceRpc.Configure
     /// <summary>An options class for configuring a <see cref="SlicClientTransport"/>.</summary>
     public sealed record class SlicClientTransportOptions : SlicTransportOptions
     {
-        /// <summary>Gets or initializes the underlying simple client transport.</summary>
-        public IClientTransport<ISimpleNetworkConnection>? SimpleClientTransport { get; init; }
+        /// <summary>Gets or sets the underlying simple client transport.</summary>
+        public IClientTransport<ISimpleNetworkConnection>? SimpleClientTransport { get; set; }
     }
 
     /// <summary>An options class for configuring a <see cref="SlicServerTransport"/>.</summary>
     public sealed record class SlicServerTransportOptions : SlicTransportOptions
     {
-        /// <summary>Gets or initializes the underlying simple server transport.</summary>
-        public IServerTransport<ISimpleNetworkConnection>? SimpleServerTransport { get; init; }
+        /// <summary>Gets or sets the underlying simple server transport.</summary>
+        public IServerTransport<ISimpleNetworkConnection>? SimpleServerTransport { get; set; }
     }
 }

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -74,8 +74,8 @@ namespace IceRpc.Configure
         /// unidirectional stream will be delayed until an unidirectional stream is closed. Since an
         /// unidirectional stream is opened for each one-way proxy invocation, the sending of the one-way
         /// invocation will be delayed until another one-way invocation on the connection completes.</summary>
-        /// <value>The unidirectional stream maximum count. It can't
-        /// be less than 1 and the default value is 100.</value>
+        /// <value>The unidirectional stream maximum count. It can't be less than 1 and the default value is
+        /// 100.</value>
         public int UnidirectionalStreamMaxCount
         {
             get => _unidirectionalStreamMaxCount;

--- a/src/IceRpc/Configure/SlicTransportOptions.cs
+++ b/src/IceRpc/Configure/SlicTransportOptions.cs
@@ -13,8 +13,7 @@ namespace IceRpc.Configure
         /// bidirectional stream will be delayed until a bidirectional stream is closed. Since an
         /// bidirectional stream is opened for each two-way proxy invocation, the sending of the two-way
         /// invocation will be delayed until another two-way invocation on the connection completes.</summary>
-        /// <value>The bidirectional stream maximum count. It can't
-        /// be less than 1 and the default value is 100.</value>
+        /// <value>The bidirectional stream maximum count. It can't be less than 1 and the default value is 100.</value>
         public int BidirectionalStreamMaxCount
         {
             get => _bidirectionalStreamMaxCount;

--- a/src/IceRpc/Configure/SliceDecodePayloadOptions.cs
+++ b/src/IceRpc/Configure/SliceDecodePayloadOptions.cs
@@ -12,24 +12,24 @@ namespace IceRpc.Configure
 
         /// <summary>The activator to use when decoding Slice classes, exceptions and traits. When <c>null</c>, the
         /// decoding of a request or response payload uses the activator injected by the Slice generated code.</summary>
-        public IActivator? Activator { get; init; }
+        public IActivator? Activator { get; set; }
 
         /// <summary>The maximum depth when decoding a type recursively.</summary>
         /// <value>A value greater than 0, or <c>-1</c> for the default value.</value>
         public int MaxDepth
         {
             get => _maxDepth;
-            init => _maxDepth = value is -1 or > 0 ? value :
+            set => _maxDepth = value is -1 or > 0 ? value :
                 throw new ArgumentException("value must be -1 or greater than 0", nameof(MaxDepth));
         }
 
         /// <summary>The invoker assigned to decoded proxies. When null, a proxy decoded from an incoming request gets
         /// <see cref="Proxy.DefaultInvoker"/> while a proxy decoded from an incoming response gets the invoker of the
         /// proxy that created the request.</summary>
-        public IInvoker? ProxyInvoker { get; init; }
+        public IInvoker? ProxyInvoker { get; set; }
 
         /// <summary>The options for decoding a Slice stream.</summary>
-        public SliceStreamDecoderOptions StreamDecoderOptions { get; init; } = SliceStreamDecoderOptions.Default;
+        public SliceStreamDecoderOptions StreamDecoderOptions { get; set; } = SliceStreamDecoderOptions.Default;
 
         private int _maxDepth = -1;
     }

--- a/src/IceRpc/Configure/TcpTransportOptions.cs
+++ b/src/IceRpc/Configure/TcpTransportOptions.cs
@@ -8,13 +8,13 @@ namespace IceRpc.Configure
     /// <summary>The base options class for TCP transports.</summary>
     public record class TcpTransportOptions
     {
-        /// <summary>Gets or initializes the idle timeout. This timeout is used to monitor the network connection. If
+        /// <summary>Gets or sets the idle timeout. This timeout is used to monitor the network connection. If
         /// the connection is idle within this timeout period, the connection is gracefully closed.</summary>
         /// <value>The network connection idle timeout value. The default is 60s.</value>
         public TimeSpan IdleTimeout
         {
             get => _idleTimeout;
-            init => _idleTimeout = value != TimeSpan.Zero ? value :
+            set => _idleTimeout = value != TimeSpan.Zero ? value :
                 throw new ArgumentException($"0 is not a valid value for {nameof(IdleTimeout)}", nameof(value));
         }
 
@@ -22,25 +22,25 @@ namespace IceRpc.Configure
         /// when this property is set to <c>true</c>.</summary>
         /// <value><c>true</c> to enable IPv6-only support, <c>false</c> to disable it. The default is <c>false</c>.
         /// </value>
-        public bool IsIPv6Only { get; init; }
+        public bool IsIPv6Only { get; set; }
 
-        /// <summary>Gets or initializes the socket receive buffer size in bytes.</summary>
+        /// <summary>Gets or sets the socket receive buffer size in bytes.</summary>
         /// <value>The receive buffer size in bytes. It can't be less than 1KB. <c>null</c> means use the operating
         /// system default.</value>
         public int? ReceiveBufferSize
         {
             get => _receiveBufferSize;
-            init => _receiveBufferSize = value == null || value >= 1024 ? value :
+            set => _receiveBufferSize = value == null || value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(ReceiveBufferSize)} can't be less than 1KB", nameof(value));
         }
 
-        /// <summary>Gets or initializes the socket send buffer size in bytes.</summary>
+        /// <summary>Gets or sets the socket send buffer size in bytes.</summary>
         /// <value>The send buffer size in bytes. It can't be less than 1KB. <c>null</c> means use the OS default.
         /// </value>
         public int? SendBufferSize
         {
             get => _sendBufferSize;
-            init => _sendBufferSize = value == null || value >= 1024 ? value :
+            set => _sendBufferSize = value == null || value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(SendBufferSize)} can't be less than 1KB", nameof(value));
         }
 
@@ -52,24 +52,24 @@ namespace IceRpc.Configure
     /// <summary>The options class for configuring <see cref="TcpClientTransport"/>.</summary>
     public sealed record class TcpClientTransportOptions : TcpTransportOptions
     {
-        /// <summary>Gets or initializes the address and port represented by a .NET IPEndPoint to use for a client
+        /// <summary>Gets or sets the address and port represented by a .NET IPEndPoint to use for a client
         /// socket. If specified the client socket will bind to this address and port before connection establishment.
         /// </summary>
         /// <value>The address and port to bind the socket to.</value>
-        public IPEndPoint? LocalEndPoint { get; init; }
+        public IPEndPoint? LocalEndPoint { get; set; }
     }
 
     /// <summary>The options class for configuring <see cref="TcpServerTransport"/>.</summary>
     public sealed record class TcpServerTransportOptions : TcpTransportOptions
     {
-        /// <summary>Gets or initializes the length of the server socket queue for accepting new connections. If a new
+        /// <summary>Gets or sets the length of the server socket queue for accepting new connections. If a new
         /// connection request arrives and the queue is full, the client connection establishment will fail with a
         /// <see cref="ConnectionRefusedException"/> exception.</summary>
         /// <value>The server socket backlog size. The default is 511</value>
         public int ListenerBackLog
         {
             get => _listenerBackLog;
-            init => _listenerBackLog = value > 0 ? value :
+            set => _listenerBackLog = value > 0 ? value :
                 throw new ArgumentException($"{nameof(ListenerBackLog)} can't be less than 1", nameof(value));
         }
 

--- a/src/IceRpc/Configure/TelemetryOptions.cs
+++ b/src/IceRpc/Configure/TelemetryOptions.cs
@@ -11,9 +11,9 @@ namespace IceRpc.Configure
     {
         /// <summary>If set to a non null object the <see cref="ActivitySource"/> is used to start the request and
         /// response activities.</summary>
-        public ActivitySource? ActivitySource { get; init; }
+        public ActivitySource? ActivitySource { get; set; }
 
         /// <summary>The logger factory used to create the IceRpc logger.</summary>
-        public ILoggerFactory? LoggerFactory { get; init; }
+        public ILoggerFactory? LoggerFactory { get; set; }
     }
 }

--- a/src/IceRpc/Configure/UdpClientTransportOptions.cs
+++ b/src/IceRpc/Configure/UdpClientTransportOptions.cs
@@ -15,19 +15,19 @@ namespace IceRpc.Configure
         public TimeSpan IdleTimeout
         {
             get => _idleTimeout;
-            init => _idleTimeout = value != TimeSpan.Zero ? value :
+            set => _idleTimeout = value != TimeSpan.Zero ? value :
                 throw new ArgumentException($"0 is not a valid value for {nameof(IdleTimeout)}", nameof(value));
         }
 
         /// <summary>Configures an IPv6 socket to only support IPv6. The socket won't support IPv4 mapped addresses
         /// when this property is set to true. The default value is false.</summary>
         /// <value>The boolean value to enable or disable IPv6-only support.</value>
-        public bool IsIPv6Only { get; init; }
+        public bool IsIPv6Only { get; set; }
 
         /// <summary>The address and port represented by a .NET IPEndPoint to use for a client socket. If specified the
         /// client socket will bind to this address and port before connection establishment.</summary>
         /// <value>The address and port to bind the socket to.</value>
-        public IPEndPoint? LocalEndPoint { get; init; }
+        public IPEndPoint? LocalEndPoint { get; set; }
 
         /// <summary>The socket send buffer size in bytes. It can't be less than 1KB. If not set, the OS default
         /// send buffer size is used.</summary>
@@ -35,7 +35,7 @@ namespace IceRpc.Configure
         public int? SendBufferSize
         {
             get => _sendBufferSize;
-            init => _sendBufferSize = value == null || value >= 1024 ? value :
+            set => _sendBufferSize = value == null || value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(SendBufferSize)} can't be less than 1KB", nameof(value));
         }
 

--- a/src/IceRpc/Configure/UdpClientTransportOptions.cs
+++ b/src/IceRpc/Configure/UdpClientTransportOptions.cs
@@ -9,9 +9,8 @@ namespace IceRpc.Configure
     public sealed record class UdpClientTransportOptions
     {
         /// <summary>The idle timeout. This timeout is used to monitor the network connection. If the connection
-        /// is idle within this timeout period, the connection is gracefully closed. It can't be 0 and the default
-        /// value is 60s.</summary>
-        /// <value>The network connection idle timeout value.</value>
+        /// is idle within this timeout period, the connection is gracefully closed.</summary>
+        /// <value>The network connection idle timeout value. It can't be 0 and the default value is 60s.</value>
         public TimeSpan IdleTimeout
         {
             get => _idleTimeout;
@@ -20,8 +19,8 @@ namespace IceRpc.Configure
         }
 
         /// <summary>Configures an IPv6 socket to only support IPv6. The socket won't support IPv4 mapped addresses
-        /// when this property is set to true. The default value is false.</summary>
-        /// <value>The boolean value to enable or disable IPv6-only support.</value>
+        /// when this property is set to true.</summary>
+        /// <value>The boolean value to enable or disable IPv6-only support. The default value is false.</value>
         public bool IsIPv6Only { get; set; }
 
         /// <summary>The address and port represented by a .NET IPEndPoint to use for a client socket. If specified the
@@ -29,9 +28,9 @@ namespace IceRpc.Configure
         /// <value>The address and port to bind the socket to.</value>
         public IPEndPoint? LocalEndPoint { get; set; }
 
-        /// <summary>The socket send buffer size in bytes. It can't be less than 1KB. If not set, the OS default
-        /// send buffer size is used.</summary>
-        /// <value>The send buffer size in bytes.</value>
+        /// <summary>The socket send buffer size in bytes.</summary>
+        /// <value>The send buffer size in bytes. It can't be less than 1KB. If not set, the OS default
+        /// send buffer size is used.</value>
         public int? SendBufferSize
         {
             get => _sendBufferSize;

--- a/src/IceRpc/Configure/UdpServerTransportOptions.cs
+++ b/src/IceRpc/Configure/UdpServerTransportOptions.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Configure
         /// <summary>Configures an IPv6 socket to only support IPv6. The socket won't support IPv4 mapped addresses
         /// when this property is set to true. The default value is false.</summary>
         /// <value>The boolean value to enable or disable IPv6-only support.</value>
-        public bool IsIPv6Only { get; init; }
+        public bool IsIPv6Only { get; set; }
 
         /// <summary>The socket receive buffer size in bytes. It can't be less than 1KB. If not set, the OS default
         /// receive buffer size is used.</summary>
@@ -18,7 +18,7 @@ namespace IceRpc.Configure
         public int? ReceiveBufferSize
         {
             get => _receiveBufferSize;
-            init => _receiveBufferSize = value == null || value >= 1024 ? value :
+            set => _receiveBufferSize = value == null || value >= 1024 ? value :
                 throw new ArgumentException($"{nameof(ReceiveBufferSize)} can't be less than 1KB", nameof(value));
         }
 


### PR DESCRIPTION
Updated Options to use `get/set` instead of `get/init`.

Resolves #882 