### PR TITLE
Remove cancellation token from ISimpleNetworkConnection.ShutdownAsync

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocNetworkConnection.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocNetworkConnection.cs
@@ -128,7 +128,7 @@ namespace IceRpc.Transports.Internal
             }
         }
 
-        public async Task ShutdownAsync(CancellationToken cancel)
+        public async Task ShutdownAsync()
         {
             if (_state.TrySetFlag(State.ShuttingDown))
             {

--- a/src/IceRpc/Transports/ISimpleNetworkConnection.cs
+++ b/src/IceRpc/Transports/ISimpleNetworkConnection.cs
@@ -16,8 +16,7 @@ namespace IceRpc.Transports
         ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancel);
 
         /// <summary>Shuts down the connection.</summary>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        Task ShutdownAsync(CancellationToken cancel);
+        Task ShutdownAsync();
 
         /// <summary>Writes data over the connection.</summary>
         /// <param name="buffers">The buffers containing the data to write.</param>

--- a/src/IceRpc/Transports/Internal/LogSimpleNetworkConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogSimpleNetworkConnectionDecorator.cs
@@ -15,9 +15,9 @@ namespace IceRpc.Transports.Internal
             return received;
         }
 
-        public async Task ShutdownAsync(CancellationToken cancel)
+        public async Task ShutdownAsync()
         {
-            await _decoratee.ShutdownAsync(cancel).ConfigureAwait(false);
+            await _decoratee.ShutdownAsync().ConfigureAwait(false);
             Logger.LogSimpleNetworkConnectionShutdown();
         }
 

--- a/src/IceRpc/Transports/Internal/LogTcpNetworkConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogTcpNetworkConnectionDecorator.cs
@@ -39,7 +39,7 @@ namespace IceRpc.Transports.Internal
         public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancel) =>
             _decoratee.ReadAsync(buffer, cancel);
 
-        public Task ShutdownAsync(CancellationToken cancel) => _decoratee.ShutdownAsync(cancel);
+        public Task ShutdownAsync() => _decoratee.ShutdownAsync();
 
         public override string? ToString() => _decoratee.ToString();
 

--- a/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
@@ -309,7 +309,7 @@ namespace IceRpc.Transports.Internal
             }
 
             // Shutdown the simple network connection.
-            await _simpleNetworkConnection.ShutdownAsync(cancel).ConfigureAwait(false);
+            await _simpleNetworkConnection.ShutdownAsync().ConfigureAwait(false);
         }
 
         internal SlicNetworkConnection(

--- a/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpNetworkConnection.cs
@@ -75,7 +75,7 @@ namespace IceRpc.Transports.Internal
             return received;
         }
 
-        public async Task ShutdownAsync(CancellationToken cancel)
+        public async Task ShutdownAsync()
         {
             try
             {

--- a/tests/IceRpc.Conformance.Tests/Transports/SimpleTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/SimpleTransportConformanceTests.cs
@@ -179,10 +179,10 @@ public abstract class SimpleTransportConformanceTests
             provider.GetRequiredService<ISimpleNetworkConnection>());
 
         // Act
-        await sut.ServerConnection.ShutdownAsync(CancellationToken.None);
+        await sut.ServerConnection.ShutdownAsync();
         int clientRead = await sut.ClientConnection.ReadAsync(new byte[1], CancellationToken.None);
 
-        await sut.ClientConnection.ShutdownAsync(CancellationToken.None);
+        await sut.ClientConnection.ShutdownAsync();
         int serverRead = await sut.ServerConnection.ReadAsync(new byte[1], CancellationToken.None);
 
         // Assert
@@ -305,7 +305,7 @@ public abstract class SimpleTransportConformanceTests
         using ClientServerSimpleTransportConnection sut = await ConnectAndAcceptAsync(
             provider.GetRequiredService<IListener<ISimpleNetworkConnection>>(),
             provider.GetRequiredService<ISimpleNetworkConnection>());
-        await sut.ServerConnection.ShutdownAsync(CancellationToken.None);
+        await sut.ServerConnection.ShutdownAsync();
 
         // Act/Assert
         Assert.CatchAsync<Exception>(async () =>
@@ -335,7 +335,7 @@ public abstract class SimpleTransportConformanceTests
         await sendTask;
 
         // Act
-        await sut.ClientConnection.ShutdownAsync(CancellationToken.None);
+        await sut.ClientConnection.ShutdownAsync();
 
         // Assert
         Assert.That(await receiveTask, Is.EqualTo(sendSize));


### PR DESCRIPTION
This PR removes the cancellation token from ISimpleNetworkConnection.ShutdownAsync, as it serves no purpose and was always ignored.

It's possible we could do the same for IMultiplexedNetworkConnection.ShutdownAsync. See #1400.