### PR TITLE
Replace request.IsSent by decorator.IsRead

### DIFF
--- a/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
@@ -10,6 +10,13 @@ namespace IceRpc.Retry.Internal;
 /// perspective).</summary>
 internal class ResettablePipeReaderDecorator : PipeReader
 {
+    /// <summary>Gets a value indicating whether any of the Read method was called and completed successfully since
+    /// its creation or the last reset.</summary>
+    /// <remarks>If no Read method completed successfully, no request or part of a request was sent to the server.
+    /// This includes the situation where this decorator decorates the empty pipe reader: if the empty pipe reader
+    /// was never read successfully, we did not send a empty-payload request to the server.</remarks>
+    internal bool IsRead { get; private set; }
+
     /// <summary>Gets or sets a value indicating whether this decorator can be reset.</summary>
     internal bool IsResettable
     {
@@ -153,6 +160,7 @@ internal class ResettablePipeReaderDecorator : PipeReader
             throw new InvalidOperationException("reading is already in progress");
 
         ThrowIfCompleted();
+
         try
         {
             if (_decoratee.TryRead(out result))
@@ -181,6 +189,7 @@ internal class ResettablePipeReaderDecorator : PipeReader
             throw new InvalidOperationException("reading is already in progress");
 
         ThrowIfCompleted();
+
         if (_consumed is SequencePosition consumed)
         {
             minimumSize += (int)_sequence!.Value.GetOffset(consumed);
@@ -222,6 +231,7 @@ internal class ResettablePipeReaderDecorator : PipeReader
             _consumed = null;
             _isReaderCompleted = false;
             _readerCompleteException = null;
+            IsRead = false;
         }
         else
         {
@@ -246,6 +256,8 @@ internal class ResettablePipeReaderDecorator : PipeReader
         {
             _isResettable = false;
         }
+
+        IsRead = true;
         return readResult;
     }
 

--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -98,7 +98,7 @@ public class RetryInterceptor : IInvoker
                         // ConnectionClosedException is a graceful connection closure that is always safe to retry.
                         if (ex is ConnectionClosedException ||
                             request.Fields.ContainsKey(RequestFieldKey.Idempotent) ||
-                            !request.IsSent)
+                            !decorator.IsRead)
                         {
                             retryPolicy = RetryPolicy.Immediately;
                         }
@@ -141,7 +141,6 @@ public class RetryInterceptor : IInvoker
                             request.Connection = null;
                         }
 
-                        request.IsSent = false;
                         decorator.Reset();
                     }
                     else

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -308,9 +308,6 @@ namespace IceRpc.Internal
                 }
             }
 
-            // Request is sent at this point.
-            request.IsSent = true;
-
             if (request.IsOneway)
             {
                 // We're done, there's no response for oneway requests.

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -562,8 +562,6 @@ namespace IceRpc.Internal
                 throw;
             }
 
-            request.IsSent = true;
-
             if (request.IsOneway)
             {
                 return new IncomingResponse(request, connection);

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -27,10 +27,6 @@ namespace IceRpc
         /// <value><c>true</c> for oneway requests, <c>false</c> otherwise. The default is <c>false</c>.</value>
         public bool IsOneway { get; init; }
 
-        /// <summary>Gets or sets a value indicating whether or not this request has been sent.</summary>
-        /// <value>When <c>true</c>, the request was sent. When <c>false</c> the request was not sent yet.</value>
-        public bool IsSent { get; set; }
-
         /// <summary>Gets or initializes the name of the operation to call on the target service.</summary>
         /// <value>The name of the operation. The default is the empty string.</value>
         public string Operation { get; init; } = "";


### PR DESCRIPTION
This PR removes OutgoingRequest.IsSent (as suggested by Benoit in #1401) and replaces it with a IsRead property on the decorator.

IsRead is set to true as soon as a read method on the decorator returns successfully. It's not quite the same as detecting when bytes are consumed. It's in theory possible for the protocol connection to read bytes, send them and then throw an exception before calling AdvanceTo or Complete on the pipe reader - so it's better to detect Reads.

Also note the interesting situation when the payload is empty. In this case, it's still necessary to call a Read method on the decorator to get an "empty" read result, and IsRead becomes true in this case, even though no bytes from the pipe reader are ever sent.

Fixes #682.