### PR TITLE
Use default value for PackageId (AssemblyName)

### DIFF
--- a/examples/Bidir/Client/Client.csproj
+++ b/examples/Bidir/Client/Client.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Bidir.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Bidir.cs">
       <SliceCompileSource>../Bidir.slice</SliceCompileSource>
     </Compile>

--- a/examples/Bidir/Server/Server.csproj
+++ b/examples/Bidir/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Bidir.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Bidir.cs">
       <SliceCompileSource>../Bidir.slice</SliceCompileSource>
     </Compile>

--- a/examples/GenericHost/Client/Client.csproj
+++ b/examples/GenericHost/Client/Client.csproj
@@ -32,10 +32,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.extensions.dependencyinjection" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.logger" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.telemetry" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/examples/GenericHost/Server/Server.csproj
+++ b/examples/GenericHost/Server/Server.csproj
@@ -32,10 +32,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.extensions.dependencyinjection" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.logger" Version="$(IceRpcVersion)" />
-    <PackageReference Include="icerpc.telemetry" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/examples/Hello/Client/Client.csproj
+++ b/examples/Hello/Client/Client.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/examples/Hello/Server/Server.csproj
+++ b/examples/Hello/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/examples/HelloSecure/Client/Client.csproj
+++ b/examples/HelloSecure/Client/Client.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/examples/HelloSecure/Server/Server.csproj
+++ b/examples/HelloSecure/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="icerpc.builder.msbuild" Version="0.1.0-preview4" PrivateAssets="All" />
-    <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
+    <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <Compile Update="generated\Hello.cs">
       <SliceCompileSource>../Hello.slice</SliceCompileSource>
     </Compile>

--- a/src/IceRpc.Binder/IceRpc.Binder.csproj
+++ b/src/IceRpc.Binder/IceRpc.Binder.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.binder</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Coloc/IceRpc.Coloc.csproj
+++ b/src/IceRpc.Coloc/IceRpc.Coloc.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.coloc</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <PackageIcon>logo.png</PackageIcon>

--- a/src/IceRpc.Deadline/IceRpc.Deadline.csproj
+++ b/src/IceRpc.Deadline/IceRpc.Deadline.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.deadline</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Deflate/IceRpc.Deflate.csproj
+++ b/src/IceRpc.Deflate/IceRpc.Deflate.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.deflate</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Extensions.DependencyInjection/IceRpc.Extensions.DependencyInjection.csproj
+++ b/src/IceRpc.Extensions.DependencyInjection/IceRpc.Extensions.DependencyInjection.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.extensions.dependencyinjection</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <PackageIcon>logo.png</PackageIcon>
@@ -18,7 +17,7 @@
         <PackageTags>IceRPC</PackageTags>
     </PropertyGroup>
     <ItemGroup>
-      <ProjectReference Include="..\IceRpc\IceRpc.csproj" />
+        <ProjectReference Include="..\IceRpc\IceRpc.csproj" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" PrivateAssets="All" />

--- a/src/IceRpc.Interop/IceRpc.Interop.csproj
+++ b/src/IceRpc.Interop/IceRpc.Interop.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.interop</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <PackageIcon>logo.png</PackageIcon>

--- a/src/IceRpc.Locator/IceRpc.Locator.csproj
+++ b/src/IceRpc.Locator/IceRpc.Locator.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.locator</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Logger/IceRpc.Logger.csproj
+++ b/src/IceRpc.Logger/IceRpc.Logger.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.logger</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Metrics/IceRpc.Metrics.csproj
+++ b/src/IceRpc.Metrics/IceRpc.Metrics.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.metrics</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.RequestContext/IceRpc.RequestContext.csproj
+++ b/src/IceRpc.RequestContext/IceRpc.RequestContext.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.requestcontext</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Retry/IceRpc.Retry.csproj
+++ b/src/IceRpc.Retry/IceRpc.Retry.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.retry</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc.Telemetry/IceRpc.Telemetry.csproj
+++ b/src/IceRpc.Telemetry/IceRpc.Telemetry.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc.telemetry</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <Copyright>Copyright (c) ZeroC, Inc. All rights reserved</Copyright>

--- a/src/IceRpc/IceRpc.csproj
+++ b/src/IceRpc/IceRpc.csproj
@@ -7,7 +7,6 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageVersion>$(IceRpcVersion)</PackageVersion>
         <Authors>ZeroC</Authors>
-        <PackageId>icerpc</PackageId>
         <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/zeroc-ice/icerpc-csharp</PackageProjectUrl>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Fixed projects to not set PackageId and keep the default value `AssemblyName`, our current lowercase names aren't the standard
```
<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" PrivateAssets="All" />
```