### PR TITLE
Fix Connection.Features

### DIFF
--- a/src/IceRpc/Connection.cs
+++ b/src/IceRpc/Connection.cs
@@ -59,7 +59,7 @@ namespace IceRpc
         }
 
         /// <inheritdoc/>
-        public FeatureCollection Features { get; private set; } = FeatureCollection.Empty;
+        public FeatureCollection Features { get; }
 
         // True once DisposeAsync is called. Once disposed the connection can't be resumed.
         private bool _disposed;


### PR DESCRIPTION
This tiny PR correctly initializes Connection.Features from ConnectionOptions.Features in the Connection constructors.