### PR TITLE
Retry interceptor simplifications

### DIFF
--- a/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
@@ -12,6 +12,9 @@ internal class ResettablePipeReaderDecorator : PipeReader, IAsyncDisposable
 {
     public bool IsResettable { get; private set; } = true;
 
+    public long Consumed =>
+        (_sequence != null && _highestExamined != null) ? _sequence.Value.GetOffset(_highestExamined.Value) : 0;
+
     // The latest sequence returned by _decoratee; not affected by Reset.
     private ReadOnlySequence<byte>? _sequence;
 

--- a/src/IceRpc.Retry/Internal/RetryInterceptorLoggerExtensions.cs
+++ b/src/IceRpc.Retry/Internal/RetryInterceptorLoggerExtensions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+
+namespace IceRpc.Retry.Internal;
+
+internal static partial class RetryInterceptorLoggerExtensions
+{
+    internal static void LogRetryRequest(
+        this ILogger logger,
+        IConnection? connection,
+        string path,
+        string operation,
+        RetryPolicy retryPolicy,
+        int attempt,
+        int maxAttempts,
+        Exception? ex)
+    {
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogRetryRequest(
+                connection?.NetworkConnectionInformation?.LocalEndPoint.ToString() ?? "undefined",
+                connection?.NetworkConnectionInformation?.RemoteEndPoint.ToString() ?? "undefined",
+                path,
+                operation,
+                retryPolicy,
+                attempt,
+                maxAttempts,
+                ex);
+        }
+    }
+
+    [LoggerMessage(
+        EventId = (int)RetryInterceptorEventIds.RetryRequest,
+        EventName = nameof(RetryInterceptorEventIds.RetryRequest),
+        Level = LogLevel.Information,
+        Message = "retrying request because of retryable exception (LocalEndPoint={LocalEndPoint}, " +
+                  "RemoteEndPoint={RemoteEndPoint}, Path={Path}, Operation={Operation}, " +
+                  "RetryPolicy={RetryPolicy}, Attempt={Attempt}/{MaxAttempts})")]
+    private static partial void LogRetryRequest(
+        this ILogger logger,
+        string localEndpoint,
+        string remoteEndpoint,
+        string path,
+        string operation,
+        RetryPolicy retryPolicy,
+        int attempt,
+        int maxAttempts,
+        Exception? ex);
+}

--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -6,6 +6,7 @@ using IceRpc.Internal;
 using IceRpc.Retry.Internal;
 using IceRpc.Slice;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
 
 namespace IceRpc.Retry;
@@ -21,202 +22,164 @@ public class RetryInterceptor : IInvoker
     /// <summary>Constructs a retry interceptor.</summary>
     /// <param name="next">The next invoker in the invocation pipeline.</param>
     /// <param name="options">The options to configure the retry interceptor.</param>
+    /// <param name="loggerFactory">The logger factory used to create loggers to log retries.</param>
     /// <see cref="RetryPolicy"/>
-    public RetryInterceptor(IInvoker next, RetryOptions options)
+    public RetryInterceptor(IInvoker next, RetryOptions options, ILoggerFactory? loggerFactory = null)
     {
         _next = next;
         _options = options;
-        _logger = options.LoggerFactory.CreateLogger("IceRpc");
+        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger("IceRpc");
     }
 
     /// <inheritdoc/>
     public async Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancel)
     {
-        IEndpointFeature? endpointFeature = request.Features.Get<IEndpointFeature>();
-        if (endpointFeature == null)
+        if (request.PayloadStream != null)
         {
-            endpointFeature = new EndpointFeature(request.Proxy);
-            request.Features = request.Features.With(endpointFeature);
+            // If the request include a payload stream it cannot be retried
+            return await _next.InvokeAsync(request, cancel).ConfigureAwait(false);
         }
-
-        // If the request size is greater than _requestMaxSize or the size of the request would increase the
-        // buffer size beyond _bufferMaxSize we release the request after it was sent to avoid holding too
-        // much memory and we won't retry in case of a failure.
-
-        // TODO: soon this won't work and the interceptor can't read the args size from the payload
-        // int requestSize = request.Payload.GetByteCount();
-
-        bool releaseRequestAfterSent = false; // requestSize > _options.RequestMaxSize;
-
-        int attempt = 1;
-        IncomingResponse? response = null;
-        Exception? exception = null;
-
-        bool tryAgain;
-
-        var decorator = new ResettablePipeReaderDecorator(request.Payload);
-        await using var _ = decorator.ConfigureAwait(false);
-
-        request.Payload = decorator;
-
-        try
+        else
         {
-            do
+            IEndpointFeature? endpointFeature = request.Features.Get<IEndpointFeature>();
+            if (endpointFeature == null)
             {
-                RetryPolicy retryPolicy = RetryPolicy.NoRetry;
-
-                // At this point, response can be non-null and carry a failure for which we're retrying. If
-                // _next.InvokeAsync throws NoEndpointException, we return this previous failure.
-                try
-                {
-                    response = await _next.InvokeAsync(request, cancel).ConfigureAwait(false);
-
-                    // TODO: release payload if releaseRequestAfterSent is true
-
-                    if (response.ResultType == ResultType.Success)
-                    {
-                        return response;
-                    }
-                    // else response carries a failure and we may want to retry
-
-                    // Extracts the retry policy from the fields
-                    retryPolicy = response.Fields.DecodeValue(
-                        ResponseFieldKey.RetryPolicy,
-                        (ref SliceDecoder decoder) => new RetryPolicy(ref decoder)) ?? RetryPolicy.NoRetry;
-                }
-                catch (NoEndpointException ex)
-                {
-                    // NoEndpointException is always considered non-retryable; it typically occurs because we
-                    // removed all remaining usable endpoints through request.ExcludedEndpoints.
-                    return response ?? throw ExceptionUtil.Throw(exception ?? ex);
-                }
-                catch (OperationCanceledException)
-                {
-                    // TODO: try other replica in some cases?
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    response = null;
-                    exception = ex;
-
-                    // ConnectionClosedException is a graceful connection closure that is always safe to retry.
-                    if (ex is ConnectionClosedException ||
-                        request.Fields.ContainsKey(RequestFieldKey.Idempotent) ||
-                        !request.IsSent)
-                    {
-                        retryPolicy = RetryPolicy.Immediately;
-                    }
-                }
-
-                // Compute retry policy based on the exception or response retry policy, whether or not the
-                // connection is established or the request sent and idempotent
-                Debug.Assert(response != null || exception != null);
-
-                // Check if we can retry
-                if (attempt == _options.MaxAttempts ||
-                    retryPolicy == RetryPolicy.NoRetry ||
-                    !decorator.IsResettable ||
-                    (request.IsSent && releaseRequestAfterSent))
-                {
-                    tryAgain = false;
-                }
-                else
-                {
-                    if (request.Connection is IClientConnection clientConnection &&
-                         retryPolicy == RetryPolicy.OtherReplica)
-                    {
-                        endpointFeature.RemoveEndpoint(clientConnection.RemoteEndpoint);
-                    }
-
-                    tryAgain = true;
-                    attempt++;
-
-                    _logger.LogRetryRequest(
-                        request.Connection,
-                        request.Proxy.Path,
-                        request.Operation,
-                        retryPolicy,
-                        attempt,
-                        _options.MaxAttempts,
-                        exception);
-
-                    if (retryPolicy.Retryable == Retryable.AfterDelay && retryPolicy.Delay != TimeSpan.Zero)
-                    {
-                        await Task.Delay(retryPolicy.Delay, cancel).ConfigureAwait(false);
-                    }
-
-                    if (request.Connection != null &&
-                        (retryPolicy == RetryPolicy.OtherReplica || !request.Connection.IsInvocable))
-                    {
-                        // Retry with a new connection
-                        request.Connection = null;
-                    }
-
-                    // Reset relevant request properties before trying again.
-                    request.IsSent = false;
-                    if (!request.Features.IsReadOnly)
-                    {
-                        request.Features.Set<RetryPolicy>(null);
-                    }
-
-                    decorator.Reset();
-                }
+                endpointFeature = new EndpointFeature(request.Proxy);
+                request.Features = request.Features.With(endpointFeature);
             }
-            while (tryAgain);
 
-            Debug.Assert(response != null || exception != null);
-            Debug.Assert(response == null || response.ResultType != ResultType.Success);
-            return response ?? throw ExceptionUtil.Throw(exception!);
-        }
-        finally
-        {
-            // TODO release the request memory if not already done after sent.
+            bool releaseRequestAfterSent = false;
+            int attempt = 1;
+            IncomingResponse? response = null;
+            Exception? exception = null;
+
+            bool tryAgain;
+
+            var decorator = new ResettablePipeReaderDecorator(request.Payload);
+            await using var _ = decorator.ConfigureAwait(false);
+
+            request.Payload = decorator;
+
+            try
+            {
+                do
+                {
+                    RetryPolicy retryPolicy = RetryPolicy.NoRetry;
+
+                    // At this point, response can be non-null and carry a failure for which we're retrying. If
+                    // _next.InvokeAsync throws NoEndpointException, we return this previous failure.
+                    try
+                    {
+                        response = await _next.InvokeAsync(request, cancel).ConfigureAwait(false);
+
+                        // TODO: release payload if releaseRequestAfterSent is true
+
+                        if (response.ResultType == ResultType.Success)
+                        {
+                            return response;
+                        }
+                        // else response carries a failure and we may want to retry
+
+                        // Extracts the retry policy from the fields
+                        retryPolicy = response.Fields.DecodeValue(
+                            ResponseFieldKey.RetryPolicy,
+                            (ref SliceDecoder decoder) => new RetryPolicy(ref decoder)) ?? RetryPolicy.NoRetry;
+                    }
+                    catch (NoEndpointException ex)
+                    {
+                        // NoEndpointException is always considered non-retryable; it typically occurs because we
+                        // removed all remaining usable endpoints through request.ExcludedEndpoints.
+                        return response ?? throw ExceptionUtil.Throw(exception ?? ex);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // TODO: try other replica in some cases?
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        response = null;
+                        exception = ex;
+
+                        // ConnectionClosedException is a graceful connection closure that is always safe to retry.
+                        if (ex is ConnectionClosedException ||
+                            request.Fields.ContainsKey(RequestFieldKey.Idempotent) ||
+                            !request.IsSent)
+                        {
+                            retryPolicy = RetryPolicy.Immediately;
+                        }
+                    }
+                    finally
+                    {
+                        // If the request size is greater than _requestMaxSize we release the request after it was sent to avoid
+                        // holding too much memory and we won't retry in case of a failure.
+                        releaseRequestAfterSent = decorator.Consumed > _options.RequestMaxSize;
+                    }
+
+                    // Compute retry policy based on the exception or response retry policy, whether or not the
+                    // connection is established or the request sent and idempotent
+                    Debug.Assert(response != null || exception != null);
+
+                    // Check if we can retry
+                    if (attempt == _options.MaxAttempts ||
+                        retryPolicy == RetryPolicy.NoRetry ||
+                        !decorator.IsResettable ||
+                        (request.IsSent && releaseRequestAfterSent))
+                    {
+                        tryAgain = false;
+                    }
+                    else
+                    {
+                        if (request.Connection is IClientConnection clientConnection &&
+                             retryPolicy == RetryPolicy.OtherReplica)
+                        {
+                            endpointFeature.RemoveEndpoint(clientConnection.RemoteEndpoint);
+                        }
+
+                        tryAgain = true;
+                        attempt++;
+
+                        _logger.LogRetryRequest(
+                            request.Connection,
+                            request.Proxy.Path,
+                            request.Operation,
+                            retryPolicy,
+                            attempt,
+                            _options.MaxAttempts,
+                            exception);
+
+                        if (retryPolicy.Retryable == Retryable.AfterDelay && retryPolicy.Delay != TimeSpan.Zero)
+                        {
+                            await Task.Delay(retryPolicy.Delay, cancel).ConfigureAwait(false);
+                        }
+
+                        if (request.Connection != null &&
+                            (retryPolicy == RetryPolicy.OtherReplica || !request.Connection.IsInvocable))
+                        {
+                            // Retry with a new connection
+                            request.Connection = null;
+                        }
+
+                        // Reset relevant request properties before trying again.
+                        request.IsSent = false;
+                        if (!request.Features.IsReadOnly)
+                        {
+                            request.Features.Set<RetryPolicy>(null);
+                        }
+
+                        decorator.Reset();
+                    }
+                }
+                while (tryAgain);
+
+                Debug.Assert(response != null || exception != null);
+                Debug.Assert(response == null || response.ResultType != ResultType.Success);
+                return response ?? throw ExceptionUtil.Throw(exception!);
+            }
+            finally
+            {
+                // TODO release the request memory if not already done after sent.
+            }
         }
     }
-}
-
-internal static partial class RetryInterceptorLoggerExtensions
-{
-    internal static void LogRetryRequest(
-        this ILogger logger,
-        IConnection? connection,
-        string path,
-        string operation,
-        RetryPolicy retryPolicy,
-        int attempt,
-        int maxAttempts,
-        Exception? ex)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            logger.LogRetryRequest(
-                connection?.NetworkConnectionInformation?.LocalEndPoint.ToString() ?? "undefined",
-                connection?.NetworkConnectionInformation?.RemoteEndPoint.ToString() ?? "undefined",
-                path,
-                operation,
-                retryPolicy,
-                attempt,
-                maxAttempts,
-                ex);
-        }
-    }
-
-    [LoggerMessage(
-        EventId = (int)RetryInterceptorEventIds.RetryRequest,
-        EventName = nameof(RetryInterceptorEventIds.RetryRequest),
-        Level = LogLevel.Information,
-        Message = "retrying request because of retryable exception (LocalEndPoint={LocalEndPoint}, " +
-                  "RemoteEndPoint={RemoteEndPoint}, Path={Path}, Operation={Operation}, " +
-                  "RetryPolicy={RetryPolicy}, Attempt={Attempt}/{MaxAttempts})")]
-    private static partial void LogRetryRequest(
-        this ILogger logger,
-        string localEndpoint,
-        string remoteEndpoint,
-        string path,
-        string operation,
-        RetryPolicy retryPolicy,
-        int attempt,
-        int maxAttempts,
-        Exception? ex);
 }

--- a/src/IceRpc.Retry/RetryOptions.cs
+++ b/src/IceRpc.Retry/RetryOptions.cs
@@ -1,35 +1,12 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Retry;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IceRpc.Configure;
 
 /// <summary>Options class to configure <see cref="RetryInterceptor"/>.</summary>
 public sealed record class RetryOptions
 {
-    /// <summary>Gets or sets the maximum amount of memory in bytes used to hold all retryable requests.
-    /// Once this limit is reached new requests are not retried and their memory is released after being sent.
-    /// </summary>
-    /// <value>The buffer maximum size in bytes. The default value is 100 MB.</value>
-    public int BufferMaxSize
-    {
-        get => _bufferMaxSize;
-        set
-        {
-            if (value < 1)
-            {
-                throw new ArgumentOutOfRangeException(
-                    $"Invalid value '{value}' for '{nameof(BufferMaxSize)}' it must be greater than 0.");
-            }
-            _bufferMaxSize = value;
-        }
-    }
-
-    /// <summary>A logger factory used to create the retry interceptor logger.</summary>
-    public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
-
     /// <summary>Gets or sets the maximum number of attempts for retrying a request.</summary>
     /// <value>The maximum number of attempts for retrying a request. The default value is 2 attempts.</value>
     public int MaxAttempts
@@ -63,7 +40,6 @@ public sealed record class RetryOptions
         }
     }
 
-    private int _bufferMaxSize = 1024 * 1024 * 100;
     private int _maxAttempts = 2;
     private int _requestMaxSize = 1024 * 1024;
 }

--- a/src/IceRpc.Retry/RetryPipelineExtensions.cs
+++ b/src/IceRpc.Retry/RetryPipelineExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Retry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IceRpc.Configure;
 
@@ -20,5 +22,13 @@ public static class RetryPipelineExtensions
     /// <param name="options">The options to configure the <see cref="RetryInterceptor"/>.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options) =>
-        pipeline.Use(next => new RetryInterceptor(next, options));
+        pipeline.UseRetry(options, NullLoggerFactory.Instance);
+
+    /// <summary>Adds a <see cref="RetryInterceptor"/> to the pipeline.</summary>
+    /// <param name="pipeline">The pipeline being configured.</param>
+    /// <param name="options">The options to configure the <see cref="RetryInterceptor"/>.</param>
+    /// <param name="loggerFactory">The logger factory used to create loggers to log retries.</param>
+    /// <returns>The pipeline being configured.</returns>
+    public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options, ILoggerFactory loggerFactory) =>
+        pipeline.Use(next => new RetryInterceptor(next, options, loggerFactory));
 }

--- a/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
+++ b/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
@@ -42,8 +42,8 @@ public sealed class RetryInterceptorTests
         });
 
         var proxy = new Proxy(Protocol.IceRpc);
-        var loggerFactory = new TestLoggerFactory();
-        var sut = new RetryInterceptor(invoker, new RetryOptions { LoggerFactory = loggerFactory });
+        using var loggerFactory = new TestLoggerFactory();
+        var sut = new RetryInterceptor(invoker, new RetryOptions(), loggerFactory);
 
         var request = new OutgoingRequest(proxy) { Operation = "Op" };
 


### PR DESCRIPTION
This PR include some simplifications for the RetryInterceptor:

- Move LoggerFactory out of RetryOptions
- Remove BufferMaxSize
- Request with payload stream are always no retryable
- Compute the request size from the ResettablePipeReaderDecorator