### PR TITLE
Fixed transport connection class names, fixes #1539

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
@@ -31,7 +31,7 @@ internal class ColocClientTransport : IDuplexClientTransport
             throw new FormatException($"cannot create a Coloc connection to endpoint '{options.Endpoint}'");
         }
 
-        return new ColocDuplexConnection(options.Endpoint.WithTransport(Name), endpoint => Connect(endpoint, options));
+        return new ColocConnection(options.Endpoint.WithTransport(Name), endpoint => Connect(endpoint, options));
     }
 
     internal ColocClientTransport(ConcurrentDictionary<Endpoint, ColocListener> listeners) =>

--- a/src/IceRpc.Coloc/Transports/Internal/ColocConnection.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocConnection.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Transports.Internal;
 
 /// <summary>The colocated connection class to exchange data within the same process. The implementation copies the send
 /// buffer into the receive buffer.</summary>
-internal class ColocDuplexConnection : IDuplexConnection
+internal class ColocConnection : IDuplexConnection
 {
     public Endpoint Endpoint { get; }
 
@@ -29,7 +29,7 @@ internal class ColocDuplexConnection : IDuplexConnection
 
     public void Dispose()
     {
-        _exception ??= new ObjectDisposedException($"{typeof(ColocDuplexConnection)}");
+        _exception ??= new ObjectDisposedException($"{typeof(ColocConnection)}");
 
         if (_state.TrySetFlag(State.Disposed))
         {
@@ -203,7 +203,7 @@ internal class ColocDuplexConnection : IDuplexConnection
         }
     }
 
-    public ColocDuplexConnection(Endpoint endpoint, Func<Endpoint, (PipeReader, PipeWriter)> connect)
+    public ColocConnection(Endpoint endpoint, Func<Endpoint, (PipeReader, PipeWriter)> connect)
     {
         Endpoint = endpoint;
         _connect = connect;

--- a/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
@@ -16,7 +16,7 @@ internal class ColocListener : IDuplexListener
     public async Task<IDuplexConnection> AcceptAsync()
     {
         (PipeReader reader, PipeWriter writer) = await _queue.DequeueAsync(default).ConfigureAwait(false);
-        return new ColocDuplexConnection(Endpoint, _ => (reader, writer));
+        return new ColocConnection(Endpoint, _ => (reader, writer));
     }
 
     public void Dispose() => _queue.TryComplete(new ObjectDisposedException(nameof(ColocListener)));

--- a/src/IceRpc/Transports/Internal/LogTcpConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Internal/LogTcpConnectionDecorator.cs
@@ -7,11 +7,11 @@ using System.Security.Authentication;
 namespace IceRpc.Transports.Internal;
 
 /// <summary>The log decorator installed by the TCP transports.</summary>
-internal class LogTcpTransportConnectionDecorator : IDuplexConnection
+internal class LogTcpConnectionDecorator : IDuplexConnection
 {
     public Endpoint Endpoint => _decoratee.Endpoint;
 
-    private readonly TcpDuplexConnection _decoratee;
+    private readonly TcpConnection _decoratee;
     private readonly ILogger _logger;
 
     public async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancel)
@@ -48,7 +48,7 @@ internal class LogTcpTransportConnectionDecorator : IDuplexConnection
     public ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancel) =>
         _decoratee.WriteAsync(buffers, cancel);
 
-    internal LogTcpTransportConnectionDecorator(TcpDuplexConnection decoratee, ILogger logger)
+    internal LogTcpConnectionDecorator(TcpConnection decoratee, ILogger logger)
     {
         _decoratee = decoratee;
         _logger = logger;

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -10,11 +10,11 @@ using System.IO.Pipelines;
 
 namespace IceRpc.Transports.Internal;
 
-/// <summary>The Slic multiplexed connection implements an <see cref="IMultiplexedConnection"/> on top of a <see
+/// <summary>The Slic connection implements an <see cref="IMultiplexedConnection"/> on top of a <see
 /// cref="IDuplexConnection"/>.</summary>
-internal class SlicMultiplexedConnection : IMultiplexedConnection
+internal class SlicConnection : IMultiplexedConnection
 {
-    public Endpoint Endpoint => _transportConnection.Endpoint;
+    public Endpoint Endpoint => _duplexConnection.Endpoint;
 
     internal bool IsServer { get; }
 
@@ -36,6 +36,9 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     private int _bidirectionalStreamCount;
     private AsyncSemaphore? _bidirectionalStreamSemaphore;
     private Task? _disposeTask;
+    private readonly IDuplexConnection _duplexConnection;
+    private readonly DuplexConnectionReader _duplexConnectionReader;
+    private readonly DuplexConnectionWriter _duplexConnectionWriter;
     private bool _isReadOnly;
     private readonly TimeSpan _localIdleTimeout;
     private long _lastRemoteBidirectionalStreamId = -1;
@@ -49,11 +52,8 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     private long _nextUnidirectionalId;
     private readonly int _packetMaxSize;
     private Task? _readFramesTask;
-    private readonly ConcurrentDictionary<long, SlicMultiplexedStream> _streams = new();
+    private readonly ConcurrentDictionary<long, SlicStream> _streams = new();
     private readonly CancellationTokenSource _tasksCancelSource = new();
-    private readonly IDuplexConnection _transportConnection;
-    private readonly DuplexConnectionReader _transportConnectionReader;
-    private readonly DuplexConnectionWriter _transportConnectionWriter;
     private int _unidirectionalStreamCount;
     private AsyncSemaphore? _unidirectionalStreamSemaphore;
     private readonly AsyncSemaphore _writeSemaphore = new(1, 1);
@@ -64,14 +64,14 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     public async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancel)
     {
         // Connect the duplex connection.
-        TransportConnectionInformation information = await _transportConnection.ConnectAsync(
+        TransportConnectionInformation information = await _duplexConnection.ConnectAsync(
             cancel).ConfigureAwait(false);
 
         // Enable the idle timeout check after the transport connection establishment. We don't want the transport
         // connection to be disposed because it's idle when the transport connection establishment is in progress. This
         // would require the duplex connection ConnectAsync/Dispose implementations to be thread safe. The transport
         // connection establishment timeout is handled by the cancellation token instead.
-        _transportConnectionReader.EnableIdleCheck();
+        _duplexConnectionReader.EnableIdleCheck();
 
         TimeSpan peerIdleTimeout = TimeSpan.MaxValue;
 
@@ -237,7 +237,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
 
     public IMultiplexedStream CreateStream(bool bidirectional) =>
         // TODO: Cache SlicMultiplexedStream
-        new SlicMultiplexedStream(this, bidirectional, remote: false);
+        new SlicStream(this, bidirectional, remote: false);
 
     public ValueTask DisposeAsync()
     {
@@ -266,9 +266,9 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
             }
 
             // Dispose the transport connection.
-            _transportConnection.Dispose();
+            _duplexConnection.Dispose();
 
-            foreach (SlicMultiplexedStream stream in _streams.Values)
+            foreach (SlicStream stream in _streams.Values)
             {
                 stream.Abort(exception);
             }
@@ -278,8 +278,8 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
             _unidirectionalStreamSemaphore?.Complete(exception);
 
             // It's now safe to dispose of the reader/writer since no more threads are sending/receiving data.
-            _transportConnectionReader.Dispose();
-            _transportConnectionWriter.Dispose();
+            _duplexConnectionReader.Dispose();
+            _duplexConnectionWriter.Dispose();
 
             _tasksCancelSource.Dispose();
         }
@@ -302,7 +302,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                 cancel).ConfigureAwait(false);
 
             // Shutdown the duplex connection.
-            await _transportConnection.ShutdownAsync(cancel).ConfigureAwait(false);
+            await _duplexConnection.ShutdownAsync(cancel).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -314,7 +314,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         }
     }
 
-    internal SlicMultiplexedConnection(
+    internal SlicConnection(
         IDuplexConnection duplexConnection,
         MultiplexedConnectionOptions options,
         SlicTransportOptions slicOptions)
@@ -337,9 +337,9 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         _localIdleTimeout = slicOptions.IdleTimeout;
         _packetMaxSize = slicOptions.PacketMaxSize;
 
-        _transportConnection = duplexConnection;
+        _duplexConnection = duplexConnection;
 
-        _transportConnectionWriter = new DuplexConnectionWriter(
+        _duplexConnectionWriter = new DuplexConnectionWriter(
             duplexConnection,
             options.Pool,
             options.MinSegmentSize);
@@ -351,7 +351,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
             keepAliveAction = () => SendFrameAsync(stream: null, FrameType.Ping, null, default).AsTask();
         }
 
-        _transportConnectionReader = new DuplexConnectionReader(
+        _duplexConnectionReader = new DuplexConnectionReader(
             duplexConnection,
             idleTimeout: _localIdleTimeout,
             options.Pool,
@@ -377,7 +377,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         }
     }
 
-    internal void AddStream(long id, SlicMultiplexedStream stream)
+    internal void AddStream(long id, SlicStream stream)
     {
         lock (_mutex)
         {
@@ -412,13 +412,13 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         IBufferWriter<byte> bufferWriter,
         int byteCount,
         CancellationToken cancel) =>
-        _transportConnectionReader.FillBufferWriterAsync(bufferWriter, byteCount, cancel);
+        _duplexConnectionReader.FillBufferWriterAsync(bufferWriter, byteCount, cancel);
 
-    internal void ReleaseStream(SlicMultiplexedStream stream)
+    internal void ReleaseStream(SlicStream stream)
     {
         Debug.Assert(stream.IsStarted);
 
-        _streams.TryRemove(stream.Id, out SlicMultiplexedStream? _);
+        _streams.TryRemove(stream.Id, out SlicStream? _);
 
         if (stream.IsRemote)
         {
@@ -438,7 +438,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     }
 
     internal async ValueTask SendFrameAsync(
-        SlicMultiplexedStream? stream,
+        SlicStream? stream,
         FrameType frameType,
         EncodeAction? encode,
         CancellationToken cancel)
@@ -459,7 +459,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     }
 
     internal async ValueTask<FlushResult> SendStreamFrameAsync(
-        SlicMultiplexedStream stream,
+        SlicStream stream,
         ReadOnlySequence<byte> source1,
         ReadOnlySequence<byte> source2,
         bool endStream,
@@ -604,7 +604,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
     {
         Debug.Assert(size > 0);
 
-        ReadOnlySequence<byte> buffer = await _transportConnectionReader.ReadAtLeastAsync(
+        ReadOnlySequence<byte> buffer = await _duplexConnectionReader.ReadAtLeastAsync(
             size, cancel).ConfigureAwait(false);
 
         if (buffer.Length > size)
@@ -613,7 +613,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         }
 
         T decodedFrame = SliceEncoding.Slice2.DecodeBuffer(buffer, decodeFunc);
-        _transportConnectionReader.AdvanceTo(buffer.End);
+        _duplexConnectionReader.AdvanceTo(buffer.End);
         return decodedFrame;
     }
 
@@ -623,9 +623,9 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         while (true)
         {
             // Read data from the pipe reader.
-            if (!_transportConnectionReader.TryRead(out ReadOnlySequence<byte> buffer))
+            if (!_duplexConnectionReader.TryRead(out ReadOnlySequence<byte> buffer))
             {
-                buffer = await _transportConnectionReader.ReadAsync(cancel).ConfigureAwait(false);
+                buffer = await _duplexConnectionReader.ReadAsync(cancel).ConfigureAwait(false);
             }
 
             if (TryDecodeHeader(
@@ -633,12 +633,12 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                 out (FrameType FrameType, int FrameSize, long? StreamId) header,
                 out int consumed))
             {
-                _transportConnectionReader.AdvanceTo(buffer.GetPosition(consumed));
+                _duplexConnectionReader.AdvanceTo(buffer.GetPosition(consumed));
                 return header;
             }
             else
             {
-                _transportConnectionReader.AdvanceTo(buffer.Start, buffer.End);
+                _duplexConnectionReader.AdvanceTo(buffer.Start, buffer.End);
             }
         }
 
@@ -733,7 +733,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                     }
 
                     int readSize = 0;
-                    if (_streams.TryGetValue(streamId.Value, out SlicMultiplexedStream? stream))
+                    if (_streams.TryGetValue(streamId.Value, out SlicStream? stream))
                     {
                         // Let the stream receive the data.
                         readSize = await stream.ReceivedStreamFrameAsync(
@@ -771,7 +771,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
 
                         // Accept the new remote stream.
                         // TODO: Cache SliceMultiplexedStream
-                        stream = new SlicMultiplexedStream(this, isBidirectional, remote: true);
+                        stream = new SlicStream(this, isBidirectional, remote: true);
 
                         try
                         {
@@ -811,7 +811,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                                 minimumSegmentSize: MinSegmentSize,
                                 writerScheduler: PipeScheduler.Inline));
 
-                        await _transportConnectionReader.FillBufferWriterAsync(
+                        await _duplexConnectionReader.FillBufferWriterAsync(
                                 pipe.Writer,
                                 dataSize - readSize,
                                 cancel).ConfigureAwait(false);
@@ -838,7 +838,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                         dataSize,
                         (ref SliceDecoder decoder) => new StreamConsumedBody(ref decoder),
                         cancel).ConfigureAwait(false);
-                    if (_streams.TryGetValue(streamId.Value, out SlicMultiplexedStream? stream))
+                    if (_streams.TryGetValue(streamId.Value, out SlicStream? stream))
                     {
                         stream.ReceivedConsumedFrame((int)consumed.Size);
                     }
@@ -860,7 +860,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                         dataSize,
                         (ref SliceDecoder decoder) => new StreamResetBody(ref decoder),
                         cancel).ConfigureAwait(false);
-                    if (_streams.TryGetValue(streamId.Value, out SlicMultiplexedStream? stream))
+                    if (_streams.TryGetValue(streamId.Value, out SlicStream? stream))
                     {
                         stream.ReceivedResetFrame(streamReset.ApplicationProtocolErrorCode);
                     }
@@ -882,7 +882,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
                         dataSize,
                         (ref SliceDecoder decoder) => new StreamStopSendingBody(ref decoder),
                         cancel).ConfigureAwait(false);
-                    if (_streams.TryGetValue(streamId.Value, out SlicMultiplexedStream? stream))
+                    if (_streams.TryGetValue(streamId.Value, out SlicStream? stream))
                     {
                         stream.ReceivedStopSendingFrame(streamStopSending.ApplicationProtocolErrorCode);
                     }
@@ -975,7 +975,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         // Use the smallest idle timeout.
         if (peerIdleTimeout is TimeSpan peerIdleTimeoutValue && peerIdleTimeoutValue < _localIdleTimeout)
         {
-            _transportConnectionReader.EnableIdleCheck(peerIdleTimeoutValue);
+            _duplexConnectionReader.EnableIdleCheck(peerIdleTimeoutValue);
         }
     }
 
@@ -986,7 +986,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
             _isReadOnly = true;
         }
 
-        foreach (SlicMultiplexedStream stream in _streams.Values)
+        foreach (SlicStream stream in _streams.Values)
         {
             stream.Abort(completeException);
         }
@@ -1004,7 +1004,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         EncodeAction? encode,
         CancellationToken cancel)
     {
-        var encoder = new SliceEncoder(_transportConnectionWriter, SliceEncoding.Slice2);
+        var encoder = new SliceEncoder(_duplexConnectionWriter, SliceEncoding.Slice2);
         encoder.EncodeUInt8((byte)frameType);
         Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
         int startPos = encoder.EncodedByteCount;
@@ -1016,7 +1016,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         encode?.Invoke(ref encoder);
         SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
 
-        return _transportConnectionWriter.FlushAsync(cancel);
+        return _duplexConnectionWriter.FlushAsync(cancel);
     }
 
     private ValueTask WriteStreamFrameAsync(
@@ -1026,7 +1026,7 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         bool endStream,
         CancellationToken cancel)
     {
-        var encoder = new SliceEncoder(_transportConnectionWriter, SliceEncoding.Slice2);
+        var encoder = new SliceEncoder(_duplexConnectionWriter, SliceEncoding.Slice2);
         encoder.EncodeUInt8((byte)(endStream ? FrameType.StreamLast : FrameType.Stream));
         Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
         int startPos = encoder.EncodedByteCount;
@@ -1034,6 +1034,6 @@ internal class SlicMultiplexedConnection : IMultiplexedConnection
         SliceEncoder.EncodeVarUInt62(
             (ulong)(encoder.EncodedByteCount - startPos + source1.Length + source2.Length), sizePlaceholder);
 
-        return _transportConnectionWriter.WriteAsync(source1, source2, cancel);
+        return _duplexConnectionWriter.WriteAsync(source1, source2, cancel);
     }
 }

--- a/src/IceRpc/Transports/Internal/SlicListener.cs
+++ b/src/IceRpc/Transports/Internal/SlicListener.cs
@@ -11,7 +11,7 @@ internal class SlicListener : IMultiplexedListener
     public Endpoint Endpoint => _duplexListener.Endpoint;
 
     public async Task<IMultiplexedConnection> AcceptAsync() =>
-        new SlicMultiplexedConnection(
+        new SlicConnection(
             await _duplexListener.AcceptAsync().ConfigureAwait(false),
             _options.ServerConnectionOptions,
             _slicOptions);

--- a/src/IceRpc/Transports/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeReader.cs
@@ -20,7 +20,7 @@ internal class SlicPipeReader : PipeReader
     private int _receiveCredit;
     private readonly int _resumeThreshold;
     private int _state;
-    private readonly SlicMultiplexedStream _stream;
+    private readonly SlicStream _stream;
 
     public override void AdvanceTo(SequencePosition consumed) => AdvanceTo(consumed, consumed);
 
@@ -139,7 +139,7 @@ internal class SlicPipeReader : PipeReader
     }
 
     internal SlicPipeReader(
-        SlicMultiplexedStream stream,
+        SlicStream stream,
         IMultiplexedStreamErrorCodeConverter errorCodeConverter,
         MemoryPool<byte> pool,
         int minimumSegmentSize,

--- a/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
@@ -15,7 +15,7 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     private readonly Pipe _pipe;
     private readonly IMultiplexedStreamErrorCodeConverter _errorCodeConverter;
     private int _state;
-    private readonly SlicMultiplexedStream _stream;
+    private readonly SlicStream _stream;
 
     public override void Advance(int bytes)
     {
@@ -159,7 +159,7 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     }
 
     internal SlicPipeWriter(
-        SlicMultiplexedStream stream,
+        SlicStream stream,
         IMultiplexedStreamErrorCodeConverter errorCodeConverter,
         MemoryPool<byte> pool,
         int minimumSegmentSize)

--- a/src/IceRpc/Transports/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Internal/SlicStream.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Transports.Internal;
 /// <summary>The stream implementation for Slic. The stream implementation implements flow control to ensure data
 /// isn't buffered indefinitely if the application doesn't consume it. Buffering and flow control are only enable
 /// when sending multiple Slic packet or if the Slic packet size exceeds the peer packet maximum size.</summary>
-internal class SlicMultiplexedStream : IMultiplexedStream
+internal class SlicStream : IMultiplexedStream
 {
     public long Id
     {
@@ -54,7 +54,7 @@ internal class SlicMultiplexedStream : IMultiplexedStream
 
     internal bool WritesCompleted => _state.HasFlag(State.WritesCompleted);
 
-    private readonly SlicMultiplexedConnection _connection;
+    private readonly SlicConnection _connection;
     private long _id = -1;
     private readonly SlicPipeReader _inputPipeReader;
     private readonly object _mutex = new();
@@ -84,7 +84,7 @@ internal class SlicMultiplexedStream : IMultiplexedStream
         }
     }
 
-    internal SlicMultiplexedStream(SlicMultiplexedConnection connection, bool bidirectional, bool remote)
+    internal SlicStream(SlicConnection connection, bool bidirectional, bool remote)
     {
         _connection = connection;
         _sendCredit = _connection.PeerPauseWriterThreshold;

--- a/src/IceRpc/Transports/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpConnection.cs
@@ -10,7 +10,7 @@ using System.Security.Authentication;
 
 namespace IceRpc.Transports.Internal;
 
-internal abstract class TcpDuplexConnection : IDuplexConnection
+internal abstract class TcpConnection : IDuplexConnection
 {
     public Endpoint Endpoint { get; }
 
@@ -73,7 +73,7 @@ internal abstract class TcpDuplexConnection : IDuplexConnection
         // a disposed Socket throws SocketException instead of ObjectDisposedException
         catch when (_isDisposed)
         {
-            throw new ObjectDisposedException($"{typeof(TcpDuplexConnection)}");
+            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
         }
         catch (Exception exception)
         {
@@ -197,7 +197,7 @@ internal abstract class TcpDuplexConnection : IDuplexConnection
         // a disposed Socket throws SocketException instead of ObjectDisposedException
         catch when (_isDisposed)
         {
-            throw new ObjectDisposedException($"{typeof(TcpDuplexConnection)}");
+            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
         }
         catch (Exception exception)
         {
@@ -205,7 +205,7 @@ internal abstract class TcpDuplexConnection : IDuplexConnection
         }
     }
 
-    private protected TcpDuplexConnection(
+    private protected TcpConnection(
         Endpoint endpoint,
         MemoryPool<byte> pool,
         int minimumSegmentSize)
@@ -216,7 +216,7 @@ internal abstract class TcpDuplexConnection : IDuplexConnection
     }
 }
 
-internal class TcpClientDuplexConnection : TcpDuplexConnection
+internal class TcpClientConnection : TcpConnection
 {
     internal override Socket Socket { get; }
 
@@ -264,7 +264,7 @@ internal class TcpClientDuplexConnection : TcpDuplexConnection
         // a disposed Socket throws SocketException instead of ObjectDisposedException
         catch when (_isDisposed)
         {
-            throw new ObjectDisposedException($"{typeof(TcpDuplexConnection)}");
+            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
         }
         catch (Exception exception)
         {
@@ -272,7 +272,7 @@ internal class TcpClientDuplexConnection : TcpDuplexConnection
         }
     }
 
-    internal TcpClientDuplexConnection(
+    internal TcpClientConnection(
         Endpoint endpoint,
         SslClientAuthenticationOptions? authenticationOptions,
         MemoryPool<byte> pool,
@@ -318,7 +318,7 @@ internal class TcpClientDuplexConnection : TcpDuplexConnection
     }
 }
 
-internal class TcpServerDuplexConnection : TcpDuplexConnection
+internal class TcpServerConnection : TcpConnection
 {
     internal override Socket Socket { get; }
 
@@ -360,7 +360,7 @@ internal class TcpServerDuplexConnection : TcpDuplexConnection
         // a disposed Socket throws SocketException instead of ObjectDisposedException
         catch when (_isDisposed)
         {
-            throw new ObjectDisposedException($"{typeof(TcpDuplexConnection)}");
+            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
         }
         catch (Exception exception)
         {
@@ -368,7 +368,7 @@ internal class TcpServerDuplexConnection : TcpDuplexConnection
         }
     }
 
-    internal TcpServerDuplexConnection(
+    internal TcpServerConnection(
         Endpoint endpoint,
         Socket socket,
         SslServerAuthenticationOptions? authenticationOptions,

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -34,7 +34,7 @@ internal sealed class TcpListener : IDuplexListener
         }
 
 #pragma warning disable CA2000 // the connection is disposed by the caller
-        var serverConnection = new TcpServerDuplexConnection(
+        var serverConnection = new TcpServerConnection(
             Endpoint,
             acceptedSocket,
             _authenticationOptions,
@@ -42,7 +42,7 @@ internal sealed class TcpListener : IDuplexListener
             _minSegmentSize);
         if (_logger.IsEnabled(TcpLoggerExtensions.MaxLogLevel))
         {
-            return new LogTcpTransportConnectionDecorator(serverConnection, _logger);
+            return new LogTcpConnectionDecorator(serverConnection, _logger);
         }
         else
         {

--- a/src/IceRpc/Transports/SlicClientTransport.cs
+++ b/src/IceRpc/Transports/SlicClientTransport.cs
@@ -36,7 +36,7 @@ public class SlicClientTransport : IMultiplexedClientTransport
 
     /// <inheritdoc/>
     public IMultiplexedConnection CreateConnection(MultiplexedClientConnectionOptions options) =>
-        new SlicMultiplexedConnection(
+        new SlicConnection(
             _duplexClientTransport.CreateConnection(
                 new DuplexClientConnectionOptions
                 {

--- a/src/IceRpc/Transports/TcpClientTransport.cs
+++ b/src/IceRpc/Transports/TcpClientTransport.cs
@@ -65,7 +65,7 @@ public class TcpClientTransport : IDuplexClientTransport
             };
         }
 
-        var clientConnection = new TcpClientDuplexConnection(
+        var clientConnection = new TcpClientConnection(
             endpoint,
             authenticationOptions,
             options.Pool,
@@ -73,7 +73,7 @@ public class TcpClientTransport : IDuplexClientTransport
             _options);
         if (options.Logger.IsEnabled(TcpLoggerExtensions.MaxLogLevel))
         {
-            return new LogTcpTransportConnectionDecorator(clientConnection, options.Logger);
+            return new LogTcpConnectionDecorator(clientConnection, options.Logger);
         }
         else
         {

--- a/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ public static class SlicTransportServiceCollectionExtensions
                 {
                     Endpoint = listener.Endpoint
                 });
-            return (SlicMultiplexedConnection)connection;
+            return (SlicConnection)connection;
         });
         return services;
     }

--- a/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
@@ -38,12 +38,12 @@ public class SlicTransportTests
             .AddSlicTest()
             .BuildServiceProvider(validateScopes: true);
 
-        var clientConnection = provider.GetRequiredService<SlicMultiplexedConnection>();
+        var clientConnection = provider.GetRequiredService<SlicConnection>();
         var listener = provider.GetRequiredService<IMultiplexedListener>();
         Task<IMultiplexedConnection> acceptTask = ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
         // Act
-        var serverConnection = (SlicMultiplexedConnection)await acceptTask;
+        var serverConnection = (SlicConnection)await acceptTask;
 
         // Assert
         Assert.Multiple(() =>
@@ -68,7 +68,7 @@ public class SlicTransportTests
 
         byte[] payload = new byte[pauseThreshold - 1];
 
-        var clientConnection = provider.GetRequiredService<SlicMultiplexedConnection>();
+        var clientConnection = provider.GetRequiredService<SlicConnection>();
         var listener = provider.GetRequiredService<IMultiplexedListener>();
         Task<IMultiplexedConnection> acceptTask = ConnectAndAcceptConnectionAsync(listener, clientConnection);
         await using IMultiplexedConnection serverConnection = await acceptTask;
@@ -99,7 +99,7 @@ public class SlicTransportTests
             .AddSlicTest(new SlicTransportOptions { PauseWriterThreshold = pauseThreshold })
             .BuildServiceProvider(validateScopes: true);
 
-        var clientConnection = provider.GetRequiredService<SlicMultiplexedConnection>();
+        var clientConnection = provider.GetRequiredService<SlicConnection>();
         var listener = provider.GetRequiredService<IMultiplexedListener>();
         Task<IMultiplexedConnection> acceptTask = ConnectAndAcceptConnectionAsync(listener, clientConnection);
         await using IMultiplexedConnection serverConnection = await acceptTask;
@@ -142,7 +142,7 @@ public class SlicTransportTests
                     ResumeWriterThreshold = resumeThreshold,
                 }).BuildServiceProvider(validateScopes: true);
 
-        var clientConnection = provider.GetRequiredService<SlicMultiplexedConnection>();
+        var clientConnection = provider.GetRequiredService<SlicConnection>();
         var listener = provider.GetRequiredService<IMultiplexedListener>();
         Task<IMultiplexedConnection> acceptTask = ConnectAndAcceptConnectionAsync(listener, clientConnection);
         await using IMultiplexedConnection serverConnection = await acceptTask;

--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -45,7 +45,7 @@ public class TcpTransportTests
     public void Configure_client_connection_buffer_size(int bufferSize)
     {
         // Act
-        using TcpClientDuplexConnection connection = CreateTcpClientConnection(
+        using TcpClientConnection connection = CreateTcpClientConnection(
             new Endpoint(Protocol.IceRpc),
             options: new TcpClientTransportOptions
             {
@@ -90,7 +90,7 @@ public class TcpTransportTests
     {
         var localNetworkAddress = new IPEndPoint(IPAddress.IPv6Loopback, 10000);
 
-        using TcpClientDuplexConnection connection = CreateTcpClientConnection(
+        using TcpClientConnection connection = CreateTcpClientConnection(
             new Endpoint(Protocol.IceRpc),
             options: new TcpClientTransportOptions
             {
@@ -121,11 +121,11 @@ public class TcpTransportTests
         IDuplexClientTransport clientTransport = new TcpClientTransport(
             new TcpClientTransportOptions());
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(listener.Endpoint);
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(listener.Endpoint);
         await clientConnection.ConnectAsync(default);
 
         // Act
-        using var serverConnection = (TcpServerDuplexConnection)await acceptTask;
+        using var serverConnection = (TcpServerConnection)await acceptTask;
 
         // Assert
         Assert.Multiple(() =>
@@ -225,10 +225,10 @@ public class TcpTransportTests
 
         using var cancellationTokenSource = new CancellationTokenSource();
         Task<TransportConnectionInformation> connectTask;
-        TcpClientDuplexConnection clientConnection;
+        TcpClientConnection clientConnection;
         while (true)
         {
-            TcpClientDuplexConnection? connection = CreateTcpClientConnection(listener.Endpoint);
+            TcpClientConnection? connection = CreateTcpClientConnection(listener.Endpoint);
             try
             {
                 connectTask = connection.ConnectAsync(cancellationTokenSource.Token);
@@ -272,7 +272,7 @@ public class TcpTransportTests
         using IDuplexListener listener = CreateTcpListener(
             authenticationOptions: DefaultSslServerAuthenticationOptions);
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions:
                 new SslClientAuthenticationOptions
@@ -302,7 +302,7 @@ public class TcpTransportTests
         using IDuplexListener listener = CreateTcpListener(
             authenticationOptions: tls ? DefaultSslServerAuthenticationOptions : null);
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: tls ? DefaultSslClientAuthenticationOptions : null);
 
@@ -337,7 +337,7 @@ public class TcpTransportTests
         // Arrange
         using IDuplexListener listener =
             CreateTcpListener(authenticationOptions: DefaultSslServerAuthenticationOptions);
-        using TcpClientDuplexConnection clientConnection =
+        using TcpClientConnection clientConnection =
             CreateTcpClientConnection(listener.Endpoint, authenticationOptions: DefaultSslClientAuthenticationOptions);
 
         Task<IDuplexConnection> acceptTask = listener.AcceptAsync();
@@ -368,7 +368,7 @@ public class TcpTransportTests
                 }
             });
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: DefaultSslClientAuthenticationOptions);
 
@@ -398,13 +398,13 @@ public class TcpTransportTests
             });
     }
 
-    private static TcpClientDuplexConnection CreateTcpClientConnection(
+    private static TcpClientConnection CreateTcpClientConnection(
         Endpoint endpoint,
         TcpClientTransportOptions? options = null,
         SslClientAuthenticationOptions? authenticationOptions = null)
     {
         IDuplexClientTransport transport = new TcpClientTransport(options ?? new());
-        return (TcpClientDuplexConnection)transport.CreateConnection(
+        return (TcpClientConnection)transport.CreateConnection(
             new DuplexClientConnectionOptions
             {
                 Endpoint = endpoint,

--- a/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
+++ b/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
@@ -31,7 +31,7 @@ public class TlsConfigurationTests
                 ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password"),
             });
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: new SslClientAuthenticationOptions
             {
@@ -78,7 +78,7 @@ public class TlsConfigurationTests
                 }
             });
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: new SslClientAuthenticationOptions
             {
@@ -129,7 +129,7 @@ public class TlsConfigurationTests
                 }
             });
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: new SslClientAuthenticationOptions
             {
@@ -170,7 +170,7 @@ public class TlsConfigurationTests
                 ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password"),
             });
 
-        using TcpClientDuplexConnection clientConnection = CreateTcpClientConnection(
+        using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.Endpoint,
             authenticationOptions: new SslClientAuthenticationOptions
             {
@@ -201,13 +201,13 @@ public class TlsConfigurationTests
             });
     }
 
-    private static TcpClientDuplexConnection CreateTcpClientConnection(
+    private static TcpClientConnection CreateTcpClientConnection(
         Endpoint endpoint,
         TcpClientTransportOptions? options = null,
         SslClientAuthenticationOptions? authenticationOptions = null)
     {
         IDuplexClientTransport transport = new TcpClientTransport(options ?? new());
-        return (TcpClientDuplexConnection)transport.CreateConnection(
+        return (TcpClientConnection)transport.CreateConnection(
             new DuplexClientConnectionOptions
             {
                 Endpoint = endpoint,


### PR DESCRIPTION
This PR fixes #1539. It removes Duplex or Multiplexed from the transport class names. This is consistent with what we were doing already for listener, client transport and server transport class names.

I've also renamed the `_transportConnection` fields from the Slic and Ice connections to `_duplexConnection`.