### PR TITLE
Set IsSent as soon as any part of the request may be sent

### DIFF
--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -27,8 +27,9 @@ namespace IceRpc
         /// <value><c>true</c> for oneway requests, <c>false</c> otherwise. The default is <c>false</c>.</value>
         public bool IsOneway { get; init; }
 
-        /// <summary>Gets or sets a value indicating whether or not this request has been sent.</summary>
-        /// <value>When <c>true</c>, the request was sent. When <c>false</c> the request was not sent yet.</value>
+        /// <summary>Gets or sets a value indicating whether this request has been sent in part or in full.</summary>
+        /// <value>When <c>true</c>, the request was sent at least partially. When <c>false</c>, no part of the request
+        /// was sent yet.</value>
         public bool IsSent { get; set; }
 
         /// <summary>Gets or initializes the name of the operation to call on the target service.</summary>

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -99,12 +99,12 @@ public sealed class IceProtocolConnectionTests
         var sut = provider.GetRequiredService<IClientServerProtocolConnection>();
         await sut.ConnectAsync();
 
-        var request = new OutgoingRequest(new Proxy(Protocol.Ice));
         var responseTasks = new List<Task<IncomingResponse>>();
 
         // Act
         for (int i = 0; i < maxConcurrentDispatches + 1; ++i)
         {
+            var request = new OutgoingRequest(new Proxy(Protocol.Ice));
             responseTasks.Add(sut.Client.InvokeAsync(request, InvalidConnection.Ice, default));
         }
         // wait for maxDispatchesPerConnection dispatches to start


### PR DESCRIPTION
This PR changes the semantics of OutgoingRequest.IsSent and sets it to true just before we may send any byte.

Fixes #682.