### PR TITLE
Simplify ClientConnection refreshing connection on exception

### DIFF
--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -160,17 +160,10 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
         {
             return await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (ConnectionClosedException)
+        catch (ConnectionClosedException) when (RefreshConnection(connection) is IProtocolConnection newConnection)
         {
-            if (RefreshConnection(connection) is IProtocolConnection newConnection)
-            {
-                // Try again once with the new connection
-                return await newConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                throw;
-            }
+            // Try again once with the new connection
+            return await newConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -233,17 +226,10 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
             {
                 return await connection.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
             }
-            catch (ConnectionClosedException)
+            catch (ConnectionClosedException) when (RefreshConnection(connection) is IProtocolConnection newConnection)
             {
-                if (RefreshConnection(connection) is IProtocolConnection newConnection)
-                {
-                    // try again once with the new connection
-                    return await newConnection.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    throw;
-                }
+                // try again once with the new connection
+                return await newConnection.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
This is a minor simplification rather than using a catch with if/else blocks, we can use catch when