### PR TITLE
Replace CreateEmptyPayload by CreateSizeZeroPayload

### DIFF
--- a/src/IceRpc/Slice/ProxyExtensions.cs
+++ b/src/IceRpc/Slice/ProxyExtensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using IceRpc.Internal;
 using System.Collections.Immutable;
 using System.IO.Pipelines;
 
@@ -25,7 +26,7 @@ namespace IceRpc.Slice
         /// <summary>Sends a request to a service and decodes the response.</summary>
         /// <param name="proxy">A proxy for the remote service.</param>
         /// <param name="operation">The name of the operation, as specified in Slice.</param>
-        /// <param name="payload">The payload of the request.</param>
+        /// <param name="payload">The payload of the request. <c>null</c> is equivalent to an empty payload.</param>
         /// <param name="payloadStream">The optional payload stream of the request.</param>
         /// <param name="responseDecodeFunc">The decode function for the response payload. It decodes and throws a
         /// <see cref="RemoteException"/> when the response payload contains a failure.</param>
@@ -39,7 +40,7 @@ namespace IceRpc.Slice
         public static Task<T> InvokeAsync<T>(
             this Proxy proxy,
             string operation,
-            PipeReader payload,
+            PipeReader? payload,
             PipeReader? payloadStream,
             ResponseDecodeFunc<T> responseDecodeFunc,
             Invocation? invocation,
@@ -53,13 +54,20 @@ namespace IceRpc.Slice
                     nameof(invocation));
             }
 
+            if (payload == null && payloadStream != null)
+            {
+                throw new ArgumentNullException(
+                    nameof(payload),
+                    $"when {nameof(payloadStream)} is not null, {nameof(payload)} cannot be null");
+            }
+
             var request = new OutgoingRequest(proxy)
             {
                 Features = invocation?.Features ?? FeatureCollection.Empty,
                 Fields = idempotent ?
                     _idempotentFields : ImmutableDictionary<RequestFieldKey, OutgoingFieldValue>.Empty,
                 Operation = operation,
-                Payload = payload,
+                Payload = payload ?? EmptyPipeReader.Instance,
                 PayloadStream = payloadStream
             };
 
@@ -103,7 +111,7 @@ namespace IceRpc.Slice
         /// <param name="proxy">A proxy for the remote service.</param>
         /// <param name="operation">The name of the operation, as specified in Slice.</param>
         /// <param name="encoding">The encoding of the request payload.</param>
-        /// <param name="payload">The payload of the request.</param>
+        /// <param name="payload">The payload of the request. <c>null</c> is equivalent to an empty payload.</param>
         /// <param name="payloadStream">The payload stream of the request.</param>
         /// <param name="defaultActivator">The optional default activator.</param>
         /// <param name="invocation">The invocation properties.</param>
@@ -119,7 +127,7 @@ namespace IceRpc.Slice
             this Proxy proxy,
             string operation,
             SliceEncoding encoding,
-            PipeReader payload,
+            PipeReader? payload,
             PipeReader? payloadStream,
             IActivator? defaultActivator,
             Invocation? invocation,
@@ -127,6 +135,13 @@ namespace IceRpc.Slice
             bool oneway = false,
             CancellationToken cancel = default)
         {
+            if (payload == null && payloadStream != null)
+            {
+                throw new ArgumentNullException(
+                    nameof(payload),
+                    $"when {nameof(payloadStream)} is not null, {nameof(payload)} cannot be null");
+            }
+
             var request = new OutgoingRequest(proxy)
             {
                 Features = invocation?.Features ?? FeatureCollection.Empty,
@@ -134,7 +149,7 @@ namespace IceRpc.Slice
                     _idempotentFields : ImmutableDictionary<RequestFieldKey, OutgoingFieldValue>.Empty,
                 IsOneway = oneway || (invocation?.IsOneway ?? false),
                 Operation = operation,
-                Payload = payload,
+                Payload = payload ?? EmptyPipeReader.Instance,
                 PayloadStream = payloadStream
             };
 

--- a/src/IceRpc/Slice/SliceEncodingExtensions.cs
+++ b/src/IceRpc/Slice/SliceEncodingExtensions.cs
@@ -9,22 +9,20 @@ namespace IceRpc.Slice
     /// <summary>Extension methods for <see cref="SliceEncoding"/>.</summary>
     public static class SliceEncodingExtensions
     {
-        private static readonly ReadOnlySequence<byte> _payloadWithZeroSize = new(new byte[] { 0 });
+        private static readonly ReadOnlySequence<byte> _sizeZeroPayload = new(new byte[] { 0 });
 
-        /// <summary>Creates an empty payload encoded with this encoding.</summary>
+        /// <summary>Creates a non-empty payload with size 0.</summary>
         /// <param name="encoding">The Slice encoding.</param>
-        /// <param name="hasStream">When true, the Slice operation includes a stream in addition to the empty parameters
-        /// or void return.</param>
-        /// <returns>A new empty payload.</returns>
-        public static PipeReader CreateEmptyPayload(this SliceEncoding encoding, bool hasStream = false)
+        /// <returns>A non-empty payload with size 0.</returns>
+        public static PipeReader CreateSizeZeroPayload(this SliceEncoding encoding)
         {
-            if (hasStream && encoding == SliceEncoding.Slice1)
+            if (encoding == SliceEncoding.Slice1)
             {
-                throw new ArgumentException(
-                    $"{nameof(hasStream)} must be false when encoding is Slice1", nameof(hasStream));
-            }
+                throw new NotSupportedException(
+                    $"{nameof(CreateSizeZeroPayload)} is only available for stream-capable Slice encodings");
 
-            return hasStream ? PipeReader.Create(_payloadWithZeroSize) : EmptyPipeReader.Instance;
+            }
+            return PipeReader.Create(_sizeZeroPayload);
         }
 
         /// <summary>Creates a payload stream from an async enumerable.</summary>

--- a/tools/slicec-cs/src/proxy_visitor.rs
+++ b/tools/slicec-cs/src/proxy_visitor.rs
@@ -228,15 +228,12 @@ if ({invocation}?.Features.Get<IceRpc.Features.CompressPayload>() == null)
     }
 
     // The payload argument
-    if parameters.is_empty() {
+    if operation.parameters.is_empty() {
+        invoke_args.push("payload: null".to_owned());
+    } else if parameters.is_empty() {
         invoke_args.push(format!(
-            "{encoding}.CreateEmptyPayload(hasStream: {has_stream})",
+            "{encoding}.CreateSizeZeroPayload()",
             encoding = encoding,
-            has_stream = if operation.parameters.is_empty() {
-                "false"
-            } else {
-                "true"
-            }
         ));
     } else {
         invoke_args.push(format!(


### PR DESCRIPTION
This PR simplifies the generated code by calling CreateSizeZeroPayload only for empty payloads followed by streams.