### PR TITLE
Refactor listener factory

### DIFF
--- a/src/IceRpc/Internal/ProtocolListener.cs
+++ b/src/IceRpc/Internal/ProtocolListener.cs
@@ -33,9 +33,9 @@ internal sealed class IceProtocolListener : ProtocolListener<IDuplexConnection>
     private readonly ConnectionOptions _connectionOptions;
 
     internal IceProtocolListener(
-        ServerOptions serverOptions,
+        ConnectionOptions connectionOptions,
         IListener<IDuplexConnection> listener)
-        : base(listener) => _connectionOptions = serverOptions.ConnectionOptions;
+        : base(listener) => _connectionOptions = connectionOptions;
 
     private protected override IProtocolConnection CreateProtocolConnection(IDuplexConnection duplexConnection) =>
         new IceProtocolConnection(duplexConnection, isServer: true, _connectionOptions);
@@ -46,9 +46,9 @@ internal sealed class IceRpcProtocolListener : ProtocolListener<IMultiplexedConn
     private readonly ConnectionOptions _connectionOptions;
 
     internal IceRpcProtocolListener(
-        ServerOptions serverOptions,
+        ConnectionOptions connectionOptions,
         IListener<IMultiplexedConnection> listener)
-        : base(listener) => _connectionOptions = serverOptions.ConnectionOptions;
+        : base(listener) => _connectionOptions = connectionOptions;
 
     private protected override IProtocolConnection CreateProtocolConnection(
         IMultiplexedConnection multiplexedConnection) =>

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -82,7 +82,7 @@ public sealed class Server : IAsyncDisposable
                         Pool = options.ConnectionOptions.Pool,
                     },
                     options.ServerAuthenticationOptions);
-                listener = new IceProtocolListener(options, transportListener);
+                listener = new IceProtocolListener(options.ConnectionOptions, transportListener);
             }
             else
             {
@@ -98,7 +98,7 @@ public sealed class Server : IAsyncDisposable
                         StreamErrorCodeConverter = IceRpcProtocol.Instance.MultiplexedStreamErrorCodeConverter
                     },
                     options.ServerAuthenticationOptions);
-                listener = new IceRpcProtocolListener(options, transportListener);
+                listener = new IceRpcProtocolListener(options.ConnectionOptions, transportListener);
             }
             return new LogListenerDecorator(listener);
         };


### PR DESCRIPTION
This PR refactors the listener factory, Ice and IceRpc protocol listener don't need to depend on the transport, injecting the transport listener is more DI friendly as we will be able to inject a decorated listener.