### PR TITLE
Fix circular references through new Connection parameter

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -303,7 +303,7 @@ namespace IceRpc
 
             try
             {
-                return await protocolConnection.InvokeAsync(request, cancel).ConfigureAwait(false);
+                return await protocolConnection.InvokeAsync(request, this, cancel).ConfigureAwait(false);
             }
             catch (ConnectionLostException exception)
             {
@@ -429,7 +429,6 @@ namespace IceRpc
                 _protocolConnection = await protocolConnectionFactory.CreateProtocolConnectionAsync(
                     networkConnection,
                     NetworkConnectionInformation.Value,
-                    this,
                     _options,
                     _serverEndpoint != null,
                     connectCancellationSource.Token).ConfigureAwait(false);
@@ -473,7 +472,7 @@ namespace IceRpc
                             Exception? exception = null;
                             try
                             {
-                                await protocolConnection.AcceptRequestsAsync().ConfigureAwait(false);
+                                await protocolConnection.AcceptRequestsAsync(this).ConfigureAwait(false);
                             }
                             catch (Exception ex)
                             {

--- a/src/IceRpc/Internal/IProtocolConnection.cs
+++ b/src/IceRpc/Internal/IProtocolConnection.cs
@@ -24,7 +24,8 @@ namespace IceRpc.Internal
         Action<string>? PeerShutdownInitiated { get; set; }
 
         /// <summary>Accepts requests and returns once the connection is closed or the shutdown completes.</summary>
-        Task AcceptRequestsAsync();
+        /// <param name="connection">The connection of incoming requests created by this method.</param>
+        Task AcceptRequestsAsync(Connection connection);
 
         /// <summary>Sends a ping frame to defer the idle timeout.</summary>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
@@ -33,9 +34,13 @@ namespace IceRpc.Internal
         /// <summary>Sends a request and returns the response. The implementation must complete the request payload
         /// and payload stream.</summary>
         /// <param name="request">The outgoing request to send.</param>
+        /// <param name="connection">The connection of incoming responses created by this method.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>The received response.</returns>
-        Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancel = default);
+        Task<IncomingResponse> InvokeAsync(
+            OutgoingRequest request,
+            Connection connection,
+            CancellationToken cancel = default);
 
         /// <summary>Shutdowns gracefully the connection.</summary>
         /// <param name="message">The reason of the connection shutdown.</param>

--- a/src/IceRpc/Internal/IProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IProtocolConnectionFactory.cs
@@ -10,7 +10,6 @@ namespace IceRpc.Internal
         Task<IProtocolConnection> CreateProtocolConnectionAsync(
             T networkConnection,
             NetworkConnectionInformation connectionInformation,
-            Connection connection,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel);

--- a/src/IceRpc/Internal/IceProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IceProtocolConnectionFactory.cs
@@ -10,13 +10,11 @@ namespace IceRpc.Internal
         public async Task<IProtocolConnection> CreateProtocolConnectionAsync(
             ISimpleNetworkConnection networkConnection,
             NetworkConnectionInformation connectionInfo,
-            Connection connection,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel)
         {
             var protocolConnection = new IceProtocolConnection(
-                connection,
                 connectionOptions.Dispatcher,
                 networkConnection,
                 connectionOptions.IceProtocolOptions ?? Configure.IceProtocolOptions.Default);

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -44,7 +44,6 @@ namespace IceRpc.Internal
         /// <inheritdoc/>
         public Action<string>? PeerShutdownInitiated { get; set; }
 
-        private readonly Connection _connection;
         private IMultiplexedStream? _controlStream;
         private readonly HashSet<CancellationTokenSource> _cancelDispatchSources = new();
         private readonly IDispatcher _dispatcher;
@@ -64,7 +63,7 @@ namespace IceRpc.Internal
         private readonly TaskCompletionSource _waitForGoAwayCompleted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public async Task AcceptRequestsAsync()
+        public async Task AcceptRequestsAsync(Connection connection)
         {
             while (true)
             {
@@ -124,7 +123,7 @@ namespace IceRpc.Internal
                     throw;
                 }
 
-                var request = new IncomingRequest(_connection, fields, fieldsPipeReader)
+                var request = new IncomingRequest(connection, fields, fieldsPipeReader)
                 {
                     Features = features,
                     IsOneway = !stream.IsBidirectional,
@@ -342,7 +341,10 @@ namespace IceRpc.Internal
         public Task PingAsync(CancellationToken cancel) =>
             SendControlFrameAsync(IceRpcControlFrameType.Ping, encodeAction: null, cancel).AsTask();
 
-        public async Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancel)
+        public async Task<IncomingResponse> InvokeAsync(
+            OutgoingRequest request,
+            Connection connection,
+            CancellationToken cancel)
         {
             IMultiplexedStream? stream = null;
             try
@@ -394,7 +396,7 @@ namespace IceRpc.Internal
 
             if (request.IsOneway)
             {
-                return new IncomingResponse(request, _connection);
+                return new IncomingResponse(request, connection);
             }
 
             Debug.Assert(stream != null);
@@ -424,7 +426,7 @@ namespace IceRpc.Internal
                     request.Features = request.Features.With(retryPolicy);
                 }
 
-                return new IncomingResponse(request, _connection, fields, fieldsPipeReader)
+                return new IncomingResponse(request, connection, fields, fieldsPipeReader)
                 {
                     Payload = stream.Input,
                     ResultType = header.ResultType
@@ -608,12 +610,10 @@ namespace IceRpc.Internal
 
         /// <inheritdoc/>
         internal IceRpcProtocolConnection(
-            Connection connection,
             IDispatcher dispatcher,
             IMultiplexedNetworkConnection networkConnection,
             IDictionary<ConnectionFieldKey, OutgoingFieldValue> localFields)
         {
-            _connection = connection;
             _dispatcher = dispatcher;
             _networkConnection = networkConnection;
             _localFields = localFields;

--- a/src/IceRpc/Internal/IceRpcProtocolConnectionFactory.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnectionFactory.cs
@@ -10,13 +10,11 @@ namespace IceRpc.Internal
         public async Task<IProtocolConnection> CreateProtocolConnectionAsync(
             IMultiplexedNetworkConnection networkConnection,
             NetworkConnectionInformation connectionInfo,
-            Connection connection,
             Configure.ConnectionOptions connectionOptions,
             bool _,
             CancellationToken cancel)
         {
             var protocolConnection = new IceRpcProtocolConnection(
-                connection,
                 connectionOptions.Dispatcher,
                 networkConnection,
                 connectionOptions.Fields);

--- a/src/IceRpc/Internal/LogProtocolConnectionDecorator.cs
+++ b/src/IceRpc/Internal/LogProtocolConnectionDecorator.cs
@@ -28,11 +28,11 @@ namespace IceRpc.Internal
         private readonly bool _isServer;
         private readonly ILogger _logger;
 
-        async Task IProtocolConnection.AcceptRequestsAsync()
+        async Task IProtocolConnection.AcceptRequestsAsync(Connection connection)
         {
             using IDisposable connectionScope = _logger.StartConnectionScope(_information, _isServer);
             _logger.LogAcceptRequests();
-            await _decoratee.AcceptRequestsAsync().ConfigureAwait(false);
+            await _decoratee.AcceptRequestsAsync(connection).ConfigureAwait(false);
         }
 
         void IDisposable.Dispose()
@@ -51,12 +51,14 @@ namespace IceRpc.Internal
 
         async Task<IncomingResponse> IProtocolConnection.InvokeAsync(
             OutgoingRequest request,
+            Connection connection,
             CancellationToken cancel)
         {
             using IDisposable connectionScope = _logger.StartConnectionScope(_information, _isServer);
             using IDisposable _ = _logger.StartSendRequestScope(request);
             IncomingResponse response = await _decoratee.InvokeAsync(
                 request,
+                connection,
                 cancel).ConfigureAwait(false);
             _logger.LogSendRequest();
             return response;

--- a/src/IceRpc/Internal/LogProtocolConnectionFactoryDecorator.cs
+++ b/src/IceRpc/Internal/LogProtocolConnectionFactoryDecorator.cs
@@ -14,7 +14,6 @@ namespace IceRpc.Internal
         async Task<IProtocolConnection> IProtocolConnectionFactory<T>.CreateProtocolConnectionAsync(
             T networkConnection,
             NetworkConnectionInformation connectionInformation,
-            Connection connection,
             Configure.ConnectionOptions connectionOptions,
             bool isServer,
             CancellationToken cancel)
@@ -24,18 +23,21 @@ namespace IceRpc.Internal
             IProtocolConnection protocolConnection = await _decoratee.CreateProtocolConnectionAsync(
                 networkConnection,
                 connectionInformation,
-                connection,
                 connectionOptions,
                 isServer,
                 cancel).ConfigureAwait(false);
 
-            _logger.LogCreateProtocolConnection(connection.Endpoint.Protocol,
-                                                connectionInformation.LocalEndPoint,
-                                                connectionInformation.RemoteEndPoint);
+            // TODO: do we need this parameter?
+            Protocol protocol = protocolConnection is IceRpcProtocolConnection ? Protocol.IceRpc : Protocol.Ice;
+
+            _logger.LogCreateProtocolConnection(
+                protocol,
+                connectionInformation.LocalEndPoint,
+                connectionInformation.RemoteEndPoint);
 
             return new LogProtocolConnectionDecorator(
                 protocolConnection,
-                connection.Endpoint.Protocol,
+                protocol,
                 connectionInformation,
                 isServer,
                 _logger);

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -79,8 +79,8 @@ public sealed class IceProtocolConnectionTests
             .BuildServiceProvider();
 
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
-        _ = sut.Client.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.Ice);
+        _ = sut.Client.AcceptRequestsAsync(InvalidConnection.Ice);
 
         var request = new OutgoingRequest(new Proxy(Protocol.Ice));
         var responseTasks = new List<Task<IncomingResponse>>();
@@ -88,7 +88,7 @@ public sealed class IceProtocolConnectionTests
         // Act
         for (int i = 0; i < maxConcurrentDispatches + 1; ++i)
         {
-            responseTasks.Add(sut.Client.InvokeAsync(request, default));
+            responseTasks.Add(sut.Client.InvokeAsync(request, InvalidConnection.Ice, default));
         }
         // wait for maxDispatchesPerConnection dispatches to start
         for (int i = 0; i < maxConcurrentDispatches; ++i)
@@ -126,11 +126,13 @@ public sealed class IceProtocolConnectionTests
             .BuildServiceProvider();
 
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
-        _ = sut.Client.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.Ice);
+        _ = sut.Client.AcceptRequestsAsync(InvalidConnection.Ice);
 
         // Act
-        var response = await sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.Ice)));
+        var response = await sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.Ice)),
+            InvalidConnection.Ice);
 
         // Assert
         Assert.That(response.ResultType, Is.EqualTo(ResultType.Failure));
@@ -157,7 +159,7 @@ public sealed class IceProtocolConnectionTests
         };
 
         // Act
-        _ = sut.Client.InvokeAsync(request);
+        _ = sut.Client.InvokeAsync(request, InvalidConnection.Ice);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -181,10 +183,12 @@ public sealed class IceProtocolConnectionTests
             .UseServerConnectionOptions(new ConnectionOptions() { Dispatcher = dispatcher })
             .BuildServiceProvider();
         await using var clientServerProtocolConnection = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = clientServerProtocolConnection.Server.AcceptRequestsAsync();
+        _ = clientServerProtocolConnection.Server.AcceptRequestsAsync(InvalidConnection.Ice);
 
         // Act
-        _ = clientServerProtocolConnection.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.Ice)));
+        _ = clientServerProtocolConnection.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.Ice)),
+            InvalidConnection.Ice);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -214,10 +218,12 @@ public sealed class IceProtocolConnectionTests
             .BuildServiceProvider();
 
         var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        var clientAcceptTask = sut.Client.AcceptRequestsAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        var clientAcceptTask = sut.Client.AcceptRequestsAsync(InvalidConnection.Ice);
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.Ice);
         sut.Server.PeerShutdownInitiated = message => sut.Server.ShutdownAsync("");
-        var invokeTask = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.Ice)));
+        var invokeTask = sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.Ice)),
+            InvalidConnection.Ice);
         await start.WaitAsync(); // Wait for the dispatch to start
 
         // Act

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -50,9 +50,11 @@ public sealed class IceRpcProtocolConnectionTests
 
         var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
         sut.Server.PeerShutdownInitiated = message => _ = sut.Server.ShutdownAsync(message);
-        _ = sut.Client.AcceptRequestsAsync();
-        var serverAcceptTask = sut.Server.AcceptRequestsAsync();
-        var invokeTask = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        _ = sut.Client.AcceptRequestsAsync(InvalidConnection.IceRpc);
+        var serverAcceptTask = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
+        var invokeTask = sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.IceRpc)),
+            InvalidConnection.IceRpc);
         await start.WaitAsync(); // Wait for the dispatch to start
 
         // Act
@@ -82,11 +84,13 @@ public sealed class IceRpcProtocolConnectionTests
             .BuildServiceProvider();
 
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
-        _ = sut.Client.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
+        _ = sut.Client.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        var response = await sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        var response = await sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.IceRpc)),
+            InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(response.ResultType, Is.EqualTo(ResultType.Failure));
@@ -156,7 +160,7 @@ public sealed class IceRpcProtocolConnectionTests
             (ref SliceEncoder encoder) => throw new NotSupportedException("invalid request fields"));
 
         // Act
-        _ = sut.Client.InvokeAsync(request);
+        _ = sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -185,10 +189,12 @@ public sealed class IceRpcProtocolConnectionTests
             .UseServerConnectionOptions(new ConnectionOptions() { Dispatcher = dispatcher })
             .BuildServiceProvider();
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        _ = sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.IceRpc)),
+            InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -212,7 +218,7 @@ public sealed class IceRpcProtocolConnectionTests
         };
 
         // Act
-        _ = sut.Client.InvokeAsync(request);
+        _ = sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.Null);
@@ -236,7 +242,7 @@ public sealed class IceRpcProtocolConnectionTests
         };
 
         // Act
-        _ = sut.Client.InvokeAsync(request);
+        _ = sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -260,7 +266,7 @@ public sealed class IceRpcProtocolConnectionTests
         };
 
         // Act
-        Task<IncomingResponse> invokeTask = sut.Client.InvokeAsync(request);
+        Task<IncomingResponse> invokeTask = sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.Multiple(async () =>
@@ -287,10 +293,10 @@ public sealed class IceRpcProtocolConnectionTests
             .UseServerConnectionOptions(new ConnectionOptions() { Dispatcher = dispatcher })
             .BuildServiceProvider();
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)), InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.Null);
@@ -313,10 +319,10 @@ public sealed class IceRpcProtocolConnectionTests
             .UseServerConnectionOptions(new ConnectionOptions() { Dispatcher = dispatcher })
             .BuildServiceProvider();
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)), InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await payloadStreamDecorator.Completed, Is.InstanceOf<NotSupportedException>());
@@ -333,7 +339,7 @@ public sealed class IceRpcProtocolConnectionTests
             .UseProtocol(Protocol.IceRpc)
             .BuildServiceProvider();
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         var request = new OutgoingRequest(new Proxy(Protocol.IceRpc))
         {
@@ -348,7 +354,7 @@ public sealed class IceRpcProtocolConnectionTests
             });
 
         // Act
-        _ = sut.Client.InvokeAsync(request);
+        _ = sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await (await payloadWriterSource.Task).Completed, Is.InstanceOf<NotSupportedException>());
@@ -382,10 +388,10 @@ public sealed class IceRpcProtocolConnectionTests
             .UseServerConnectionOptions(new ConnectionOptions() { Dispatcher = dispatcher })
             .BuildServiceProvider();
         await using var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
-        _ = sut.Server.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
+        _ = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)), InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(await (await payloadWriterSource.Task).Completed, Is.InstanceOf<NotSupportedException>());
@@ -413,11 +419,11 @@ public sealed class IceRpcProtocolConnectionTests
 
         var payloadDecorator = new PayloadPipeReaderDecorator(EmptyPipeReader.Instance);
         var request = new OutgoingRequest(new Proxy(Protocol.IceRpc));
-        _ = sut.Server.AcceptRequestsAsync();
-        _ = sut.Client.AcceptRequestsAsync();
+        _ = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
+        _ = sut.Client.AcceptRequestsAsync(InvalidConnection.IceRpc);
 
         // Act
-        var response = await sut.Client.InvokeAsync(request);
+        var response = await sut.Client.InvokeAsync(request, InvalidConnection.IceRpc);
 
         // Assert
         Assert.That(
@@ -449,8 +455,10 @@ public sealed class IceRpcProtocolConnectionTests
 
         var sut = await serviceProvider.GetClientServerProtocolConnectionAsync();
         sut.Server.PeerShutdownInitiated = message => _ = sut.Server.ShutdownAsync(message);
-        var invokeTask = sut.Client.InvokeAsync(new OutgoingRequest(new Proxy(Protocol.IceRpc)));
-        var serverAcceptTask = sut.Server.AcceptRequestsAsync();
+        var invokeTask = sut.Client.InvokeAsync(
+            new OutgoingRequest(new Proxy(Protocol.IceRpc)),
+            InvalidConnection.IceRpc);
+        var serverAcceptTask = sut.Server.AcceptRequestsAsync(InvalidConnection.IceRpc);
         await start.WaitAsync(); // Wait for the dispatch to start
 
         // Act

--- a/tests/IceRpc.Tests/ProtocolServiceCollection.cs
+++ b/tests/IceRpc.Tests/ProtocolServiceCollection.cs
@@ -76,6 +76,10 @@ namespace IceRpc.Tests
                 serverProtocolConnection);
         }
 
+        internal static Connection GetInvalidConnection(this IServiceProvider serviceProvider) =>
+            serviceProvider.GetRequiredService<Protocol>() == Protocol.Ice ? InvalidConnection.Ice :
+                InvalidConnection.IceRpc;
+
         private static Task<(INetworkConnection, IProtocolConnection)> GetClientProtocolConnectionAsync(
             this IServiceProvider serviceProvider) => serviceProvider.GetRequiredService<Protocol>() == Protocol.Ice ?
                 GetProtocolConnectionAsync(
@@ -100,7 +104,6 @@ namespace IceRpc.Tests
                 await serviceProvider.GetRequiredService<IProtocolConnectionFactory<T>>().CreateProtocolConnectionAsync(
                     networkConnection,
                     connectionInformation: new(),
-                    connection: protocol == Protocol.Ice ? InvalidConnection.Ice : InvalidConnection.IceRpc,
                     connectionOptions: isServer ?
                         serviceProvider.GetService<ServerConnectionOptions>()?.Value ?? new() :
                         serviceProvider.GetService<ClientConnectionOptions>()?.Value ?? new(),


### PR DESCRIPTION
This PR is another attempt to fix #1032. It removes the _connection fields from the IProtocolConnection implementations by passing a Connection parameter to IProtocolConnection.AcceptRequestAsync and IProtocolConnection.InvokeAsync.

I think that's the correct solution to this issue.