### PR TITLE
Added close reason to ConnectionClosedException raised by a close connection

### DIFF
--- a/src/IceRpc/ConnectionExceptions.cs
+++ b/src/IceRpc/ConnectionExceptions.cs
@@ -51,7 +51,7 @@ public class ConnectionClosedException : Exception
     /// error message.</summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
-    public ConnectionClosedException(string? message, Exception? innerException)
+    public ConnectionClosedException(string message, Exception innerException)
         : base(message, innerException)
     {
     }


### PR DESCRIPTION
This PR provides a fix for #1605 

Invocation on a closed connection will now provide the reason why the connection was closed and eventually the unexpected transport exception that cause the connection loss.

I'm not very happy with this fix because we spread all over the place different reason messages for the connection close reason. I opened #1707 to discuss this. It's also the reason why I didn't add tests... comparing reason strings is very fragile.