### PR TITLE
Fixed #813

### DIFF
--- a/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
@@ -80,11 +80,6 @@ namespace IceRpc.Transports.Internal
                 throw ex.ToTransportException(cancel);
             }
 
-            if (received == 0)
-            {
-                throw new ConnectionLostException();
-            }
-
             Interlocked.Exchange(ref _lastActivity, (long)Time.Elapsed.TotalMilliseconds);
             return received;
         }

--- a/tests/IceRpc.Tests.Internal/TcpNetworkConnectionReadWriteTests.cs
+++ b/tests/IceRpc.Tests.Internal/TcpNetworkConnectionReadWriteTests.cs
@@ -130,11 +130,12 @@ namespace IceRpc.Tests.Internal
         }
 
         [Test]
-        public async Task TcpNetworkConnectionReadWrite_ReadAsync_ConnectionLostException()
+        public async Task TcpNetworkConnectionReadWrite_ReadAsync_ReturnsZero()
         {
             await _serverConnection!.DisposeAsync();
-            Assert.CatchAsync<ConnectionLostException>(
-                async () => await ClientConnection.ReadAsync(new byte[1], default));
+            int read = await ClientConnection.ReadAsync(new byte[1], default);
+
+            Assert.That(read, Is.Zero);
         }
 
         [Test]

--- a/tests/IceRpc.Tests.Internal/TcpNetworkConnectionTests.cs
+++ b/tests/IceRpc.Tests.Internal/TcpNetworkConnectionTests.cs
@@ -121,8 +121,7 @@ namespace IceRpc.Tests.Internal
                 // Server side ConnectAsync is a no-op for non secure TCP connections so it won't throw.
                 _ = await serverConnection.ConnectAsync(default);
 
-                Assert.ThrowsAsync<ConnectionLostException>(
-                    async () => await serverConnection.ReadAsync(new byte[1], default));
+                Assert.That(await serverConnection.ReadAsync(new byte[1], default), Is.Zero);
             }
             else
             {


### PR DESCRIPTION
This PR fixes #813. The transport no longer has to raise `ConnectionLostException` if it returns 0 bytes.