### PR TITLE
Fixed ignored tests, fixes #1656

### DIFF
--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -185,7 +185,7 @@ public class TcpTransportTests
         // Act
         while (true)
         {
-            using var source = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            using var source = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
             try
             {
                 IDuplexConnection clientConnection = clientTransport.CreateConnection(


### PR DESCRIPTION
This PR fixes and enables ignored tests. It also bumps the cancellation token of a TCP test to minimise the chances of a sporadic failure.