### PR TITLE
Sequece test cleanup

### DIFF
--- a/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
@@ -38,7 +38,7 @@ public class SequenceDecodingTests
     {
         get
         {
-            foreach (SliceEncoding encoding in new SliceEncoding[] { SliceEncoding.Slice11, SliceEncoding.Slice20 })
+            foreach (SliceEncoding encoding in Enum.GetValues(typeof(SliceEncoding)))
             {
                 foreach (int size in new int[] { 0, 256 })
                 {


### PR DESCRIPTION
Updated the test to use `SliceEncoder.GetSizeLength` to compute the size, and a few minor fixes.