### PR TITLE
Fix for issue #1407

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicNetworkConnection.cs
@@ -260,10 +260,7 @@ internal class SlicNetworkConnection : IMultiplexedNetworkConnection
                 try
                 {
                     // Read frames. This will return when the Close frame is received.
-                    ulong errorCode = await ReadFramesAsync(_readCancelSource.Token).ConfigureAwait(false);
-
-                    // Send back a Close frame to the peer with the same error code.
-                    await ShutdownAsync(errorCode, _readCancelSource.Token).ConfigureAwait(false);
+                    await ReadFramesAsync(_readCancelSource.Token).ConfigureAwait(false);
 
                     // Notify opened streams of the connection closure.
                     Abort(new ConnectionClosedException());
@@ -593,7 +590,7 @@ internal class SlicNetworkConnection : IMultiplexedNetworkConnection
         }
     }
 
-    private async Task<ulong> ReadFramesAsync(CancellationToken cancel)
+    private async Task ReadFramesAsync(CancellationToken cancel)
     {
         while (true)
         {
@@ -617,7 +614,7 @@ internal class SlicNetworkConnection : IMultiplexedNetworkConnection
                         cancel).ConfigureAwait(false);
 
                     // Graceful connection shutdown, we're done.
-                    return closeBody.ApplicationProtocolErrorCode;
+                    return;
                 }
                 case FrameType.Ping:
                 {


### PR DESCRIPTION
This PR changes the Slic network connection implementation to no longer send back a close frame in response to a close frame.

The error code transmitted with the close frame is not used. While we could remove it, keeping it is probably safer if one day with we want actually use it.