### PR TITLE
Revise log message of Logger interceptor

### DIFF
--- a/src/IceRpc.Logger/LoggerInterceptor.cs
+++ b/src/IceRpc.Logger/LoggerInterceptor.cs
@@ -60,7 +60,6 @@ internal static partial class LoggerInterceptorLoggerExtensions
             logger.LogInvoke(
                 request.ServiceAddress,
                 request.Operation,
-                request.IsOneway,
                 response.ResultType,
                 response.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
                 response.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress,
@@ -79,7 +78,6 @@ internal static partial class LoggerInterceptorLoggerExtensions
             logger.LogInvokeException(
                 request.ServiceAddress,
                 request.Operation,
-                request.IsOneway,
                 totalMilliseconds,
                 exception);
         }
@@ -89,14 +87,12 @@ internal static partial class LoggerInterceptorLoggerExtensions
         EventId = (int)LoggerInterceptorEventIds.Invoke,
         EventName = nameof(LoggerInterceptorEventIds.Invoke),
         Level = LogLevel.Information,
-        Message = "sent request and received response {{ ServiceAddress = {ServiceAddress}, Operation = {Operation}, " +
-            "IsOneway = {IsOneway}, ResultType = {ResultType}, LocalNetworkAddress = {LocalNetworkAddress}, " +
-            "RemoteNetworkAddress = {RemoteNetworkAddress}, Time = {TotalMilliseconds:F} ms }}")]
+        Message = "sent {Operation} to {ServiceAddress} using {LocalNetworkAddress}->{RemoteNetworkAddress} and " +
+            "received {ResultType} response after {TotalMilliseconds:F} ms")]
     private static partial void LogInvoke(
         this ILogger logger,
         ServiceAddress serviceAddress,
         string operation,
-        bool isOneway,
         ResultType resultType,
         EndPoint? localNetworkAddress,
         EndPoint? remoteNetworkAddress,
@@ -106,13 +102,11 @@ internal static partial class LoggerInterceptorLoggerExtensions
         EventId = (int)LoggerInterceptorEventIds.InvokeException,
         EventName = nameof(LoggerInterceptorEventIds.InvokeException),
         Level = LogLevel.Information,
-        Message = "failed to send request {{ ServiceAddress = {ServiceAddress}, Operation = {Operation}, " +
-            "IsOneway = {IsOneway}, Time = {TotalMilliseconds:F} ms }}")]
+        Message = "failed to send {Operation} to {ServiceAddress} in {TotalMilliseconds:F} ms")]
     private static partial void LogInvokeException(
         this ILogger logger,
         ServiceAddress serviceAddress,
         string operation,
-        bool isOneway,
         double totalMilliseconds,
         Exception exception);
 }

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -63,8 +63,6 @@ public sealed class LoggerMiddlewareTests
 
     private static void CheckEntryState(TestLoggerEntry entry)
     {
-        Assert.That(entry.State["LocalNetworkAddress"], Is.EqualTo("undefined"));
-        Assert.That(entry.State["RemoteNetworkAddress"], Is.EqualTo("undefined"));
         Assert.That(entry.State["Operation"], Is.EqualTo("operation"));
         Assert.That(entry.State["Path"], Is.EqualTo("/path"));
     }

--- a/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
+++ b/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports;
+using System.Net;
+using System.Net.Sockets;
 
 namespace IceRpc.Tests.Common;
 
@@ -12,7 +14,8 @@ public sealed class FakeConnectionContext : IConnectionContext
 
     public IInvoker Invoker => NotImplementedInvoker.Instance;
 
-    public TransportConnectionInformation TransportConnectionInformation => default;
+    public TransportConnectionInformation TransportConnectionInformation =>
+        new(IPEndPoint.Parse("192.168.7.7:10000"), IPEndPoint.Parse("10.10.10.10:11000"), null);
 
     public Protocol Protocol { get; }
 


### PR DESCRIPTION
This PR changes the messages generated by the Logger interceptor.

Rather than a record ToString-like message, it's a sentence.

This PR also removes the IsOneway logging since:
 - I could not find a nice way to include it in the log message
 - It's not that important: in Slice, it's specified by an attribute in your Slice definitions, and does not change from call to call
 - All parameters used for structured logging needs to be referenced by the message

Example output:
```
info: IceRpc.Logger[0]
      => SpanId:02ae64beb7b0b473, TraceId:4b6c7ebd799e5427fa3e45b645958505, ParentId:0000000000000000
      sent sayHello to icerpc:/Demo.Hello using 127.0.0.1:62478->127.0.0.1:10000 and received Success response after 210.08 ms
```