### PR TITLE
Fix rust license line ending

### DIFF
--- a/tools/slicec-cs/.gitattributes
+++ b/tools/slicec-cs/.gitattributes
@@ -1,0 +1,3 @@
+# On Windows files are checkout wiht CRLF Line endings are normalized as LF during commit, we checkout the lincese
+# with LF so that when rustfmt runs in the pre-commit hook the linces template matches the commit files.
+.rustfmt-license-template text eol=lf


### PR DESCRIPTION
This a fix suggested by @externl to avoid issues with rustfmt license checks when running in the pre-commit hook