### PR TITLE
Fix Log decorator

### DIFF
--- a/src/IceRpc/Internal/LogClientProtocolConnectionFactoryDecorator.cs
+++ b/src/IceRpc/Internal/LogClientProtocolConnectionFactoryDecorator.cs
@@ -59,8 +59,7 @@ internal class LogClientProtocolConnectionFactoryDecorator : IClientProtocolConn
         public async ValueTask DisposeAsync()
         {
             await _decoratee.DisposeAsync().ConfigureAwait(false);
-            await _logShutdownAsync.ConfigureAwait(false); // make sure the task completes before ConnectionStop
-            ClientEventSource.Log.ConnectionStop(ServerAddress, _localNetworkAddress);
+            await _logShutdownAsync.ConfigureAwait(false);
         }
 
         public Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken) =>
@@ -74,6 +73,7 @@ internal class LogClientProtocolConnectionFactoryDecorator : IClientProtocolConn
             _decoratee = decoratee;
             _logShutdownAsync = LogShutdownAsync();
 
+            // This task executes exactly once per decorated connection.
             async Task LogShutdownAsync()
             {
                 try
@@ -86,6 +86,7 @@ internal class LogClientProtocolConnectionFactoryDecorator : IClientProtocolConn
                 {
                     ClientEventSource.Log.ConnectionFailure(ServerAddress, _localNetworkAddress, exception);
                 }
+                ClientEventSource.Log.ConnectionStop(ServerAddress, _localNetworkAddress);
             }
         }
     }

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -390,8 +390,7 @@ public sealed class Server : IAsyncDisposable
         public async ValueTask DisposeAsync()
         {
             await _decoratee.DisposeAsync().ConfigureAwait(false);
-            await _logShutdownTask.ConfigureAwait(false); // make sure the task completes before ConnectionStop
-            ServerEventSource.Log.ConnectionStop(ServerAddress, _remoteNetworkAddress);
+            await _logShutdownTask.ConfigureAwait(false);
         }
 
         public Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken) =>
@@ -407,6 +406,7 @@ public sealed class Server : IAsyncDisposable
 
             _logShutdownTask = LogShutdownAsync();
 
+            // This task executes once per decorated connection.
             async Task LogShutdownAsync()
             {
                 try
@@ -421,6 +421,7 @@ public sealed class Server : IAsyncDisposable
                         remoteNetworkAddress,
                         exception);
                 }
+                ServerEventSource.Log.ConnectionStop(ServerAddress, _remoteNetworkAddress);
             }
         }
     }


### PR DESCRIPTION
This PR fixes the client and server log decorators for protocol connection to ensure ConnectionStop is called exactly once per connection.

The 2 LogProtocolConnectionDecorator private classes intercept only 2 methods of IProtocolConnection:
 - ConnectAsync, to log the connection establishment (ConnectStart, ConnectSuccess/Failure, ConnectStop)
 - DisposeAsync, to await for the "log task" created in the constructor after awaiting the decoratee disposal

This log task logs the successful Shutdown or Abort=ConnectionFailure (as applicable) and ConnectionStop, exactly once per connection.