### PR TITLE
Do not use expliticit interface implementation in the Router

### DIFF
--- a/src/IceRpc/Configure/Router.cs
+++ b/src/IceRpc/Configure/Router.cs
@@ -47,7 +47,7 @@ namespace IceRpc.Configure
         }
 
         /// <inheritdoc/>
-        public ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancel) =>
+        public ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancel = default) =>
             (_dispatcher ??= CreateDispatchPipeline()).DispatchAsync(request, cancel);
 
         /// <summary>Registers a route with a path. If there is an existing route at the same path, it is replaced.

--- a/src/IceRpc/IDispatcher.cs
+++ b/src/IceRpc/IDispatcher.cs
@@ -9,7 +9,7 @@ namespace IceRpc
         /// <param name="request">The incoming request being dispatched.</param>
         /// <param name="cancel">The cancellation token.</param>
         /// <returns>The corresponding <see cref="OutgoingResponse"/>.</returns>
-        public ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancel) =>
+        public ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancel = default) =>
             throw new NotImplementedException();
     }
 

--- a/tests/IceRpc.Tests.Internal/LoggingTests.cs
+++ b/tests/IceRpc.Tests.Internal/LoggingTests.cs
@@ -165,7 +165,7 @@ namespace IceRpc.Tests.Internal
             router.UseLogger(loggerFactory);
             router.Use(next => new InlineDispatcher((request, cancel) => new(response)));
 
-            Assert.That(await router.DispatchAsync(request, default), Is.EqualTo(response));
+            Assert.That(await router.DispatchAsync(request), Is.EqualTo(response));
 
             Assert.That(loggerFactory.Logger!.Category, Is.EqualTo("IceRpc"));
             Assert.That(loggerFactory.Logger!.Entries.Count, Is.EqualTo(twoway ? 2 : 1));
@@ -211,8 +211,7 @@ namespace IceRpc.Tests.Internal
             router.UseLogger(loggerFactory);
             router.Use(next => new InlineDispatcher((request, cancel) => throw exception));
 
-            Assert.CatchAsync<ArgumentException>(
-                async () => await router.DispatchAsync(request, default));
+            Assert.CatchAsync<ArgumentException>(async () => await router.DispatchAsync(request));
 
             Assert.That(loggerFactory.Logger!.Entries.Count, Is.EqualTo(2));
 

--- a/tests/IceRpc.Tests/RouterTests.cs
+++ b/tests/IceRpc.Tests/RouterTests.cs
@@ -76,8 +76,7 @@ public class RouterTests
             new IncomingRequest(Protocol.IceRpc)
             {
                 Path = path
-            },
-            default);
+            });
 
         // Assert
         Assert.That(currentPath, Is.EqualTo(path));
@@ -119,8 +118,7 @@ public class RouterTests
             new IncomingRequest(Protocol.IceRpc)
             {
                 Path = path
-            },
-            default);
+            });
 
         // Assert
         Assert.That(currentPath, Is.EqualTo(path));
@@ -144,7 +142,7 @@ public class RouterTests
         var router = new Router();
 
         DispatchException ex = Assert.ThrowsAsync<DispatchException>(
-            async () => await router.DispatchAsync(new IncomingRequest(Protocol.IceRpc), default));
+            async () => await router.DispatchAsync(new IncomingRequest(Protocol.IceRpc)));
 
         Assert.That(ex.ErrorCode, Is.EqualTo(DispatchErrorCode.ServiceNotFound));
     }
@@ -223,8 +221,7 @@ public class RouterTests
             new IncomingRequest(Protocol.IceRpc)
             {
                 Path = path
-            },
-            default);
+            });
 
         // Assert
         Assert.That(calls, Is.EqualTo(expectedCalls));
@@ -240,7 +237,7 @@ public class RouterTests
         var router = new Router();
         router.Mount("/", dispatcher);
 
-        _ = await router.DispatchAsync(new IncomingRequest(Protocol.IceRpc), default);
+        _ = await router.DispatchAsync(new IncomingRequest(Protocol.IceRpc));
         return router;
     }
 }


### PR DESCRIPTION
This avoid the need to cast the Router to an `IDispatcher` to call `DispatchAsync`, and it is consistent with the pipeline implementation of the invoker. 