### PR TITLE
Fix nonmutating bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "decoratee",
         "icerpc",
         "inheritdoc",
+        "Nonmutating",
         "Parallelizable",
         "paramref",
         "Slic",

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -906,8 +906,9 @@ internal sealed class IceProtocolConnection : ProtocolConnection
                     [RequestFieldKey.Context] = result.Buffer
                 };
 
-                if (requestHeader.OperationMode == OperationMode.Idempotent)
+                if (requestHeader.OperationMode != OperationMode.Normal)
                 {
+                    // OperationMode can be Idempotent or Nonmutating.
                     fields[RequestFieldKey.Idempotent] = default;
                 }
             }


### PR DESCRIPTION
This PR fixes a small "nonmutating" bug.

When we receive a "nonmutating" request, we must consider this request idempotent as opposed to normal, and we got this wrong prior to this PR.

This was pretty bad because the bad situation is when a client thinks it's idempotent and the implementation is not. With this bug, we would convert an operation that is nonmutating (idempotent) from the client point of view into a "normal" operation for the server, which is always ok.

See https://github.com/zeroc-ice/icerpc-csharp/blob/main/src/IceRpc/Slice/IncomingRequestExtensions.cs#L16

Note that nonmutating is still used extensively in Ice 3.7 Slice definitions:
```
Bernards-MBP:slice bernard$ rg nonmutating
IceBox/IceBox.ice
173:    ["nonmutating", "cpp:const"] idempotent Ice::SliceChecksumDict getSliceChecksums();

IceStorm/IceStorm.ice
183:    ["nonmutating", "cpp:const"] idempotent string getName();
196:    ["nonmutating", "cpp:const"] idempotent Object* getPublisher();
208:    ["nonmutating", "cpp:const"] idempotent Object* getNonReplicatedPublisher();
280:    ["nonmutating", "cpp:const"] idempotent LinkInfoSeq getLinkInfoSeq();
289:    ["nonmutating", "cpp:const"] Ice::IdentitySeq getSubscribers();
372:    ["nonmutating", "cpp:const"] idempotent Topic* retrieve(string name) throws NoSuchTopic;
381:    ["nonmutating", "cpp:const"] idempotent TopicDict retrieveAll();
390:    ["nonmutating", "cpp:const"] idempotent Ice::SliceChecksumDict getSliceChecksums();

Glacier2/Router.ice
70:    ["nonmutating", "cpp:const"] idempotent string getCategoryForClient();
170:    ["nonmutating", "cpp:const"] idempotent long getSessionTimeout();
183:    ["nonmutating", "cpp:const"] idempotent int getACMTimeout();

Glacier2/PermissionsVerifier.ice
74:    ["nonmutating", "cpp:const", "format:sliced"]
106:    ["nonmutating", "cpp:const", "format:sliced"]

IcePatch2/FileServer.ice
103:     "nonmutating", "cpp:const"] idempotent FileInfoSeq getFileInfoSeq(int partition)
117:    ["nonmutating", "cpp:const"] idempotent LargeFileInfoSeq getLargeFileInfoSeq(int partition)
131:    ["nonmutating", "cpp:const"] idempotent ByteSeqSeq getChecksumSeq();
141:    ["nonmutating", "cpp:const"] idempotent Ice::ByteSeq getChecksum();
165:     "amd", "nonmutating", "cpp:const", "cpp:array"]
186:    ["amd", "nonmutating", "cpp:const", "cpp:array"]
```

and many more.