### PR TITLE
Removed IceRpcStreamErroCode.InvalidData which is no longer used

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocol.cs
+++ b/src/IceRpc/Internal/IceRpcProtocol.cs
@@ -37,9 +37,6 @@ internal sealed class IceRpcProtocol : Protocol
                 IceRpcStreamErrorCode.ConnectionShutdown =>
                     new ConnectionClosedException("the connection was shut down by the remote peer"),
 
-                IceRpcStreamErrorCode.InvalidData =>
-                    new InvalidDataException("the remote peer failed to decode data from the stream"),
-
                 _ => new IceRpcProtocolStreamException((IceRpcStreamErrorCode)errorCode)
             };
 
@@ -51,8 +48,6 @@ internal sealed class IceRpcProtocol : Protocol
                 ConnectionClosedException => (ulong)IceRpcStreamErrorCode.ConnectionShutdown,
 
                 IceRpcProtocolStreamException streamException => (ulong)streamException.ErrorCode,
-
-                InvalidDataException => (ulong)IceRpcStreamErrorCode.InvalidData,
 
                 _ => (ulong)IceRpcStreamErrorCode.Unspecified
             };


### PR DESCRIPTION
This PR removed `IceRpcStreamErroCode.InvalidData`. A dispatch throwing this exception raises `DispatchException(DispatchErrorCode.InvalidData)` instead of resulting in an `IceRpcProtocolStreamException`.