### PR TITLE
Do not use DecodeNullableProxy/EncodeNullableProxy with Slice2

### DIFF
--- a/src/IceRpc/Slice/SliceDecoder.cs
+++ b/src/IceRpc/Slice/SliceDecoder.cs
@@ -354,12 +354,6 @@ namespace IceRpc.Slice
             return path != "/" ? DecodeProxy(path) : null;
         }
 
-        /// <summary>Decodes a nullable proxy.</summary>
-        /// <param name="bitSequenceReader">The bit sequence reader.</param>
-        /// <returns>The decoded proxy, or null.</returns>
-        public Proxy? DecodeNullableProxy(ref BitSequenceReader bitSequenceReader) =>
-            bitSequenceReader.Read() ? DecodeProxy() : null;
-
         /// <summary>Decodes a proxy.</summary>
         /// <returns>The decoded proxy</returns>
         public Proxy DecodeProxy()

--- a/src/IceRpc/Slice/SliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/SliceDecoderExtensions.cs
@@ -87,15 +87,6 @@ namespace IceRpc.Slice
         public static T? DecodeNullablePrx<T>(ref this SliceDecoder decoder) where T : struct, IPrx =>
             decoder.DecodeNullableProxy() is Proxy proxy ? new T { Proxy = proxy } : null;
 
-        /// <summary>Decodes a nullable Prx struct.</summary>
-        /// <param name="decoder">The Slice decoder.</param>
-        /// <param name="bitSequenceReader">The bit sequence reader.</param>
-        /// <returns>The decoded Prx struct, or null.</returns>
-        public static T? DecodeNullablePrx<T>(
-            ref this SliceDecoder decoder,
-            ref BitSequenceReader bitSequenceReader) where T : struct, IPrx =>
-            decoder.DecodeNullableProxy(ref bitSequenceReader) is Proxy proxy ? new T { Proxy = proxy } : null;
-
         /// <summary>Decodes a sequence of fixed-size numeric values.</summary>
         /// <param name="decoder">The Slice decoder.</param>
         /// <param name="checkElement">A delegate used to check each element of the array (optional).</param>

--- a/src/IceRpc/Slice/SliceEncoder.cs
+++ b/src/IceRpc/Slice/SliceEncoder.cs
@@ -250,22 +250,6 @@ namespace IceRpc.Slice
             }
         }
 
-        /// <summary>Encodes a nullable proxy.</summary>
-        /// <param name="bitSequenceWriter">The bit sequence writer.</param>
-        /// <param name="proxy">The proxy to encode, or null.</param>
-        public void EncodeNullableProxy(ref BitSequenceWriter bitSequenceWriter, Proxy? proxy)
-        {
-            if (proxy == null)
-            {
-                bitSequenceWriter.Write(false);
-            }
-            else
-            {
-                bitSequenceWriter.Write(true);
-                EncodeProxy(proxy);
-            }
-        }
-
         /// <summary>Encodes a non-null proxy.</summary>
         /// <param name="proxy">The proxy to encode.</param>
         public void EncodeProxy(Proxy proxy)

--- a/tests/IceRpc.Tests/Slice/ProxyTests.cs
+++ b/tests/IceRpc.Tests/Slice/ProxyTests.cs
@@ -47,24 +47,7 @@ public class ProxyTests
         }
     }
 
-    /// <summary>Verifies that nullable proxies are correctly encoded with both Slice1 and Slice2 encoding.</summary>
-    /// <param name="expected">The nullable proxy to test with.</param>
-    [Test, TestCaseSource(nameof(DecodeNullableProxySource))]
-    public void Decode_slice2_nullable_proxy(Proxy? expected)
-    {
-        var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
-        BitSequenceWriter bitSequenceWritter = encoder.GetBitSequenceWriter(1);
-        encoder.EncodeNullableProxy(ref bitSequenceWritter, expected);
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
-        BitSequenceReader bitsequenceReader = decoder.GetBitSequenceReader(1);
-
-        Proxy? decoded = decoder.DecodeNullableProxy(ref bitsequenceReader);
-
-        Assert.That(decoded, Is.EqualTo(expected));
-    }
-
-    /// <summary>Verifies that nullable proxies are correctly encoded with both Slice1 and Slice2 encoding.</summary>
+    /// <summary>Verifies that nullable proxies are correctly encoded withSlice1 encoding.</summary>
     /// <param name="expected">The nullable proxy to test with.</param>
     [Test, TestCaseSource(nameof(DecodeNullableProxySource))]
     public void Decode_slice1_nullable_proxy(Proxy? expected)

--- a/tests/IceRpc.Tests/Slice/StructTests.cs
+++ b/tests/IceRpc.Tests/Slice/StructTests.cs
@@ -186,7 +186,7 @@ public sealed class StructTests
         else
         {
             bitSequenceWriter.Write(true);
-            encoder.EncodeNullableProxy(ref bitSequenceWriter, expected.I.Value.Proxy);
+            encoder.EncodeProxy(expected.I.Value.Proxy);
         }
         var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
 
@@ -460,7 +460,9 @@ public sealed class StructTests
         var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
         var bitSequenceReader = decoder.GetBitSequenceReader(1);
         Assert.That(decoder.DecodeInt32(), Is.EqualTo(expected.A));
-        Assert.That(decoder.DecodeNullablePrx<ServicePrx>(ref bitSequenceReader), Is.EqualTo(expected.I));
+        Assert.That(
+            bitSequenceReader.Read() ? new ServicePrx(decoder.DecodeProxy()) : (ServicePrx?)null,
+            Is.EqualTo(expected.I));
     }
 
     [Test]

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -59,16 +59,8 @@ fn decode_member(
     if data_type.is_optional {
         assert!(encoding.is_some());
         match data_type.concrete_type() {
-            Types::Interface(_) => {
-                if encoding == Some(Encoding::Slice2) {
-                    writeln!(
-                        code,
-                        "decoder.DecodeNullablePrx<{}>(ref bitSequenceReader);",
-                        type_string
-                    );
-                } else {
-                    writeln!(code, "decoder.DecodeNullablePrx<{}>();", type_string);
-                }
+            Types::Interface(_) if encoding == Some(Encoding::Slice1) => {
+                writeln!(code, "decoder.DecodeNullablePrx<{}>();", type_string);
                 return code;
             }
             _ if data_type.is_class_type() => {
@@ -85,7 +77,6 @@ fn decode_member(
 
     match &data_type.concrete_typeref() {
         TypeRefs::Interface(_) => {
-            assert!(!data_type.is_optional);
             write!(code, "new {}(decoder.DecodeProxy())", type_string);
         }
         TypeRefs::Class(_) => {


### PR DESCRIPTION
A follow up to #1186 that treat Slice optional proxies as any other optional as suggested by @externl and got rid of the encode/decode methods for proxies that take a bitsequence reader/writer.