### PR TITLE
Use coloc for protocol bridging tests

### DIFF
--- a/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
@@ -11,9 +11,11 @@ namespace IceRpc.Tests;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection UseColoc(this IServiceCollection collection)
+    public static IServiceCollection UseColoc(this IServiceCollection collection) =>
+        collection.UseColoc(new ColocTransport());
+
+    public static IServiceCollection UseColoc(this IServiceCollection collection, ColocTransport coloc)
     {
-        var coloc = new ColocTransport();
         collection.AddScoped(_ => coloc.ServerTransport);
         collection.AddScoped(_ => coloc.ClientTransport);
         collection.AddScoped(

--- a/tests/IntegrationTests/ProtocolBridgingTests.cs
+++ b/tests/IntegrationTests/ProtocolBridgingTests.cs
@@ -3,6 +3,7 @@
 using IceRpc.Configure;
 using IceRpc.Slice;
 using IceRpc.Tests;
+using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System.Collections.Immutable;
@@ -23,11 +24,13 @@ public sealed class ProtocolBridgingTests
         var targetServiceCollection = new IntegrationTestServiceCollection();
         var forwarderServiceCollection = new IntegrationTestServiceCollection();
 
+        // We need to use the same coloc transport everywhere for connections to work.
+        var coloc = new ColocTransport();
+        targetServiceCollection.UseColoc(coloc);
+        forwarderServiceCollection.UseColoc(coloc);
+
         targetServiceCollection.UseProtocol(targetProtocol).AddTransient<IDispatcher>(_ => router);
         forwarderServiceCollection.UseProtocol(forwarderProtocol).AddTransient<IDispatcher>(_ => router);
-
-        targetServiceCollection.UseTcp();
-        forwarderServiceCollection.UseTcp();
 
         targetServiceCollection.AddTransient<IInvoker>(serviceProvider =>
             new Pipeline().UseBinder(serviceProvider.GetRequiredService<ConnectionPool>()));


### PR DESCRIPTION
This PR updates the protocol bridging test to use the coloc transport instead of the tcp transport.

Fixes #1151.
