### PR TITLE
Additional Slic shutdown fix

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -1138,6 +1138,7 @@ public abstract class MultiplexedTransportConformanceTests
 
         // Act/Assert
         Assert.That(async () => await clientConnection.ShutdownAsync(0ul, CancellationToken.None), Throws.Nothing);
+        Assert.That(async () => await serverConnection.ShutdownAsync(0ul, CancellationToken.None), Throws.Nothing);
     }
 
     [Test]


### PR DESCRIPTION
This PR fixes an issue where the Slic connection would not gracefully shutdown the TCP connection because shutdown returned too soon.