### PR TITLE
Refactor icerpc control frames

### DIFF
--- a/slice/IceRpc/Internal/IceRpcDefinitions.slice
+++ b/slice/IceRpc/Internal/IceRpcDefinitions.slice
@@ -11,7 +11,7 @@ enum IceRpcControlFrameType : byte
     /// The Initialize frame is sent by each side on connection establishment to exchange connection fields.
     Initialize = 0,
 
-    /// The Ping frame is sent to keep alive the icerpc connection. This frame does not have a body.
+    /// The Ping frame is sent to keep alive the connection. This frame does not have a body.
     Ping = 1,
 
     /// The GoAway frame is sent to notify the peer that the connection is being shutdown. The shutdown initiator

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -679,10 +679,7 @@ namespace IceRpc.Internal
             }
 
             return frameType == IceRpcControlFrameType.GoAwayCompleted ?
-                output.WriteAsync(
-                    ReadOnlySequence<byte>.Empty,
-                    completeWhenDone: true,
-                    cancel) :
+                output.WriteAsync(ReadOnlySequence<byte>.Empty, completeWhenDone: true, cancel) :
                 output.FlushAsync(cancel);
         }
 


### PR DESCRIPTION
This PR refactors the icerpc control frames as proposed by #900.

It's currently based on PR #899 and it will rebased on #899 is merged. Almost all the code is in IceRpcProtocolConnection.cs.