### PR TITLE
Fixes for Handle exceptions throw from IceRpc EncodeHeader

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -259,8 +259,8 @@ namespace IceRpc.Internal
                 catch (Exception exception)
                 {
                     await response.CompleteAsync(exception).ConfigureAwait(false);
-                    await stream.Output.CompleteAsync().ConfigureAwait(false);
-                    throw;
+                    await SendPayloadAsync(response, stream.Output, CancellationToken.None).ConfigureAwait(false);
+                    return;
                 }
 
                 // SendPayloadAsync takes care of the completion of the payload, payload stream and stream output.

--- a/src/IceRpc/OutgoingFieldValue.cs
+++ b/src/IceRpc/OutgoingFieldValue.cs
@@ -2,8 +2,6 @@
 
 using IceRpc.Slice;
 using System.Buffers;
-using System.Diagnostics;
-
 
 namespace IceRpc
 {


### PR DESCRIPTION
Resolves #979.

* Side question from looking at this why do we not call `stream.Output.CompleteAsync().ConfigureAwait(false)`  for oneway?
@bentoi 