### PR TITLE
Removed Proxy CheckFragment

### DIFF
--- a/src/IceRpc/Proxy.cs
+++ b/src/IceRpc/Proxy.cs
@@ -308,10 +308,10 @@ public sealed record class Proxy
             if (Protocol.IsSupported)
             {
                 Protocol.CheckPath(_path);
-                // if (!Protocol.HasFragment && _fragment.Length > 0)
-                // {
-                //     throw new ArgumentException($"cannot create an {Protocol} proxy with a fragment", nameof(uri));
-                // }
+                if (!Protocol.HasFragment && _fragment.Length > 0)
+                {
+                    throw new ArgumentException($"cannot create an {Protocol} proxy with a fragment", nameof(uri));
+                }
 
                 (ImmutableDictionary<string, string> queryParams, string? altEndpointValue) = uri.ParseQuery();
 


### PR DESCRIPTION
Resolves #1453

`Uri` already handles checking for the bad characters below and replaces them with `%`. As such, we do not need to be making the call to `CheckFragment`. Additionally for Slice1 proxies the validation occurs in `FragmentSliceDecoderExtensions.cs` where we escape any bad characters with the `Uri.EscapeDataString(decoder.DecodeString())`.

```
"\"<>\\^`{|}"
```

