### PR TITLE
Remove rustfmt license template

### DIFF
--- a/tools/slicec-cs/.gitattributes
+++ b/tools/slicec-cs/.gitattributes
@@ -1,3 +1,0 @@
-# On Windows files are checkout wiht CRLF Line endings are normalized as LF during commit, we checkout the lincese
-# with LF so that when rustfmt runs in the pre-commit hook the linces template matches the commit files.
-.rustfmt-license-template text eol=lf

--- a/tools/slicec-cs/.rustfmt-license-template
+++ b/tools/slicec-cs/.rustfmt-license-template
@@ -1,1 +1,0 @@
-// Copyright (c) ZeroC, Inc. All rights reserved.

--- a/tools/slicec-cs/rustfmt.toml
+++ b/tools/slicec-cs/rustfmt.toml
@@ -5,7 +5,6 @@
 # enum_discrim_align_threshold (https://github.com/rust-lang/rustfmt/issues/3372)
 # format_code_in_doc_comments (https://github.com/rust-lang/rustfmt/issues/3348)
 # format_macro_matchers (https://github.com/rust-lang/rustfmt/issues/3354)
-# license_template_path (https://github.com/rust-lang/rustfmt/issues/3352)
 # normalize_doc_attributes (https://github.com/rust-lang/rustfmt/issues/3351)
 # overflow_delimited_expression (https://github.com/rust-lang/rustfmt/issues/3370)
 # wrap_comments (https://github.com/rust-lang/rustfmt/issues/3347)
@@ -21,8 +20,6 @@ struct_variant_width = 40
 
 format_code_in_doc_comments = true
 format_macro_matchers = true
-
-license_template_path = ".rustfmt-license-template"
 
 merge_derives = true
 


### PR DESCRIPTION
This feature has been removed from `rustfmt`. See https://github.com/rust-lang/rustfmt/issues/5103