### PR TITLE
Test for canceling reads on outgoing request payload

### DIFF
--- a/tests/IceRpc.Tests/InvocationTests.cs
+++ b/tests/IceRpc.Tests/InvocationTests.cs
@@ -4,7 +4,6 @@ using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using System.Buffers;
 using System.IO.Pipelines;
 
 namespace IceRpc.Tests;
@@ -85,15 +84,12 @@ public class InvocationTests
     [Test]
     public async Task Cancel_the_payload_reads_while_the_server_is_reading_the_arguments_fails_with_dispatch_exception()
     {
-        var payload = new HoldPipeReader(new byte[] { 0x1, 0x2, 0x3 });
-
+        // Arrange
         await using ServiceProvider provider = new ServiceCollection()
             .AddColocTest(new InlineDispatcher(
                 async (request, cancellationToken) =>
                 {
-                    await payload.ReadStart;
-                    payload.CancelPendingRead();
-                    await request.Payload.ReadAllAsync(CancellationToken.None);
+                    await request.Payload.ReadAllAsync(cancellationToken);
                     return new OutgoingResponse(request);
                 }))
             .BuildServiceProvider(validateScopes: true);
@@ -101,72 +97,44 @@ public class InvocationTests
         provider.GetRequiredService<Server>().Listen();
         ClientConnection connection = provider.GetRequiredService<ClientConnection>();
 
-        var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/test")));
-        request.Payload = payload;
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync(new ReadOnlyMemory<byte>(new byte[] { 0x1, 0x2, 0x3 }));
 
+        var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/test")));
+        request.Payload = new CancelPendingReadPipeReader(pipe.Reader);
+
+        // Act
         IncomingResponse responnse = await connection.InvokeAsync(request);
 
+        // Assert
         RemoteException exception = await responnse.DecodeFailureAsync(request, new ServiceProxy());
         Assert.Multiple(
             () =>
             {
                 Assert.That(responnse.ResultType, Is.EqualTo(ResultType.Failure));
                 Assert.That(exception, Is.TypeOf<DispatchException>());
+                DispatchException dispatchException = (DispatchException)exception;
+                Assert.That(dispatchException.ErrorCode, Is.EqualTo(DispatchErrorCode.UnhandledException));
             });
     }
 
-    private class HoldPipeReader : PipeReader
+    // A pipe reader that calls CancelPendingRead after the first read
+    private class CancelPendingReadPipeReader : PipeReader
     {
-        internal Task ReadStart => _readStartTcs.Task;
+        private readonly PipeReader _decoratee;
 
-        private byte[] _initialData;
+        internal CancelPendingReadPipeReader(PipeReader decoratee) => _decoratee = decoratee;
 
-        private readonly TaskCompletionSource _readStartTcs =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        private readonly TaskCompletionSource<ReadResult> _readTcs =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public override void AdvanceTo(SequencePosition consumed)
+        public override void AdvanceTo(SequencePosition consumed) => _decoratee.AdvanceTo(consumed);
+        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined) => _decoratee.AdvanceTo(consumed, examined);
+        public override void CancelPendingRead() => _decoratee.CancelPendingRead();
+        public override void Complete(Exception? exception = null) => _decoratee.Complete(exception);
+        public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
+            var result = _decoratee.ReadAsync(cancellationToken);
+            CancelPendingRead();
+            return result;
         }
-
-        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
-        {
-        }
-
-        public override void CancelPendingRead() =>
-            _readTcs.SetResult(new ReadResult(ReadOnlySequence<byte>.Empty, isCanceled: true, isCompleted: false));
-
-        public override void Complete(Exception? exception = null)
-        {
-        }
-
-        public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken)
-        {
-            _readStartTcs.TrySetResult();
-
-            if (_initialData.Length > 0)
-            {
-                var buffer = new ReadOnlySequence<byte>(_initialData);
-                _initialData = Array.Empty<byte>();
-                return new(new ReadResult(buffer, isCanceled: false, isCompleted: false));
-            }
-            else
-            {
-                // Hold until ReadAsync is canceled.
-                return new(_readTcs.Task.WaitAsync(cancellationToken));
-            }
-        }
-
-        public override bool TryRead(out ReadResult result)
-        {
-            result = new ReadResult();
-            return false;
-        }
-
-        internal HoldPipeReader(byte[] initialData) => _initialData = initialData;
-
-        internal void SetReadException(Exception exception) => _readTcs.SetException(exception);
+        public override bool TryRead(out ReadResult result) => _decoratee.TryRead(out result);
     }
 }


### PR DESCRIPTION
This PR adds a test for calling `CancelPendingRead` on the outgoing request payload while the server is still reading the args, related to #1709 