### PR TITLE
Change key of ConnectionCache dictionaries

### DIFF
--- a/src/IceRpc.Coloc/Transports/ColocTransport.cs
+++ b/src/IceRpc.Coloc/Transports/ColocTransport.cs
@@ -26,7 +26,5 @@ public sealed class ColocTransport
         ServerTransport = new ColocServerTransport(listeners);
     }
 
-    internal static bool CheckParams(Endpoint endpoint) =>
-        endpoint.Params.TryGetValue("transport", out string? transportValue) ?
-            transportValue == Name && endpoint.Params.Count == 1 : endpoint.Params.Count == 0;
+    internal static bool CheckParams(Endpoint endpoint) => endpoint.Params.Count == 0;
 }

--- a/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
@@ -31,7 +31,7 @@ internal class ColocClientTransport : IDuplexClientTransport
             throw new FormatException($"cannot create a Coloc connection to endpoint '{options.Endpoint}'");
         }
 
-        return new ColocConnection(options.Endpoint.WithTransport(Name), endpoint => Connect(endpoint, options));
+        return new ColocConnection(options.Endpoint with { Transport = Name }, endpoint => Connect(endpoint, options));
     }
 
     internal ColocClientTransport(ConcurrentDictionary<Endpoint, ColocListener> listeners) =>

--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -27,7 +27,8 @@ internal class ColocServerTransport : IDuplexServerTransport
             throw new FormatException($"cannot create a Coloc listener for endpoint '{options.Endpoint}'");
         }
 
-        var listener = new ColocListener(options with { Endpoint = options.Endpoint.WithTransport(Name) });
+        var listener = new ColocListener(options with { Endpoint = options.Endpoint with { Transport = Name } });
+
         if (!_listeners.TryAdd(listener.Endpoint, listener))
         {
             throw new TransportException($"endpoint '{listener.Endpoint}' is already in use");

--- a/src/IceRpc/Endpoint.cs
+++ b/src/IceRpc/Endpoint.cs
@@ -68,9 +68,19 @@ public readonly record struct Endpoint
     /// <summary>Gets the URI used to create this endpoint, if this endpoint was created from a URI.</summary>
     public Uri? OriginalUri { get; private init; }
 
+    /// <summary>Gets the value of the transport parameter of this endpoint.</summary>
+    public string? Transport
+    {
+        get => _transport;
+
+        init => _transport = value is null || (ServiceAddress.IsValidParamValue(value) && value.Length > 0) ? value :
+            throw new ArgumentException($"`{value}` is not valid transport name", nameof(value));
+    }
+
     private readonly string _host = "::0";
     private readonly ImmutableDictionary<string, string> _params = ImmutableDictionary<string, string>.Empty;
     private readonly ushort _port;
+    private readonly string? _transport;
 
     /// <summary>Constructs an endpoint with default values.</summary>
     public Endpoint()
@@ -91,6 +101,7 @@ public readonly record struct Endpoint
 
         Protocol = protocol;
         _port = (ushort)Protocol.DefaultUriPort;
+        _transport = null;
         OriginalUri = null;
     }
 
@@ -136,7 +147,7 @@ public readonly record struct Endpoint
 
         try
         {
-            (_params, string? altEndpointValue) = uri.ParseQuery();
+            (_params, string? altEndpointValue, _transport) = uri.ParseQuery();
 
             if (altEndpointValue is not null)
             {
@@ -161,11 +172,12 @@ public readonly record struct Endpoint
         Protocol == other.Protocol &&
         Host == other.Host &&
         Port == other.Port &&
+        Transport == other.Transport &&
         Params.DictionaryEqual(other.Params);
 
     /// <summary>Computes the hash code for this endpoint.</summary>
     /// <returns>The hash code.</returns>
-    public override int GetHashCode() => HashCode.Combine(Protocol, Host, Port, Params.Count);
+    public override int GetHashCode() => HashCode.Combine(Protocol, Host, Port, Transport, Params.Count);
 
     /// <summary>Converts this endpoint into a string.</summary>
     /// <returns>The string representation of this endpoint.</returns>
@@ -184,11 +196,13 @@ public readonly record struct Endpoint
         Protocol protocol,
         string host,
         ushort port,
+        string? transport,
         ImmutableDictionary<string, string> endpointParams)
     {
         Protocol = protocol;
         _host = host;
         _port = port;
+        _transport = transport;
         _params = endpointParams;
         OriginalUri = null;
     }
@@ -197,18 +211,21 @@ public readonly record struct Endpoint
 /// <summary>Equality comparer for <see cref="Endpoint"/>.</summary>
 public abstract class EndpointComparer : EqualityComparer<Endpoint>
 {
-    /// <summary>Gets an endpoint comparer that compares all endpoint properties except the parameters.</summary>
-    public static EndpointComparer ParameterLess { get; } = new ParamLessEndpointComparer();
+    /// <summary>Gets an endpoint comparer that compares all endpoint properties, except a transport mismatch where the
+    /// transport of one of the endpoints is null results in equality.</summary>
+    public static EndpointComparer OptionalTransport { get; } = new OptionalTransportEndpointComparer();
 
-    private class ParamLessEndpointComparer : EndpointComparer
+    private class OptionalTransportEndpointComparer : EndpointComparer
     {
         public override bool Equals(Endpoint lhs, Endpoint rhs) =>
-                lhs.Protocol == rhs.Protocol &&
-                lhs.Host == rhs.Host &&
-                lhs.Port == rhs.Port;
+            lhs.Protocol == rhs.Protocol &&
+            lhs.Host == rhs.Host &&
+            lhs.Port == rhs.Port &&
+            (lhs.Transport == rhs.Transport || lhs.Transport is null || rhs.Transport is null) &&
+            lhs.Params.DictionaryEqual(rhs.Params);
 
         public override int GetHashCode(Endpoint endpoint) =>
-            HashCode.Combine(endpoint.Protocol, endpoint.Host, endpoint.Port);
+            HashCode.Combine(endpoint.Protocol, endpoint.Host, endpoint.Port, endpoint.Params.Count);
     }
 }
 

--- a/src/IceRpc/Internal/EndpointExtensions.cs
+++ b/src/IceRpc/Internal/EndpointExtensions.cs
@@ -52,13 +52,19 @@ internal static class EndpointExtensions
             sb.Append(path);
         }
 
-        bool firstOption = true;
+        bool firstParam = true;
+        if (endpoint.Transport is not null)
+        {
+            firstParam = false;
+            sb.Append("?transport=").Append(endpoint.Transport);
+        }
+
         foreach ((string name, string value) in endpoint.Params)
         {
-            if (firstOption)
+            if (firstParam)
             {
                 sb.Append('?');
-                firstOption = false;
+                firstParam = false;
             }
             else
             {

--- a/src/IceRpc/Internal/UriExtensions.cs
+++ b/src/IceRpc/Internal/UriExtensions.cs
@@ -8,19 +8,20 @@ namespace IceRpc.Internal;
 internal static class UriExtensions
 {
     /// <summary>Parses the query portion of a URI into a dictionary of name/value. The value of the alt-endpoint
-    /// parameter, if set, is returned separately.</summary>
-    internal static (ImmutableDictionary<string, string> QueryParams, string? AltEndpointValue) ParseQuery(
+    /// and transport parameters, if set, are returned separately.</summary>
+    internal static (ImmutableDictionary<string, string> QueryParams, string? AltEndpointValue, string? TransportValue) ParseQuery(
         this Uri uri)
     {
         if (uri.Query.Length < 2)
         {
             // no query or empty query
-            return (ImmutableDictionary<string, string>.Empty, null);
+            return (ImmutableDictionary<string, string>.Empty, null, null);
         }
         else
         {
-            var queryParams = new Dictionary<string, string>();
+            ImmutableDictionary<string, string> queryParams = ImmutableDictionary<string, string>.Empty;
             string? altEndpoint = null;
+            string? transport = null;
 
             foreach (string p in uri.Query.TrimStart('?').Split('&'))
             {
@@ -32,27 +33,31 @@ internal static class UriExtensions
                 {
                     altEndpoint = altEndpoint is null ? value : $"{altEndpoint},{value}";
                 }
+                else if (name == "transport")
+                {
+                    // This is the regular parsing for query parameters, even though it's not meaningful for transport.
+                    transport = transport is null ? value : $"{transport},{value}";
+                }
                 else
                 {
                     if (name.Length == 0)
                     {
-                        throw new FormatException(
-                            $"invalid empty query parameter name in URI '{uri.OriginalString}'");
+                        throw new FormatException($"invalid empty query parameter name in URI '{uri.OriginalString}'");
                     }
 
                     // we assume the C# URI parser validates the name and value sufficiently
 
                     if (queryParams.TryGetValue(name, out string? existingValue))
                     {
-                        queryParams[name] = $"{existingValue},{value}";
+                        queryParams = queryParams.SetItem(name, $"{existingValue},{value}");
                     }
                     else
                     {
-                        queryParams.Add(name, value);
+                        queryParams = queryParams.Add(name, value);
                     }
                 }
             }
-            return (queryParams.ToImmutableDictionary(), altEndpoint);
+            return (queryParams, altEndpoint, transport);
         }
     }
 }

--- a/src/IceRpc/ServiceAddress.cs
+++ b/src/IceRpc/ServiceAddress.cs
@@ -218,7 +218,8 @@ public sealed record class ServiceAddress
                         nameof(uri));
                 }
 
-                (ImmutableDictionary<string, string> queryParams, string? altEndpointValue) = uri.ParseQuery();
+                (ImmutableDictionary<string, string> queryParams, string? altEndpointValue, string? transport) =
+                    uri.ParseQuery();
 
                 if (uri.Authority.Length > 0)
                 {
@@ -234,6 +235,7 @@ public sealed record class ServiceAddress
                         Protocol,
                         host,
                         port: checked((ushort)(uri.Port == -1 ? Protocol.DefaultUriPort : uri.Port)),
+                        transport,
                         queryParams);
 
                     if (altEndpointValue is not null)
@@ -480,6 +482,13 @@ public sealed record class ServiceAddress
         }
     }
 
+    /// <summary>Checks if <paramref name="value"/> contains only unreserved characters, <c>%</c>, or reserved
+    /// characters other than <c>#</c> and <c>&#38;</c>.</summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns><c>true</c> if <paramref name="value"/> is a valid parameter value; otherwise, <c>false</c>.
+    /// </returns>
+    internal static bool IsValidParamValue(string value) => IsValid(value, "\"<>#&\\^`{|}");
+
     /// <summary>"unchecked" constructor used by the Slice decoder when decoding a Slice1 encoded service address.
     /// </summary>
     internal ServiceAddress(
@@ -539,13 +548,6 @@ public sealed record class ServiceAddress
     /// in a name.</remarks>
     private static bool IsValidParamName(string name) =>
         name.Length > 0 && name != "alt-endpoint" && IsValid(name, "\"<>#&=\\^`{|}");
-
-    /// <summary>Checks if <paramref name="value"/> contains only unreserved characters, <c>%</c>, or reserved
-    /// characters other than <c>#</c> and <c>&#38;</c>.</summary>
-    /// <param name="value">The value to check.</param>
-    /// <returns><c>true</c> if <paramref name="value"/> is a valid parameter value; otherwise, <c>false</c>.
-    /// </returns>
-    private static bool IsValidParamValue(string value) => IsValid(value, "\"<>#&\\^`{|}");
 
     private void CheckSupportedProtocol(string propertyName)
     {

--- a/src/IceRpc/Slice/SliceDecoder.cs
+++ b/src/IceRpc/Slice/SliceDecoder.cs
@@ -432,7 +432,8 @@ public ref partial struct SliceDecoder
                     string target = requestFailed.Fragment.Length > 0 ?
                         $"{requestFailed.Path}#{requestFailed.Fragment}" : requestFailed.Path;
 
-                    message = @$"{nameof(DispatchException)} {{ ErrorCode = {errorCode} }} while dispatching '{requestFailed.Operation}' on '{target}'";
+                    message = @$"{nameof(DispatchException)} {{ ErrorCode = {errorCode
+                    } }} while dispatching '{requestFailed.Operation}' on '{target}'";
                 }
                 // else message remains null
                 break;
@@ -962,7 +963,6 @@ public ref partial struct SliceDecoder
                         }
 
                         var builder = ImmutableDictionary.CreateBuilder<string, string>();
-                        builder.Add("transport", TransportNames.Opaque);
                         builder.Add("t", ((short)transportCode).ToString(CultureInfo.InvariantCulture));
                         builder.Add("v", Convert.ToBase64String(vSpan));
 
@@ -970,6 +970,7 @@ public ref partial struct SliceDecoder
                             Protocol.Ice,
                             OpaqueTransport.Host,
                             OpaqueTransport.Port,
+                            TransportNames.Opaque,
                             builder.ToImmutable());
                         break;
                     }
@@ -1001,7 +1002,9 @@ public ref partial struct SliceDecoder
         if (endpoint is null)
         {
             throw new InvalidDataException(
-                @$"cannot decode endpoint for protocol '{protocol}' and transport '{transportCode.ToString().ToLowerInvariant()}' with endpoint encapsulation encoded with encoding '{encodingMajor}.{encodingMinor}'");
+                @$"cannot decode endpoint for protocol '{protocol
+                }' and transport '{transportCode.ToString().ToLowerInvariant()
+                }' with endpoint encapsulation encoded with encoding '{encodingMajor}.{encodingMinor}'");
         }
 
         return endpoint.Value;

--- a/src/IceRpc/Slice/SliceEncoder.cs
+++ b/src/IceRpc/Slice/SliceEncoder.cs
@@ -680,11 +680,8 @@ public ref partial struct SliceEncoder
     {
         Debug.Assert(Encoding == SliceEncoding.Slice1);
 
-        // If there is no transport parameter, we default to TCP.
-        if (!endpoint.Params.TryGetValue("transport", out string? transport))
-        {
-            transport = TransportNames.Tcp;
-        }
+        // If the endpoint does not specify a transport, we default to tcp.
+        string transport = endpoint.Transport ?? TransportNames.Tcp;
 
         // The Slice1 encoding of ice endpoints is transport-specific, and hard-coded here. The preferred and
         // fallback encoding for new transports is TransportCode.Uri.

--- a/src/IceRpc/Transports/Internal/EndpointExtensions.cs
+++ b/src/IceRpc/Transports/Internal/EndpointExtensions.cs
@@ -20,14 +20,6 @@ internal static class EndpointExtensions
         {
             switch (name)
             {
-                case "transport":
-                    if (value != TransportNames.Opaque)
-                    {
-                        throw new FormatException(
-                            $"invalid value for transport parameter in endpoint '{endpoint}'");
-                    }
-                    break;
-
                 case "e":
                     (encodingMajor, encodingMinor) = value switch
                     {
@@ -84,30 +76,5 @@ internal static class EndpointExtensions
         }
 
         return (transportCode.Value, encodingMajor, encodingMinor, bytes);
-    }
-
-    /// <summary>Adds the transport parameter to this endpoint if null, and does nothing if it's already set to the
-    /// correct value.</summary>
-    /// <exception cref="ArgumentException">Thrown if endpoint already holds another transport.</exception>
-    internal static Endpoint WithTransport(this Endpoint endpoint, string transport)
-    {
-        if (endpoint.Params.TryGetValue("transport", out string? endpointTransport))
-        {
-            if (endpointTransport != transport)
-            {
-                throw new ArgumentException(
-                    $"cannot use {transport} transport with endpoint '{endpoint}'",
-                    nameof(endpoint));
-            }
-        }
-        else
-        {
-            endpoint = endpoint with
-            {
-                Params = endpoint.Params.Add("transport", transport)
-            };
-        }
-
-        return endpoint;
     }
 }

--- a/src/IceRpc/Transports/TcpClientTransport.cs
+++ b/src/IceRpc/Transports/TcpClientTransport.cs
@@ -32,7 +32,30 @@ public class TcpClientTransport : IDuplexClientTransport
     public TcpClientTransport(TcpClientTransportOptions options) => _options = options;
 
     /// <inheritdoc/>
-    public bool CheckParams(Endpoint endpoint) => CheckParams(endpoint, out _);
+    public bool CheckParams(Endpoint endpoint)
+    {
+        if (endpoint.Protocol != Protocol.Ice)
+        {
+            return endpoint.Params.Count == 0;
+        }
+        else
+        {
+            foreach (string name in endpoint.Params.Keys)
+            {
+                switch (name)
+                {
+                    case "t":
+                    case "z":
+                        // we don't check the value since we ignore it
+                        break;
+
+                    default:
+                        return false;
+                }
+            }
+            return true;
+        }
+    }
 
     /// <inheritdoc/>
     public IDuplexConnection CreateConnection(DuplexClientConnectionOptions options)
@@ -40,18 +63,21 @@ public class TcpClientTransport : IDuplexClientTransport
         // This is the composition root of the tcp client transport, where we install log decorators when logging
         // is enabled.
         Endpoint endpoint = options.Endpoint;
-        if (!CheckParams(endpoint, out string? endpointTransport))
+        if ((endpoint.Transport is string transport &&
+            transport != TransportNames.Tcp &&
+            transport != TransportNames.Ssl) ||
+            !CheckParams(endpoint))
         {
             throw new FormatException($"cannot create a TCP connection to endpoint '{endpoint}'");
         }
 
-        if (endpointTransport is null)
+        if (endpoint.Transport is null)
         {
-            endpoint = endpoint with { Params = endpoint.Params.Add("transport", Name) };
+            endpoint = endpoint with { Transport = Name };
         }
 
         SslClientAuthenticationOptions? authenticationOptions = options.ClientAuthenticationOptions?.Clone() ??
-            (endpointTransport == TransportNames.Ssl ? new SslClientAuthenticationOptions() : null);
+            (endpoint.Transport == TransportNames.Ssl ? new SslClientAuthenticationOptions() : null);
         if (authenticationOptions is not null)
         {
             // Add the endpoint protocol to the SSL application protocols (used by TLS ALPN) and set the
@@ -81,45 +107,6 @@ public class TcpClientTransport : IDuplexClientTransport
         }
     }
 
-    /// <summary>Checks the parameters of a tcp endpoint and returns the value of the transport parameter. The "t"
-    /// and "z" parameters are supported and ignored for the ice protocol.</summary>
-    /// <returns><c>true</c> when the endpoint parameters are valid; otherwise, <c>false</c>.</returns>
-    internal static bool CheckParams(Endpoint endpoint, out string? transportValue)
-    {
-        transportValue = null;
-
-        foreach ((string name, string value) in endpoint.Params)
-        {
-            switch (name)
-            {
-                case "transport":
-                    if (value is TransportNames.Tcp or TransportNames.Ssl)
-                    {
-                        transportValue = value;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                    break;
-
-                case "t":
-                case "z":
-                    if (endpoint.Protocol != Protocol.Ice)
-                    {
-                        return false;
-                    }
-                    // else keep going; we don't check the value since we ignore it
-                    break;
-
-                default:
-                    return false;
-            }
-        }
-
-        return true;
-    }
-
     /// <summary>Decodes the body of a tcp or ssl ice endpoint encoded using Slice1.</summary>
     internal static Endpoint DecodeEndpoint(ref SliceDecoder decoder, string transport)
     {
@@ -135,21 +122,17 @@ public class TcpClientTransport : IDuplexClientTransport
         int timeout = decoder.DecodeInt32();
         bool compress = decoder.DecodeBool();
 
-        ImmutableDictionary<string, string>.Builder builder =
-            ImmutableDictionary.CreateBuilder<string, string>();
-
-        builder.Add("transport", transport);
-
+        ImmutableDictionary<string, string> parameters = ImmutableDictionary<string, string>.Empty;
         if (timeout != DefaultTcpTimeout)
         {
-            builder.Add("t", timeout.ToString(CultureInfo.InvariantCulture));
+            parameters = parameters.Add("t", timeout.ToString(CultureInfo.InvariantCulture));
         }
         if (compress)
         {
-            builder.Add("z", "");
+            parameters = parameters.Add("z", "");
         }
 
-        return new Endpoint(Protocol.Ice, host, port, builder.ToImmutable());
+        return new Endpoint(Protocol.Ice, host, port, transport, parameters);
     }
 
     /// <summary>Encodes the body of a tcp or ssl ice endpoint using Slice1.</summary>

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -30,27 +30,24 @@ public class TcpServerTransport : IDuplexServerTransport
         // This is the composition root of the tcp server transport, where we install log decorators when logging
         // is enabled.
 
-        if (TcpClientTransport.CheckParams(options.Endpoint, out string? endpointTransport))
-        {
-            if (endpointTransport is null)
-            {
-                options = options with
-                {
-                    Endpoint = options.Endpoint with { Params = options.Endpoint.Params.Add("transport", Name) }
-                };
-            }
-            else if (endpointTransport == TransportNames.Ssl &&
-                     options.ServerConnectionOptions.ServerAuthenticationOptions is null)
-            {
-                throw new ArgumentNullException(
-                    nameof(options.ServerConnectionOptions.ServerAuthenticationOptions),
-                    @$"{nameof(options.ServerConnectionOptions.ServerAuthenticationOptions)
-                        } cannot be null with the ssl transport");
-            }
-        }
-        else
+        if (options.Endpoint.Params.Count > 0)
         {
             throw new FormatException($"cannot create a TCP listener for endpoint '{options.Endpoint}'");
+        }
+
+        if (options.Endpoint.Transport is not string transport)
+        {
+            options = options with
+            {
+                Endpoint = options.Endpoint with { Transport = Name }
+            };
+        }
+        else if (transport == TransportNames.Ssl && options.ServerConnectionOptions.ServerAuthenticationOptions is null)
+        {
+            throw new ArgumentNullException(
+                nameof(options.ServerConnectionOptions.ServerAuthenticationOptions),
+                @$"{nameof(options.ServerConnectionOptions.ServerAuthenticationOptions)
+                    } cannot be null with the ssl transport");
         }
 
         return new TcpListener(options, _options);

--- a/tests/IceRpc.Tests/ConnectionTests.cs
+++ b/tests/IceRpc.Tests/ConnectionTests.cs
@@ -25,8 +25,8 @@ public class ConnectionTests
         server.Listen();
         var connection = provider.GetRequiredService<ClientConnection>();
 
-        Assert.That(server.Endpoint.Params["transport"], Is.EqualTo("coloc"));
-        Assert.That(connection.Endpoint.Params["transport"], Is.EqualTo("coloc"));
+        Assert.That(server.Endpoint.Transport, Is.EqualTo("coloc"));
+        Assert.That(connection.Endpoint.Transport, Is.EqualTo("coloc"));
     }
 
     /// <summary>Verifies that Server.Endpoint and ClientConnection.Endpoint include a tcp transport parameter when
@@ -42,8 +42,8 @@ public class ConnectionTests
         server.Listen();
         var connection = provider.GetRequiredService<ClientConnection>();
 
-        Assert.That(server.Endpoint.Params["transport"], Is.EqualTo("tcp"));
-        Assert.That(connection.Endpoint.Params["transport"], Is.EqualTo("tcp"));
+        Assert.That(server.Endpoint.Transport, Is.EqualTo("tcp"));
+        Assert.That(connection.Endpoint.Transport, Is.EqualTo("tcp"));
     }
 
     [Test]
@@ -57,8 +57,8 @@ public class ConnectionTests
         server.Listen();
         var connection = provider.GetRequiredService<ClientConnection>();
 
-        Assert.That(server.Endpoint.Params["transport"], Is.EqualTo("coloc"));
-        Assert.That(connection.Endpoint.Params["transport"], Is.EqualTo("coloc"));
+        Assert.That(server.Endpoint.Transport, Is.EqualTo("coloc"));
+        Assert.That(connection.Endpoint.Transport, Is.EqualTo("coloc"));
     }
 
     /// <summary>Verifies that aborting the connection aborts the invocations.</summary>
@@ -207,6 +207,8 @@ public class ConnectionTests
     [TestCase("icerpc://foo.com", "icerpc://foo.com?transport=coloc")]
     [TestCase("icerpc://foo.com", "icerpc://bar.com")]
     [TestCase("icerpc://foo.com", "icerpc://foo.com:10000")]
+    [TestCase("icerpc://foo.com", "icerpc://foo.com?tanpot=tcp")]
+    [TestCase("icerpc://foo.com", "icerpc://foo.com?t=10000")]
     [TestCase("ice://foo.com?t=10000&z", "ice://foo.com:10000/path?t=10000&z")]
     public async Task InvokeAsync_fails_without_a_compatible_endpoint(Endpoint endpoint, ServiceAddress serviceAddress)
     {
@@ -217,20 +219,6 @@ public class ConnectionTests
         Assert.That(
             async () => await connection.InvokeAsync(new OutgoingRequest(serviceAddress), default),
             Throws.TypeOf<InvalidOperationException>());
-    }
-
-    /// <summary>Verifies that InvokeAsync fails when the endpoint has a bogus endpoint parameter.</summary>
-    [TestCase("icerpc://foo.com", "icerpc://foo.com?tanpot=tcp")]
-    [TestCase("icerpc://foo.com", "icerpc://foo.com?t=10000")] // t is not valid with the icerpc protocol
-    public async Task InvokeAsync_fails_with_unknown_endpoint_param(Endpoint endpoint, ServiceAddress serviceAddress)
-    {
-        // Arrange
-        await using var connection = new ClientConnection(endpoint);
-
-        // Assert
-        Assert.That(
-            async () => await connection.InvokeAsync(new OutgoingRequest(serviceAddress), default),
-            Throws.TypeOf<FormatException>());
     }
 
     [Test]

--- a/tests/IntegrationTests/CustomTransportTests.cs
+++ b/tests/IntegrationTests/CustomTransportTests.cs
@@ -19,9 +19,9 @@ public class CustomClientTransport : IMultiplexedClientTransport
 
     public IMultiplexedConnection CreateConnection(MultiplexedClientConnectionOptions options)
     {
-        if (options.Endpoint.Params.TryGetValue("transport", out string? endpointTransport))
+        if (options.Endpoint.Transport is string transport)
         {
-            if (endpointTransport != "tcp" && endpointTransport != "custom")
+            if (transport != "tcp" && transport != "custom")
             {
                 throw new ArgumentException(
                     $"cannot use custom transport with endpoint '{options.Endpoint}'",
@@ -33,7 +33,8 @@ public class CustomClientTransport : IMultiplexedClientTransport
         {
             Endpoint = options.Endpoint with
             {
-                Params = options.Endpoint.Params.Remove("custom-p").SetItem("transport", "tcp")
+                Params = options.Endpoint.Params.Remove("custom-p"),
+                Transport = "tcp"
             }
         };
 
@@ -50,9 +51,9 @@ public class CustomServerTransport : IMultiplexedServerTransport
 
     public IMultiplexedListener Listen(MultiplexedListenerOptions options)
     {
-        if (options.Endpoint.Params.TryGetValue("transport", out string? endpointTransport))
+        if (options.Endpoint.Transport is string transport)
         {
-            if (endpointTransport != "tcp" && endpointTransport != "custom")
+            if (transport != "tcp" && transport != "custom")
             {
                 throw new ArgumentException(
                     $"cannot use custom transport with endpoint '{options.Endpoint}'",
@@ -64,7 +65,8 @@ public class CustomServerTransport : IMultiplexedServerTransport
         {
             Endpoint = options.Endpoint with
             {
-                Params = options.Endpoint.Params.Remove("custom-p").SetItem("transport", "tcp")
+                Params = options.Endpoint.Params.Remove("custom-p"),
+                Transport = "tcp"
             }
         };
 


### PR DESCRIPTION
This PR changes the key of the dictionaries used by ConnectionCache from Endpoint (compared parameterless) to Endpoint (compared parameterless) + transportName.

It is (or will be) more correct when a connection cache can be configured with a "composite" client transport, such as a multiplexed composite transport that can create quic or slic/tcp connections. Then we'd want:
 - `icerpc://foo.com?transport=quic` to use/match the quic transport
 - `icerpc://foo.com?transport=tcp` to use/match the slic/tcp transport
 - `icerpc://foo.com` to use/match the default transport--presumably the first transport installed in the composite transport

For this last case, this PR uses `_multiplexedClientTransport.Name` to find this default transport name.

This PR also moves the endpoint checking from the ConnectionCache to ClientConnection. See my blog.