### PR TITLE
Fix for issue #1060

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicMultiplexedStream.cs
+++ b/src/IceRpc/Transports/Internal/SlicMultiplexedStream.cs
@@ -126,12 +126,15 @@ namespace IceRpc.Transports.Internal
 
         internal void AbortRead(long errorCode)
         {
-            if (!IsStarted || IsShutdown)
+            if (!IsStarted)
             {
-                return;
+                // If the stream is not started, there's no need to send a stop sending frame.
+                TrySetReadCompleted();
             }
-
-            _ = SendStopSendingFrameAndCompleteReadsAsync();
+            else if (!ReadsCompleted)
+            {
+                _ = SendStopSendingFrameAndCompleteReadsAsync();
+            }
 
             async Task SendStopSendingFrameAndCompleteReadsAsync()
             {
@@ -166,12 +169,15 @@ namespace IceRpc.Transports.Internal
 
         internal void AbortWrite(long errorCode)
         {
-            if (!IsStarted || IsShutdown)
+            if (!IsStarted)
             {
-                return;
+                // If the stream is not started, there's no need to send a reset frame.
+                TrySetWriteCompleted();
             }
-
-            _ = SendResetFrameAndCompleteWritesAsync();
+            else if (!WritesCompleted)
+            {
+                _ = SendResetFrameAndCompleteWritesAsync();
+            }
 
             async Task SendResetFrameAndCompleteWritesAsync()
             {


### PR DESCRIPTION
This PR fixes the retry graceful close test failure by ensuring that reads/writes are completed on the Slic stream if the stream isn't started.