### PR TITLE
Fix locator interceptor exception handling

### DIFF
--- a/src/IceRpc.Interop/LocatorInterceptor.cs
+++ b/src/IceRpc.Interop/LocatorInterceptor.cs
@@ -96,13 +96,16 @@ namespace IceRpc
                         }
                         // else, resolution failed and we don't update anything
                     }
-                    catch (Slice.RemoteException)
+                    catch (Exception exception)
                     {
-                        // Ignore any remote exception from the location resolver. It should have been logged earlier.
-                    }
-                    catch (InvalidDataException)
-                    {
-                        // Ignored.
+                        // Clean-up request
+                        await request.PayloadSource.CompleteAsync(exception).ConfigureAwait(false);
+                        if (request.PayloadSourceStream != null)
+                        {
+                            await request.PayloadSourceStream.CompleteAsync(exception).ConfigureAwait(false);
+                        }
+                        await request.PayloadSink.CompleteAsync().ConfigureAwait(false);
+                        throw;
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes the exception handling in the locator interceptor.

When the implementation throws an exception, this exception is no longer "eaten": we clean-up the request and throw it up the chain to the application.

I think this is a more logical behavior than eating the exception. When you're resolving an endpoint-less proxy and your locator resolution fails, it's very very likely your invocation will fail. Failing with "no endpoint found" because of some bug/issue with the locator that you can only find by looking at the logs (if you have logging enabled) is not very helpful.

For example, the call to your locator could throw DispatchException(ServiceNotFound) because there is a typo in your URI. With this PR, this exception is now thrown to the application.