### PR TITLE
Move NetworkConnectionInformation to ConnectAsync

### DIFF
--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -25,10 +25,6 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     // TODO: should we remove this property?
     public Endpoint Endpoint { get; }
 
-    /// <summary>Gets the network connection information or <c>null</c> if the connection is not connected.
-    /// </summary>
-    public NetworkConnectionInformation? NetworkConnectionInformation { get; private set; }
-
     /// <summary>Gets the protocol of this connection.</summary>
     public Protocol Protocol => Endpoint.Protocol;
 
@@ -122,8 +118,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
 
     /// <summary>Establishes the connection. This method can be called multiple times, even concurrently.</summary>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A task that represents the completion of the connect operation. This task can complete with one of the
-    /// following exceptions:
+    /// <returns>A task that provides the <see cref="NetworkConnectionInformation"/> of the transport connection, once
+    /// this connection is established. This task can also complete with one of the following exceptions:
     /// <list type="bullet">
     /// <item><description><see cref="ConnectionAbortedException"/>if the connection was aborted.</description></item>
     /// <item><description><see cref="ObjectDisposedException"/>if this connection is disposed.</description></item>
@@ -133,8 +129,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     /// <see cref="ConnectionOptions.ConnectTimeout"/>.</description></item>
     /// </list>
     /// </returns>
-    public async Task ConnectAsync(CancellationToken cancel = default) =>
-        NetworkConnectionInformation = await _protocolConnection.ConnectAsync(cancel: cancel).ConfigureAwait(false);
+    public Task<NetworkConnectionInformation> ConnectAsync(CancellationToken cancel = default) =>
+        _protocolConnection.ConnectAsync(cancel);
 
     /// <inheritdoc/>
     public ValueTask DisposeAsync() => _protocolConnection.DisposeAsync();

--- a/tests/IceRpc.Tests/ConnectionTests.cs
+++ b/tests/IceRpc.Tests/ConnectionTests.cs
@@ -300,7 +300,7 @@ public class ConnectionTests
     }
 
     [Test]
-    public async Task Connect_sets_network_connection_information([Values("ice", "icerpc")] string protocol)
+    public async Task Connect_returns_network_connection_information([Values("ice", "icerpc")] string protocol)
     {
         // Arrange
         IServiceCollection services = new ServiceCollection().AddColocTest(
@@ -311,17 +311,12 @@ public class ConnectionTests
 
         provider.GetRequiredService<Server>().Listen();
         var connection = provider.GetRequiredService<ClientConnection>();
-        var networkConnectionInformation = connection.NetworkConnectionInformation;
 
         // Act
-        await connection.ConnectAsync(default);
+        NetworkConnectionInformation networkConnectionInformation = await connection.ConnectAsync(default);
 
         // Assert
-        Assert.Multiple(() =>
-        {
-            Assert.That(networkConnectionInformation, Is.Null);
-            Assert.That(connection.NetworkConnectionInformation, Is.Not.Null);
-        });
+        Assert.That(networkConnectionInformation, Is.Not.EqualTo(new NetworkConnectionInformation()));
     }
 
     [Test]


### PR DESCRIPTION
This PR removes (Resumable)ClientConnection.NetworkConnectionInformation and changes their ConnectAsync to return a `Task<NetworkConnectionInformation>` just like `IProtocolConnection.ConnectAsync`.