### PR TITLE
Add factories to remove _connection from XxxProtocolConnection

### DIFF
--- a/src/IceRpc/Internal/IProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IProtocolConnectionFactory.cs
@@ -1,16 +1,36 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Buffers;
+using System.IO.Pipelines;
 using IceRpc.Transports;
 
 namespace IceRpc.Internal
 {
+    internal delegate IncomingRequest IncomingRequestFactory(
+        FeatureCollection features,
+        IDictionary<RequestFieldKey, ReadOnlySequence<byte>> fields,
+        PipeReader? fieldsPipeReader,
+        string fragment,
+        bool oneway,
+        string operation,
+        string path,
+        PipeReader payload);
+
+    internal delegate IncomingResponse IncomingResponseFactory(
+        OutgoingRequest request,
+        IDictionary<ResponseFieldKey, ReadOnlySequence<byte>> fields,
+        PipeReader? fieldsPipeReader,
+        PipeReader payload,
+        ResultType resultType);
+
     internal interface IProtocolConnectionFactory<T> where T : INetworkConnection
     {
         /// <summary>Creates a protocol connection from a network connection.</summary>
         Task<IProtocolConnection> CreateProtocolConnectionAsync(
             T networkConnection,
             NetworkConnectionInformation connectionInformation,
-            Connection connection,
+            IncomingRequestFactory incomingRequestFactory,
+            IncomingResponseFactory incomingResponseFactory,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel);

--- a/src/IceRpc/Internal/IceProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IceProtocolConnectionFactory.cs
@@ -10,15 +10,17 @@ namespace IceRpc.Internal
         public async Task<IProtocolConnection> CreateProtocolConnectionAsync(
             ISimpleNetworkConnection networkConnection,
             NetworkConnectionInformation connectionInfo,
-            Connection connection,
+            IncomingRequestFactory incomingRequestFactory,
+            IncomingResponseFactory incomingResponseFactory,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel)
         {
             var protocolConnection = new IceProtocolConnection(
-                connection,
                 connectionOptions.Dispatcher,
                 networkConnection,
+                incomingRequestFactory,
+                incomingResponseFactory,
                 connectionOptions.IceProtocolOptions ?? Configure.IceProtocolOptions.Default);
 
             try

--- a/src/IceRpc/Internal/IceRpcProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnectionFactory.cs
@@ -10,15 +10,17 @@ namespace IceRpc.Internal
         public async Task<IProtocolConnection> CreateProtocolConnectionAsync(
             IMultiplexedNetworkConnection networkConnection,
             NetworkConnectionInformation connectionInfo,
-            Connection connection,
+            IncomingRequestFactory incomingRequestFactory,
+            IncomingResponseFactory incomingResponseFactory,
             Configure.ConnectionOptions connectionOptions,
             bool _,
             CancellationToken cancel)
         {
             var protocolConnection = new IceRpcProtocolConnection(
-                connection,
                 connectionOptions.Dispatcher,
                 networkConnection,
+                incomingRequestFactory,
+                incomingResponseFactory,
                 connectionOptions.Fields);
             try
             {

--- a/src/IceRpc/Internal/LogProtocolConnectionFactoryDecorator.cs
+++ b/src/IceRpc/Internal/LogProtocolConnectionFactoryDecorator.cs
@@ -14,7 +14,8 @@ namespace IceRpc.Internal
         async Task<IProtocolConnection> IProtocolConnectionFactory<T>.CreateProtocolConnectionAsync(
             T networkConnection,
             NetworkConnectionInformation connectionInformation,
-            Connection connection,
+            IncomingRequestFactory incomingRequestFactory,
+            IncomingResponseFactory incomingResponseFactory,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel)
@@ -24,18 +25,23 @@ namespace IceRpc.Internal
             IProtocolConnection protocolConnection = await _decoratee.CreateProtocolConnectionAsync(
                 networkConnection,
                 connectionInformation,
-                connection,
+                incomingRequestFactory,
+                incomingResponseFactory,
                 connectionOptions,
                 isServer,
                 cancel).ConfigureAwait(false);
 
-            _logger.LogCreateProtocolConnection(connection.Endpoint.Protocol,
-                                                connectionInformation.LocalEndPoint,
-                                                connectionInformation.RemoteEndPoint);
+            // TODO: do we really need this parameter?
+            Protocol protocol = protocolConnection is IceRpcProtocolConnection ? Protocol.IceRpc : Protocol.Ice;
+
+            _logger.LogCreateProtocolConnection(
+                protocol,
+                connectionInformation.LocalEndPoint,
+                connectionInformation.RemoteEndPoint);
 
             return new LogProtocolConnectionDecorator(
                 protocolConnection,
-                connection.Endpoint.Protocol,
+                protocol,
                 connectionInformation,
                 isServer,
                 _logger);


### PR DESCRIPTION
This PR is an attempt to fix #1032 by adding factory methods that create incoming requests and incoming responses.

It was inspired by this comment from Jose:
https://github.com/zeroc-ice/icerpc-csharp/issues/1032#issuecomment-1100157368

The Dispatcher "wrapper" proposed by Jose requires making IncomingFrame.Connection get/set with a temporary unitialized state ... until this Dispatcher wrapper sets it. I find the factory approach I implemented cleaner.

Nevertheless, I recommend to reject this PR as it does not remove the circular reference between connection and protocol connection, it just obfuscates it.

Currently on main, there is a clear circular reference: Connection holds an IProtocolConnection? and each IProtocolConnection implementation holds a Connection.

With this PR, we still have a circular reference, just not as obvious:
Connection holds an IProtocolConnection? and each ProtocolConnection implementation holds 2 factories that capture a non-null Connection. The same would be true with a Dispatcher wrapper that holds and sets Connection.

The whole point of #1032 is to avoid such circular references. When we take a snapshot of what's going on in an IceRPC application, we don't want to have 2 objects holding each other even through some indirection.

The only solution I see is passing Connection as a parameter to IProtocolConnection.AcceptRequestsAsync and IProtocolConnection.InvokeAsync.