### PR TITLE
Rename MaxIncomingFrameSize to MaxFrameSize

### DIFF
--- a/src/IceRpc/Configure/IceOptions.cs
+++ b/src/IceRpc/Configure/IceOptions.cs
@@ -18,25 +18,25 @@ public record class IceOptions
             throw new ArgumentOutOfRangeException(nameof(value), "value must be 0 or greater");
     }
 
-    /// <summary>Gets or sets the maximum size of an incoming ice frame.</summary>
-    /// <value>The maximum size of an incoming ice frame, in bytes. This value must be at least 256. The default
-    /// value is 1 MB.</value>
-    public int MaxIncomingFrameSize
+    /// <summary>Gets or sets the maximum size of a frame received over the ice protocol.</summary>
+    /// <value>The maximum size of an incoming frame, in bytes. This value must be at least 256. The default value is
+    /// 1 MB.</value>
+    public int MaxFrameSize
     {
-        get => _maxIncomingFrameSize;
-        set => _maxIncomingFrameSize = value >= MinIncomingFrameSizeValue ? value :
+        get => _maxFrameSize;
+        set => _maxFrameSize = value >= MinFrameSize ? value :
             throw new ArgumentOutOfRangeException(
                 nameof(value),
-                $"{nameof(MaxIncomingFrameSize)} must be at least {MinIncomingFrameSizeValue}");
+                $"{nameof(MaxFrameSize)} must be at least {MinFrameSize}");
     }
 
     /// <summary>A shared instance that holds the default options.</summary>
     /// <remarks>It's internal to avoid accidental changes to these shared default options.</remarks>
     internal static IceOptions Default { get; } = new();
 
-    private const int MinIncomingFrameSizeValue = 256;
+    private const int MinFrameSize = 256;
     private int _maxConcurrentDispatches = 100;
-    private int _maxIncomingFrameSize = 1024 * 1024;
+    private int _maxFrameSize = 1024 * 1024;
 }
 
 /// <summary>A property bag used to configure a client connection using the ice protocol.</summary>

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -690,10 +690,10 @@ namespace IceRpc.Internal
                 _networkConnectionReader.AdvanceTo(prologueBuffer.End);
 
                 IceDefinitions.CheckPrologue(prologue);
-                if (prologue.FrameSize > _options.MaxIncomingFrameSize)
+                if (prologue.FrameSize > _options.MaxFrameSize)
                 {
                     throw new InvalidDataException(
-                        $"incoming frame size ({prologue.FrameSize}) is greater than max incoming frame size");
+                        $"received frame with size ({prologue.FrameSize}) greater than max frame size");
                 }
 
                 if (prologue.CompressionStatus == 2)

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -42,13 +42,6 @@ namespace IceRpc.Internal
         internal static partial void LogReceivedIceValidateConnectionFrame(this ILogger logger);
 
         [LoggerMessage(
-            EventId = (int)ProtocolEventIds.ReceivedInitializeFrame,
-            EventName = nameof(ProtocolEventIds.ReceivedInitializeFrame),
-            Level = LogLevel.Debug,
-            Message = "received initialize frame (MaxIncomingFrameSize={maxIncomingFrameSize})")]
-        internal static partial void LogReceivedInitializeFrame(this ILogger logger, int maxIncomingFrameSize);
-
-        [LoggerMessage(
             EventId = (int)ProtocolEventIds.SentGoAwayFrame,
             EventName = nameof(ProtocolEventIds.SentGoAwayFrame),
             Level = LogLevel.Debug,
@@ -73,12 +66,5 @@ namespace IceRpc.Internal
             Level = LogLevel.Debug,
             Message = "sent validate connection frame")]
         internal static partial void LogSentIceValidateConnectionFrame(this ILogger logger);
-
-        [LoggerMessage(
-            EventId = (int)ProtocolEventIds.SentInitializeFrame,
-            EventName = nameof(ProtocolEventIds.SentInitializeFrame),
-            Level = LogLevel.Debug,
-            Message = "sent initialize frame (MaxIncomingFrameSize={MaxIncomingFrameSize})")]
-        internal static partial void LogSentInitializeFrame(this ILogger logger, int MaxIncomingFrameSize);
     }
 }

--- a/src/IceRpc/ProtocolEventIds.cs
+++ b/src/IceRpc/ProtocolEventIds.cs
@@ -19,9 +19,6 @@ namespace IceRpc
         /// <summary>Received an icerpc go away frame.</summary>
         ReceivedGoAwayFrame,
 
-        /// <summary>Received an icerpc initialize frame.</summary>
-        ReceivedInitializeFrame,
-
         /// <summary>An ice validate connection frame was sent.</summary>
         SentIceValidateConnectionFrame,
 
@@ -30,8 +27,5 @@ namespace IceRpc
 
         /// <summary>An icerpc go away frame was sent.</summary>
         SentGoAwayFrame,
-
-        /// <summary>An icerpc initialize frame was sent.</summary>
-        SentInitializeFrame,
     }
 }


### PR DESCRIPTION
This PR renames IceOptions.MaxIncomingFrameSize to simply MaxFrameSize, for consistency with MaxHeaderSize, MaxSegmentSize.