### PR TITLE
Internals usage cleanup

### DIFF
--- a/src/IceRpc/AssemblyInfo.cs
+++ b/src/IceRpc/AssemblyInfo.cs
@@ -12,11 +12,9 @@ using System.Runtime.CompilerServices;
 
 // Make internals visible to the tests assembly, to allow writing unit tests for the internal classes
 [assembly: InternalsVisibleTo("IceRpc.Tests")]
-[assembly: InternalsVisibleTo("IceRpc.Interop.Tests")]
 [assembly: InternalsVisibleTo("IceRpc.Conformance.Tests")]
 [assembly: InternalsVisibleTo("IceRpc.Tests.Common")]
 
-[assembly: InternalsVisibleTo("IceRpc.Retry.Tests")] // For EmptyPipeReader
-[assembly: InternalsVisibleTo("IceRpc.Telemetry.Tests")] // For EmptyPipeReader
-[assembly: InternalsVisibleTo("IceRpc.Timeout.Tests")]
 [assembly: InternalsVisibleTo("IceRpc.Deflate.Tests")]
+[assembly: InternalsVisibleTo("IceRpc.Retry.Tests")]
+[assembly: InternalsVisibleTo("IceRpc.Telemetry.Tests")]

--- a/src/IceRpc/RetryPolicy.cs
+++ b/src/IceRpc/RetryPolicy.cs
@@ -41,14 +41,18 @@ namespace IceRpc
             _ => "unknown"
         };
 
-        internal RetryPolicy(ref SliceDecoder decoder)
+        /// <summary>Encodes this retry policy instance into the given encoder.</summary>
+        /// <param name="decoder">The decoder.</param>
+        public RetryPolicy(ref SliceDecoder decoder)
         {
             Retryable = decoder.DecodeRetryable();
             Delay = Retryable == Retryable.AfterDelay ?
                 TimeSpan.FromMilliseconds(decoder.DecodeVarUInt62()) : TimeSpan.Zero;
         }
 
-        internal void Encode(ref SliceEncoder encoder)
+        /// <summary>Encodes this retry policy instance into the given encoder.</summary>
+        /// <param name="encoder">The encoder</param>
+        public void Encode(ref SliceEncoder encoder)
         {
             encoder.EncodeRetryable(Retryable);
             if (Retryable == Retryable.AfterDelay)


### PR DESCRIPTION
This a first step for fixing #1236 

The remaining internals used by non IceRpc.Tests are

- MemoryBufferWriter
- EmptyPipeReader
- OutgoingFrame.GetPayloadWriter