### PR TITLE
Support for `ListenAsync` operation on the listener interfaces and `Server`

### DIFF
--- a/examples/Compress/Server/Program.cs
+++ b/examples/Compress/Server/Program.cs
@@ -19,7 +19,7 @@ Console.CancelKeyPress += (sender, eventArgs) =>
 };
 
 // Start the server
-server.Listen();
+await server.ListenAsync();
 
 Console.WriteLine("Server is waiting for connections...");
 

--- a/examples/Download/Server/Program.cs
+++ b/examples/Download/Server/Program.cs
@@ -13,6 +13,6 @@ Console.CancelKeyPress += (sender, eventArgs) =>
 };
 
 Console.WriteLine("Server is waiting for connections...");
-server.Listen();
+await server.ListenAsync();
 
 await server.ShutdownComplete;

--- a/examples/GenericHost/Server/Program.cs
+++ b/examples/GenericHost/Server/Program.cs
@@ -66,12 +66,9 @@ public static class Program
 
         public ValueTask DisposeAsync() => _server.DisposeAsync();
 
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
+        public Task StartAsync(CancellationToken cancellationToken) =>
             // Start listening for client connections.
-            _server.Listen();
-            return Task.CompletedTask;
-        }
+            _server.ListenAsync(cancellationToken);
 
         public Task StopAsync(CancellationToken cancellationToken) =>
             // Shutdown the IceRPC server when the hosted service is stopped.

--- a/examples/Hello/Server/Program.cs
+++ b/examples/Hello/Server/Program.cs
@@ -12,5 +12,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/OpenTelemetry/CrmServer/Program.cs
+++ b/examples/OpenTelemetry/CrmServer/Program.cs
@@ -32,5 +32,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/OpenTelemetry/HelloServer/Program.cs
+++ b/examples/OpenTelemetry/HelloServer/Program.cs
@@ -39,5 +39,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/RequestContext/Server/Program.cs
+++ b/examples/RequestContext/Server/Program.cs
@@ -16,5 +16,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/Retry/Server/Program.cs
+++ b/examples/Retry/Server/Program.cs
@@ -27,5 +27,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/Secure/Server/Program.cs
+++ b/examples/Secure/Server/Program.cs
@@ -20,5 +20,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/examples/Stream/Server/Program.cs
+++ b/examples/Stream/Server/Program.cs
@@ -14,7 +14,7 @@ Console.CancelKeyPress += (sender, eventArgs) =>
 };
 
 // Start the server
-server.Listen();
+await server.ListenAsync();
 
 Console.WriteLine("Server is waiting for connections...");
 

--- a/examples/Upload/Server/Program.cs
+++ b/examples/Upload/Server/Program.cs
@@ -13,6 +13,6 @@ Console.CancelKeyPress += (sender, eventArgs) =>
 };
 
 Console.WriteLine("Server is waiting for connections...");
-server.Listen();
+await server.ListenAsync();
 
 await server.ShutdownComplete;

--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -14,12 +14,12 @@ internal class ColocServerTransport : IDuplexServerTransport
     private readonly ConcurrentDictionary<ServerAddress, ColocListener> _listeners;
 
     /// <inheritdoc/>
-    public IListener<IDuplexConnection> Listen(
+    public IListener<IDuplexConnection> CreateListener(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticatioinOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions)
     {
-        if (serverAuthenticatioinOptions is not null)
+        if (serverAuthenticationOptions is not null)
         {
             throw new NotSupportedException("cannot create secure Coloc server");
         }
@@ -29,12 +29,7 @@ internal class ColocServerTransport : IDuplexServerTransport
             throw new FormatException($"cannot create a Coloc listener for server address '{serverAddress}'");
         }
 
-        var listener = new ColocListener(serverAddress with { Transport = Name }, options);
-        if (!_listeners.TryAdd(listener.ServerAddress, listener))
-        {
-            throw new TransportException(TransportErrorCode.AddressInUse);
-        }
-        return listener;
+        return new ColocListener(_listeners, serverAddress with { Transport = Name }, options);
     }
 
     internal ColocServerTransport(ConcurrentDictionary<ServerAddress, ColocListener> listeners) =>

--- a/src/IceRpc.ProjectTemplates/Templates/Server/Program.cs
+++ b/src/IceRpc.ProjectTemplates/Templates/Server/Program.cs
@@ -10,5 +10,5 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     _ = server.ShutdownAsync();
 };
 
-server.Listen();
+await server.ListenAsync();
 await server.ShutdownComplete;

--- a/src/IceRpc/Internal/IProtocolListener.cs
+++ b/src/IceRpc/Internal/IProtocolListener.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using System.Net;
+
+namespace IceRpc.Internal;
+
+/// <summary>The base interface for protocol listeners.</summary>
+public interface IProtocolListener : IDisposable
+{
+    /// <summary>Gets the server address of this listener. That's the address a client would connect to.</summary>
+    ServerAddress ServerAddress { get; }
+
+    /// <summary>Accepts a new connection.</summary>
+    /// <returns>The accepted connection and the network address of the client.</returns>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<(IProtocolConnection Connection, EndPoint RemoteNetworkAddress)> AcceptAsync(
+        CancellationToken cancellationToken);
+
+    /// <summary>Starts listening on the listener server address.</summary>
+    Task ListenAsync(CancellationToken cancellationToken);
+}

--- a/src/IceRpc/Internal/ProtocolListener.cs
+++ b/src/IceRpc/Internal/ProtocolListener.cs
@@ -5,9 +5,9 @@ using System.Net;
 
 namespace IceRpc.Internal;
 
-/// <summary>Implements <see cref="IListener{T}"/> for protocol connections.</summary>
+/// <summary>Implements <see cref="IProtocolListener"/> for protocol connections.</summary>
 /// <typeparam name="T">The transport connection type.</typeparam>
-internal abstract class ProtocolListener<T> : IListener<IProtocolConnection>
+internal abstract class ProtocolListener<T> : IProtocolListener
 {
     public ServerAddress ServerAddress => _transportListener.ServerAddress;
 
@@ -22,6 +22,8 @@ internal abstract class ProtocolListener<T> : IListener<IProtocolConnection>
     }
 
     public void Dispose() => _transportListener.Dispose();
+
+    public Task ListenAsync(CancellationToken cancellationToken) => _transportListener.ListenAsync(cancellationToken);
 
     internal ProtocolListener(IListener<T> transportListener) => _transportListener = transportListener;
 

--- a/src/IceRpc/Transports/IDuplexServerTransport.cs
+++ b/src/IceRpc/Transports/IDuplexServerTransport.cs
@@ -13,12 +13,12 @@ public interface IDuplexServerTransport
     /// <summary>Gets the transport's name.</summary>
     string Name { get; }
 
-    /// <summary>Starts listening on a server address.</summary>
+    /// <summary>Creates a listener to listen on a server address.</summary>
     /// <param name="serverAddress">The server address of the listener.</param>
     /// <param name="options">The duplex connection options.</param>
     /// <param name="serverAuthenticationOptions">The SSL server authentication options.</param>
     /// <returns>The new listener.</returns>
-    IListener<IDuplexConnection> Listen(
+    IListener<IDuplexConnection> CreateListener(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions);

--- a/src/IceRpc/Transports/IListener.cs
+++ b/src/IceRpc/Transports/IListener.cs
@@ -9,6 +9,9 @@ public interface IListener : IDisposable
 {
     /// <summary>Gets the server address of this listener. That's the address a client would connect to.</summary>
     ServerAddress ServerAddress { get; }
+
+    /// <summary>Starts listening on the listener server address.</summary>
+    Task ListenAsync(CancellationToken cancellationToken);
 }
 
 /// <summary>A listener listens for connection requests from clients.</summary>

--- a/src/IceRpc/Transports/IMultiplexedServerTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedServerTransport.cs
@@ -13,12 +13,12 @@ public interface IMultiplexedServerTransport
     /// <summary>Gets the transport's name.</summary>
     string Name { get; }
 
-    /// <summary>Starts listening on a server address.</summary>
+    /// <summary>Creates a listener to listen on a server address.</summary>
     /// <param name="serverAddress">The server address of the listener.</param>
     /// <param name="options">The multiplexed connection options.</param>
     /// <param name="serverAuthenticationOptions">The SSL server authentication options.</param>
     /// <returns>The new listener.</returns>
-    IListener<IMultiplexedConnection> Listen(
+    IListener<IMultiplexedConnection> CreateListener(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions);

--- a/src/IceRpc/Transports/Internal/SlicListener.cs
+++ b/src/IceRpc/Transports/Internal/SlicListener.cs
@@ -21,6 +21,8 @@ internal class SlicListener : IListener<IMultiplexedConnection>
 
     public void Dispose() => _duplexListener.Dispose();
 
+    public Task ListenAsync(CancellationToken cancellationToken) => _duplexListener.ListenAsync(cancellationToken);
+
     internal SlicListener(
         IListener<IDuplexConnection> duplexListener,
         MultiplexedConnectionOptions options,

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -31,12 +31,12 @@ public class SlicServerTransport : IMultiplexedServerTransport
     }
 
     /// <inheritdoc/>
-    public IListener<IMultiplexedConnection> Listen(
+    public IListener<IMultiplexedConnection> CreateListener(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions) =>
         new SlicListener(
-            _duplexServerTransport.Listen(
+            _duplexServerTransport.CreateListener(
                 serverAddress,
                 new DuplexConnectionOptions
                 {

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -24,7 +24,7 @@ public class TcpServerTransport : IDuplexServerTransport
     public TcpServerTransport(TcpServerTransportOptions options) => _options = options;
 
     /// <inheritdoc/>
-    public IListener<IDuplexConnection> Listen(
+    public IListener<IDuplexConnection> CreateListener(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions)

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -25,6 +25,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -49,6 +50,7 @@ public abstract class MultiplexedTransportConformanceTests
         IMultiplexedConnection clientConnection =
             provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -106,6 +108,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -166,6 +169,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -211,6 +215,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -252,6 +257,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
         IMultiplexedStream stream = clientConnection.CreateStream(bidirectional: true);
@@ -279,6 +285,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
 
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
 
         await using var clientConnection = clientTransport.CreateConnection(
@@ -322,6 +329,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
 
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
         await using var clientConnection = clientTransport.CreateConnection(
             listener.ServerAddress,
@@ -355,6 +363,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -389,6 +398,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -422,6 +432,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -479,6 +490,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -574,6 +586,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -659,6 +672,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -694,6 +708,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -732,6 +747,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -828,6 +844,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -892,6 +909,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -933,6 +951,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -953,6 +972,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -977,6 +997,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -1001,6 +1022,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -1028,6 +1050,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -1054,6 +1077,7 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -1071,6 +1095,8 @@ public abstract class MultiplexedTransportConformanceTests
     public async Task Create_client_connection_with_unknown_server_address_parameter_fails_with_format_exception()
     {
         await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
 
         var serverAddress = new ServerAddress(new Uri("icerpc://foo?unknown-parameter=foo"));
@@ -1090,7 +1116,7 @@ public abstract class MultiplexedTransportConformanceTests
 
         // Act/Asserts
         Assert.Throws<FormatException>(
-            () => serverTransport.Listen(serverAddress, new MultiplexedConnectionOptions(), null));
+            () => serverTransport.CreateListener(serverAddress, new MultiplexedConnectionOptions(), null));
     }
 
     [Test]
@@ -1103,6 +1129,7 @@ public abstract class MultiplexedTransportConformanceTests
         var transport = provider.GetRequiredService<IMultiplexedClientTransport>().Name;
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
 
         // Act
         await using IMultiplexedConnection serverConnection =
@@ -1155,6 +1182,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
 
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
@@ -1179,6 +1207,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         await using IMultiplexedConnection serverConnection =
             await ConnectAndAcceptConnectionAsync(listener, clientConnection);
 
@@ -1201,6 +1230,8 @@ public abstract class MultiplexedTransportConformanceTests
         await using ServiceProvider provider = CreateServiceCollection()
             .AddMultiplexedTransportTest()
             .BuildServiceProvider(validateScopes: true);
+        IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
 
         // Act
@@ -1225,6 +1256,7 @@ public abstract class MultiplexedTransportConformanceTests
             .BuildServiceProvider(validateScopes: true);
         IMultiplexedConnection clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
         IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        await listener.ListenAsync(default);
 
         IMultiplexedConnection? serverConnection = null;
         Task acceptTask = AcceptAndCloseAsync();

--- a/tests/IceRpc.Deflate.Tests/OperationCompressTests.cs
+++ b/tests/IceRpc.Deflate.Tests/OperationCompressTests.cs
@@ -46,7 +46,7 @@ public class OperationGeneratedCodeTests
             .AddIceRpcProxy<IMyOperationsAProxy, MyOperationsAProxy>(new Uri("icerpc:/"))
             .BuildServiceProvider(validateScopes: true);
 
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync(default);
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
 
         // Act

--- a/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
@@ -52,7 +52,7 @@ public static class ServiceCollectionExtensions
             SslServerAuthenticationOptions? serverAuthenticationOptions =
                 provider.GetService<IOptions<SslServerAuthenticationOptions>>()?.Value;
             IDuplexServerTransport serverTransport = provider.GetRequiredService<IDuplexServerTransport>();
-            return serverTransport.Listen(
+            return serverTransport.CreateListener(
                 serverAddress,
                 connectionOptions ?? new DuplexConnectionOptions(),
                 serverAuthenticationOptions);

--- a/tests/IceRpc.Tests/ClientConnectionTests.cs
+++ b/tests/IceRpc.Tests/ClientConnectionTests.cs
@@ -30,7 +30,7 @@ public class ClientConnectionTests
             },
             multiplexedServerTransport: new SlicServerTransport(new TcpServerTransport()),
             duplexServerTransport: new TcpServerTransport());
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection = new ClientConnection(
             new ClientConnectionOptions() { ServerAddress = server.ServerAddress },
@@ -53,13 +53,13 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri("icerpc://127.0.0.1:0"));
-        server.Listen();
+        await server.ListenAsync();
         ServerAddress serverAddress = server.ServerAddress;
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
         await server.DisposeAsync();
         server = new Server(ServiceNotFoundDispatcher.Instance, serverAddress);
-        server.Listen();
+        await server.ListenAsync();
 
         // Act/Assert
         Assert.That(async () => await connection.ConnectAsync(), Throws.Nothing);
@@ -72,7 +72,7 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri("icerpc://127.0.0.1:0"));
-        server.Listen();
+        await server.ListenAsync();
         ServerAddress serverAddress = server.ServerAddress;
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
@@ -88,7 +88,7 @@ public class ClientConnectionTests
         await server.DisposeAsync();
 
         server = new Server(ServiceNotFoundDispatcher.Instance, serverAddress);
-        server.Listen();
+        await server.ListenAsync();
 
         // Act/Assert
         Assert.That(async () => await connection.ConnectAsync(), Throws.Nothing);
@@ -101,13 +101,13 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri($"{protocol.Name}://127.0.0.1:0"));
-        server.Listen();
+        await server.ListenAsync();
         ServerAddress serverAddress = server.ServerAddress;
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
         await server.DisposeAsync();
         server = new Server(ServiceNotFoundDispatcher.Instance, serverAddress);
-        server.Listen();
+        await server.ListenAsync();
 
         var request = new OutgoingRequest(new ServiceAddress(protocol));
 
@@ -149,7 +149,7 @@ public class ClientConnectionTests
         Server server = provider.GetRequiredService<Server>();
         ClientConnection connection = provider.GetRequiredService<ClientConnection>();
 
-        server.Listen();
+        await server.ListenAsync();
 
         // Assert
         Assert.That(
@@ -197,7 +197,7 @@ public class ClientConnectionTests
         Server server = provider.GetRequiredService<Server>();
         ClientConnection connection = provider.GetRequiredService<ClientConnection>();
 
-        server.Listen();
+        await server.ListenAsync();
 
         // Assert
         Assert.That(

--- a/tests/IceRpc.Tests/ConnectionCacheTests.cs
+++ b/tests/IceRpc.Tests/ConnectionCacheTests.cs
@@ -24,7 +24,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server1.Listen();
+        await server1.ListenAsync();
 
         await using var server2 = new Server(
             new ServerOptions
@@ -33,7 +33,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://bar")),
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server2.Listen();
+        await server2.ListenAsync();
 
         await using var cache = new ConnectionCache(
             new ConnectionCacheOptions { PreferExistingConnection = false },
@@ -77,7 +77,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server.Listen();
+        await server.ListenAsync();
 
         await using var cache = new ConnectionCache(
             new ConnectionCacheOptions(),
@@ -114,7 +114,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server1.Listen();
+        await server1.ListenAsync();
 
         await using var server2 = new Server(
             new ServerOptions
@@ -123,7 +123,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://bar"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server2.Listen();
+        await server2.ListenAsync();
 
         await using var cache = new ConnectionCache(
             new ConnectionCacheOptions(),
@@ -161,7 +161,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server1.Listen();
+        await server1.ListenAsync();
 
         await using var server2 = new Server(
             new ServerOptions()
@@ -170,7 +170,7 @@ public sealed class ConnectionCacheTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://bar"))
             },
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
-        server2.Listen();
+        await server2.ListenAsync();
 
         await using var cache = new ConnectionCache(
            new ConnectionCacheOptions(),

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -175,13 +175,13 @@ public sealed class IceProtocolConnectionTests
     public async Task Shutdown_non_connected_connection_disposes_underlying_transport_connection()
     {
         // Arrange
-        IListener<IDuplexConnection> transportListener = IDuplexServerTransport.Default.Listen(
+        IListener<IDuplexConnection> transportListener = IDuplexServerTransport.Default.CreateListener(
             new ServerAddress(new Uri("icerpc://127.0.0.1:0")),
             new DuplexConnectionOptions(),
             null);
 
-        using IListener<IProtocolConnection> listener =
-            new IceProtocolListener(new ConnectionOptions(), transportListener);
+        using IProtocolListener listener = new IceProtocolListener(new ConnectionOptions(), transportListener);
+        await listener.ListenAsync(default);
 
         IDuplexConnection clientTransport = IDuplexClientTransport.Default.CreateConnection(
             transportListener.ServerAddress,

--- a/tests/IceRpc.Tests/InvocationTests.cs
+++ b/tests/IceRpc.Tests/InvocationTests.cs
@@ -28,7 +28,7 @@ public class InvocationTests
                 Protocol.Ice)
             .BuildServiceProvider(validateScopes: true);
 
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         var request = new OutgoingRequest(new ServiceAddress(new Uri("ice:/test")));
         await provider.GetRequiredService<ClientConnection>().InvokeAsync(request);
@@ -67,7 +67,7 @@ public class InvocationTests
                 }))
             .BuildServiceProvider(validateScopes: true);
 
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/test")));
         await provider.GetRequiredService<ClientConnection>().InvokeAsync(request);
@@ -98,7 +98,7 @@ public class InvocationTests
                 }))
             .BuildServiceProvider(validateScopes: true);
 
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
         ClientConnection connection = provider.GetRequiredService<ClientConnection>();
 
         var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/test")));

--- a/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
@@ -179,7 +179,7 @@ internal class DuplexListenerDecorator : IListener<IDuplexConnection>
         IDuplexServerTransport serverTransport,
         IOptions<ServerOptions> serverOptions,
         IOptions<DuplexConnectionOptions> duplexConnectionOptions) =>
-        _listener = serverTransport.Listen(
+        _listener = serverTransport.CreateListener(
             serverOptions.Value.ServerAddress,
             duplexConnectionOptions.Value,
             serverOptions.Value.ServerAuthenticationOptions);
@@ -188,6 +188,8 @@ internal class DuplexListenerDecorator : IListener<IDuplexConnection>
         CancellationToken cancellationToken) => _listener.AcceptAsync(cancellationToken);
 
     public void Dispose() => _listener.Dispose();
+
+    public Task ListenAsync(CancellationToken cancellationToken) => _listener.ListenAsync(cancellationToken);
 }
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -204,7 +206,7 @@ internal class MultiplexedListenerDecorator : IListener<IMultiplexedConnection>
         IMultiplexedServerTransport serverTransport,
         IOptions<ServerOptions> serverOptions,
         IOptions<MultiplexedConnectionOptions> multiplexedConnectionOptions) =>
-        _listener = serverTransport.Listen(
+        _listener = serverTransport.CreateListener(
             serverOptions.Value.ServerAddress,
             multiplexedConnectionOptions.Value,
             serverOptions.Value.ServerAuthenticationOptions);
@@ -213,4 +215,6 @@ internal class MultiplexedListenerDecorator : IListener<IMultiplexedConnection>
         CancellationToken cancellationToken) => _listener.AcceptAsync(cancellationToken);
 
     public void Dispose() => _listener.Dispose();
+
+    public Task ListenAsync(CancellationToken cancellationToken) => _listener.ListenAsync(cancellationToken);
 }

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -9,18 +9,18 @@ namespace IceRpc.Tests;
 [Parallelizable(scope: ParallelScope.All)]
 public class ServerTests
 {
-    /// <summary>Verifies that calling <see cref="Server.Listen"/> more than once fails with
+    /// <summary>Verifies that calling <see cref="Server.ListenAsync"/> more than once fails with
     /// <see cref="InvalidOperationException"/> exception.</summary>
     [Test]
     public async Task Cannot_call_listen_twice()
     {
         await using var server = new Server(ServiceNotFoundDispatcher.Instance);
-        server.Listen();
+        await server.ListenAsync();
 
-        Assert.Throws<InvalidOperationException>(() => server.Listen());
+        Assert.ThrowsAsync<InvalidOperationException>(() => server.ListenAsync());
     }
 
-    /// <summary>Verifies that calling <see cref="Server.Listen"/> on a disposed server fails with
+    /// <summary>Verifies that calling <see cref="Server.ListenAsync"/> on a disposed server fails with
     /// <see cref="ObjectDisposedException"/>.</summary>
     [Test]
     public async Task Cannot_call_listen_on_a_disposed_server()
@@ -28,7 +28,7 @@ public class ServerTests
         var server = new Server(ServiceNotFoundDispatcher.Instance);
         await server.DisposeAsync();
 
-        Assert.Throws<ObjectDisposedException>(() => server.Listen());
+        Assert.ThrowsAsync<ObjectDisposedException>(() => server.ListenAsync());
     }
 
     /// <summary>Verifies that <see cref="Server.ShutdownComplete"/> task is completed after
@@ -70,7 +70,7 @@ public class ServerTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://127.0.0.1:0")),
             });
 
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection1 = new ClientConnection(
             new ClientConnectionOptions
@@ -102,7 +102,7 @@ public class ServerTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://127.0.0.1:0")),
             });
 
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection1 = new ClientConnection(
             new ClientConnectionOptions

--- a/tests/IceRpc.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Tests/ServiceAddressTests.cs
@@ -503,7 +503,7 @@ public class ServiceAddressTests
             .BuildServiceProvider(validateScopes: true);
 
         var proxy = new SendProxyTestProxy(provider.GetRequiredService<ClientConnection>());
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         await proxy.SendProxyAsync(proxy);
 
@@ -521,7 +521,7 @@ public class ServiceAddressTests
             .BuildServiceProvider(validateScopes: true);
 
         var proxy = new SendProxyTestProxy(provider.GetRequiredService<ClientConnection>());
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         await proxy.SendProxyAsync(proxy);
 
@@ -538,7 +538,7 @@ public class ServiceAddressTests
             .AddColocTest(new ReceiveProxyTest())
             .BuildServiceProvider(validateScopes: true);
 
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
         ClientConnection connection = provider.GetRequiredService<ClientConnection>();
         IInvoker invoker = new Pipeline().Into(connection);
         var proxy = new ReceiveProxyTestProxy(invoker);

--- a/tests/IceRpc.Tests/Slice/ExceptionTests.cs
+++ b/tests/IceRpc.Tests/Slice/ExceptionTests.cs
@@ -440,7 +440,7 @@ public sealed class ExceptionTests
                 ServerAddress = new ServerAddress(new Uri($"icerpc://{Guid.NewGuid()}/"))
             },
             multiplexedServerTransport: new SlicServerTransport(coloc.ServerTransport));
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection = new ClientConnection(
             new ClientConnectionOptions
@@ -472,7 +472,7 @@ public sealed class ExceptionTests
                 ServerAddress = new ServerAddress(new Uri($"icerpc://{Guid.NewGuid()}/"))
             },
             multiplexedServerTransport: new SlicServerTransport(coloc.ServerTransport));
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection = new ClientConnection(
             new ClientConnectionOptions

--- a/tests/IceRpc.Tests/Slice/NamespaceAttributeTests.cs
+++ b/tests/IceRpc.Tests/Slice/NamespaceAttributeTests.cs
@@ -28,7 +28,7 @@ public class NamespaceAttributeTests
             .BuildServiceProvider(validateScopes: true);
 
         INamespaceOperationsProxy proxy = provider.GetRequiredService<INamespaceOperationsProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         NamespaceAttribute.WithNamespace.N1.N2.S1 r =
             await proxy.Op1Async(new NamespaceAttribute.M1.M2.M3.S1(10));

--- a/tests/IceRpc.Tests/Slice/OperationTests.cs
+++ b/tests/IceRpc.Tests/Slice/OperationTests.cs
@@ -22,7 +22,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         Assert.That(async () => await proxy.OpWithoutParametersAndVoidReturnAsync(), Throws.Nothing);
     }
@@ -36,7 +36,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyDerivedOperationsAProxy proxy = provider.GetRequiredService<IMyDerivedOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         Assert.That(async () => await proxy.OpWithoutParametersAndVoidReturnAsync(), Throws.Nothing);
     }
@@ -50,7 +50,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         int r = await proxy.OpWithSingleParameterAndReturnValueAsync(10);
 
@@ -66,7 +66,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         (int r1, int r2) = await proxy.OpWithMultipleParametersAndReturnValuesAsync(10, 20);
 
@@ -84,7 +84,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         var data = new byte[] { 1, 2, 3 };
         var pipe = new Pipe();
@@ -113,7 +113,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         var r = await proxy.OpWithIntStreamArgumentAndReturnAsync(GetDataAsync());
@@ -150,7 +150,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         var r = await proxy.OpWithStringStreamArgumentAndReturnAsync(GetDataAsync());
@@ -187,7 +187,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         (int r1, IAsyncEnumerable<int> r2) =
@@ -227,7 +227,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         Assert.That(
@@ -248,7 +248,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         Assert.That(async () => await proxy.OpWithCsAttributeAsync(10), Throws.Nothing);
@@ -264,7 +264,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         var r = await proxy.OpWithSingleReturnValueAndEncodedResultAttributeAsync();
@@ -283,7 +283,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         // Act
         (int r1, int r2) = await proxy.OpWithMultipleReturnValuesAndEncodedResultAttributeAsync();
@@ -443,7 +443,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyTaggedOperationsProxy proxy = provider.GetRequiredService<IMyTaggedOperationsProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         await proxy.OpAsync(1, z: 10);
 
@@ -465,7 +465,7 @@ public class OperationTests
 
         IMyTaggedOperationsReadOnlyMemoryParamsProxy proxy =
             provider.GetRequiredService<IMyTaggedOperationsReadOnlyMemoryParamsProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         await proxy.OpAsync(new int[] { 1 }, z: new int[] { 10 });
 
@@ -484,7 +484,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         ServiceProxy receivedProxy = await proxy.OpWithProxyReturnValueAsync();
 
@@ -501,7 +501,7 @@ public class OperationTests
             .BuildServiceProvider(validateScopes: true);
 
         IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
         await proxy.OpWithProxyParameterAsync(ServiceProxy.FromPath("/hello"));
 
         Assert.That(service.ReceivedProxy, Is.Not.Null);
@@ -592,7 +592,7 @@ public class OperationTests
             int[]? p1,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new(p1);
-        
+
         public ValueTask OpWithProxyParameterAsync(
             ServiceProxy service,
             IFeatureCollection features,

--- a/tests/IceRpc.Tests/Slice/ProxyTests.cs
+++ b/tests/IceRpc.Tests/Slice/ProxyTests.cs
@@ -112,7 +112,7 @@ public class ProxyTests
             .BuildServiceProvider(validateScopes: true);
 
         var proxy = new MyBaseInterfaceProxy(provider.GetRequiredService<ClientConnection>());
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         MyDerivedInterfaceProxy? derived = await proxy.AsAsync<MyDerivedInterfaceProxy>();
 
@@ -127,7 +127,7 @@ public class ProxyTests
             .BuildServiceProvider(validateScopes: true);
 
         var proxy = new MyBaseInterfaceProxy(provider.GetRequiredService<ClientConnection>());
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         MyDerivedInterfaceProxy? derived = await proxy.AsAsync<MyDerivedInterfaceProxy>();
 

--- a/tests/IceRpc.Tests/Slice/TypeNameQualificationTests.cs
+++ b/tests/IceRpc.Tests/Slice/TypeNameQualificationTests.cs
@@ -22,7 +22,7 @@ public class TypeNameQualificationTests
             .BuildServiceProvider(validateScopes: true);
 
         ITypeNameQualificationOperationsProxy proxy = provider.GetRequiredService<ITypeNameQualificationOperationsProxy>();
-        provider.GetRequiredService<Server>().Listen();
+        await provider.GetRequiredService<Server>().ListenAsync();
 
         var r = await proxy.OpWithTypeNamesDefinedInMultipleModulesAsync(new Inner.S(10));
 

--- a/tests/IceRpc.Tests/Transports/ColocTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/ColocTransportTests.cs
@@ -14,11 +14,17 @@ public class ColocTransportTests
     {
         var colocTransport = new ColocTransport();
         var serverAddress = new ServerAddress(new Uri($"icerpc://{Guid.NewGuid()}"));
-        var listener = colocTransport.ServerTransport.Listen(serverAddress, new DuplexConnectionOptions(), null);
+
+        using var listener = colocTransport.ServerTransport.CreateListener(
+            serverAddress,
+            new DuplexConnectionOptions(),
+            serverAuthenticationOptions: null);
+        await listener.ListenAsync(default);
+
         var clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            clientAuthenticationOptions: null);
 
         var transportConnectionInformation = await clientConnection.ConnectAsync(default);
 

--- a/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
+++ b/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
@@ -25,6 +25,7 @@ public class DuplexConnectionReaderTests
             .BuildServiceProvider(validateScopes: true);
 
         var listener = provider.GetRequiredService<IListener<IDuplexConnection>>();
+        await listener.ListenAsync(default);
         var clientConnection = provider.GetRequiredService<IDuplexConnection>();
         Task<(IDuplexConnection Connection, EndPoint RemoteNetworkAddress)> acceptTask = listener.AcceptAsync(default);
         Task<TransportConnectionInformation> clientConnectTask = clientConnection.ConnectAsync(default);
@@ -65,6 +66,7 @@ public class DuplexConnectionReaderTests
             .BuildServiceProvider(validateScopes: true);
 
         var listener = provider.GetRequiredService<IListener<IDuplexConnection>>();
+        await listener.ListenAsync(default);
         var clientConnection = provider.GetRequiredService<IDuplexConnection>();
         Task<(IDuplexConnection Connection, EndPoint RemoteNetworkAddress)> acceptTask = listener.AcceptAsync(default);
         Task<TransportConnectionInformation> clientConnectTask = clientConnection.ConnectAsync(default);
@@ -99,6 +101,7 @@ public class DuplexConnectionReaderTests
             .BuildServiceProvider(validateScopes: true);
 
         var listener = provider.GetRequiredService<IListener<IDuplexConnection>>();
+        await listener.ListenAsync(default);
         var clientConnection = provider.GetRequiredService<IDuplexConnection>();
         Task<(IDuplexConnection Connection, EndPoint RemoteNetworkAddress)> acceptTask = listener.AcceptAsync(default);
         Task<TransportConnectionInformation> clientConnectTask = clientConnection.ConnectAsync(default);

--- a/tests/IceRpc.Tests/Transports/SlicTransportConformanceTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportConformanceTests.cs
@@ -52,7 +52,7 @@ public class SlicOverTcpConformanceTests : SlicConformanceTests
             .AddSingleton(provider =>
             {
                 IMultiplexedServerTransport transport = provider.GetRequiredService<IMultiplexedServerTransport>();
-                return transport.Listen(
+                return transport.CreateListener(
                     new ServerAddress(Protocol.IceRpc) { Host = "127.0.0.1", Port = 0 },
                     provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
                     null);
@@ -70,7 +70,7 @@ public class SlicOverColocConformanceTests : SlicConformanceTests
         .AddSingleton(provider =>
         {
             IMultiplexedServerTransport transport = provider.GetRequiredService<IMultiplexedServerTransport>();
-            return transport.Listen(
+            return transport.CreateListener(
                 new ServerAddress(Protocol.IceRpc) { Host = "colochost" },
                 provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
                 null);

--- a/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
@@ -37,7 +37,7 @@ public static class SlicTransportServiceCollectionExtensions
         services.AddSingleton(provider =>
         {
             var serverTransport = provider.GetRequiredService<IMultiplexedServerTransport>();
-            var listener = serverTransport.Listen(
+            var listener = serverTransport.CreateListener(
                 serverAddress,
                 provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
                 null);

--- a/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
+++ b/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
@@ -29,6 +29,7 @@ public class TlsConfigurationTests
                 RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => false,
                 ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password"),
             });
+        await listener.ListenAsync(default);
 
         using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.ServerAddress,
@@ -76,6 +77,7 @@ public class TlsConfigurationTests
                     return true;
                 }
             });
+        await listener.ListenAsync(default);
 
         using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.ServerAddress,
@@ -127,6 +129,7 @@ public class TlsConfigurationTests
                     return true;
                 }
             });
+        await listener.ListenAsync(default);
 
         using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.ServerAddress,
@@ -168,6 +171,7 @@ public class TlsConfigurationTests
             {
                 ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password"),
             });
+        await listener.ListenAsync(default);
 
         using TcpClientConnection clientConnection = CreateTcpClientConnection(
             listener.ServerAddress,
@@ -192,7 +196,7 @@ public class TlsConfigurationTests
         SslServerAuthenticationOptions? authenticationOptions = null)
     {
         IDuplexServerTransport serverTransport = new TcpServerTransport(options ?? new());
-        return serverTransport.Listen(
+        return serverTransport.CreateListener(
             serverAddress ?? new ServerAddress(Protocol.IceRpc) { Host = "::1", Port = 0 },
             new DuplexConnectionOptions(),
             authenticationOptions);

--- a/tests/IntegrationTests/CustomTransportTests.cs
+++ b/tests/IntegrationTests/CustomTransportTests.cs
@@ -48,7 +48,7 @@ public class CustomServerTransport : IMultiplexedServerTransport
     private readonly IMultiplexedServerTransport _transport =
         new SlicServerTransport(new TcpServerTransport());
 
-    public IListener<IMultiplexedConnection> Listen(
+    public IListener<IMultiplexedConnection> CreateListener(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions)
@@ -64,7 +64,7 @@ public class CustomServerTransport : IMultiplexedServerTransport
             Transport = "tcp"
         };
 
-        return _transport.Listen(serverAddress, options, serverAuthenticationOptions);
+        return _transport.CreateListener(serverAddress, options, serverAuthenticationOptions);
     }
 }
 
@@ -84,7 +84,7 @@ public class CustomTransportTests
             },
             multiplexedServerTransport: new CustomServerTransport());
 
-        server.Listen();
+        await server.ListenAsync();
 
         await using var connection = new ClientConnection(
             new ClientConnectionOptions
@@ -111,7 +111,7 @@ public class CustomTransportTests
                 }
             },
                 multiplexedServerTransport: new CustomServerTransport());
-            server.Listen();
+            await server.ListenAsync();
 
             await using var connection1 = new ClientConnection(
                 new ClientConnectionOptions

--- a/tests/IntegrationTests/ProtocolBridgingTests.cs
+++ b/tests/IntegrationTests/ProtocolBridgingTests.cs
@@ -66,7 +66,7 @@ public sealed class ProtocolBridgingTests
 
         foreach (Server server in serviceProvider.GetServices<Server>())
         {
-            server.Listen();
+            await server.ListenAsync();
         }
 
         // TODO: test with the other encoding; currently, the encoding is always slice2

--- a/tests/IntegrationTests/ServiceTests.cs
+++ b/tests/IntegrationTests/ServiceTests.cs
@@ -20,7 +20,7 @@ public class ServiceTests
             .BuildServiceProvider(validateScopes: true);
         IServiceProxy proxy = provider.GetRequiredService<IServiceProxy>();
         Server server = provider.GetRequiredService<Server>();
-        server.Listen();
+        await server.ListenAsync();
 
         string[] ids = new string[]
         {


### PR DESCRIPTION
This is draft PR to refactor the listener interfaces to support an asynchronous `ListenAsync` operation. Some tests still need fixing and I didn't closely review the documentation. I will if you're OK with this refactoring.

I think it's cleaner to split the listener creation and the listen operation. 