### PR TITLE
Fix for #1770

### DIFF
--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -347,8 +347,6 @@ internal abstract class ProtocolConnection : IProtocolConnection
 
     private async Task CreateShutdownTask(string message, bool cancelDispatchesAndInvocations = false)
     {
-        Debug.Assert(_connectTask is null || _connectTask.IsCompletedSuccessfully);
-
         // Make sure we execute the function without holding the connection mutex lock.
         await Task.Yield();
 


### PR DESCRIPTION
This PR fixes #1770. The hang was caused by an incorrect assert that ended up as an unexpected exception with the tests.