### PR TITLE
Slicec-cs DiagnosticReporter added

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/zeroc-ice/icerpc#b362afc73405b0d70b17f7f736247dce116bb85f"
+source = "git+ssh://git@github.com/zeroc-ice/icerpc#3d922d3181908778d022bd7e0fdac219482e2dbe"
 dependencies = [
  "convert_case",
  "pest",

--- a/tools/slicec-cs/src/cs_validator.rs
+++ b/tools/slicec-cs/src/cs_validator.rs
@@ -1,12 +1,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use slice::errors::{ErrorReporter, LogicKind};
+use slice::diagnostics::{DiagnosticReporter, LogicErrorKind};
 use slice::grammar::*;
 use slice::parse_result::{ParsedData, ParserResult};
 use slice::visitor::Visitor;
 
 pub(crate) fn validate_cs_attributes(mut parsed_data: ParsedData) -> ParserResult {
-    let mut visitor = CsValidator { error_reporter: &mut parsed_data.error_reporter };
+    let mut visitor = CsValidator { diagnostic_reporter: &mut parsed_data.diagnostic_reporter };
     for slice_file in parsed_data.files.values() {
         slice_file.visit_with(&mut visitor);
     }
@@ -18,7 +18,7 @@ pub(crate) fn validate_cs_attributes(mut parsed_data: ParsedData) -> ParserResul
 /// before code generation occurs.
 #[derive(Debug)]
 struct CsValidator<'a> {
-    pub error_reporter: &'a mut ErrorReporter,
+    pub diagnostic_reporter: &'a mut DiagnosticReporter,
 }
 
 fn cs_attributes(attributes: &[Attribute]) -> Vec<Attribute> {
@@ -31,68 +31,73 @@ fn cs_attributes(attributes: &[Attribute]) -> Vec<Attribute> {
         .collect::<Vec<_>>()
 }
 
-fn report_unexpected_attribute(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
-    error_reporter.report(
-        LogicKind::UnexpectedAttribute(format!("cs::{}", attribute.directive)),
+fn report_unexpected_attribute(
+    attribute: &Attribute,
+    diagnostic_reporter: &mut DiagnosticReporter,
+) {
+    diagnostic_reporter.report(
+        LogicErrorKind::UnexpectedAttribute(format!("cs::{}", attribute.directive)),
         Some(&attribute.span),
     );
 }
 
-fn validate_cs_attribute(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_cs_attribute(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     match attribute.arguments.len() {
         1 => (), // Expected 1 argument
-        0 => error_reporter.report(
-            LogicKind::MissingRequiredArgument(r#"cs::attribute("<attribute-value>")"#.to_owned()),
+        0 => diagnostic_reporter.report(
+            LogicErrorKind::MissingRequiredArgument(
+                r#"cs::attribute("<attribute-value>")"#.to_owned(),
+            ),
             Some(&attribute.span),
         ),
-        _ => error_reporter.report(
-            LogicKind::TooManyArguments(r#"cs::attribute("<attribute-value>")"#.to_owned()),
+        _ => diagnostic_reporter.report(
+            LogicErrorKind::TooManyArguments(r#"cs::attribute("<attribute-value>")"#.to_owned()),
             Some(&attribute.span),
         ),
     }
 }
 
-fn validate_cs_internal(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_cs_internal(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     if !attribute.arguments.is_empty() {
-        error_reporter.report(
-            LogicKind::TooManyArguments(r#"cs::internal"#.to_owned()),
+        diagnostic_reporter.report(
+            LogicErrorKind::TooManyArguments(r#"cs::internal"#.to_owned()),
             Some(&attribute.span),
         );
     }
 }
 
-fn validate_cs_encoded_result(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_cs_encoded_result(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     if !attribute.arguments.is_empty() {
-        error_reporter.report(
-            LogicKind::TooManyArguments(r#"cs::encodedResult"#.to_owned()),
+        diagnostic_reporter.report(
+            LogicErrorKind::TooManyArguments(r#"cs::encodedResult"#.to_owned()),
             Some(&attribute.span),
         );
     }
 }
 
-fn validate_cs_generic(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_cs_generic(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     match attribute.arguments.len() {
         1 => (), // Expected 1 argument
-        0 => error_reporter.report(
-            LogicKind::MissingRequiredArgument(r#"cs::generic("<generic-type>")"#.to_owned()),
+        0 => diagnostic_reporter.report(
+            LogicErrorKind::MissingRequiredArgument(r#"cs::generic("<generic-type>")"#.to_owned()),
             Some(&attribute.span),
         ),
-        _ => error_reporter.report(
-            LogicKind::TooManyArguments(r#"cs::generic("<generic-type>")"#.to_owned()),
+        _ => diagnostic_reporter.report(
+            LogicErrorKind::TooManyArguments(r#"cs::generic("<generic-type>")"#.to_owned()),
             Some(&attribute.span),
         ),
     }
 }
 
-fn validate_cs_type(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_cs_type(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     match attribute.arguments.len() {
         1 => (), // Expected 1 argument
-        0 => error_reporter.report(
-            LogicKind::MissingRequiredArgument(r#"cs::type("<type>")"#.to_owned()),
+        0 => diagnostic_reporter.report(
+            LogicErrorKind::MissingRequiredArgument(r#"cs::type("<type>")"#.to_owned()),
             Some(&attribute.span),
         ),
-        _ => error_reporter.report(
-            LogicKind::TooManyArguments(r#"cs::type("<type>")"#.to_owned()),
+        _ => diagnostic_reporter.report(
+            LogicErrorKind::TooManyArguments(r#"cs::type("<type>")"#.to_owned()),
             Some(&attribute.span),
         ),
     }
@@ -100,38 +105,41 @@ fn validate_cs_type(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
 
 fn validate_collection_attributes<T: Attributable>(
     attributable: &T,
-    error_reporter: &mut ErrorReporter,
+    diagnostic_reporter: &mut DiagnosticReporter,
 ) {
     for attribute in &cs_attributes(attributable.attributes()) {
         match attribute.directive.as_ref() {
-            "generic" => validate_cs_generic(attribute, error_reporter),
-            _ => report_unexpected_attribute(attribute, error_reporter),
+            "generic" => validate_cs_generic(attribute, diagnostic_reporter),
+            _ => report_unexpected_attribute(attribute, diagnostic_reporter),
         }
     }
 }
 
-fn validate_common_attributes(attribute: &Attribute, error_reporter: &mut ErrorReporter) {
+fn validate_common_attributes(attribute: &Attribute, diagnostic_reporter: &mut DiagnosticReporter) {
     match attribute.directive.as_ref() {
-        "attribute" => validate_cs_attribute(attribute, error_reporter),
-        _ => report_unexpected_attribute(attribute, error_reporter),
+        "attribute" => validate_cs_attribute(attribute, diagnostic_reporter),
+        _ => report_unexpected_attribute(attribute, diagnostic_reporter),
     }
 }
 
-fn validate_data_type_attributes(data_type: &TypeRef, error_reporter: &mut ErrorReporter) {
+fn validate_data_type_attributes(
+    data_type: &TypeRef,
+    diagnostic_reporter: &mut DiagnosticReporter,
+) {
     match data_type.concrete_type() {
         Types::Sequence(_) | Types::Dictionary(_) => {
-            validate_collection_attributes(data_type, error_reporter)
+            validate_collection_attributes(data_type, diagnostic_reporter)
         }
-        _ => report_typeref_unexpected_attributes(data_type, error_reporter),
+        _ => report_typeref_unexpected_attributes(data_type, diagnostic_reporter),
     }
 }
 
 fn report_typeref_unexpected_attributes<T: Attributable>(
     attributable: &T,
-    error_reporter: &mut ErrorReporter,
+    diagnostic_reporter: &mut DiagnosticReporter,
 ) {
     for attribute in &cs_attributes(attributable.attributes()) {
-        report_unexpected_attribute(attribute, error_reporter);
+        report_unexpected_attribute(attribute, diagnostic_reporter);
     }
 }
 
@@ -142,30 +150,30 @@ impl Visitor for CsValidator<'_> {
                 "namespace" => {
                     match attribute.arguments.len() {
                         1 => (), // Expected 1 argument
-                        0 => self.error_reporter.report(
-                            LogicKind::MissingRequiredArgument(
+                        0 => self.diagnostic_reporter.report(
+                            LogicErrorKind::MissingRequiredArgument(
                                 r#"cs::namespace("<namespace>")"#.to_owned(),
                             ),
                             Some(&attribute.span),
                         ),
-                        _ => self.error_reporter.report(
-                            LogicKind::TooManyArguments(
+                        _ => self.diagnostic_reporter.report(
+                            LogicErrorKind::TooManyArguments(
                                 r#"cs::namespace("<namespace>")"#.to_owned(),
                             ),
                             Some(&attribute.span),
                         ),
                     }
                     if !module_def.is_top_level() {
-                        self.error_reporter.report(
-                            LogicKind::AttributeOnlyValidForTopLevelModules(
+                        self.diagnostic_reporter.report(
+                            LogicErrorKind::AttributeOnlyValidForTopLevelModules(
                                 "cs::namespace".to_owned(),
                             ),
                             Some(&attribute.span),
                         );
                     }
                 }
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -175,14 +183,14 @@ impl Visitor for CsValidator<'_> {
             match attribute.directive.as_ref() {
                 "readonly" => {
                     if !attribute.arguments.is_empty() {
-                        self.error_reporter.report(
-                            LogicKind::TooManyArguments(r#"cs::readonly"#.to_owned()),
+                        self.diagnostic_reporter.report(
+                            LogicErrorKind::TooManyArguments(r#"cs::readonly"#.to_owned()),
                             Some(&attribute.span),
                         );
                     }
                 }
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -190,8 +198,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_class_start(&mut self, class_def: &Class) {
         for attribute in &cs_attributes(class_def.attributes()) {
             match attribute.directive.as_ref() {
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -199,8 +207,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_exception_start(&mut self, exception_def: &Exception) {
         for attribute in &cs_attributes(exception_def.attributes()) {
             match attribute.directive.as_ref() {
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -208,9 +216,9 @@ impl Visitor for CsValidator<'_> {
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         for attribute in &cs_attributes(interface_def.attributes()) {
             match attribute.directive.as_ref() {
-                "encodedResult" => validate_cs_encoded_result(attribute, self.error_reporter),
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "encodedResult" => validate_cs_encoded_result(attribute, self.diagnostic_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -218,8 +226,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_enum_start(&mut self, enum_def: &Enum) {
         for attribute in &cs_attributes(enum_def.attributes()) {
             match attribute.directive.as_ref() {
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -227,8 +235,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_operation_start(&mut self, operation: &Operation) {
         for attribute in &cs_attributes(operation.attributes()) {
             match attribute.directive.as_ref() {
-                "encodedResult" => validate_cs_encoded_result(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "encodedResult" => validate_cs_encoded_result(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -236,8 +244,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_trait(&mut self, trait_def: &Trait) {
         for attribute in &cs_attributes(trait_def.attributes()) {
             match attribute.directive.as_ref() {
-                "internal" => validate_cs_internal(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "internal" => validate_cs_internal(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
@@ -245,33 +253,33 @@ impl Visitor for CsValidator<'_> {
     fn visit_custom_type(&mut self, custom_type: &CustomType) {
         // We require 'cs::type' on custom types to know how to encode/decode it.
         if !custom_type.has_attribute("cs::type", false) {
-            self.error_reporter.report(
-                LogicKind::MissingRequiredAttribute("cs::type".to_owned()),
+            self.diagnostic_reporter.report(
+                LogicErrorKind::MissingRequiredAttribute("cs::type".to_owned()),
                 Some(&custom_type.span),
             );
         }
 
         for attribute in &cs_attributes(custom_type.attributes()) {
             match attribute.directive.as_ref() {
-                "type" => validate_cs_type(attribute, self.error_reporter),
-                _ => validate_common_attributes(attribute, self.error_reporter),
+                "type" => validate_cs_type(attribute, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_type_alias(&mut self, type_alias: &TypeAlias) {
-        validate_data_type_attributes(&type_alias.underlying, self.error_reporter);
+        validate_data_type_attributes(&type_alias.underlying, self.diagnostic_reporter);
     }
 
     fn visit_data_member(&mut self, data_member: &DataMember) {
-        validate_data_type_attributes(&data_member.data_type, self.error_reporter);
+        validate_data_type_attributes(&data_member.data_type, self.diagnostic_reporter);
     }
 
     fn visit_parameter(&mut self, parameter: &Parameter) {
-        validate_data_type_attributes(&parameter.data_type, self.error_reporter);
+        validate_data_type_attributes(&parameter.data_type, self.diagnostic_reporter);
     }
 
     fn visit_return_member(&mut self, parameter: &Parameter) {
-        validate_data_type_attributes(&parameter.data_type, self.error_reporter);
+        validate_data_type_attributes(&parameter.data_type, self.diagnostic_reporter);
     }
 }

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -31,7 +31,7 @@ use exception_visitor::ExceptionVisitor;
 use generated_code::GeneratedCode;
 use module_visitor::ModuleVisitor;
 use proxy_visitor::ProxyVisitor;
-use slice::errors::ErrorKind;
+use slice::diagnostics::DiagnosticKind;
 use slice::parse_result::ParserResult;
 use slice::slice_file::SliceFile;
 use std::fs::File;
@@ -114,8 +114,8 @@ fn try_main() -> ParserResult {
                 match write_file(&path, &code_string) {
                     Ok(_) => (),
                     Err(err) => {
-                        parsed_data.error_reporter.report(
-                            ErrorKind::IO(format!(
+                        parsed_data.diagnostic_reporter.report(
+                            DiagnosticKind::IOError(format!(
                                 "failed to write to file {}: {}",
                                 &path.display(),
                                 err


### PR DESCRIPTION
This is a sister PR to https://github.com/zeroc-ice/icerpc/commit/3d922d3181908778d022bd7e0fdac219482e2dbe
where `Error` was renamed to `Diagnostic`, `ErrorReporter` to `DiagnosticReporter`, ... etc.

