### PR TITLE
Updated IceRpc.Builder.MSBuild to use preview6 release

### DIFF
--- a/examples/Compress/Client/Client.csproj
+++ b/examples/Compress/Client/Client.csproj
@@ -12,7 +12,7 @@
    </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Deflate" Version="$(IceRpcVersion)" />
   </ItemGroup>

--- a/examples/Compress/Server/Server.csproj
+++ b/examples/Compress/Server/Server.csproj
@@ -12,7 +12,7 @@
    </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Deflate" Version="$(IceRpcVersion)" />
   </ItemGroup>

--- a/examples/Download/Client/Client.csproj
+++ b/examples/Download/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Downloader.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Download/Server/Server.csproj
+++ b/examples/Download/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Downloader.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/GenericHost/Client/Client.csproj
+++ b/examples/GenericHost/Client/Client.csproj
@@ -30,7 +30,7 @@
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/GenericHost/Server/Server.csproj
+++ b/examples/GenericHost/Server/Server.csproj
@@ -30,7 +30,7 @@
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/Hello/Client/Client.csproj
+++ b/examples/Hello/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Hello/Server/Server.csproj
+++ b/examples/Hello/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Interop/IceGrid/Client/Client.csproj
+++ b/examples/Interop/IceGrid/Client/Client.csproj
@@ -13,7 +13,7 @@
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Locator" Version="$(IceRpcVersion)" />

--- a/examples/Interop/Minimal/Client/Client.csproj
+++ b/examples/Interop/Minimal/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Metrics/Client/Client.csproj
+++ b/examples/Metrics/Client/Client.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="0.1.0-preview1" />
   </ItemGroup>
 </Project>

--- a/examples/Metrics/Server/Server.csproj
+++ b/examples/Metrics/Server/Server.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="0.1.0-preview1" />
     <PackageReference Include="IceRpc.Metrics" Version="$(IceRpcVersion)" />
   </ItemGroup>

--- a/examples/OpenTelemetry/Client/Client.csproj
+++ b/examples/OpenTelemetry/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />

--- a/examples/OpenTelemetry/CrmServer/CrmServer.csproj
+++ b/examples/OpenTelemetry/CrmServer/CrmServer.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../CRM.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />

--- a/examples/OpenTelemetry/HelloServer/HelloServer.csproj
+++ b/examples/OpenTelemetry/HelloServer/HelloServer.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice;../CRM.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />

--- a/examples/RequestContext/Client/Client.csproj
+++ b/examples/RequestContext/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.RequestContext" Version="$(IceRpcVersion)" />
   </ItemGroup>

--- a/examples/RequestContext/Server/Server.csproj
+++ b/examples/RequestContext/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.RequestContext" Version="$(IceRpcVersion)" />
   </ItemGroup>

--- a/examples/Retry/Client/Client.csproj
+++ b/examples/Retry/Client/Client.csproj
@@ -14,7 +14,7 @@
     <SliceCompile Include="../Hello.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Retry" Version="$(IceRpcVersion)" />

--- a/examples/Retry/Server/Server.csproj
+++ b/examples/Retry/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Secure/Client/Client.csproj
+++ b/examples/Secure/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Secure/Server/Server.csproj
+++ b/examples/Secure/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Hello.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Stream/Client/Client.csproj
+++ b/examples/Stream/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../NumberStream.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Stream/Server/Server.csproj
+++ b/examples/Stream/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../NumberStream.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Upload/Client/Client.csproj
+++ b/examples/Upload/Client/Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Uploader.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/examples/Upload/Server/Server.csproj
+++ b/examples/Upload/Server/Server.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../Uploader.slice" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="icerpc" Version="$(IceRpcVersion)" />
   </ItemGroup>
 </Project>

--- a/src/IceRpc.Coloc/IceRpc.Coloc.csproj
+++ b/src/IceRpc.Coloc/IceRpc.Coloc.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\IceRpc\IceRpc.csproj" />
-        <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
         <!-- TODO update to 1.2 stable release https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187#issuecomment-1043221630 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/src/IceRpc.Locator/IceRpc.Locator.csproj
+++ b/src/IceRpc.Locator/IceRpc.Locator.csproj
@@ -17,7 +17,7 @@
     <ItemGroup>
         <ProjectReference Include="..\IceRpc\IceRpc.csproj" />
         <SliceCompile Include="../../slice/Ice/Locator.slice;../../slice/Ice/Process.slice" OutputDir="$(MSBuildProjectDirectory)/generated" />
-        <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
         <!-- TODO update to 1.2 stable release https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187#issuecomment-1043221630 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/src/IceRpc.ProjectTemplates/Templates/Client/Client.csproj
+++ b/src/IceRpc.ProjectTemplates/Templates/Client/Client.csproj
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="0.1.0-preview1" />
   </ItemGroup>
 </Project>

--- a/src/IceRpc.ProjectTemplates/Templates/Server/Server.csproj
+++ b/src/IceRpc.ProjectTemplates/Templates/Server/Server.csproj
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="0.1.0-preview1" />
   </ItemGroup>
 </Project>

--- a/src/IceRpc/IceRpc.csproj
+++ b/src/IceRpc/IceRpc.csproj
@@ -54,6 +54,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
-      <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/tests/IceRpc.Conformance.Tests/IceRpc.Conformance.Tests.csproj
+++ b/tests/IceRpc.Conformance.Tests/IceRpc.Conformance.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
 
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.Deflate.Tests/IceRpc.Deflate.Tests.csproj
+++ b/tests/IceRpc.Deflate.Tests/IceRpc.Deflate.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.Logger.Tests/IceRpc.Logger.Tests.csproj
+++ b/tests/IceRpc.Logger.Tests/IceRpc.Logger.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.Metrics.Tests/IceRpc.Metrics.Tests.csproj
+++ b/tests/IceRpc.Metrics.Tests/IceRpc.Metrics.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.RequestContext.Tests/IceRpc.RequestContext.Tests.csproj
+++ b/tests/IceRpc.RequestContext.Tests/IceRpc.RequestContext.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.Retry.Tests/IceRpc.Retry.Tests.csproj
+++ b/tests/IceRpc.Retry.Tests/IceRpc.Retry.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IceRpc.Tests.ReferencedAssemblies/A/A.csproj
+++ b/tests/IceRpc.Tests.ReferencedAssemblies/A/A.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Tests.ReferencedAssemblies/B/B.csproj
+++ b/tests/IceRpc.Tests.ReferencedAssemblies/B/B.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Tests.ReferencedAssemblies/C/C.csproj
+++ b/tests/IceRpc.Tests.ReferencedAssemblies/C/C.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Tests.ReferencedAssemblies/D/D.csproj
+++ b/tests/IceRpc.Tests.ReferencedAssemblies/D/D.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Tests/IceRpc.Tests.csproj
+++ b/tests/IceRpc.Tests/IceRpc.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/tests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/IntegrationTests/IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview5" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Builder.MSBuild" Version="0.1.0-preview6" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the `.csproj`s to use preview6 of the MSBuilder. https://github.com/zeroc-ice/icerpc-builder-msbuild/pull/5