### PR TITLE
DecodeSequence with checkElement action test

### DIFF
--- a/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
@@ -129,13 +129,12 @@ public class SequenceDecodingTests
             expected,
             (ref SliceEncoder encoder, TestEnum value) => encoder.EncodeInt16((short)value));
 
-        // Action to check enum is in the correct range
         var checkedValues = new List<TestEnum>();
         var sut = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
 
         // Act
         TestEnum[]? decoded = sut.DecodeSequence<TestEnum>(value => checkedValues.Add(value));
-
+        
         // Assert
         Assert.That(decoded, Is.EqualTo(expected));
         Assert.That(checkedValues, Is.EqualTo(expected));


### PR DESCRIPTION
This PR adds a missing test that verifies that the `checkAction` argument for the `DecodeSequence<T>` works as expected.

To test this feature a test enum called `TestEnum` is created where it is backed by a short but should only ever have a value of 1, 2, or 3. The action checks that a decoded value outside of this range is not allowed.