### PR TITLE
Update generic host client

### DIFF
--- a/examples/GenericHost/Client/Program.cs
+++ b/examples/GenericHost/Client/Program.cs
@@ -56,7 +56,7 @@ public static class Program
                     });
 
                 // Add an IInvoker service.
-                services.AddSingleton<IInvoker>(serviceProvider =>
+                services.AddScoped<IInvoker>(serviceProvider =>
                 {
                     // The invoker is a pipeline configured with the logger and telemetry interceptors. The
                     // interceptors use the logger factory provided by the .NET Generic Host.
@@ -66,7 +66,7 @@ public static class Program
                         .UseTelemetry(new TelemetryOptions { LoggerFactory = loggerFactory });
                 });
 
-                services.AddSingleton<IConnection, Connection>(serviceProvider =>
+                services.AddScoped<IConnection, Connection>(serviceProvider =>
                 {
                     IOptions<ClientHostedServiceOptions> options =
                         serviceProvider.GetRequiredService<IOptions<ClientHostedServiceOptions>>();
@@ -82,7 +82,7 @@ public static class Program
                     return new Connection(connectionOptions);
                 });
 
-                services.AddSingleton<IHelloPrx>(serviceProvider =>
+                services.AddScoped<IHelloPrx>(serviceProvider =>
                     HelloPrx.FromConnection(
                         serviceProvider.GetRequiredService<IConnection>(),
                         invoker: serviceProvider.GetRequiredService<IInvoker>()));


### PR DESCRIPTION
This PR makes the GenericHost client much more "DI", by registering services for IInvoker, IConnection and IOptions<SslClientAuthenticationOptions>, IOptions<ClientHostServiceOptions> and IHelloPrx.

It also converts the registration to transient services. Probably does not make a different here, but Transient is supposed to be the default here, isn't it?

It's actually not clear to me what AddOptions does - register a transient `IOptions<>` service?

See https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.optionsservicecollectionextensions.addoptions?view=dotnet-plat-ext-6.0#microsoft-extensions-dependencyinjection-optionsservicecollectionextensions-addoptions(microsoft-extensions-dependencyinjection-iservicecollection)

So Microsoft.Extensions.Options.dll actually depends on Microsoft.Extensions.DependencyInjection.Abstractions.dll ... not DI-neutral after all.