### PR TITLE
ShutdownComplete completes after diposing not connected connection

### DIFF
--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -46,7 +46,6 @@ public sealed class ProtocolConnectionTests
         }
     }
 
-
     /// <summary>Verifies that disposing a connection that was not connected completes the
     /// <see cref="ProtocolConnection.ShutdownComplete"/> task.</summary>
     [Test, TestCaseSource(nameof(Protocols))]


### PR DESCRIPTION
Add test for disposing not connected connection, fix #1680 