### PR TITLE
Revert updates SimpleNetworkConnectionWriter

### DIFF
--- a/src/IceRpc/Internal/IcePayloadPipeWriter.cs
+++ b/src/IceRpc/Internal/IcePayloadPipeWriter.cs
@@ -35,18 +35,26 @@ namespace IceRpc.Internal
 
         public override Span<byte> GetSpan(int sizeHint = 0) => _networkConnectionWriter.GetSpan(sizeHint);
 
-        public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancel) =>
+        public override async ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancel)
+        {
             // The write can't be canceled because it would lead to the writing of an incomplete payload.
-            _networkConnectionWriter.WriteAsync(new ReadOnlySequence<byte>(source), CancellationToken.None);
+            await _networkConnectionWriter.WriteAsync(
+                new ReadOnlySequence<byte>(source),
+                CancellationToken.None).ConfigureAwait(false);
+            return default;
+        }
 
-        /// <summary>Write the source to the simple network connection. <paramref name="endStream"/> is ignored because
+        /// <summary>Writes the source to the simple network connection. <paramref name="endStream"/> is ignored because
         /// the simple network connection has no use for it.</summary>
-        public override ValueTask<FlushResult> WriteAsync(
+        public override async ValueTask<FlushResult> WriteAsync(
             ReadOnlySequence<byte> source,
             bool endStream,
-            CancellationToken cancel) =>
+            CancellationToken cancel)
+        {
             // The write can't be canceled because it would lead to the writing of an incomplete payload.
-            _networkConnectionWriter.WriteAsync(source, CancellationToken.None);
+            await _networkConnectionWriter.WriteAsync(source, CancellationToken.None).ConfigureAwait(false);
+            return default;
+        }
 
         internal IcePayloadPipeWriter(SimpleNetworkConnectionWriter networkConnectionWriter) =>
             _networkConnectionWriter = networkConnectionWriter;

--- a/src/IceRpc/Transports/Internal/SimpleNetworkConnectionWriter.cs
+++ b/src/IceRpc/Transports/Internal/SimpleNetworkConnectionWriter.cs
@@ -46,7 +46,11 @@ namespace IceRpc.Transports.Internal
         internal ValueTask FlushAsync(CancellationToken cancel) =>
             WriteAsync(ReadOnlySequence<byte>.Empty, ReadOnlySequence<byte>.Empty, cancel);
 
-        /// <summary>Writes the two sources to the simple network connection.</summary>
+        /// <summary>Writes a sequence of bytes.</summary>
+        internal ValueTask WriteAsync(ReadOnlySequence<byte> source, CancellationToken cancel) =>
+            WriteAsync(source, ReadOnlySequence<byte>.Empty, cancel);
+
+        /// <summary>Writes two sequences of bytes.</summary>
         internal async ValueTask WriteAsync(
             ReadOnlySequence<byte> source1,
             ReadOnlySequence<byte> source2,
@@ -113,21 +117,6 @@ namespace IceRpc.Transports.Internal
                     }
                 }
             }
-        }
-    }
-
-    internal static class SimpleNetworkConnectionWriterExtensions
-    {
-        /// <summary>A WriteAsync convenience extension method. Since <see
-        /// cref="SimpleNetworkConnectionWriter.WriteAsync(ReadOnlySequence{byte}, ReadOnlySequence{byte},
-        /// CancellationToken)"/> can never be canceled or completed, we return a default flush result.</summary>
-        internal static async ValueTask<FlushResult> WriteAsync(
-            this SimpleNetworkConnectionWriter writer,
-            ReadOnlySequence<byte> source,
-            CancellationToken cancel)
-        {
-            await writer.WriteAsync(source, ReadOnlySequence<byte>.Empty, cancel).ConfigureAwait(false);
-            return default;
         }
     }
 }


### PR DESCRIPTION
This PR reverts some of the updates to SimpleNetworkConnectionWriter.

It does not make sense to add an extension class for this internal class, and returning a plain `ValueTask` like the other internal methods is more consistent with these other methods.