### PR TITLE
Slice InvokeAsync tests

### DIFF
--- a/tests/IceRpc.Tests/Slice/InvocationTests.cs
+++ b/tests/IceRpc.Tests/Slice/InvocationTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
-[Timeout(30000)]
+[Timeout(5000)]
 public class InvocationTests
 {
     /// <summary>Verifies that the request context feature is set to the invocation context.</summary>

--- a/tests/IceRpc.Tests/Slice/InvokeAsyncTests.cs
+++ b/tests/IceRpc.Tests/Slice/InvokeAsyncTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
-[Timeout(30000)]
+[Timeout(5000)]
 public class InvokeAsyncTests
 {
     /// <summary>Verifies that InvokeAsync completes the outgoing request and incoming response payloads.</summary>


### PR DESCRIPTION
This PR adds 2 new tests for Slice Proxy.InvokeAsync. These tests verifies InvokeAsync completes the request... indirectly by verifying the request/response payloads are completed.