### PR TITLE
Update doc-comment for OutgoingRequest.Connection

### DIFF
--- a/src/IceRpc/IncomingResponse.cs
+++ b/src/IceRpc/IncomingResponse.cs
@@ -22,6 +22,9 @@ namespace IceRpc
         /// <summary>Constructs an incoming response.</summary>
         /// <param name="request">The corresponding outgoing request.</param>
         /// <param name="connection">The connection that received the response.</param>
+        /// <remarks>While <paramref name="connection"/> is usually the same as the request's
+        /// <see cref="OutgoingRequest.Connection"/>, it may be a different connection since an invoker can ignore the
+        /// request's connection when sending this request.</remarks>
         public IncomingResponse(OutgoingRequest request, Connection connection)
             : base(connection) => Request = request;
     }

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -7,7 +7,13 @@ namespace IceRpc
     /// <summary>Represents an ice or icerpc request frame sent by the application.</summary>
     public sealed class OutgoingRequest : OutgoingFrame
     {
-        /// <summary>Gets or sets the connection that will be used (or was used ) to send this request.</summary>
+        /// <summary>Gets or sets the connection associated with this request. This connection is used by the
+        /// <see cref="Proxy.DefaultInvoker"/> to send the request and by interceptors such as the
+        /// <see cref="BinderInterceptor"/> to agree on which connection to use. While this connection is usually the
+        /// connection used to send this request and receive the corresponding response, an invoker can use a different
+        /// connection without setting this property.</summary>
+        /// <value>The connection associated with this request. Its initial value is <see cref="Proxy.Connection"/>.
+        /// </value>
         public Connection? Connection { get; set; }
 
         /// <summary>Gets or sets the features of this request.</summary>


### PR DESCRIPTION
This is the alternative to my other PR: keep OutgoingRequest.Connection as-is but with better doc-comments.