### PR TITLE
Test failure fix and renaming

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -203,10 +203,10 @@ public abstract class MultiplexedTransportConformanceTests
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
-        IMultiplexedConnection disposedConnection =
-            disposeServerConnection ? serverConnection : clientConnection;
-        IMultiplexedConnection peerConnection =
-            disposeServerConnection ? clientConnection : serverConnection;
+        IMultiplexedConnection disposedConnection = disposeServerConnection ? serverConnection : clientConnection;
+        IMultiplexedConnection peerConnection = disposeServerConnection ? clientConnection : serverConnection;
+        IMultiplexedStream peerStream = peerConnection.CreateStream(true);
+        await peerStream.Output.WriteAsync(_oneBytePayload); // Make sure the stream is started before DisposeAsync
 
         // Act
         await disposedConnection.DisposeAsync();
@@ -219,7 +219,6 @@ public abstract class MultiplexedTransportConformanceTests
         Assert.ThrowsAsync<ConnectionAbortedException>(
             async () => await disposedStream.Output.WriteAsync(_oneBytePayload));
 
-        IMultiplexedStream peerStream = peerConnection.CreateStream(true);
         Assert.ThrowsAsync<ConnectionLostException>(async () =>
             {
                 // It can take few writes for the peer to detect the connection closure.

--- a/tests/IceRpc.Tests/ConnectionTests.cs
+++ b/tests/IceRpc.Tests/ConnectionTests.cs
@@ -396,8 +396,8 @@ public class ConnectionTests
         var server = provider.GetRequiredService<Server>();
         server.Listen();
         var clientConnection = provider.GetRequiredService<ClientConnection>();
-        var serviceAddress = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
-        var pingTask = serviceAddress.IcePingAsync();
+        var proxy = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
+        var pingTask = proxy.IcePingAsync();
         await start.WaitAsync();
 
         // Act
@@ -460,8 +460,8 @@ public class ConnectionTests
         var server = provider.GetRequiredService<Server>();
         server.Listen();
         var clientConnection = provider.GetRequiredService<ClientConnection>();
-        var serviceAddress = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
-        var pingTask = serviceAddress.IcePingAsync();
+        var proxy = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
+        var pingTask = proxy.IcePingAsync();
         await start.WaitAsync();
         Task shutdownTask = closeClientSide ? clientConnection.ShutdownAsync() : serverConnection!.ShutdownAsync("");
 
@@ -557,8 +557,8 @@ public class ConnectionTests
         var server = provider.GetRequiredService<Server>();
         server.Listen();
         var clientConnection = provider.GetRequiredService<ClientConnection>();
-        var serviceAddress = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
-        var pingTask = serviceAddress.IcePingAsync();
+        var proxy = new ServiceProxy(clientConnection, new Uri($"{protocol}:/path"));
+        var pingTask = proxy.IcePingAsync();
         await start.WaitAsync();
 
         // Act


### PR DESCRIPTION
This PR fixes a sporadic `Cannot_create_streams_with_a_disposed_connection` test failure. 