### PR TITLE
Resurrect Stream_peer_options_are_set_after_connect

### DIFF
--- a/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
@@ -9,22 +9,28 @@ namespace IceRpc.Transports.Tests;
 
 public static class SlicTransportServiceCollectionExtensions
 {
-    public static IServiceCollection AddSlicTest(this IServiceCollection services, SlicTransportOptions slicTransportOptions)
+    public static IServiceCollection AddSlicTest(
+        this IServiceCollection services,
+        SlicTransportOptions slicTransportOptions,
+        SlicTransportOptions? clientSlicTransportOptions = null)
     {
+        clientSlicTransportOptions ??= slicTransportOptions;
+
         services.AddColocTransport();
         var endpoint = new Endpoint(Protocol.IceRpc) { Host = "colochost" };
 
         services.
-            TryAddSingleton<IServerTransport<IMultiplexedNetworkConnection>>(
+            AddSingleton<IServerTransport<IMultiplexedNetworkConnection>>(
                 provider => new SlicServerTransport(
                     slicTransportOptions,
                     provider.GetRequiredService<IServerTransport<ISimpleNetworkConnection>>()));
 
         services.
-            TryAddSingleton<IClientTransport<IMultiplexedNetworkConnection>>(
+            AddSingleton<IClientTransport<IMultiplexedNetworkConnection>>(
                 provider => new SlicClientTransport(
-                    slicTransportOptions,
+                    clientSlicTransportOptions,
                     provider.GetRequiredService<IClientTransport<ISimpleNetworkConnection>>()));
+
         services.AddSingleton(provider =>
         {
             var serverTransport = provider.GetRequiredService<IServerTransport<IMultiplexedNetworkConnection>>();

--- a/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
@@ -22,6 +22,12 @@ public class SlicTransportTests
                     PauseWriterThreshold = 6893,
                     ResumeWriterThreshold = 2000,
                     PacketMaxSize = 2098
+                },
+                clientSlicTransportOptions: new SlicTransportOptions
+                {
+                    PauseWriterThreshold = 2405,
+                    ResumeWriterThreshold = 2000,
+                    PacketMaxSize = 4567
                 })
             .BuildServiceProvider();
 
@@ -34,9 +40,9 @@ public class SlicTransportTests
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(serverConnection.PeerPauseWriterThreshold, Is.EqualTo(6893));
+            Assert.That(serverConnection.PeerPauseWriterThreshold, Is.EqualTo(2405));
             Assert.That(clientConnection.PeerPauseWriterThreshold, Is.EqualTo(6893));
-            Assert.That(serverConnection.PeerPacketMaxSize, Is.EqualTo(2098));
+            Assert.That(serverConnection.PeerPacketMaxSize, Is.EqualTo(4567));
             Assert.That(clientConnection.PeerPacketMaxSize, Is.EqualTo(2098));
         });
     }


### PR DESCRIPTION
This PR fixes #1285. 