### PR TITLE
NuGet and cargo dependency caching in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: 📦 NuGet Cache
       uses: actions/cache@v3
       with:
-        path: ~/.nuget
+        path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-


### PR DESCRIPTION
This PR adds dependency caching for `NuGet` and `cargo` to the Github workflow. Seems to save about a minute on the workflow execution time.

Seems like the slowest part of the workflow now is building the examples. Perhaps we could move that to a separate job or try to optimize the build? Thoughts @pepone , @externl.