### PR TITLE
ConnectionCache & ObjectDisposedException

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -92,12 +92,109 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
             throw new NoEndpointException(request.ServiceAddress);
         }
 
-        return PerformInvokeAsync();
+        ClientConnection? connection = null;
+        Endpoint mainEndpoint = endpointFeature.Endpoint!.Value;
+
+        if (_options.PreferExistingConnection)
+        {
+            lock (_mutex)
+            {
+                connection = GetActiveConnection(mainEndpoint);
+                if (connection is null)
+                {
+                    for (int i = 0; i < endpointFeature.AltEndpoints.Count; ++i)
+                    {
+                        Endpoint altEndpoint = endpointFeature.AltEndpoints[i];
+                        connection = GetActiveConnection(altEndpoint);
+                        if (connection is not null)
+                        {
+                            // This altEndpoint becomes the main endpoint, and the existing main endpoint becomes
+                            // the first alt endpoint.
+                            endpointFeature.AltEndpoints = endpointFeature.AltEndpoints
+                                .RemoveAt(i)
+                                .Insert(0, mainEndpoint);
+                            endpointFeature.Endpoint = altEndpoint;
+
+                            break; // foreach
+                        }
+                    }
+                }
+            }
+
+            ClientConnection? GetActiveConnection(Endpoint endpoint) =>
+                _activeConnections.TryGetValue(endpoint, out ClientConnection? connection) ? connection : null;
+        }
+
+        if (connection is not null)
+        {
+            try
+            {
+                return connection.InvokeAsync(request, cancel);
+            }
+            catch (ObjectDisposedException)
+            {
+                // This can occasionally happen if we find a connection that was just closed by the peer or transport
+                // and then automatically disposed by this connection cache.
+                throw new ConnectionClosedException();
+            }
+        }
+        else
+        {
+            return PerformInvokeAsync();
+        }
 
         async Task<IncomingResponse> PerformInvokeAsync()
         {
-            ClientConnection connection = await GetClientConnectionAsync(endpointFeature, cancel).ConfigureAwait(false);
-            return await connection.InvokeAsync(request, cancel).ConfigureAwait(false);
+            try
+            {
+                connection = await ConnectAsync(mainEndpoint, cancel).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                List<Exception>? exceptionList = null;
+
+                for (int i = 0; i < endpointFeature.AltEndpoints.Count; ++i)
+                {
+                    // Rotate the endpoints before each new connection attempt: the first alt endpoint becomes the main
+                    // endpoint and the main endpoint becomes the last alt endpoint.
+                    endpointFeature.Endpoint = endpointFeature.AltEndpoints[0];
+                    endpointFeature.AltEndpoints = endpointFeature.AltEndpoints.RemoveAt(0).Add(mainEndpoint);
+                    mainEndpoint = endpointFeature.Endpoint.Value;
+
+                    try
+                    {
+                        connection = await ConnectAsync(mainEndpoint, cancel).ConfigureAwait(false);
+                        break; // for
+                    }
+                    catch (Exception altEx)
+                    {
+                        exceptionList ??= new List<Exception> { exception };
+                        exceptionList.Add(altEx);
+                        // and keep trying
+                    }
+                }
+
+                if (connection is null)
+                {
+                    if (exceptionList is null)
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        throw new AggregateException(exceptionList);
+                    }
+                }
+            }
+
+            try
+            {
+                return await connection.InvokeAsync(request, cancel).ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                throw new ConnectionClosedException();
+            }
         }
     }
 
@@ -265,96 +362,6 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
                 if (!_isReadOnly)
                 {
                     _ = _shutdownPendingConnections.Remove(clientConnection);
-                }
-            }
-        }
-    }
-
-    /// <summary>Returns a client connection to one of the specified endpoints.</summary>
-    /// <param name="endpointFeature">The endpoint feature.</param>
-    /// <param name="cancel">The cancellation token.</param>
-    private ValueTask<ClientConnection> GetClientConnectionAsync(
-        IEndpointFeature endpointFeature,
-        CancellationToken cancel)
-    {
-        ClientConnection? connection = null;
-        Endpoint mainEndpoint = endpointFeature.Endpoint!.Value;
-
-        if (_options.PreferExistingConnection)
-        {
-            lock (_mutex)
-            {
-                connection = GetActiveConnection(mainEndpoint);
-                if (connection is null)
-                {
-                    for (int i = 0; i < endpointFeature.AltEndpoints.Count; ++i)
-                    {
-                        Endpoint altEndpoint = endpointFeature.AltEndpoints[i];
-                        connection = GetActiveConnection(altEndpoint);
-                        if (connection is not null)
-                        {
-                            // This altEndpoint becomes the main endpoint, and the existing main endpoint becomes
-                            // the first alt endpoint.
-                            endpointFeature.AltEndpoints = endpointFeature.AltEndpoints
-                                .RemoveAt(i)
-                                .Insert(0, mainEndpoint);
-                            endpointFeature.Endpoint = altEndpoint;
-
-                            break; // foreach
-                        }
-                    }
-                }
-            }
-            if (connection is not null)
-            {
-                return new(connection);
-            }
-        }
-
-        return GetOrCreateAsync();
-
-        ClientConnection? GetActiveConnection(Endpoint endpoint) =>
-            _activeConnections.TryGetValue(endpoint, out ClientConnection? connection) ? connection : null;
-
-        // Retrieve a pending connection and wait for its ConnectAsync to complete successfully, or create and connect
-        // a brand new connection.
-        async ValueTask<ClientConnection> GetOrCreateAsync()
-        {
-            try
-            {
-                return await ConnectAsync(mainEndpoint, cancel).ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                List<Exception>? exceptionList = null;
-
-                for (int i = 0; i < endpointFeature.AltEndpoints.Count; ++i)
-                {
-                    // Rotate the endpoints before each new connection attempt: the first alt endpoint becomes the main
-                    // endpoint and the main endpoint becomes the last alt endpoint.
-                    endpointFeature.Endpoint = endpointFeature.AltEndpoints[0];
-                    endpointFeature.AltEndpoints = endpointFeature.AltEndpoints.RemoveAt(0).Add(mainEndpoint);
-                    mainEndpoint = endpointFeature.Endpoint.Value;
-
-                    try
-                    {
-                        return await ConnectAsync(mainEndpoint, cancel).ConfigureAwait(false);
-                    }
-                    catch (Exception altEx)
-                    {
-                        exceptionList ??= new List<Exception> { exception };
-                        exceptionList.Add(altEx);
-                        // and keep trying
-                    }
-                }
-
-                if (exceptionList is null)
-                {
-                    throw;
-                }
-                else
-                {
-                    throw new AggregateException(exceptionList);
                 }
             }
         }


### PR DESCRIPTION
This PR updates ConnectionCache to catch ObjectDisposedException when making an InvokeAsync call and throwing instead ConnectionClosedException.

See #1443.

It also reshuffles a bit the ConnectionCache code.