### PR TITLE
Fix is null / is not null

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -360,7 +360,7 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
             {
                 await stream.Input.CompleteAsync(exception).ConfigureAwait(false);
             }
-            if (_dispatchesAndInvocationsCanceledException != null)
+            if (_dispatchesAndInvocationsCanceledException is not null)
             {
                 throw ExceptionUtil.Throw(_dispatchesAndInvocationsCanceledException);
             }
@@ -400,7 +400,7 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
         catch (Exception exception)
         {
             await stream.Input.CompleteAsync(exception).ConfigureAwait(false);
-            if (_dispatchesAndInvocationsCanceledException != null)
+            if (_dispatchesAndInvocationsCanceledException is not null)
             {
                 throw ExceptionUtil.Throw(_dispatchesAndInvocationsCanceledException);
             }

--- a/src/IceRpc/Slice/Internal/StreamDecoder.cs
+++ b/src/IceRpc/Slice/Internal/StreamDecoder.cs
@@ -126,9 +126,9 @@ internal class StreamDecoder<T>
                     {
                         // We will never get more items
                         _readerState = ReaderState.Completed;
-                        if (_exception != null)
+                        if (_exception is not null)
                         {
-                            ExceptionUtil.Throw(_exception);
+                            throw ExceptionUtil.Throw(_exception);
                         }
                         yield break;
                     }
@@ -147,9 +147,9 @@ internal class StreamDecoder<T>
 
             lock (_mutex)
             {
-                if (_exception != null)
+                if (_exception is not null)
                 {
-                    ExceptionUtil.Throw(_exception);
+                    throw ExceptionUtil.Throw(_exception);
                 }
 
                 if (_readerState == ReaderState.Completed)

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -684,7 +684,7 @@ public sealed class IceRpcProtocolConnectionTests
             MultiplexedConnectionOptions options,
             SslClientAuthenticationOptions? clientAuthenticationOptions)
         {
-            Debug.Assert(_connection == null);
+            Debug.Assert(_connection is null);
             _connection = new HoldMultiplexedConnection(
                 _decoratee.CreateConnection(serverAddress, options, clientAuthenticationOptions));
             return _connection;
@@ -706,7 +706,7 @@ public sealed class IceRpcProtocolConnectionTests
 
         public async Task<(IMultiplexedConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
         {
-            Debug.Assert(_connection == null);
+            Debug.Assert(_connection is null);
             (IMultiplexedConnection connection, EndPoint address) = await _decoratee.AcceptAsync(cancellationToken);
             _connection = new HoldMultiplexedConnection(connection!);
             return (_connection, address);


### PR DESCRIPTION
This PR fixes a number of "is null" / "is not null".

Note that "is null" does not appear to work with value types such as Span. For them, we need to keep `!= null` (or == null).