### PR TITLE
Fix CreateShutdownTask for canceled _connectTask

### DIFF
--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -335,8 +335,6 @@ internal abstract class ProtocolConnection : IProtocolConnection
 
         try
         {
-            cts.Token.ThrowIfCancellationRequested();
-
             // Wait for connect to complete first.
             _ = await _connectTask.WaitAsync(cts.Token).ConfigureAwait(false);
 
@@ -350,21 +348,29 @@ internal abstract class ProtocolConnection : IProtocolConnection
 
             _shutdownCompleteSource.SetResult(message);
         }
-        catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+        catch (OperationCanceledException operationCanceledException)
         {
-            var exception = new ConnectionAbortedException(
-                _disposeTask is null ? "connection shutdown canceled" : "connection disposed");
+            Exception exception;
 
-            _ = _shutdownCompleteSource.TrySetException(exception);
-            throw exception;
-        }
-        catch (OperationCanceledException)
-        {
-            Debug.Assert(cts.IsCancellationRequested);
+            if (_disposeTask is not null)
+            {
+                exception = new ConnectionAbortedException("connection disposed");
+            }
+            else if (_shutdownCts.IsCancellationRequested)
+            {
+                exception = new ConnectionAbortedException("connection shutdown canceled");
+            }
+            else if (operationCanceledException.CancellationToken == cts.Token)
+            {
+                exception = new TimeoutException(
+                    $"connection shutdown timed out after {_shutdownTimeout.TotalSeconds}s");
+            }
+            else
+            {
+                // By elimination
+                exception = new ConnectionAbortedException("connection establishment failed");
+            }
 
-            // Triggered by the CancelAfter above.
-            var exception = new TimeoutException(
-                $"connection shutdown timed out after {_shutdownTimeout.TotalSeconds}s");
             _ = _shutdownCompleteSource.TrySetException(exception);
             throw exception;
         }


### PR DESCRIPTION
This PR fixes CreateShudownTask to throw the correct exception when _connectTask is canceled.

Also fixes #1667.