### PR TITLE
Add option class to configure binder interceptor

### DIFF
--- a/src/IceRpc.Binder/BinderInterceptor.cs
+++ b/src/IceRpc.Binder/BinderInterceptor.cs
@@ -15,17 +15,16 @@ public class BinderInterceptor : IInvoker
 
     /// <summary>Constructs a binder interceptor.</summary>
     /// <param name="next">The next invoker in the pipeline.</param>
+    /// <param name="options">The options to configure the binder interceptor.</param>
     /// <param name="clientConnectionProvider">The client connection provider.</param>
-    /// <param name="cacheConnection">When <c>true</c> (the default), the binder stores the connection it retrieves
-    /// from its client connection provider in the proxy that created the request.</param>
     public BinderInterceptor(
         IInvoker next,
-        IClientConnectionProvider clientConnectionProvider,
-        bool cacheConnection = true)
+        BinderOptions options,
+        IClientConnectionProvider clientConnectionProvider)
     {
         _next = next;
         _clientConnectionProvider = clientConnectionProvider;
-        _cacheConnection = cacheConnection;
+        _cacheConnection = options.CacheConnection;
     }
 
     Task<IncomingResponse> IInvoker.InvokeAsync(OutgoingRequest request, CancellationToken cancel)

--- a/src/IceRpc.Binder/BinderOptions.cs
+++ b/src/IceRpc.Binder/BinderOptions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+namespace IceRpc.Binder;
+
+/// <summary>An options class for configuring a <see cref="BinderInterceptor"/>.</summary>
+public sealed record class BinderOptions
+{
+    /// <summary>Gets or sets a value indicating whether the binder stores the connection it retrieves from its client
+    /// connection provider in the proxy that created the request. The default is <c>true</c>.</summary>
+    public bool CacheConnection { get; set; } = true;
+}

--- a/src/IceRpc.Binder/BinderPipelineExtensions.cs
+++ b/src/IceRpc.Binder/BinderPipelineExtensions.cs
@@ -11,12 +11,20 @@ public static class BinderPipelineExtensions
     /// <summary>Adds a <see cref="BinderInterceptor"/> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="connectionProvider">The connection provider.</param>
-    /// <param name="cacheConnection">When <c>true</c> (the default), the binder stores the connection it retrieves
-    /// from its connection provider in the proxy that created the request.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseBinder(
         this Pipeline pipeline,
-        IClientConnectionProvider connectionProvider,
-        bool cacheConnection = true) =>
-        pipeline.Use(next => new BinderInterceptor(next, connectionProvider, cacheConnection));
+        IClientConnectionProvider connectionProvider) =>
+        pipeline.Use(next => new BinderInterceptor(next, new BinderOptions(), connectionProvider));
+
+    /// <summary>Adds a <see cref="BinderInterceptor"/> to the pipeline.</summary>
+    /// <param name="pipeline">The pipeline being configured.</param>
+    /// <param name="options">The options to configure the <see cref="BinderInterceptor"/>.</param>
+    /// <param name="connectionProvider">The connection provider.</param>
+    /// <returns>The pipeline being configured.</returns>
+    public static Pipeline UseBinder(
+        this Pipeline pipeline,
+        BinderOptions options,
+        IClientConnectionProvider connectionProvider) =>
+        pipeline.Use(next => new BinderInterceptor(next, options, connectionProvider));
 }


### PR DESCRIPTION
This PR adds a BinderOptions class to configure the binder interceptor, this allows configuring the binder interceptor using the options pattern.