### PR TITLE
Remove cancellation token from ISimpleNetworkConnection.WriteAsync

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocNetworkConnection.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocNetworkConnection.cs
@@ -144,7 +144,7 @@ namespace IceRpc.Transports.Internal
             }
         }
 
-        public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancel)
+        public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers)
         {
             if (!_state.TrySetFlag(State.Writing))
             {
@@ -164,7 +164,7 @@ namespace IceRpc.Transports.Internal
                         throw new TransportException("connection is shutdown");
                     }
 
-                    _ = await _writer.WriteAsync(buffer, cancel).ConfigureAwait(false);
+                    _ = await _writer.WriteAsync(buffer, CancellationToken.None).ConfigureAwait(false);
                 }
             }
             catch (Exception exception)

--- a/src/IceRpc/Internal/IcePayloadPipeWriter.cs
+++ b/src/IceRpc/Internal/IcePayloadPipeWriter.cs
@@ -25,7 +25,7 @@ namespace IceRpc.Internal
         public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancel = default)
         {
             // The flush can't be canceled because it would lead to the writing of an incomplete payload.
-            await _networkConnectionWriter.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+            await _networkConnectionWriter.FlushAsync().ConfigureAwait(false);
             return default;
         }
 
@@ -36,9 +36,7 @@ namespace IceRpc.Internal
         public override async ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancel)
         {
             // The write can't be canceled because it would lead to the writing of an incomplete payload.
-            await _networkConnectionWriter.WriteAsync(
-                new ReadOnlySequence<byte>(source),
-                CancellationToken.None).ConfigureAwait(false);
+            await _networkConnectionWriter.WriteAsync(new ReadOnlySequence<byte>(source)).ConfigureAwait(false);
             return default;
         }
 
@@ -50,7 +48,7 @@ namespace IceRpc.Internal
             CancellationToken cancel)
         {
             // The write can't be canceled because it would lead to the writing of an incomplete payload.
-            await _networkConnectionWriter.WriteAsync(source, CancellationToken.None).ConfigureAwait(false);
+            await _networkConnectionWriter.WriteAsync(source).ConfigureAwait(false);
             return default;
         }
 

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -426,7 +426,7 @@ namespace IceRpc.Internal
                 {
                     // Encode and write the CloseConnection frame once all the dispatches are done.
                     EncodeCloseConnectionFrame(_networkConnectionWriter);
-                    await _networkConnectionWriter.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                    await _networkConnectionWriter.FlushAsync().ConfigureAwait(false);
                 }
                 finally
                 {
@@ -498,7 +498,7 @@ namespace IceRpc.Internal
                 {
                     EncodeValidateConnectionFrame(_networkConnectionWriter);
                     // The flush can't be canceled because it would lead to the writing of an incomplete frame.
-                    await _networkConnectionWriter.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                    await _networkConnectionWriter.FlushAsync().ConfigureAwait(false);
                 }
                 finally
                 {
@@ -529,7 +529,7 @@ namespace IceRpc.Internal
                 EncodeValidateConnectionFrame(_networkConnectionWriter);
 
                 // The flush can't be canceled because it would lead to the writing of an incomplete frame.
-                await _networkConnectionWriter.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                await _networkConnectionWriter.FlushAsync().ConfigureAwait(false);
             }
             else
             {

--- a/src/IceRpc/Transports/ISimpleNetworkConnection.cs
+++ b/src/IceRpc/Transports/ISimpleNetworkConnection.cs
@@ -21,11 +21,11 @@ namespace IceRpc.Transports
 
         /// <summary>Writes data over the connection.</summary>
         /// <param name="buffers">The buffers containing the data to write.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>A value task that completes once the buffers are written.</returns>
         /// <exception cref="ConnectionLostException">Thrown if the peer closed its side of the connection.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
-        /// <exception cref="OperationCanceledException">Thrown if the cancellation token was canceled.</exception>
-        ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancel);
+        /// <remarks>This method does not accept a cancellation token because we never want to write buffers partially.
+        /// The only way to interrupt a blocked WriteAsync is to dispose the connection.</remarks>
+        ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers);
     }
 }

--- a/src/IceRpc/Transports/Internal/LogSimpleNetworkConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogSimpleNetworkConnectionDecorator.cs
@@ -21,9 +21,9 @@ namespace IceRpc.Transports.Internal
             Logger.LogSimpleNetworkConnectionShutdown();
         }
 
-        public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancel)
+        public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers)
         {
-            await _decoratee.WriteAsync(buffers, cancel).ConfigureAwait(false);
+            await _decoratee.WriteAsync(buffers).ConfigureAwait(false);
             int size = 0;
             foreach (ReadOnlyMemory<byte> buffer in buffers)
             {

--- a/src/IceRpc/Transports/Internal/LogTcpNetworkConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogTcpNetworkConnectionDecorator.cs
@@ -43,8 +43,7 @@ namespace IceRpc.Transports.Internal
 
         public override string? ToString() => _decoratee.ToString();
 
-        public ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancel) =>
-            _decoratee.WriteAsync(buffers, cancel);
+        public ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers) => _decoratee.WriteAsync(buffers);
 
         internal LogTcpNetworkConnectionDecorator(TcpNetworkConnection decoratee, ILogger logger)
         {

--- a/src/IceRpc/Transports/Internal/SlicFrameWriter.cs
+++ b/src/IceRpc/Transports/Internal/SlicFrameWriter.cs
@@ -19,10 +19,7 @@ namespace IceRpc.Transports.Internal
             _writer.EncodeFrame(frameType, streamId, encodeAction);
 
             // The write can't be canceled because it would lead to the writing of an incomplete Slic frame.
-            return _writer.WriteAsync(
-                ReadOnlySequence<byte>.Empty,
-                ReadOnlySequence<byte>.Empty,
-                CancellationToken.None);
+            return _writer.WriteAsync(ReadOnlySequence<byte>.Empty, ReadOnlySequence<byte>.Empty);
         }
 
         public ValueTask WriteStreamFrameAsync(
@@ -35,7 +32,7 @@ namespace IceRpc.Transports.Internal
             _writer.EncodeStreamFrameHeader(streamId, (int)(source1.Length + source2.Length), endStream);
 
             // The write can't be canceled because it would lead to the writing of an incomplete Slic frame.
-            return _writer.WriteAsync(source1, source2, CancellationToken.None);
+            return _writer.WriteAsync(source1, source2);
         }
 
         internal SlicFrameWriter(SimpleNetworkConnectionWriter writer) => _writer = writer;

--- a/tests/IceRpc.Tests/Transports/SimpleNetworkConnectionReaderTests.cs
+++ b/tests/IceRpc.Tests/Transports/SimpleNetworkConnectionReaderTests.cs
@@ -41,7 +41,7 @@ public class SimpleNetworkConnectionReaderTests
         reader.SetIdleTimeout(TimeSpan.FromMilliseconds(1000));
 
         // Write and read data.
-        await serverConnection.WriteAsync(new ReadOnlyMemory<byte>[] { new byte[1] }, default);
+        await serverConnection.WriteAsync(new ReadOnlyMemory<byte>[] { new byte[1] });
         ReadOnlySequence<byte> buffer = await reader.ReadAsync(default);
         reader.AdvanceTo(buffer.End);
 
@@ -113,7 +113,7 @@ public class SimpleNetworkConnectionReaderTests
         reader.SetIdleTimeout(TimeSpan.FromMilliseconds(500));
 
         // Write and read data to defer the idle timeout
-        await serverConnection.WriteAsync(new ReadOnlyMemory<byte>[] { new byte[1] }, default);
+        await serverConnection.WriteAsync(new ReadOnlyMemory<byte>[] { new byte[1] });
         ReadOnlySequence<byte> buffer = await reader.ReadAsync(default);
         reader.AdvanceTo(buffer.End);
 


### PR DESCRIPTION
This PR removes the cancellation token from ISimpleNetworkConnection.WriteAsync and related APIs.

We were always passing CancellationToken.None for this token. If there is a good reason to keep this cancellation token in WriteAsync, I'll close this PR and add a remarks to  ISimpleNetworkConnection.WriteAsync.

Fixes #1395.