### PR TITLE
Remove lifetimes not used in impl

### DIFF
--- a/tools/slicec-cs/src/class_visitor.rs
+++ b/tools/slicec-cs/src/class_visitor.rs
@@ -20,7 +20,7 @@ pub struct ClassVisitor<'a> {
     pub generated_code: &'a mut GeneratedCode,
 }
 
-impl<'a> Visitor for ClassVisitor<'_> {
+impl Visitor for ClassVisitor<'_> {
     fn visit_class_start(&mut self, class_def: &Class) {
         let class_name = class_def.escape_identifier();
         let namespace = class_def.namespace();

--- a/tools/slicec-cs/src/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/dispatch_visitor.rs
@@ -19,7 +19,7 @@ pub struct DispatchVisitor<'a> {
     pub generated_code: &'a mut GeneratedCode,
 }
 
-impl<'a> Visitor for DispatchVisitor<'_> {
+impl Visitor for DispatchVisitor<'_> {
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         let bases = interface_def.base_interfaces();
         let interface_name = interface_def.interface_name();

--- a/tools/slicec-cs/src/exception_visitor.rs
+++ b/tools/slicec-cs/src/exception_visitor.rs
@@ -20,7 +20,7 @@ pub struct ExceptionVisitor<'a> {
     pub generated_code: &'a mut GeneratedCode,
 }
 
-impl<'a> Visitor for ExceptionVisitor<'_> {
+impl Visitor for ExceptionVisitor<'_> {
     fn visit_exception_start(&mut self, exception_def: &Exception) {
         let exception_name = exception_def.escape_identifier();
         let has_base = exception_def.base.is_some();

--- a/tools/slicec-cs/src/proxy_visitor.rs
+++ b/tools/slicec-cs/src/proxy_visitor.rs
@@ -19,7 +19,7 @@ pub struct ProxyVisitor<'a> {
     pub generated_code: &'a mut GeneratedCode,
 }
 
-impl<'a> Visitor for ProxyVisitor<'_> {
+impl Visitor for ProxyVisitor<'_> {
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         let namespace = interface_def.namespace();
         let proxy_interface = interface_def.proxy_name(); // IFooProxy


### PR DESCRIPTION
The Github actions revealed that we currently have some build warnings in slicec-cs. This PR resolves these errors.

```
warning: this lifetime isn't used in the impl
  --> src/dispatch_visitor.rs:22:6
   |
22 | impl<'a> Visitor for DispatchVisitor<'_> {
   |      ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
```