### PR TITLE
Remove unnecessary `encoding_name` method

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -465,7 +465,7 @@ r#"if ({encoding_variable} != {encoding})
                                 identifier = self.identifier,
                                 encoding_variable = self.encoding_variable,
                                 encoding = encoding.to_cs_encoding(),
-                                encoding_name = encoding.encoding_name(),
+                                encoding_name = encoding,
                             )
                         } else {
                             "".to_owned()

--- a/tools/slicec-cs/src/slicec_ext/slice_encoding_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/slice_encoding_ext.rs
@@ -4,7 +4,6 @@ use slice::grammar::Encoding;
 
 pub trait EncodingExt {
     fn to_cs_encoding(&self) -> &str;
-    fn encoding_name(&self) -> &str;
 }
 
 impl EncodingExt for Encoding {
@@ -12,14 +11,6 @@ impl EncodingExt for Encoding {
         match self {
             Encoding::Slice11 => "SliceEncoding.Slice1",
             Encoding::Slice2 => "SliceEncoding.Slice2",
-        }
-    }
-
-    // TODO: this can be removed once we rename the Slice2 encoding to "2"
-    fn encoding_name(&self) -> &str {
-        match self {
-            Encoding::Slice11 => "1.1",
-            Encoding::Slice2 => "2.0",
         }
     }
 }


### PR DESCRIPTION
`SliceEncoding` already implements `Display`, so it can be used directly.