### PR TITLE
Fix race condition in ProtocolConnection.InvokeAsync

### DIFF
--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -182,13 +182,33 @@ internal abstract class ProtocolConnection : IProtocolConnection
                 throw new ConnectionClosedException(
                     _shutdownTask.IsCompleted ? "connection is shutdown" : "connection is shutting down");
             }
-            else if (_connectTask is null || !_connectTask.IsCompletedSuccessfully)
+            else if (_connectTask is null)
             {
                 throw new InvalidOperationException("cannot call InvokeAsync before calling ConnectAsync");
             }
         }
 
-        return InvokeAsyncCore(request, cancellationToken);
+        if (_connectTask.IsCompletedSuccessfully)
+        {
+            return InvokeAsyncCore(request, cancellationToken);
+        }
+        else if (_connectTask.IsCompleted)
+        {
+            throw new InvalidOperationException("cannot call InvokeAsync after ConnectAsync failed");
+        }
+        else
+        {
+            return IsServer ? PerformInvokeAsync() :
+                throw new InvalidOperationException("cannot call InvokeAsync while connecting a client connection");
+        }
+
+        async Task<IncomingResponse> PerformInvokeAsync()
+        {
+            // It's possible to dispatch a request and expose its connection (invoker) before ConnectAsync completes;
+            // in this rare case, we wait for _connectTask to complete before calling InvokeAsyncCore.
+            _ = await _connectTask.ConfigureAwait(false);
+            return await InvokeAsyncCore(request, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public void OnAbort(Action<Exception> callback)


### PR DESCRIPTION
This is new attempt to fix #1675.

I am unable to reproduce the bug in my computer.

From looking at the code, I suspect the issue is we're dispatching and exposing the server connection invoker before the ProtocolConnection's connectTask has completed. The fix is to wait for this task to complete in ProtocolConnection.InvokeAsync.

A better fix could be to wait for the connect task to complete before dispatching but this seems more complicated to do.

Fixes #1675.