### PR TITLE
Fix max server connections test (#1799)

### DIFF
--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -127,6 +127,8 @@ public class ServerTests
         // Act/Assert
         Assert.ThrowsAsync<ConnectFailedException>(() => connection2.ConnectAsync());
         await connection1.ShutdownAsync();
+        // Artificial delay to ensure the server has time to cleanup connection.
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
         await connection3.ConnectAsync();
     }
 }


### PR DESCRIPTION
I added a 500ms delay to ensure the server has removed the old connection from its list.