### PR TITLE
Added missing space for self-closing xml documentation tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,29 +1,26 @@
 {
-    "cSpell.words": [
-        "_decoratee",
-        "coloc",
-        "colocated",
-        "cref",
-        "decoratee",
-        "icerpc",
-        "inheritdoc",
-        "langword",
-        "Nonmutating",
-        "Parallelizable",
-        "paramref",
-        "seealso",
-        "Slic",
-        "slicec",
-        "struct",
-        "typeparam",
-        "varint",
-        "varuint",
-        "zeroc"
-    ],
-    "rust-analyzer.linkedProjects": [
-        "tools/slicec-cs/Cargo.toml"
-    ],
-    "rust-analyzer.rustfmt.extraArgs": [
-        "+nightly"
-    ],
+  "cSpell.words": [
+    "_decoratee",
+    "coloc",
+    "colocated",
+    "cref",
+    "decoratee",
+    "icerpc",
+    "inheritdoc",
+    "langword",
+    "Nonmutating",
+    "Parallelizable",
+    "paramref",
+    "Quic",
+    "seealso",
+    "Slic",
+    "slicec",
+    "struct",
+    "typeparam",
+    "varint",
+    "varuint",
+    "zeroc"
+  ],
+  "rust-analyzer.linkedProjects": ["tools/slicec-cs/Cargo.toml"],
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
 }

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -12,9 +12,9 @@
                 TaskFactory="CodeTaskFactory"
                 AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
         <ParameterGroup>
-            <WorkingDirectory ParameterType="System.String" Required="true"/>
-            <AdditionalOptions ParameterType="System.String" Required="true"/>
-            <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="True"/>
+            <WorkingDirectory ParameterType="System.String" Required="true" />
+            <AdditionalOptions ParameterType="System.String" Required="true" />
+            <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="True" />
         </ParameterGroup>
         <Task>
             <Code Type="Class" Language="cs" Source="$(MSBuildThisFileDirectory)/SignTask.cs" />
@@ -45,17 +45,17 @@
     <SignTask
         WorkingDirectory="$(IntermediateOutputPath)"
         AdditionalOptions="$(SignCommandSHA1)"
-        Files="$(TargetName)$(TargetExt)"/>
+        Files="$(TargetName)$(TargetExt)" />
 
     <SignTask
         WorkingDirectory="$(IntermediateOutputPath)"
         AdditionalOptions="$(SignCommandSHA256)"
-        Files="$(TargetName)$(TargetExt)"/>
+        Files="$(TargetName)$(TargetExt)" />
 
     <WriteLinesToFile File                = "$(IntermediateOutputPath)sign.log"
                       Encoding            = "Unicode"
                       Overwrite           = "true"
-                      Lines               = "Signing $(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
+                      Lines               = "Signing $(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
   </Target>
 
   <Target Name="SignPackageClean" AfterTargets="Clean" Condition="'$(OS)' == 'Windows_NT' ">

--- a/build/test.props
+++ b/build/test.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSbuildThisFileDirectory)common.props"/>
+  <Import Project="$(MSbuildThisFileDirectory)common.props" />
   <PropertyGroup>
     <OutputPath>.</OutputPath>
     <!-- Missing XML comment for publicly visible type or member, we disable this warning because we don't care about

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,9 +8,9 @@
         <IsSrcProject Condition="$(MSBuildProjectDirectory.StartsWith('$(SrcDirectory)')) AND '$(IsTemplateProject)' != 'true'">true</IsSrcProject>
         <IsUnitTestProject Condition="'$(IsUnitTestProject)' == ''">false</IsUnitTestProject>
     </PropertyGroup>
-    <Import Project="$(MSBuildThisFileDirectory)../build/icerpc.props" Condition="'$(IsSrcProject)' == 'true'"/>
-    <Import Project="$(MSBuildThisFileDirectory)../build/icerpc.version.props" Condition="'$(IsTemplateProject)' == 'true'"/>
-    <Import Project="$(MSBuildThisFileDirectory)../build/test.props" Condition="'$(IsUnitTestProject)' == 'true'"/>
+    <Import Project="$(MSBuildThisFileDirectory)../build/icerpc.props" Condition="'$(IsSrcProject)' == 'true'" />
+    <Import Project="$(MSBuildThisFileDirectory)../build/icerpc.version.props" Condition="'$(IsTemplateProject)' == 'true'" />
+    <Import Project="$(MSBuildThisFileDirectory)../build/test.props" Condition="'$(IsUnitTestProject)' == 'true'" />
     <PropertyGroup>
         <!-- Include PDB in the built .nupkg -->
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -18,7 +18,7 @@
     <ItemGroup>
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)../build/stylecop.json" Link="stylecop.json" />
         <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.base.globalconfig" />
-        <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.src.globalconfig" Condition="'$(IsSrcProject)' == 'true'"/>
-        <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.tests.globalconfig" Condition="'$(IsUnitTestProject)' == 'true'"/>
+        <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.src.globalconfig" Condition="'$(IsSrcProject)' == 'true'" />
+        <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.tests.globalconfig" Condition="'$(IsUnitTestProject)' == 'true'" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildThisFileDirectory)../build/sign.targets"/>
+    <Import Project="$(MSBuildThisFileDirectory)../build/sign.targets" />
 </Project>

--- a/src/IceRpc.Coloc/Transports/ColocTransport.cs
+++ b/src/IceRpc.Coloc/Transports/ColocTransport.cs
@@ -18,7 +18,7 @@ public sealed class ColocTransport
     /// <summary>Gets the colocated server transport.</summary>
     public IDuplexServerTransport ServerTransport { get; }
 
-    /// <summary>Constructs a <see cref="ColocTransport"/>.</summary>
+    /// <summary>Constructs a <see cref="ColocTransport" />.</summary>
     public ColocTransport()
     {
         var listeners = new ConcurrentDictionary<ServerAddress, ColocListener>();

--- a/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
@@ -6,7 +6,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports.Internal;
 
-/// <summary>Implements <see cref="IDuplexClientTransport"/> for the coloc transport.</summary>
+/// <summary>Implements <see cref="IDuplexClientTransport" /> for the coloc transport.</summary>
 internal class ColocClientTransport : IDuplexClientTransport
 {
     /// <inheritdoc/>

--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -5,7 +5,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports.Internal;
 
-/// <summary>Implements <see cref="IDuplexServerTransport"/> for the coloc transport.</summary>
+/// <summary>Implements <see cref="IDuplexServerTransport" /> for the coloc transport.</summary>
 internal class ColocServerTransport : IDuplexServerTransport
 {
     /// <inheritdoc/>

--- a/src/IceRpc.Deadline/DeadlineDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Deadline/DeadlineDispatcherBuilderExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Deadline;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the deadline middleware to a <see cref="IDispatcherBuilder"/>.
-/// </summary>
+/// <summary>This class provides extension methods to add the deadline middleware to a
+/// <see cref="IDispatcherBuilder" />.</summary>
 public static class DeadlineDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="DeadlineMiddleware"/> to this dispatcher builder.</summary>
+    /// <summary>Adds a <see cref="DeadlineMiddleware" /> to this dispatcher builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IDispatcherBuilder UseDeadline(this IDispatcherBuilder builder) =>

--- a/src/IceRpc.Deadline/DeadlineFeature.cs
+++ b/src/IceRpc.Deadline/DeadlineFeature.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Deadline;
 
-/// <summary>The default implementation of <see cref="IDeadlineFeature"/>.</summary>
+/// <summary>The default implementation of <see cref="IDeadlineFeature" />.</summary>
 public sealed class DeadlineFeature : IDeadlineFeature
 {
     /// <summary>Creates a deadline from a timeout.</summary>

--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -6,7 +6,7 @@ namespace IceRpc.Deadline;
 
 /// <summary>The deadline interceptor adds a deadline to requests without a deadline feature and encodes the deadline
 /// field. When the deadline expires, the invocation is canceled and the interceptor throws
-/// <see cref="TimeoutException"/>. When used in conjunction with the retry interceptor it is important to install this
+/// <see cref="TimeoutException" />. When used in conjunction with the retry interceptor it is important to install this
 /// interceptor before the retry interceptor to ensure that the deadline is computed once per invocation and not once
 /// per each retry.</summary>
 public class DeadlineInterceptor : IInvoker

--- a/src/IceRpc.Deadline/DeadlineInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Deadline/DeadlineInvokerBuilderExtensions.cs
@@ -4,17 +4,17 @@ using IceRpc.Deadline;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the deadline interceptor to an <see cref="IInvokerBuilder"/>.
+/// <summary>This class provides extension methods to add the deadline interceptor to an <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class DeadlineInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="DeadlineInterceptor"/> with an infinite default timeout to the builder.</summary>
+    /// <summary>Adds a <see cref="DeadlineInterceptor" /> with an infinite default timeout to the builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseDeadline(this IInvokerBuilder builder) =>
         builder.UseDeadline(Timeout.InfiniteTimeSpan);
 
-    /// <summary>Adds a <see cref="DeadlineInterceptor"/> to the builder.</summary>
+    /// <summary>Adds a <see cref="DeadlineInterceptor" /> to the builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <param name="defaultTimeout">The default timeout.</param>
     /// <param name="alwaysEnforceDeadline">When <see langword="true" /> and the request carries a deadline, the

--- a/src/IceRpc.Deadline/DeadlineMiddleware.cs
+++ b/src/IceRpc.Deadline/DeadlineMiddleware.cs
@@ -6,8 +6,8 @@ using IceRpc.Slice;
 namespace IceRpc.Deadline;
 
 /// <summary>The deadline middleware decodes the deadline field into the deadline feature. When the deadline expires,
-/// the dispatch is canceled and the middleware throws <see cref="DispatchException"/> with the
-/// <see cref="DispatchErrorCode.DeadlineExpired"/> error code.</summary>
+/// the dispatch is canceled and the middleware throws <see cref="DispatchException" /> with the
+/// <see cref="DispatchErrorCode.DeadlineExpired" /> error code.</summary>
 public class DeadlineMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;

--- a/src/IceRpc.Deadline/DeadlinePipelineExtensions.cs
+++ b/src/IceRpc.Deadline/DeadlinePipelineExtensions.cs
@@ -4,16 +4,16 @@ using IceRpc.Deadline;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the deadline interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the deadline interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class DeadlinePipelineExtensions
 {
-    /// <summary>Adds a <see cref="DeadlineInterceptor"/> with an infinite default timeout to the pipeline.</summary>
+    /// <summary>Adds a <see cref="DeadlineInterceptor" /> with an infinite default timeout to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseDeadline(this Pipeline pipeline) => pipeline.UseDeadline(Timeout.InfiniteTimeSpan);
 
-    /// <summary>Adds a <see cref="DeadlineInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="DeadlineInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="defaultTimeout">The default timeout.</param>
     /// <param name="alwaysEnforceDeadline">When <see langword="true" /> and the request carries a deadline, the

--- a/src/IceRpc.Deadline/DeadlineRouterExtensions.cs
+++ b/src/IceRpc.Deadline/DeadlineRouterExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Deadline;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the deadline middleware to a <see cref="Router"/>.
+/// <summary>This class provides extension methods to add the deadline middleware to a <see cref="Router" />.
 /// </summary>
 public static class DeadlineRouterExtensions
 {
-    /// <summary>Adds a <see cref="DeadlineMiddleware"/> to the router.</summary>
+    /// <summary>Adds a <see cref="DeadlineMiddleware" /> to the router.</summary>
     /// <param name="router">The router being configured.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseDeadline(this Router router) => router.Use(next => new DeadlineMiddleware(next));

--- a/src/IceRpc.Deadline/IDeadlineFeature.cs
+++ b/src/IceRpc.Deadline/IDeadlineFeature.cs
@@ -8,6 +8,6 @@ namespace IceRpc.Deadline;
 /// deadline middleware.</summary>
 public interface IDeadlineFeature
 {
-    /// <summary>Gets the value of deadline. <see cref="DateTime.MaxValue"/> means no deadline.</summary>
+    /// <summary>Gets the value of deadline. <see cref="DateTime.MaxValue" /> means no deadline.</summary>
     DateTime Value { get; }
 }

--- a/src/IceRpc.Deflate/DeflateDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Deflate/DeflateDispatcherBuilderExtensions.cs
@@ -5,11 +5,11 @@ using System.IO.Compression;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the deflate middleware to a <see cref="IDispatcherBuilder"/>.
+/// <summary>This class provides extension methods to add the deflate middleware to a <see cref="IDispatcherBuilder" />.
 /// </summary>
 public static class DeflateDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="DeflateMiddleware"/> to this dispatcher builder.</summary>
+    /// <summary>Adds a <see cref="DeflateMiddleware" /> to this dispatcher builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <param name="compressionLevel">The compression level for the compress operation.</param>
     /// <returns>The builder being configured.</returns>

--- a/src/IceRpc.Deflate/DeflateInterceptor.cs
+++ b/src/IceRpc.Deflate/DeflateInterceptor.cs
@@ -9,7 +9,7 @@ using System.IO.Pipelines;
 namespace IceRpc.Deflate;
 
 /// <summary>An interceptor that applies the deflate compression algorithm to the payload of a request depending on
-/// the <see cref="ICompressFeature"/> feature.</summary>
+/// the <see cref="ICompressFeature" /> feature.</summary>
 public class DeflateInterceptor : IInvoker
 {
     private static readonly ReadOnlySequence<byte> _encodedCompressionFormatValue =

--- a/src/IceRpc.Deflate/DeflateInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Deflate/DeflateInvokerBuilderExtensions.cs
@@ -5,11 +5,11 @@ using System.IO.Compression;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the deflate interceptor to an <see cref="IInvokerBuilder"/>.
+/// <summary>This class provides extension methods to add the deflate interceptor to an <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class DeflateInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="DeflateInterceptor"/> to the builder.</summary>
+    /// <summary>Adds a <see cref="DeflateInterceptor" /> to the builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <param name="compressionLevel">The compression level for the compress operation.</param>
     /// <returns>The builder being configured.</returns>

--- a/src/IceRpc.Deflate/DeflateMiddleware.cs
+++ b/src/IceRpc.Deflate/DeflateMiddleware.cs
@@ -9,7 +9,7 @@ using System.IO.Pipelines;
 namespace IceRpc.Deflate;
 
 /// <summary>A middleware that applies the deflate compression algorithm to the payload of a response depending on
-/// the <see cref="ICompressFeature"/> feature.</summary>
+/// the <see cref="ICompressFeature" /> feature.</summary>
 public class DeflateMiddleware : IDispatcher
 {
     private static readonly ReadOnlySequence<byte> _encodedCompressionFormatValue =

--- a/src/IceRpc.Deflate/DeflatePipelineExtensions.cs
+++ b/src/IceRpc.Deflate/DeflatePipelineExtensions.cs
@@ -5,11 +5,11 @@ using System.IO.Compression;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the deflate interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the deflate interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class DeflatePipelineExtensions
 {
-    /// <summary>Adds a <see cref="DeflateInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="DeflateInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="compressionLevel">The compression level for the compress operation.</param>
     /// <returns>The pipeline being configured.</returns>

--- a/src/IceRpc.Deflate/DeflateRouterExtensions.cs
+++ b/src/IceRpc.Deflate/DeflateRouterExtensions.cs
@@ -5,11 +5,11 @@ using System.IO.Compression;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the deflate middleware to a <see cref="Router"/>.
+/// <summary>This class provides extension methods to add the deflate middleware to a <see cref="Router" />.
 /// </summary>
 public static class DeflateRouterExtensions
 {
-    /// <summary>Adds a <see cref="DeflateMiddleware"/> to the router.</summary>
+    /// <summary>Adds a <see cref="DeflateMiddleware" /> to the router.</summary>
     /// <param name="router">The router being configured.</param>
     /// <param name="compressionLevel">The compression level for the compress operation.</param>
     /// <returns>The router being configured.</returns>

--- a/src/IceRpc.Extensions.DependencyInjection/Builder/DispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/Builder/DispatcherBuilderExtensions.cs
@@ -6,12 +6,12 @@ using Microsoft.Extensions.Options;
 
 namespace IceRpc.Builder;
 
-/// <summary>Extension methods for <see cref="IDispatcherBuilder"/>.</summary>
+/// <summary>Extension methods for <see cref="IDispatcherBuilder" />.</summary>
 public static class DispatcherBuilderExtensions
 {
     /// <summary>Registers a middleware with one service dependency in its DispatchAsync method. Such a middleware
-    /// implements <see cref="IMiddleware{TDep}"/> and provides a single constructor that accepts a dispatcher (the next
-    /// dispatcher) followed by 0 or more DI-injected services.</summary>
+    /// implements <see cref="IMiddleware{TDep}" /> and provides a single constructor that accepts a dispatcher (the
+    /// next dispatcher) followed by 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TDep">The type of the service dependency.</typeparam>
     /// <param name="builder">This dispatcher builder.</param>
@@ -23,9 +23,9 @@ public static class DispatcherBuilderExtensions
             ActivatorUtilities.CreateInstance<TMiddleware>(builder.ServiceProvider, next)));
 
     /// <summary>Registers a middleware with an explicit Options parameter and with one service dependency in its
-    /// DispatchAsync method. Such a middleware implements <see cref="IMiddleware{TDep}"/> and provides a single
+    /// DispatchAsync method. Such a middleware implements <see cref="IMiddleware{TDep}" /> and provides a single
     /// constructor that accepts a dispatcher (the next dispatcher) followed by an instance of
-    /// <see cref="IOptions{TMiddlewareOptions}"/> and then 0 or more DI-injected services.</summary>
+    /// <see cref="IOptions{TMiddlewareOptions}" /> and then 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TMiddlewareOptions">The type of the Options parameter of this middleware.</typeparam>
     /// <typeparam name="TDep">The type of the service dependency.</typeparam>
@@ -42,7 +42,7 @@ public static class DispatcherBuilderExtensions
             ActivatorUtilities.CreateInstance<TMiddleware>(builder.ServiceProvider, next, Options.Create(options))));
 
     /// <summary>Registers a middleware with 2 service dependencies in its DispatchAsync method. Such a middleware
-    /// implements <see cref="IMiddleware{TDep1, TDep2}"/> and provides a single constructor that accepts a dispatcher
+    /// implements <see cref="IMiddleware{TDep1, TDep2}" /> and provides a single constructor that accepts a dispatcher
     /// (the next dispatcher) followed by 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TDep1">The type of the first service dependency.</typeparam>
@@ -57,9 +57,9 @@ public static class DispatcherBuilderExtensions
             ActivatorUtilities.CreateInstance<TMiddleware>(builder.ServiceProvider, next)));
 
     /// <summary>Registers a middleware with an Options parameter and with 2 service dependencies in its DispatchAsync
-    /// method. Such a middleware implements <see cref="IMiddleware{TDep1, TDep2}"/> and provides a single constructor
+    /// method. Such a middleware implements <see cref="IMiddleware{TDep1, TDep2}" /> and provides a single constructor
     /// that accepts a dispatcher (the next dispatcher) followed by an instance of
-    /// <see cref="IOptions{TMiddlewareOptions}"/> and then 0 or more DI-injected services.</summary>
+    /// <see cref="IOptions{TMiddlewareOptions}" /> and then 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TMiddlewareOptions">The type of Options parameter of this middleware.</typeparam>
     /// <typeparam name="TDep1">The type of the first service dependency.</typeparam>
@@ -78,7 +78,7 @@ public static class DispatcherBuilderExtensions
             ActivatorUtilities.CreateInstance<TMiddleware>(builder.ServiceProvider, next, Options.Create(options))));
 
     /// <summary>Registers a middleware with 3 service dependencies in its DispatchAsync method. Such a middleware
-    /// implements <see cref="IMiddleware{TDep1, TDep2, TDep3}"/> and provides a single constructor that accepts a
+    /// implements <see cref="IMiddleware{TDep1, TDep2, TDep3}" /> and provides a single constructor that accepts a
     /// dispatcher (the next dispatcher) followed by 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TDep1">The type of the first service dependency.</typeparam>
@@ -95,9 +95,9 @@ public static class DispatcherBuilderExtensions
             ActivatorUtilities.CreateInstance<TMiddleware>(builder.ServiceProvider, next)));
 
     /// <summary>Registers a middleware with an Options parameter and with 3 service dependencies in its DispatchAsync
-    /// method. Such a middleware implements <see cref="IMiddleware{TDep1, TDep2, TDep3}"/> and provides a single
+    /// method. Such a middleware implements <see cref="IMiddleware{TDep1, TDep2, TDep3}" /> and provides a single
     /// constructor that accepts a dispatcher (the next dispatcher) followed by an instance of
-    /// <see cref="IOptions{TMiddlewareOptions}"/> and then 0 or more DI-injected services.</summary>
+    /// <see cref="IOptions{TMiddlewareOptions}" /> and then 0 or more DI-injected services.</summary>
     /// <typeparam name="TMiddleware">The type of the middleware to register.</typeparam>
     /// <typeparam name="TMiddlewareOptions">The type of Options parameter of this middleware.</typeparam>
     /// <typeparam name="TDep1">The type of the first service dependency.</typeparam>

--- a/src/IceRpc.Extensions.DependencyInjection/Builder/Internal/DispatcherBuilder.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/Builder/Internal/DispatcherBuilder.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace IceRpc.Builder.Internal;
 
-/// <summary>Provides the default implementation of <see cref="IDispatcherBuilder"/>.</summary>
+/// <summary>Provides the default implementation of <see cref="IDispatcherBuilder" />.</summary>
 internal class DispatcherBuilder : IDispatcherBuilder
 {
     /// <inheritdoc/>

--- a/src/IceRpc.Extensions.DependencyInjection/Builder/Internal/InvokerBuilder.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/Builder/Internal/InvokerBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Builder.Internal;
 
-/// <summary>Provides the default implementation of <see cref="IInvokerBuilder"/>.</summary>
+/// <summary>Provides the default implementation of <see cref="IInvokerBuilder" />.</summary>
 internal class InvokerBuilder : IInvokerBuilder
 {
     /// <inheritdoc/>

--- a/src/IceRpc.Extensions.DependencyInjection/Features/ServiceProviderFeature.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/Features/ServiceProviderFeature.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Features;
 
-/// <summary>The default implementation of <see cref="IServiceProviderFeature"/>.</summary>
+/// <summary>The default implementation of <see cref="IServiceProviderFeature" />.</summary>
 public class ServiceProviderFeature : IServiceProviderFeature
 {
     /// <inheritdoc/>

--- a/src/IceRpc.Extensions.DependencyInjection/IceRpcServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/IceRpcServiceCollectionExtensions.cs
@@ -9,11 +9,11 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-/// <summary>Extension methods for setting up IceRpc services in an <see cref="IServiceCollection"/>.</summary>
+/// <summary>Extension methods for setting up IceRpc services in an <see cref="IServiceCollection" />.</summary>
 public static class IceRpcServiceCollectionExtensions
 {
-    /// <summary>Adds a <see cref="ClientConnection"/> and <see cref="IInvoker"/> singleton to this service collection.
-    /// </summary>
+    /// <summary>Adds a <see cref="ClientConnection" /> and <see cref="IInvoker" /> singleton to this service
+    /// collection.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddIceRpcClientConnection(this IServiceCollection services) =>
@@ -26,7 +26,7 @@ public static class IceRpcServiceCollectionExtensions
                     provider.GetRequiredService<IMultiplexedClientTransport>()))
             .AddSingleton<IInvoker>(provider => provider.GetRequiredService<ClientConnection>());
 
-    /// <summary>Adds a <see cref="ConnectionCache"/> and <see cref="IInvoker"/> singleton to this service collection.
+    /// <summary>Adds a <see cref="ConnectionCache" /> and <see cref="IInvoker" /> singleton to this service collection.
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The service collection.</returns>
@@ -40,7 +40,7 @@ public static class IceRpcServiceCollectionExtensions
                     provider.GetRequiredService<IMultiplexedClientTransport>()))
             .AddSingleton<IInvoker>(provider => provider.GetRequiredService<ConnectionCache>());
 
-    /// <summary>Adds an <see cref="IDispatcher"/> singleton to this service collection using a builder.</summary>
+    /// <summary>Adds an <see cref="IDispatcher" /> singleton to this service collection using a builder.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="configure">The action to configure the dispatcher builder.</param>
     /// <returns>The service collection.</returns>
@@ -55,7 +55,7 @@ public static class IceRpcServiceCollectionExtensions
                 return builder.Build();
             });
 
-    /// <summary>Adds an <see cref="IInvoker"/> singleton to this service collection using a builder.</summary>
+    /// <summary>Adds an <see cref="IInvoker" /> singleton to this service collection using a builder.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="configure">The action to configure the invoker builder.</param>
     /// <returns>The service collection.</returns>
@@ -70,7 +70,7 @@ public static class IceRpcServiceCollectionExtensions
                 return builder.Build();
             });
 
-    /// <summary>Adds a <see cref="Server"/> to this service collection.</summary>
+    /// <summary>Adds a <see cref="Server" /> to this service collection.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The name of the ServerOptions instance.</param>
     /// <returns>The service collection.</returns>
@@ -83,14 +83,14 @@ public static class IceRpcServiceCollectionExtensions
                     provider.GetRequiredService<IDuplexServerTransport>(),
                     provider.GetRequiredService<IMultiplexedServerTransport>()));
 
-    /// <summary>Adds a <see cref="Server"/> to this service collection. This method uses the default name ("") for the
+    /// <summary>Adds a <see cref="Server" /> to this service collection. This method uses the default name ("") for the
     /// ServerOptions instance.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddIceRpcServer(this IServiceCollection services) =>
         services.AddIceRpcServer(Options.Options.DefaultName);
 
-    /// <summary>Adds a <see cref="Server"/> with the specified dispatcher to this service collection.</summary>
+    /// <summary>Adds a <see cref="Server" /> with the specified dispatcher to this service collection.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The name of the ServerOptions instance.</param>
     /// <param name="dispatcher">The server dispatcher.</param>
@@ -105,7 +105,7 @@ public static class IceRpcServiceCollectionExtensions
         return services.AddIceRpcServer(optionsName);
     }
 
-    /// <summary>Adds a <see cref="Server"/> with the specified dispatcher to this service collection. This method uses
+    /// <summary>Adds a <see cref="Server" /> with the specified dispatcher to this service collection. This method uses
     /// the default name ("") for the ServerOptions instance.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="dispatcher">The server dispatcher.</param>
@@ -113,10 +113,10 @@ public static class IceRpcServiceCollectionExtensions
     public static IServiceCollection AddIceRpcServer(this IServiceCollection services, IDispatcher dispatcher) =>
         services.AddIceRpcServer(optionsName: Options.Options.DefaultName, dispatcher);
 
-    /// <summary>Adds a <see cref="Server"/> with the specified name to this service collection. </summary>
+    /// <summary>Adds a <see cref="Server" /> with the specified name to this service collection. </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The server name.</param>
-    /// <param name="configure">The action to configure the dispatcher using a <see cref="DispatcherBuilder"/>.</param>
+    /// <param name="configure">The action to configure the dispatcher using a <see cref="DispatcherBuilder" />.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddIceRpcServer(
         this IServiceCollection services,
@@ -138,10 +138,10 @@ public static class IceRpcServiceCollectionExtensions
                     provider.GetRequiredService<IMultiplexedServerTransport>());
             });
 
-    /// <summary>Adds a <see cref="Server"/> to this service collection. This method uses the default name ("") for the
+    /// <summary>Adds a <see cref="Server" /> to this service collection. This method uses the default name ("") for the
     /// ServerOptions instance.</summary>
     /// <param name="services">The service collection to add services to.</param>
-    /// <param name="configure">The action to configure the dispatcher using a <see cref="DispatcherBuilder"/>.</param>
+    /// <param name="configure">The action to configure the dispatcher using a <see cref="DispatcherBuilder" />.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddIceRpcServer(
         this IServiceCollection services,

--- a/src/IceRpc.Extensions.DependencyInjection/IceRpcSliceServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/IceRpcSliceServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ using IceRpc.Slice;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-/// <summary>Extension methods for setting up IceRpc.Slice services in an <see cref="IServiceCollection"/>.</summary>
+/// <summary>Extension methods for setting up IceRpc.Slice services in an <see cref="IServiceCollection" />.</summary>
 public static class IceRpcSliceServiceCollectionExtensions
 {
     /// <summary>Adds a proxy singleton to this service collection.</summary>

--- a/src/IceRpc.Locator/Internal/LocationResolver.cs
+++ b/src/IceRpc.Locator/Internal/LocationResolver.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Locator.Internal;
 
-/// <summary>An implementation of <see cref="ILocationResolver"/> without a cache.</summary>
+/// <summary>An implementation of <see cref="ILocationResolver" /> without a cache.</summary>
 internal class CacheLessLocationResolver : ILocationResolver
 {
     private readonly IServerAddressFinder _serverAddressFinder;
@@ -33,7 +33,7 @@ internal class CacheLessLocationResolver : ILocationResolver
     }
 }
 
-/// <summary>The main implementation of <see cref="ILocationResolver"/>, with a cache.</summary>
+/// <summary>The main implementation of <see cref="ILocationResolver" />, with a cache.</summary>
 internal class LocationResolver : ILocationResolver
 {
     private readonly bool _background;

--- a/src/IceRpc.Locator/Internal/LocatorEventSource.cs
+++ b/src/IceRpc.Locator/Internal/LocatorEventSource.cs
@@ -5,12 +5,13 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Locator.Internal;
 
-/// <summary>An <see cref="EventSource"/> implementation used to log locator events.</summary>
+/// <summary>An <see cref="EventSource" /> implementation used to log locator events.</summary>
 internal sealed class LocatorEventSource : EventSource
 {
     internal static readonly LocatorEventSource Log = new("IceRpc-Locator");
 
-    /// <summary>Creates a new instance of the <see cref="LocatorEventSource"/> class with the specified name.</summary>
+    /// <summary>Creates a new instance of the <see cref="LocatorEventSource" /> class with the specified name.
+    /// </summary>
     /// <param name="eventSourceName">The name to apply to the event source.</param>
     internal LocatorEventSource(string eventSourceName)
         : base(eventSourceName)

--- a/src/IceRpc.Locator/Internal/ServerAddressCache.cs
+++ b/src/IceRpc.Locator/Internal/ServerAddressCache.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Locator.Internal;
 
 /// <summary>A server address cache maintains a dictionary of location to server address(es), where the server
 /// addresses are held by a dummy service address. It also keeps track of the insertion time of each entry. It's
-/// consumed by <see cref="LocationResolver"/>.</summary>
+/// consumed by <see cref="LocationResolver" />.</summary>
 internal interface IServerAddressCache
 {
     void Remove(Location location);
@@ -17,7 +17,7 @@ internal interface IServerAddressCache
     bool TryGetValue(Location location, out (TimeSpan InsertionTime, ServiceAddress ServiceAddress) value);
 }
 
-/// <summary>The main implementation for <see cref="IServerAddressCache"/>.</summary>
+/// <summary>The main implementation for <see cref="IServerAddressCache" />.</summary>
 internal sealed class ServerAddressCache : IServerAddressCache
 {
     private readonly ConcurrentDictionary<Location, (TimeSpan InsertionTime, ServiceAddress ServiceAddress, LinkedListNode<Location> Node)> _cache;

--- a/src/IceRpc.Locator/Internal/ServerAddressFinder.cs
+++ b/src/IceRpc.Locator/Internal/ServerAddressFinder.cs
@@ -6,7 +6,7 @@ namespace IceRpc.Locator.Internal;
 
 /// <summary>A server address finder finds the server address(es) of a location. These server address(es) are carried
 /// by a dummy service address. When this dummy service address is not null, its ServerAddress property is guaranteed to
-/// be not null. Unlike <see cref="ILocationResolver"/>, a server address finder does not provide cache-related
+/// be not null. Unlike <see cref="ILocationResolver" />, a server address finder does not provide cache-related
 /// parameters and typically does not maintain a cache.</summary>
 internal interface IServerAddressFinder
 {

--- a/src/IceRpc.Locator/LocatorInterceptor.cs
+++ b/src/IceRpc.Locator/LocatorInterceptor.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace IceRpc.Locator;
 
 /// <summary>A locator interceptor intercepts ice requests that have no server address and attempts to assign a usable
-/// server address (and alt-server addresses) to such requests via the <see cref="IServerAddressFeature"/>. You would
+/// server address (and alt-server addresses) to such requests via the <see cref="IServerAddressFeature" />. You would
 /// usually install the retry interceptor before the locator interceptor in the invocation pipeline and use the
 /// connection cache invoker for the pipeline, with this setup the locator interceptor would be able to detect
 /// invocation retries and refreshes the server address when required, and the connection cache would take care of
@@ -20,7 +20,7 @@ public class LocatorInterceptor : IInvoker
 
     /// <summary>Constructs a locator interceptor.</summary>
     /// <param name="next">The next invoker in the invocation pipeline.</param>
-    /// <param name="locationResolver">The location resolver. It is usually a <see cref="LocatorLocationResolver"/>.
+    /// <param name="locationResolver">The location resolver. It is usually a <see cref="LocatorLocationResolver" />.
     /// </param>
     public LocatorInterceptor(IInvoker next, ILocationResolver locationResolver)
     {
@@ -153,7 +153,7 @@ public readonly record struct Location
 
 /// <summary>A location resolver resolves a location into one or more server addresses carried by a dummy service
 /// address, and optionally maintains a cache for these resolutions. It's the "brain" of
-/// <see cref="LocatorInterceptor"/>. The same location resolver can be shared by multiple locator interceptors.
+/// <see cref="LocatorInterceptor" />. The same location resolver can be shared by multiple locator interceptors.
 /// </summary>
 public interface ILocationResolver
 {
@@ -171,7 +171,7 @@ public interface ILocationResolver
         CancellationToken cancellationToken);
 }
 
-/// <summary>Implements <see cref="ILocationResolver"/> using a locator proxy.</summary>
+/// <summary>Implements <see cref="ILocationResolver" /> using a locator proxy.</summary>
 public class LocatorLocationResolver : ILocationResolver
 {
     private readonly ILocationResolver _locationResolver;

--- a/src/IceRpc.Locator/LocatorInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Locator/LocatorInvokerBuilderExtensions.cs
@@ -5,11 +5,11 @@ using IceRpc.Locator;
 namespace IceRpc.Builder;
 
 /// <summary>This class provides extension methods to install the locator interceptor in an
-/// <see cref="IInvokerBuilder"/>.</summary>
+/// <see cref="IInvokerBuilder" />.</summary>
 public static class LocatorInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="LocatorInterceptor"/> to the builder. This interceptor relies on the
-    /// <see cref="LocatorLocationResolver"/> service managed by the service provider.</summary>
+    /// <summary>Adds a <see cref="LocatorInterceptor" /> to the builder. This interceptor relies on the
+    /// <see cref="LocatorLocationResolver" /> service managed by the service provider.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseLocator(this IInvokerBuilder builder) =>

--- a/src/IceRpc.Locator/LocatorOptions.cs
+++ b/src/IceRpc.Locator/LocatorOptions.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Locator;
 
-/// <summary>An options class for configuring a <see cref="LocatorLocationResolver"/>.</summary>
+/// <summary>An options class for configuring a <see cref="LocatorLocationResolver" />.</summary>
 public sealed record class LocatorOptions
 {
     /// <summary>Gets or sets a value indicating whether or not the locator must enable background lookups.</summary>

--- a/src/IceRpc.Locator/LocatorPipelineExtensions.cs
+++ b/src/IceRpc.Locator/LocatorPipelineExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Locator;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to install the locator interceptor in a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to install the locator interceptor in a <see cref="Pipeline" />.
 /// </summary>
 public static class LocatorPipelineExtensions
 {
-    /// <summary>Adds a <see cref="LocatorInterceptor"/> to the pipeline, using the specified locator proxy.
+    /// <summary>Adds a <see cref="LocatorInterceptor" /> to the pipeline, using the specified locator proxy.
     /// </summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="locator">The locator proxy used for the resolutions.</param>
@@ -16,7 +16,7 @@ public static class LocatorPipelineExtensions
     public static Pipeline UseLocator(this Pipeline pipeline, ILocatorProxy locator) =>
         UseLocator(pipeline, new LocatorLocationResolver(locator, new LocatorOptions()));
 
-    /// <summary>Adds a <see cref="LocatorInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="LocatorInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="locatorLocationResolver">The locator-based location resolver instance.</param>
     /// <returns>The pipeline being configured.</returns>

--- a/src/IceRpc.Logger/LoggerDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Logger/LoggerDispatcherBuilderExtensions.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.Logging;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the logger middleware to a <see cref="IDispatcherBuilder"/>.
+/// <summary>This class provides extension methods to add the logger middleware to a <see cref="IDispatcherBuilder" />.
 /// </summary>
 public static class LoggerDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="LoggerMiddleware"/> to this dispatcher builder. This interceptor relies on the
-    /// <see cref="ILogger{T}"/> service managed by the service provider.</summary>
+    /// <summary>Adds a <see cref="LoggerMiddleware" /> to this dispatcher builder. This interceptor relies on the
+    /// <see cref="ILogger{T}" /> service managed by the service provider.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IDispatcherBuilder UseLogger(this IDispatcherBuilder builder) =>

--- a/src/IceRpc.Logger/LoggerInterceptor.cs
+++ b/src/IceRpc.Logger/LoggerInterceptor.cs
@@ -5,7 +5,7 @@ using System.Net;
 
 namespace IceRpc.Logger;
 
-/// <summary>An interceptor that logs invocations to an <see cref="ILogger"/>. When used in conjunction with the
+/// <summary>An interceptor that logs invocations to an <see cref="ILogger" />. When used in conjunction with the
 /// telemetry interceptor, install the logger interceptor after the telemetry interceptor; this way, the logger includes
 /// the scopes created by the telemetry activities.</summary>
 public class LoggerInterceptor : IInvoker

--- a/src/IceRpc.Logger/LoggerInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Logger/LoggerInvokerBuilderExtensions.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.Logging;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the logger interceptor to an <see cref="IInvokerBuilder"/>.
+/// <summary>This class provides extension methods to add the logger interceptor to an <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class LoggerInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="LoggerInterceptor"/> to the builder. This interceptor relies on the
-    /// <see cref="ILogger{T}"/> service managed by the service provider.</summary>
+    /// <summary>Adds a <see cref="LoggerInterceptor" /> to the builder. This interceptor relies on the
+    /// <see cref="ILogger{T}" /> service managed by the service provider.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseLogger(this IInvokerBuilder builder) =>

--- a/src/IceRpc.Logger/LoggerMiddleware.cs
+++ b/src/IceRpc.Logger/LoggerMiddleware.cs
@@ -6,7 +6,7 @@ using System.Net;
 
 namespace IceRpc.Logger;
 
-/// <summary>A middleware that logs request and response messages to an <see cref="ILogger"/>. When used in conjunction
+/// <summary>A middleware that logs request and response messages to an <see cref="ILogger" />. When used in conjunction
 /// with the telemetry middleware, install the logger middleware after the telemetry middleware, this way the logger
 /// includes the scopes created by the telemetry activities.</summary>
 public class LoggerMiddleware : IDispatcher

--- a/src/IceRpc.Logger/LoggerPipelineExtensions.cs
+++ b/src/IceRpc.Logger/LoggerPipelineExtensions.cs
@@ -5,21 +5,21 @@ using Microsoft.Extensions.Logging;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the logger interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the logger interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class LoggerPipelineExtensions
 {
-    /// <summary>Adds a <see cref="LoggerInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="LoggerInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <param name="logger">The logger to log to.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseLogger(this Pipeline pipeline, ILogger logger) =>
         pipeline.Use(next => new LoggerInterceptor(next, logger));
 
-    /// <summary>Adds a <see cref="LoggerInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="LoggerInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
-    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}"/> for
-    /// <see cref="LoggerInterceptor"/>.</param>
+    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}" /> for
+    /// <see cref="LoggerInterceptor" />.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseLogger(this Pipeline pipeline, ILoggerFactory loggerFactory) =>
         pipeline.UseLogger(loggerFactory.CreateLogger<LoggerInterceptor>());

--- a/src/IceRpc.Logger/LoggerRouterExtensions.cs
+++ b/src/IceRpc.Logger/LoggerRouterExtensions.cs
@@ -5,21 +5,21 @@ using Microsoft.Extensions.Logging;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the logger middleware to a <see cref="Router"/>.
+/// <summary>This class provides extension methods to add the logger middleware to a <see cref="Router" />.
 /// </summary>
 public static class LoggerRouterExtensions
 {
-    /// <summary>Adds a <see cref="LoggerMiddleware"/> to this router.</summary>
+    /// <summary>Adds a <see cref="LoggerMiddleware" /> to this router.</summary>
     /// <param name="router">The router being configured.</param>
     /// <param name="logger">The logger to log to.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseLogger(this Router router, ILogger logger) =>
         router.Use(next => new LoggerMiddleware(next, logger));
 
-    /// <summary>Adds a <see cref="LoggerMiddleware"/> to this router.</summary>
+    /// <summary>Adds a <see cref="LoggerMiddleware" /> to this router.</summary>
     /// <param name="router">The router being configured.</param>
-    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}"/> for
-    /// <see cref="LoggerMiddleware"/>.</param>
+    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}" /> for
+    /// <see cref="LoggerMiddleware" />.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseLogger(this Router router, ILoggerFactory loggerFactory) =>
        router.UseLogger(loggerFactory.CreateLogger<LoggerMiddleware>());

--- a/src/IceRpc.Metrics/Internal/DispatchEventSource.cs
+++ b/src/IceRpc.Metrics/Internal/DispatchEventSource.cs
@@ -6,10 +6,10 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Metrics.Internal;
 
-/// <summary>An <see cref="EventSource"/> implementation used to log request dispatch events.</summary>
+/// <summary>An <see cref="EventSource" /> implementation used to log request dispatch events.</summary>
 internal sealed class DispatchEventSource : EventSource
 {
-    /// <summary>The default <c>DispatchEventSource</c> used by <see cref="MetricsMiddleware"/>.
+    /// <summary>The default <c>DispatchEventSource</c> used by <see cref="MetricsMiddleware" />.
     /// </summary>
     internal static readonly DispatchEventSource Log = new("IceRpc-Dispatch");
     private static readonly double _ticksPerMillisecond = Stopwatch.Frequency / 1000d;
@@ -24,7 +24,7 @@ internal sealed class DispatchEventSource : EventSource
     private long _totalRequests;
     private readonly PollingCounter _totalRequestsCounter;
 
-    /// <summary>Creates a new instance of the <see cref="DispatchEventSource"/> class with the specified name.
+    /// <summary>Creates a new instance of the <see cref="DispatchEventSource" /> class with the specified name.
     /// </summary>
     /// <param name="eventSourceName">The name to apply to the event source. Must not be <c>null</c>.</param>
     internal DispatchEventSource(string eventSourceName)

--- a/src/IceRpc.Metrics/Internal/InvocationEventSource.cs
+++ b/src/IceRpc.Metrics/Internal/InvocationEventSource.cs
@@ -6,10 +6,10 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Metrics.Internal;
 
-/// <summary>An <see cref="EventSource"/> implementation used to log invocation dispatch events.</summary>
+/// <summary>An <see cref="EventSource" /> implementation used to log invocation dispatch events.</summary>
 internal sealed class InvocationEventSource : EventSource
 {
-    /// <summary>The default <c>InvocationEventSource</c> used by <see cref="MetricsInterceptor"/>.
+    /// <summary>The default <c>InvocationEventSource</c> used by <see cref="MetricsInterceptor" />.
     /// </summary>
     internal static readonly InvocationEventSource Log = new("IceRpc-Invocation");
     private static readonly double _ticksPerMillisecond = Stopwatch.Frequency / 1000d;
@@ -24,7 +24,7 @@ internal sealed class InvocationEventSource : EventSource
     private long _totalRequests;
     private readonly PollingCounter _totalRequestsCounter;
 
-    /// <summary>Creates a new instance of the <see cref="InvocationEventSource"/> class with the specified name.
+    /// <summary>Creates a new instance of the <see cref="InvocationEventSource" /> class with the specified name.
     /// </summary>
     /// <param name="eventSourceName">The name to apply to the event source. Must not be <c>null</c>.</param>
     internal InvocationEventSource(string eventSourceName)

--- a/src/IceRpc.Metrics/MetricsDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsDispatcherBuilderExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Metrics;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the metrics middleware to a <see cref="IDispatcherBuilder"/>.
+/// <summary>This class provides extension methods to add the metrics middleware to a <see cref="IDispatcherBuilder" />.
 /// </summary>
 public static class MetricsDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="MetricsMiddleware"/> to this dispatcher builder.</summary>
+    /// <summary>Adds a <see cref="MetricsMiddleware" /> to this dispatcher builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IDispatcherBuilder UseMetrics(this IDispatcherBuilder builder) =>

--- a/src/IceRpc.Metrics/MetricsInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsInvokerBuilderExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Metrics;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the metrics interceptor to an <see cref="IInvokerBuilder"/>.
+/// <summary>This class provides extension methods to add the metrics interceptor to an <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class MetricsInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="MetricsInterceptor"/> to the builder.</summary>
+    /// <summary>Adds a <see cref="MetricsInterceptor" /> to the builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseMetrics(this IInvokerBuilder builder) =>

--- a/src/IceRpc.Metrics/MetricsPipelineExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsPipelineExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Metrics;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the metrics interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the metrics interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class MetricsPipelineExtensions
 {
-    /// <summary>Adds a <see cref="MetricsInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="MetricsInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseMetrics(this Pipeline pipeline) =>

--- a/src/IceRpc.Metrics/MetricsRouterExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsRouterExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.Metrics;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the metrics middleware to a <see cref="Router"/>.
+/// <summary>This class provides extension methods to add the metrics middleware to a <see cref="Router" />.
 /// </summary>
 public static class MetricsRouterExtensions
 {
-    /// <summary>Adds a <see cref="MetricsMiddleware"/> to the router.</summary>
+    /// <summary>Adds a <see cref="MetricsMiddleware" /> to the router.</summary>
     /// <param name="router">The router being configured.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseMetrics(this Router router) =>

--- a/src/IceRpc.RequestContext/RequestContextDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextDispatcherBuilderExtensions.cs
@@ -5,10 +5,10 @@ using IceRpc.RequestContext;
 namespace IceRpc.Builder;
 
 /// <summary>This class provides extension methods to add the request context middleware to a
-/// <see cref="IDispatcherBuilder"/>.</summary>
+/// <see cref="IDispatcherBuilder" />.</summary>
 public static class RequestContextDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="RequestContextMiddleware"/> to this dispatcher builder.</summary>
+    /// <summary>Adds a <see cref="RequestContextMiddleware" /> to this dispatcher builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IDispatcherBuilder UseRequestContext(this IDispatcherBuilder builder) =>

--- a/src/IceRpc.RequestContext/RequestContextFeature.cs
+++ b/src/IceRpc.RequestContext/RequestContextFeature.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace IceRpc.RequestContext;
 
-/// <summary>The default implementation of <see cref="IRequestContextFeature"/>.</summary>
+/// <summary>The default implementation of <see cref="IRequestContextFeature" />.</summary>
 public sealed class RequestContextFeature : IRequestContextFeature
 {
     /// <inheritdoc/>

--- a/src/IceRpc.RequestContext/RequestContextInvokerBuilderExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextInvokerBuilderExtensions.cs
@@ -5,10 +5,10 @@ using IceRpc.RequestContext;
 namespace IceRpc.Builder;
 
 /// <summary>This class provides extension methods to add the request context interceptor to an
-/// <see cref="IInvokerBuilder"/>.</summary>
+/// <see cref="IInvokerBuilder" />.</summary>
 public static class RequestContextInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="RequestContextInterceptor"/> to the builder.</summary>
+    /// <summary>Adds a <see cref="RequestContextInterceptor" /> to the builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseRequestContext(this IInvokerBuilder builder) =>

--- a/src/IceRpc.RequestContext/RequestContextPipelineExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextPipelineExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.RequestContext;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the request context interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the request context interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class RequestContextPipelineExtensions
 {
-    /// <summary>Adds a <see cref="RequestContextInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="RequestContextInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseRequestContext(this Pipeline pipeline) =>

--- a/src/IceRpc.RequestContext/RequestContextRouterExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextRouterExtensions.cs
@@ -4,11 +4,11 @@ using IceRpc.RequestContext;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the request context middleware to a <see cref="Router"/>.
+/// <summary>This class provides extension methods to add the request context middleware to a <see cref="Router" />.
 /// </summary>
 public static class RequestContextRouterExtensions
 {
-    /// <summary>Adds a <see cref="RequestContextMiddleware"/> to the router.</summary>
+    /// <summary>Adds a <see cref="RequestContextMiddleware" /> to the router.</summary>
     /// <param name="router">The router being configured.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseRequestContext(this Router router) =>

--- a/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc.Retry/Internal/ResettablePipeReaderDecorator.cs
@@ -217,7 +217,7 @@ internal class ResettablePipeReaderDecorator : PipeReader
     }
 
     /// <summary>Resets this pipe reader.</summary>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IsResettable"/> is <see langword="false" />.
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IsResettable" /> is <see langword="false" />.
     /// </exception>
     internal void Reset()
     {

--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -21,7 +21,7 @@ public class RetryInterceptor : IInvoker
     /// <param name="next">The next invoker in the invocation pipeline.</param>
     /// <param name="options">The options to configure the retry interceptor.</param>
     /// <param name="logger">The logger.</param>
-    /// <see cref="RetryPolicy"/>
+    /// <see cref="RetryPolicy" />
     public RetryInterceptor(IInvoker next, RetryOptions options, ILogger logger)
     {
         _next = next;

--- a/src/IceRpc.Retry/RetryInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Retry/RetryInvokerBuilderExtensions.cs
@@ -5,20 +5,20 @@ using Microsoft.Extensions.Logging;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the retry interceptor to a <see cref="IInvokerBuilder"/>.
+/// <summary>This class provides extension methods to add the retry interceptor to a <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class RetryInvokerBuilderExtensions
 {
-    /// <summary>Adds a <see cref="RetryInterceptor"/> that uses the default <see cref="RetryOptions"/>.</summary>
+    /// <summary>Adds a <see cref="RetryInterceptor" /> that uses the default <see cref="RetryOptions" />.</summary>
     /// <param name="builder">The pipeline being configured.</param>
     /// <returns>The pipeline being configured.</returns>
     public static IInvokerBuilder UseRetry(this IInvokerBuilder builder) =>
         builder.UseRetry(new RetryOptions());
 
-    /// <summary>Adds a <see cref="RetryInterceptor"/> to the builder. This interceptor relies on the
-    /// <see cref="ILoggerFactory"/> service managed by the service provider.</summary>
+    /// <summary>Adds a <see cref="RetryInterceptor" /> to the builder. This interceptor relies on the
+    /// <see cref="ILoggerFactory" /> service managed by the service provider.</summary>
     /// <param name="builder">The builder being configured.</param>
-    /// <param name="options">The options to configure the <see cref="RetryInterceptor"/>.</param>
+    /// <param name="options">The options to configure the <see cref="RetryInterceptor" />.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseRetry(this IInvokerBuilder builder, RetryOptions options) =>
         builder.ServiceProvider.GetService(typeof(ILogger<RetryInterceptor>)) is ILogger logger ?

--- a/src/IceRpc.Retry/RetryOptions.cs
+++ b/src/IceRpc.Retry/RetryOptions.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Retry;
 
-/// <summary>Options class to configure <see cref="RetryInterceptor"/>.</summary>
+/// <summary>Options class to configure <see cref="RetryInterceptor" />.</summary>
 public sealed record class RetryOptions
 {
     /// <summary>Gets or sets the maximum number of attempts for retrying a request.</summary>

--- a/src/IceRpc.Retry/RetryPipelineExtensions.cs
+++ b/src/IceRpc.Retry/RetryPipelineExtensions.cs
@@ -6,29 +6,29 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IceRpc;
 
-/// <summary>This class provides extension methods to add the retry interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provides extension methods to add the retry interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class RetryPipelineExtensions
 {
-    /// <summary>Adds a <see cref="RetryInterceptor"/> that uses the default <see cref="RetryOptions"/> to the
+    /// <summary>Adds a <see cref="RetryInterceptor" /> that uses the default <see cref="RetryOptions" /> to the
     /// pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseRetry(this Pipeline pipeline) =>
         pipeline.UseRetry(new RetryOptions());
 
-    /// <summary>Adds a <see cref="RetryInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="RetryInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
-    /// <param name="options">The options to configure the <see cref="RetryInterceptor"/>.</param>
+    /// <param name="options">The options to configure the <see cref="RetryInterceptor" />.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options) =>
         pipeline.UseRetry(options, NullLoggerFactory.Instance);
 
-    /// <summary>Adds a <see cref="RetryInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds a <see cref="RetryInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
-    /// <param name="options">The options to configure the <see cref="RetryInterceptor"/>.</param>
-    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}"/> for
-    /// <see cref="RetryInterceptor"/>.</param>
+    /// <param name="options">The options to configure the <see cref="RetryInterceptor" />.</param>
+    /// <param name="loggerFactory">The logger factory used to create a <see cref="ILogger{TCategoryName}" /> for
+    /// <see cref="RetryInterceptor" />.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options, ILoggerFactory loggerFactory) =>
         pipeline.Use(next => new RetryInterceptor(next, options, loggerFactory.CreateLogger<RetryInterceptor>()));

--- a/src/IceRpc.Telemetry/TelemetryDispatcherBuilderExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryDispatcherBuilderExtensions.cs
@@ -5,11 +5,11 @@ using System.Diagnostics;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provides extension methods to add the telemetry middleware to a <see cref="IDispatcherBuilder"/>.
-/// </summary>
+/// <summary>This class provides extension methods to add the telemetry middleware to a
+/// <see cref="IDispatcherBuilder" />.</summary>
 public static class TelemetryDispatcherBuilderExtensions
 {
-    /// <summary>Adds a <see cref="TelemetryMiddleware"/> to the dispatcher builder.</summary>
+    /// <summary>Adds a <see cref="TelemetryMiddleware" /> to the dispatcher builder.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IDispatcherBuilder UseTelemetry(this IDispatcherBuilder builder) =>

--- a/src/IceRpc.Telemetry/TelemetryInterceptor.cs
+++ b/src/IceRpc.Telemetry/TelemetryInterceptor.cs
@@ -6,9 +6,9 @@ using System.Diagnostics;
 
 namespace IceRpc.Telemetry;
 
-/// <summary>An interceptor that starts an <see cref="Activity"/> per request, following OpenTelemetry conventions. The
-/// activity context is written in the request <see cref="RequestFieldKey.TraceContext"/> field and can be restored on
-/// the server-side by installing the <see cref="TelemetryMiddleware"/>. The activities are only created for requests
+/// <summary>An interceptor that starts an <see cref="Activity" /> per request, following OpenTelemetry conventions. The
+/// activity context is written in the request <see cref="RequestFieldKey.TraceContext" /> field and can be restored on
+/// the server-side by installing the <see cref="TelemetryMiddleware" />. The activities are only created for requests
 /// using the icerpc protocol.</summary>
 public class TelemetryInterceptor : IInvoker
 {
@@ -17,7 +17,7 @@ public class TelemetryInterceptor : IInvoker
 
     /// <summary>Constructs a telemetry interceptor.</summary>
     /// <param name="next">The next invoker in the invocation pipeline.</param>
-    /// <param name="activitySource">The <see cref="ActivitySource"/> used to start the request activity.</param>
+    /// <param name="activitySource">The <see cref="ActivitySource" /> used to start the request activity.</param>
     public TelemetryInterceptor(IInvoker next, ActivitySource activitySource)
     {
         _next = next;

--- a/src/IceRpc.Telemetry/TelemetryInvokerBuilderExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryInvokerBuilderExtensions.cs
@@ -5,12 +5,12 @@ using System.Diagnostics;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provide extension methods to add the telemetry interceptor to an <see cref="IInvokerBuilder"/>.
+/// <summary>This class provide extension methods to add the telemetry interceptor to an <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class TelemetryInvokerBuilderExtensions
 {
-    /// <summary>Adds the <see cref="TelemetryInterceptor"/> to the builder. This interceptor relies on the
-    /// <see cref="ActivitySource"/> service managed by the service provider.</summary>
+    /// <summary>Adds the <see cref="TelemetryInterceptor" /> to the builder. This interceptor relies on the
+    /// <see cref="ActivitySource" /> service managed by the service provider.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder being configured.</returns>
     public static IInvokerBuilder UseTelemetry(this IInvokerBuilder builder) =>

--- a/src/IceRpc.Telemetry/TelemetryMiddleware.cs
+++ b/src/IceRpc.Telemetry/TelemetryMiddleware.cs
@@ -6,11 +6,11 @@ using System.Diagnostics;
 
 namespace IceRpc.Telemetry;
 
-/// <summary>A middleware that starts an <see cref="Activity"/> per request, following OpenTelemetry conventions. The
-/// middleware restores the parent invocation activity from the request <see cref="RequestFieldKey.TraceContext"/>
+/// <summary>A middleware that starts an <see cref="Activity" /> per request, following OpenTelemetry conventions. The
+/// middleware restores the parent invocation activity from the request <see cref="RequestFieldKey.TraceContext" />
 /// field before starting the dispatch activity. The activities are only created for requests using the icerpc
 /// protocol.</summary>
-/// <seealso cref="TelemetryInterceptor"/>
+/// <seealso cref="TelemetryInterceptor" />
 public class TelemetryMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;
@@ -18,7 +18,7 @@ public class TelemetryMiddleware : IDispatcher
 
     /// <summary>Constructs a telemetry middleware.</summary>
     /// <param name="next">The next dispatcher in the dispatch pipeline.</param>
-    /// <param name="activitySource">The <see cref="ActivitySource"/> is used to start the request activity.</param>
+    /// <param name="activitySource">The <see cref="ActivitySource" /> is used to start the request activity.</param>
     public TelemetryMiddleware(IDispatcher next, ActivitySource activitySource)
     {
         _next = next;

--- a/src/IceRpc.Telemetry/TelemetryPipelineExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryPipelineExtensions.cs
@@ -5,13 +5,13 @@ using System.Diagnostics;
 
 namespace IceRpc;
 
-/// <summary>This class provide extension methods to add the telemetry interceptor to a <see cref="Pipeline"/>.
+/// <summary>This class provide extension methods to add the telemetry interceptor to a <see cref="Pipeline" />.
 /// </summary>
 public static class TelemetryPipelineExtensions
 {
-    /// <summary>Adds the <see cref="TelemetryInterceptor"/> to the pipeline.</summary>
+    /// <summary>Adds the <see cref="TelemetryInterceptor" /> to the pipeline.</summary>
     /// <param name="pipeline">The pipeline being configured.</param>
-    /// <param name="activitySource">If set to a non null object the <see cref="ActivitySource"/> is used to start the
+    /// <param name="activitySource">If set to a non null object the <see cref="ActivitySource" /> is used to start the
     /// request and response activities.</param>
     /// <returns>The pipeline being configured.</returns>
     public static Pipeline UseTelemetry(this Pipeline pipeline, ActivitySource activitySource) =>

--- a/src/IceRpc.Telemetry/TelemetryRouterExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryRouterExtensions.cs
@@ -5,13 +5,13 @@ using System.Diagnostics;
 
 namespace IceRpc;
 
-/// <summary>This class provide extension methods to add the telemetry middleware to a <see cref="Router"/>.
+/// <summary>This class provide extension methods to add the telemetry middleware to a <see cref="Router" />.
 /// </summary>
 public static class TelemetryRouterExtensions
 {
-    /// <summary>Adds a <see cref="TelemetryMiddleware"/> to the router.</summary>
+    /// <summary>Adds a <see cref="TelemetryMiddleware" /> to the router.</summary>
     /// <param name="router">The router being configured.</param>
-    /// <param name="activitySource">If set to a non null object the <see cref="ActivitySource"/> is used to start the
+    /// <param name="activitySource">If set to a non null object the <see cref="ActivitySource" /> is used to start the
     /// request and response activities.</param>
     /// <returns>The router being configured.</returns>
     public static Router UseTelemetry(this Router router, ActivitySource activitySource) =>

--- a/src/IceRpc/Builder/DispatcherBuilderExtensions.cs
+++ b/src/IceRpc/Builder/DispatcherBuilderExtensions.cs
@@ -5,11 +5,11 @@ using IceRpc.Slice;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provide extension methods to add built-in middleware to a <see cref="IDispatcherBuilder"/>.
+/// <summary>This class provide extension methods to add built-in middleware to a <see cref="IDispatcherBuilder" />.
 /// </summary>
 public static class DispatcherBuilderExtensions
 {
-    /// <summary>Adds a middleware that creates and inserts the <see cref="IDispatchInformationFeature"/> feature
+    /// <summary>Adds a middleware that creates and inserts the <see cref="IDispatchInformationFeature" /> feature
     /// in all requests.</summary>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>The builder.</returns>
@@ -36,7 +36,7 @@ public static class DispatcherBuilderExtensions
     /// <summary>Registers a route to a service that uses the service default path as the route path. If there is
     /// an existing route at the same path, it is replaced.</summary>
     /// <typeparam name="TService">The type of the DI service that will handle the requests. The implementation of this
-    /// service must implement <see cref="IDispatcher"/>.</typeparam>
+    /// service must implement <see cref="IDispatcher" />.</typeparam>
     /// <param name="builder">The builder being configured.</param>
     /// <returns>This builder.</returns>
     public static IDispatcherBuilder Map<TService>(this IDispatcherBuilder builder) where TService : notnull =>

--- a/src/IceRpc/Builder/IDispatcherBuilder.cs
+++ b/src/IceRpc/Builder/IDispatcherBuilder.cs
@@ -12,20 +12,20 @@ public interface IDispatcherBuilder
     /// <summary>Registers a route with a path. If there is an existing route at the same path, it is replaced.
     /// </summary>
     /// <typeparam name="TService">The type of the DI service that will handle the requests. The implementation of this
-    /// service must implement <see cref="IDispatcher"/>.</typeparam>
+    /// service must implement <see cref="IDispatcher" />.</typeparam>
     /// <param name="path">The path of this route. It must match exactly the path of the request. In particular, it
     /// must start with a <c>/</c>.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="path"/> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown if <paramref name="path" /> is not a valid path.</exception>
     /// <returns>This builder.</returns>
     IDispatcherBuilder Map<TService>(string path) where TService : notnull;
 
     /// <summary>Registers a route with a prefix. If there is an existing route at the same prefix, it is replaced.
     /// </summary>
     /// <typeparam name="TService">The type of the DI service that will handle the requests. The implementation of this
-    /// service must implement <see cref="IDispatcher"/>.</typeparam>
+    /// service must implement <see cref="IDispatcher" />.</typeparam>
     /// <param name="prefix">The prefix of this route. This prefix will be compared with the start of the path of
     /// the request.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix"/> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
     /// <returns>This builder.</returns>
     IDispatcherBuilder Mount<TService>(string prefix) where TService : notnull;
 

--- a/src/IceRpc/Builder/InvokerBuilderExtensions.cs
+++ b/src/IceRpc/Builder/InvokerBuilderExtensions.cs
@@ -4,7 +4,7 @@ using IceRpc.Features;
 
 namespace IceRpc.Builder;
 
-/// <summary>This class provide extension methods for interface <see cref="IInvokerBuilder"/>.
+/// <summary>This class provide extension methods for interface <see cref="IInvokerBuilder" />.
 /// </summary>
 public static class InvokerBuilderExtensions
 {

--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -14,7 +14,7 @@ namespace IceRpc;
 public sealed class ClientConnection : IInvoker, IAsyncDisposable
 {
     /// <summary>Gets the server address of this connection.</summary>
-    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport"/> property is always
+    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport" /> property is always
     /// non-null.</value>
     public ServerAddress ServerAddress => _connection.ServerAddress;
 
@@ -126,15 +126,16 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
 
     /// <summary>Establishes the connection.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A task that provides the <see cref="TransportConnectionInformation"/> of the transport connection, once
-    /// this connection is established. This task can also complete with one of the following exceptions:
+    /// <returns>A task that provides the <see cref="TransportConnectionInformation" /> of the transport connection,
+    /// once this connection is established. This task can also complete with one of the following exceptions:
     /// <list type="bullet">
-    /// <item><description><see cref="ConnectionException"/>if the connection establishment failed.</description></item>
-    /// <item><description><see cref="ObjectDisposedException"/>if this connection is disposed.</description></item>
-    /// <item><description><see cref="OperationCanceledException"/>if cancellation was requested through the
+    /// <item><description><see cref="ConnectionException" />if the connection establishment failed.</description>
+    /// </item>
+    /// <item><description><see cref="ObjectDisposedException" />if this connection is disposed.</description></item>
+    /// <item><description><see cref="OperationCanceledException" />if cancellation was requested through the
     /// cancellation token.</description></item>
-    /// <item><description><see cref="TimeoutException"/>if this connection attempt or a previous attempt exceeded
-    /// <see cref="ConnectionOptions.ConnectTimeout"/>.</description></item>
+    /// <item><description><see cref="TimeoutException" />if this connection attempt or a previous attempt exceeded
+    /// <see cref="ConnectionOptions.ConnectTimeout" />.</description></item>
     /// </list>
     /// </returns>
     /// <exception cref="ConnectionException">Thrown if the connection is closed.</exception>
@@ -336,11 +337,11 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
         }
     }
 
-    /// <summary>Provides a decorator for <see cref="IProtocolConnection"/> that ensures
-    /// <see cref="IInvoker.InvokeAsync"/> calls <see cref="IProtocolConnection.ConnectAsync"/> when the connection is
+    /// <summary>Provides a decorator for <see cref="IProtocolConnection" /> that ensures
+    /// <see cref="IInvoker.InvokeAsync" /> calls <see cref="IProtocolConnection.ConnectAsync" /> when the connection is
     /// not connected yet. This decorator also allows multiple and concurrent calls to
-    /// <see cref="IProtocolConnection.ConnectAsync"/>.</summary>
-    /// <seealso cref="ClientProtocolConnectionFactory.CreateConnection"/>
+    /// <see cref="IProtocolConnection.ConnectAsync" />.</summary>
+    /// <seealso cref="ClientProtocolConnectionFactory.CreateConnection" />
     private class ConnectProtocolConnectionDecorator : IProtocolConnection
     {
         public ServerAddress ServerAddress => _decoratee.ServerAddress;

--- a/src/IceRpc/ClientConnectionOptions.cs
+++ b/src/IceRpc/ClientConnectionOptions.cs
@@ -4,12 +4,12 @@ using System.Net.Security;
 
 namespace IceRpc;
 
-/// <summary>A property bag used to configure a <see cref="ClientConnection"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="ClientConnection" />.</summary>
 public sealed record class ClientConnectionOptions : ConnectionOptions
 {
     /// <summary>Gets or sets the SSL client authentication options.</summary>
     /// <value>The SSL client authentication options. When not null,
-    /// <see cref="ClientConnection.ConnectAsync(CancellationToken)"/> will either establish a secure connection or
+    /// <see cref="ClientConnection.ConnectAsync(CancellationToken)" /> will either establish a secure connection or
     /// fail.</value>
     public SslClientAuthenticationOptions? ClientAuthenticationOptions { get; set; }
 

--- a/src/IceRpc/ClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/ClientProtocolConnectionFactory.cs
@@ -6,7 +6,7 @@ using System.Net.Security;
 
 namespace IceRpc;
 
-/// <summary>The default implementation of <see cref="IClientProtocolConnectionFactory"/>.</summary>
+/// <summary>The default implementation of <see cref="IClientProtocolConnectionFactory" />.</summary>
 public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionFactory
 {
     private readonly SslClientAuthenticationOptions? _clientAuthenticationOptions;
@@ -20,9 +20,9 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
     /// <param name="connectionOptions">The connection options.</param>
     /// <param name="clientAuthenticationOptions">The client authentication options.</param>
     /// <param name="duplexClientTransport">The duplex client transport. Null is equivalent to
-    /// <see cref="IDuplexClientTransport.Default"/>.</param>
+    /// <see cref="IDuplexClientTransport.Default" />.</param>
     /// <param name="multiplexedClientTransport">The multiplexed client transport. Null is equivalent to
-    /// <see cref="IMultiplexedClientTransport.Default"/>.</param>
+    /// <see cref="IMultiplexedClientTransport.Default" />.</param>
     public ClientProtocolConnectionFactory(
         ConnectionOptions connectionOptions,
         SslClientAuthenticationOptions? clientAuthenticationOptions = null,
@@ -59,8 +59,8 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
     /// <param name="serverAddress">The address of the server.</param>
     /// <returns>The new protocol connection.</returns>
     /// <remarks>The protocol connection returned by this factory method is not connected. The caller must call
-    /// <see cref="IProtocolConnection.ConnectAsync"/> exactly once on this connection before calling
-    /// <see cref="IInvoker.InvokeAsync"/>.</remarks>
+    /// <see cref="IProtocolConnection.ConnectAsync" /> exactly once on this connection before calling
+    /// <see cref="IInvoker.InvokeAsync" />.</remarks>
     public IProtocolConnection CreateConnection(ServerAddress serverAddress) =>
         serverAddress.Protocol == Protocol.Ice ?
             new IceProtocolConnection(

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace IceRpc;
 
 /// <summary>A connection cache is an invoker that routes outgoing requests to connections it manages. This routing is
-/// based on the <see cref="IServerAddressFeature"/> and the server addresses of the service address carried by each
+/// based on the <see cref="IServerAddressFeature" /> and the server addresses of the service address carried by each
 /// outgoing request. The connection cache keeps at most one active connection per server address.</summary>
 public sealed class ConnectionCache : IInvoker, IAsyncDisposable
 {
@@ -83,20 +83,20 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     }
 
     /// <summary>Sends an outgoing request and returns the corresponding incoming response. If the request
-    /// <see cref="IServerAddressFeature"/> feature is not set, the cache sets it from the server addresses of the
+    /// <see cref="IServerAddressFeature" /> feature is not set, the cache sets it from the server addresses of the
     /// target service. It then looks for an active connection.
-    /// The <see cref="ConnectionCacheOptions.PreferExistingConnection"/> property influences how the cache selects this
-    /// active connection. If no active connection can be found, the cache creates a new connection to one of the server
-    /// address from the request <see cref="IServerAddressFeature"/> feature. If the connection establishment to
-    /// <see cref="IServerAddressFeature.ServerAddress"/> is unsuccessful, the cache will try to establish a connection
-    /// to one of the <see cref="IServerAddressFeature.AltServerAddresses"/> addresses. Each connection attempt rotates
+    /// The <see cref="ConnectionCacheOptions.PreferExistingConnection" /> property influences how the cache selects
+    /// this active connection. If no active connection can be found, the cache creates a new connection to one of the
+    /// server address from the request <see cref="IServerAddressFeature" /> feature. If the connection establishment to
+    /// <see cref="IServerAddressFeature.ServerAddress" /> is unsuccessful, the cache will try to establish a connection
+    /// to one of the <see cref="IServerAddressFeature.AltServerAddresses" /> addresses. Each connection attempt rotates
     /// the server addresses of the server address feature, the main server address corresponding to the last attempt
-    /// failure is appended at the end of <see cref="IServerAddressFeature.AltServerAddresses"/> and the first address
-    /// from <see cref="IServerAddressFeature.AltServerAddresses"/> replaces
-    /// <see cref="IServerAddressFeature.ServerAddress"/>.</summary>
+    /// failure is appended at the end of <see cref="IServerAddressFeature.AltServerAddresses" /> and the first address
+    /// from <see cref="IServerAddressFeature.AltServerAddresses" /> replaces
+    /// <see cref="IServerAddressFeature.ServerAddress" />.</summary>
     /// <param name="request">The outgoing request being sent.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The corresponding <see cref="IncomingResponse"/>.</returns>
+    /// <returns>The corresponding <see cref="IncomingResponse" />.</returns>
     public Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken)
     {
         if (request.Features.Get<IServerAddressFeature>() is not IServerAddressFeature serverAddressFeature)

--- a/src/IceRpc/ConnectionCacheOptions.cs
+++ b/src/IceRpc/ConnectionCacheOptions.cs
@@ -4,7 +4,7 @@ using System.Net.Security;
 
 namespace IceRpc;
 
-/// <summary>A property bag used to configure a <see cref="ConnectionCache"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="ConnectionCache" />.</summary>
 public record class ConnectionCacheOptions
 {
     /// <summary>Gets or sets the SSL client authentication options.</summary>

--- a/src/IceRpc/ConnectionException.cs
+++ b/src/IceRpc/ConnectionException.cs
@@ -4,7 +4,7 @@ using IceRpc.Transports;
 
 namespace IceRpc;
 
-/// <summary>The possible error codes carried by a <see cref="ConnectionException"/>. The error code specifies the
+/// <summary>The possible error codes carried by a <see cref="ConnectionException" />. The error code specifies the
 /// reason of the connection failure.</summary>
 public enum ConnectionErrorCode
 {
@@ -18,12 +18,12 @@ public enum ConnectionErrorCode
     OperationAborted,
 
     /// <summary>The connection establishment or shutdown failed because of a transport error. The <see
-    /// cref="Exception.InnerException"/> is set to the <see cref="TransportException"/> that caused the
+    /// cref="Exception.InnerException" /> is set to the <see cref="TransportException" /> that caused the
     /// error.</summary>
     TransportError,
 
     /// <summary>The connection establishment or shutdown failed because of an unspecified error. The <see
-    /// cref="Exception.InnerException"/> is set to the exception that caused the error.</summary>
+    /// cref="Exception.InnerException" /> is set to the exception that caused the error.</summary>
     Unspecified,
 }
 
@@ -33,20 +33,20 @@ public class ConnectionException : Exception
     /// <summary>Gets the connection error code.</summary>
     public ConnectionErrorCode ErrorCode { get; }
 
-    /// <summary>Constructs a new instance of the <see cref="ConnectionException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="ConnectionException" /> class with a specified error
     /// code.</summary>
     /// <param name="errorCode">The error code.</param>
     public ConnectionException(ConnectionErrorCode errorCode)
         : base($"{nameof(ConnectionException)} {{ ErrorCode = {errorCode} }}") => ErrorCode = errorCode;
 
-    /// <summary>Constructs a new instance of the <see cref="ConnectionException"/> class with a specified error code
+    /// <summary>Constructs a new instance of the <see cref="ConnectionException" /> class with a specified error code
     /// and message.</summary>
     /// <param name="errorCode">The error code.</param>
     /// <param name="message">The message.</param>
     public ConnectionException(ConnectionErrorCode errorCode, string message)
         : base(message) => ErrorCode = errorCode;
 
-    /// <summary>Constructs a new instance of the <see cref="ConnectionException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="ConnectionException" /> class with a specified error
     /// code and inner exception.</summary>
     /// <param name="errorCode">The error code.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -42,8 +42,8 @@ public record class ConnectionOptions
     /// limit is reached, the connection stops reading new requests off its underlying transport connection.</summary>
     /// <value>The maximum number of requests that a connection can dispatch concurrently. 0 means no maximum. The
     /// default value is 100 requests.</value>
-    /// <remarks>With the icerpc protocol, you may also need to set <see cref="MaxIceRpcBidirectionalStreams"/> and
-    /// <see cref="MaxIceRpcUnidirectionalStreams"/>. A typical two-way dispatch holds onto one bidirectional stream
+    /// <remarks>With the icerpc protocol, you may also need to set <see cref="MaxIceRpcBidirectionalStreams" /> and
+    /// <see cref="MaxIceRpcUnidirectionalStreams" />. A typical two-way dispatch holds onto one bidirectional stream
     /// while a typical oneway dispatch quickly releases its unidirectional stream and then executes without consuming
     /// any stream.</remarks>
     public int MaxDispatches
@@ -104,8 +104,8 @@ public record class ConnectionOptions
         set => _maxIceRpcHeaderSize = IceRpcCheckMaxHeaderSize(value);
     }
 
-    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool"/>.</summary>
-    /// <value>The minimum size of the segment requested from the <see cref="Pool"/>.</value>
+    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
+    /// <value>The minimum size of the segment requested from the <see cref="Pool" />.</value>
     public int MinSegmentSize
     {
         get => _minSegmentSize;
@@ -129,7 +129,7 @@ public record class ConnectionOptions
             throw new ArgumentException($"0 is not a valid value for {nameof(ShutdownTimeout)}", nameof(value));
     }
 
-    /// <summary>The default value for <see cref="MaxIceRpcHeaderSize"/>.</summary>
+    /// <summary>The default value for <see cref="MaxIceRpcHeaderSize" />.</summary>
     internal const int DefaultMaxIceRpcHeaderSize = 16_383;
 
     private const int IceMinFrameSize = 256;

--- a/src/IceRpc/Features/CompressFeature.cs
+++ b/src/IceRpc/Features/CompressFeature.cs
@@ -2,14 +2,14 @@
 
 namespace IceRpc.Features;
 
-/// <summary>The default implementation for <see cref="ICompressFeature"/>.</summary>
+/// <summary>The default implementation for <see cref="ICompressFeature" />.</summary>
 public sealed class CompressFeature : ICompressFeature
 {
-    /// <summary>Gets the <see cref="CompressFeature"/> instance that specifies that the payload of a request or
+    /// <summary>Gets the <see cref="CompressFeature" /> instance that specifies that the payload of a request or
     /// response must not be compressed.</summary>
     public static CompressFeature Compress { get; } = new CompressFeature(true);
 
-    /// <summary>Gets <see cref="CompressFeature"/> instance that specifies that the payload of a request or
+    /// <summary>Gets <see cref="CompressFeature" /> instance that specifies that the payload of a request or
     /// response must be compressed.</summary>
     public static CompressFeature DoNotCompress { get; } = new CompressFeature(false);
 

--- a/src/IceRpc/Features/DispatchInformationFeature.cs
+++ b/src/IceRpc/Features/DispatchInformationFeature.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Features;
 
-/// <summary>The default implementation of <see cref="IDispatchInformationFeature"/>.</summary>
+/// <summary>The default implementation of <see cref="IDispatchInformationFeature" />.</summary>
 public sealed class DispatchInformationFeature : IDispatchInformationFeature
 {
     /// <inheritdoc/>

--- a/src/IceRpc/Features/FeatureCollection.cs
+++ b/src/IceRpc/Features/FeatureCollection.cs
@@ -4,7 +4,7 @@ using System.Collections;
 
 namespace IceRpc.Features;
 
-/// <summary>The default read-write implementation of <see cref="IFeatureCollection"/>.</summary>
+/// <summary>The default read-write implementation of <see cref="IFeatureCollection" />.</summary>
 public class FeatureCollection : IFeatureCollection
 {
     /// <summary>Gets a shared empty read-only instance.</summary>

--- a/src/IceRpc/Features/FeatureCollectionExtensions.cs
+++ b/src/IceRpc/Features/FeatureCollectionExtensions.cs
@@ -4,7 +4,7 @@ using IceRpc.Features.Internal;
 
 namespace IceRpc.Features;
 
-/// <summary>Provides extension methods for <see cref="IFeatureCollection"/>.</summary>
+/// <summary>Provides extension methods for <see cref="IFeatureCollection" />.</summary>
 public static class FeatureCollectionExtensions
 {
     /// <summary>Creates a read-only collection decorator over this feature collection.</summary>

--- a/src/IceRpc/Features/IFeatureCollection.cs
+++ b/src/IceRpc/Features/IFeatureCollection.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Features;
 
-/// <summary>A collection of features carried by <see cref="IncomingRequest"/> or <see cref="OutgoingRequest"/>. It is
+/// <summary>A collection of features carried by <see cref="IncomingRequest" /> or <see cref="OutgoingRequest" />. It is
 /// similar but not identical to the IFeatureCollection in Microsoft.AspNetCore.Http.Features.</summary>
 public interface IFeatureCollection : IEnumerable<KeyValuePair<Type, object>>
 {

--- a/src/IceRpc/Features/IServerAddressFeature.cs
+++ b/src/IceRpc/Features/IServerAddressFeature.cs
@@ -8,11 +8,11 @@ namespace IceRpc.Features;
 /// </summary>
 public interface IServerAddressFeature
 {
-    /// <summary>Gets or sets the alternatives to <see cref="ServerAddress"/>. It is empty when ServerAddress is null.
+    /// <summary>Gets or sets the alternatives to <see cref="ServerAddress" />. It is empty when ServerAddress is null.
     /// </summary>
     ImmutableList<ServerAddress> AltServerAddresses { get; set; }
 
-    /// <summary>Gets or sets the list of <see cref="ServerAddress"/> that have been removed and will not be used for
+    /// <summary>Gets or sets the list of <see cref="ServerAddress" /> that have been removed and will not be used for
     /// the invocation.</summary>
     ImmutableList<ServerAddress> RemovedServerAddresses { get; set; }
 

--- a/src/IceRpc/Features/ServerAddressFeature.cs
+++ b/src/IceRpc/Features/ServerAddressFeature.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace IceRpc.Features;
 
-/// <summary>The default implementation of <see cref="IServerAddressFeature"/>.</summary>
+/// <summary>The default implementation of <see cref="IServerAddressFeature" />.</summary>
 public sealed class ServerAddressFeature : IServerAddressFeature
 {
     /// <inheritdoc/>

--- a/src/IceRpc/Features/ServerAddressFeatureExtensions.cs
+++ b/src/IceRpc/Features/ServerAddressFeatureExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Features;
 
-/// <summary>Extension methods for interface <see cref="IServerAddressFeature"/>.</summary>
+/// <summary>Extension methods for interface <see cref="IServerAddressFeature" />.</summary>
 public static class ServerAddressFeatureExtensions
 {
     /// <summary>Tries to remove a server address from this server address feature. The server address is added to the

--- a/src/IceRpc/FieldsExtensions.cs
+++ b/src/IceRpc/FieldsExtensions.cs
@@ -9,7 +9,7 @@ namespace IceRpc;
 public static class FieldsExtensions
 {
     /// <summary>Sets an entry in the outgoing fields dictionary and returns the fields dictionary. If
-    /// <paramref name="fields"/> is read-only, a copy is created, modified then returned.</summary>
+    /// <paramref name="fields" /> is read-only, a copy is created, modified then returned.</summary>
     /// <typeparam name="TKey">The type of the field key.</typeparam>
     /// <param name="fields">A fields dictionary.</param>
     /// <param name="key">The key of the entry to set.</param>
@@ -30,7 +30,7 @@ public static class FieldsExtensions
     }
 
     /// <summary>Sets an entry in the outgoing fields dictionary and returns the fields dictionary. If
-    /// <paramref name="fields"/> is read-only, a copy is created, modified then returned.</summary>
+    /// <paramref name="fields" /> is read-only, a copy is created, modified then returned.</summary>
     /// <typeparam name="TKey">The type of the field key.</typeparam>
     /// <param name="fields">A fields dictionary.</param>
     /// <param name="key">The key of the entry to set.</param>
@@ -50,7 +50,7 @@ public static class FieldsExtensions
     }
 
     /// <summary>Removes an entry in the fields dictionary and returns the fields dictionary. If
-    /// <paramref name="fields"/> is read-only and contains the value, a copy is created, modified then returned.
+    /// <paramref name="fields" /> is read-only and contains the value, a copy is created, modified then returned.
     /// </summary>
     /// <typeparam name="TKey">The type of the field key.</typeparam>
     /// <param name="fields">A fields dictionary.</param>

--- a/src/IceRpc/IClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/IClientProtocolConnectionFactory.cs
@@ -7,7 +7,7 @@ public interface IClientProtocolConnectionFactory
 {
     /// <summary>Creates a protocol connection to the specified server address.</summary>
     /// <param name="serverAddress">The address of the server.</param>
-    /// <returns>The new protocol connection. The caller must call <see cref="IProtocolConnection.ConnectAsync"/> on
+    /// <returns>The new protocol connection. The caller must call <see cref="IProtocolConnection.ConnectAsync" /> on
     /// this connection to connect it.</returns>
     IProtocolConnection CreateConnection(ServerAddress serverAddress);
 }

--- a/src/IceRpc/IConnectionContext.cs
+++ b/src/IceRpc/IConnectionContext.cs
@@ -11,7 +11,7 @@ public interface IConnectionContext
     IInvoker Invoker { get; }
 
     /// <summary>Gets the server address of this connection.</summary>
-    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport"/> property is always
+    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport" /> property is always
     /// non-null.</value>
     ServerAddress ServerAddress { get; }
 

--- a/src/IceRpc/IDispatcher.cs
+++ b/src/IceRpc/IDispatcher.cs
@@ -8,6 +8,6 @@ public interface IDispatcher
     /// <summary>Dispatches an incoming request and returns the corresponding outgoing response.</summary>
     /// <param name="request">The incoming request being dispatched.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The corresponding <see cref="OutgoingResponse"/>.</returns>
+    /// <returns>The corresponding <see cref="OutgoingResponse" />.</returns>
     ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/IceRpc/IInvoker.cs
+++ b/src/IceRpc/IInvoker.cs
@@ -8,6 +8,6 @@ public interface IInvoker
     /// <summary>Sends an outgoing request and returns the corresponding incoming response.</summary>
     /// <param name="request">The outgoing request being sent.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The corresponding <see cref="IncomingResponse"/>.</returns>
+    /// <returns>The corresponding <see cref="IncomingResponse" />.</returns>
     Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/IceRpc/IProtocolConnection.cs
+++ b/src/IceRpc/IProtocolConnection.cs
@@ -4,14 +4,15 @@ using IceRpc.Transports;
 
 namespace IceRpc;
 
-/// <summary>Represents a connection for a <see cref="Protocol"/>. It is the building block for
-/// <see cref="ClientConnection"/>, <see cref="ConnectionCache"/> and the connections created by <see cref="Server"/>.
-/// Applications can use this interface to build their own custom client connection and connection cache classes.
+/// <summary>Represents a connection for a <see cref="Protocol" />. It is the building block for
+/// <see cref="ClientConnection" />, <see cref="ConnectionCache" /> and the connections created by
+/// <see cref="Server" />. Applications can use this interface to build their own custom client connection and
+/// connection cache classes.
 /// </summary>
 public interface IProtocolConnection : IInvoker, IAsyncDisposable
 {
     /// <summary>Gets the server address of this connection.</summary>
-    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport"/> property is always
+    /// <value>The server address of this connection. Its <see cref="ServerAddress.Transport" /> property is always
     /// non-null.</value>
     ServerAddress ServerAddress { get; }
 
@@ -23,14 +24,15 @@ public interface IProtocolConnection : IInvoker, IAsyncDisposable
     /// <summary>Establishes the connection to the peer.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes once the connection is established  provides the <see
-    /// cref="TransportConnectionInformation"/> for this connection. This task can also complete with one of the
+    /// cref="TransportConnectionInformation" /> for this connection. This task can also complete with one of the
     /// following exceptions:
     /// <list type="bullet">
-    /// <item><description><see cref="ConnectionException"/>if the connection establishment failed.</description></item>
-    /// <item><description><see cref="OperationCanceledException"/>if cancellation was requested through the
+    /// <item><description><see cref="ConnectionException" />if the connection establishment failed.</description>
+    /// </item>
+    /// <item><description><see cref="OperationCanceledException" />if cancellation was requested through the
     /// cancellation token.</description></item>
-    /// <item><description><see cref="TimeoutException"/>if the connection establishment attempt exceeded <see
-    /// cref="ConnectionOptions.ConnectTimeout"/>.</description></item>
+    /// <item><description><see cref="TimeoutException" />if the connection establishment attempt exceeded <see
+    /// cref="ConnectionOptions.ConnectTimeout" />.</description></item>
     /// </list>
     /// </returns>
     /// <exception cref="ConnectionException">Thrown if the connection is closed but not disposed yet.</exception>
@@ -43,11 +45,11 @@ public interface IProtocolConnection : IInvoker, IAsyncDisposable
     /// <returns>A task that completes once the shutdown is complete. This task can also complete with one of the
     /// following exceptions:
     /// <list type="bullet">
-    /// <item><description><see cref="ConnectionException"/>if the connection shutdown failed.</description></item>
-    /// <item><description><see cref="OperationCanceledException"/>if cancellation was requested through the
+    /// <item><description><see cref="ConnectionException" />if the connection shutdown failed.</description></item>
+    /// <item><description><see cref="OperationCanceledException" />if cancellation was requested through the
     /// cancellation token.</description></item>
-    /// <item><description><see cref="TimeoutException"/>if this shutdown attempt or a previous attempt exceeded
-    /// <see cref="ConnectionOptions.ShutdownTimeout"/>.</description></item>
+    /// <item><description><see cref="TimeoutException" />if this shutdown attempt or a previous attempt exceeded
+    /// <see cref="ConnectionOptions.ShutdownTimeout" />.</description></item>
     /// </list>
     /// </returns>
     /// <exception cref="ConnectionException">Thrown if the connection is closed but not disposed yet.</exception>

--- a/src/IceRpc/IceRpcProtocolStreamException.cs
+++ b/src/IceRpc/IceRpcProtocolStreamException.cs
@@ -8,7 +8,7 @@ namespace IceRpc;
 /// <summary>This exception represents an icerpc-specific error transmitted as an error code over a multiplexed stream.
 /// The multiplexed stream APIs throw this exception when the error code carried by the stream does not map to another
 /// exception.</summary>
-/// <seealso cref="IMultiplexedStreamErrorCodeConverter"/>
+/// <seealso cref="IMultiplexedStreamErrorCodeConverter" />
 public class IceRpcProtocolStreamException : Exception
 {
     /// <summary>Gets the error code carried by this exception.</summary>

--- a/src/IceRpc/IncomingFrame.cs
+++ b/src/IceRpc/IncomingFrame.cs
@@ -12,7 +12,7 @@ public class IncomingFrame
     public IConnectionContext ConnectionContext { get; set; }
 
     /// <summary>Gets or sets the payload of this frame.</summary>
-    /// <value>The payload of this frame. The default value is an empty <see cref="PipeReader"/>.</value>
+    /// <value>The payload of this frame. The default value is an empty <see cref="PipeReader" />.</value>
     public PipeReader Payload { get; set; } = EmptyPipeReader.Instance;
 
     /// <summary>Gets the protocol of this frame.</summary>

--- a/src/IceRpc/IncomingResponse.cs
+++ b/src/IceRpc/IncomingResponse.cs
@@ -12,8 +12,8 @@ public sealed class IncomingResponse : IncomingFrame
     /// <summary>Gets the fields of this incoming response.</summary>
     public IDictionary<ResponseFieldKey, ReadOnlySequence<byte>> Fields { get; private set; }
 
-    /// <summary>Gets or initializes the <see cref="IceRpc.ResultType"/> of this response.</summary>
-    /// <value>The result type of the response. The default value is <see cref="ResultType.Success"/>.</value>
+    /// <summary>Gets or initializes the <see cref="IceRpc.ResultType" /> of this response.</summary>
+    /// <value>The result type of the response. The default value is <see cref="ResultType.Success" />.</value>
     public ResultType ResultType { get; init; } = ResultType.Success;
 
     private readonly PipeReader? _fieldsPipeReader;

--- a/src/IceRpc/InlineDispatcher.cs
+++ b/src/IceRpc/InlineDispatcher.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc;
 
-/// <summary>Adapts a dispatcher delegate to the <see cref="IDispatcher"/> interface.</summary>
+/// <summary>Adapts a dispatcher delegate to the <see cref="IDispatcher" /> interface.</summary>
 public class InlineDispatcher : IDispatcher
 {
     private readonly Func<IncomingRequest, CancellationToken, ValueTask<OutgoingResponse>> _function;

--- a/src/IceRpc/InlineInvoker.cs
+++ b/src/IceRpc/InlineInvoker.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc;
 
-/// <summary>Adapts a function to the <see cref="IInvoker"/> interface.</summary>
+/// <summary>Adapts a function to the <see cref="IInvoker" /> interface.</summary>
 public class InlineInvoker : IInvoker
 {
     private readonly Func<OutgoingRequest, CancellationToken, Task<IncomingResponse>> _function;

--- a/src/IceRpc/Internal/BufferWriterExtensions.cs
+++ b/src/IceRpc/Internal/BufferWriterExtensions.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 
 namespace IceRpc.Internal;
 
-/// <summary>This class provides extension methods for <see cref="IBufferWriter{T}"/>.</summary>
+/// <summary>This class provides extension methods for <see cref="IBufferWriter{T}" />.</summary>
 internal static partial class BufferWriterExtensions
 {
     /// <summary>Writes a sequence of bytes to a buffer writer.</summary>

--- a/src/IceRpc/Internal/ClientEventSource.cs
+++ b/src/IceRpc/Internal/ClientEventSource.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Internal;
 
-/// <summary>An <see cref="EventSource"/> implementation used to log client connection events.</summary>
+/// <summary>An <see cref="EventSource" /> implementation used to log client connection events.</summary>
 internal sealed class ClientEventSource : EventSource
 {
     internal static readonly ClientEventSource Log = new("IceRpc-Client");
@@ -30,7 +30,7 @@ internal sealed class ClientEventSource : EventSource
     private long _totalFailedConnections;
     private PollingCounter? _totalFailedConnectionsCounter;
 
-    /// <summary>Creates a new instance of the <see cref="ClientEventSource"/> class with the specified name.
+    /// <summary>Creates a new instance of the <see cref="ClientEventSource" /> class with the specified name.
     /// </summary>
     /// <param name="eventSourceName">The name to apply to the event source.</param>
     internal ClientEventSource(string eventSourceName)

--- a/src/IceRpc/Internal/ConnectionContext.cs
+++ b/src/IceRpc/Internal/ConnectionContext.cs
@@ -4,7 +4,7 @@ using IceRpc.Transports;
 
 namespace IceRpc.Internal;
 
-/// <summary>Implements <see cref="IConnectionContext"/> using a protocol connection.</summary>
+/// <summary>Implements <see cref="IConnectionContext" /> using a protocol connection.</summary>
 internal sealed class ConnectionContext : IConnectionContext
 {
     public IInvoker Invoker => _protocolConnection;

--- a/src/IceRpc/Internal/IcePayloadPipeWriter.cs
+++ b/src/IceRpc/Internal/IcePayloadPipeWriter.cs
@@ -42,7 +42,7 @@ internal sealed class IcePayloadPipeWriter : ReadOnlySequencePipeWriter
         return default;
     }
 
-    /// <summary>Writes the source to the duplex connection. <paramref name="endStream"/> is ignored
+    /// <summary>Writes the source to the duplex connection. <paramref name="endStream" /> is ignored
     /// because the duplex connection has no use for it.</summary>
     public override async ValueTask<FlushResult> WriteAsync(
         ReadOnlySequence<byte> source,

--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace IceRpc.Internal;
 
-/// <summary>The base implementation of <see cref="IProtocolConnection"/>.</summary>
+/// <summary>The base implementation of <see cref="IProtocolConnection" />.</summary>
 internal abstract class ProtocolConnection : IProtocolConnection
 {
     public abstract ServerAddress ServerAddress { get; }

--- a/src/IceRpc/Internal/ProtocolListener.cs
+++ b/src/IceRpc/Internal/ProtocolListener.cs
@@ -5,7 +5,7 @@ using System.Net;
 
 namespace IceRpc.Internal;
 
-/// <summary>Implements <see cref="IListener{T}"/> for protocol connections.</summary>
+/// <summary>Implements <see cref="IListener{T}" /> for protocol connections.</summary>
 /// <typeparam name="T">The transport connection type.</typeparam>
 internal abstract class ProtocolListener<T> : IListener<IProtocolConnection>
 {

--- a/src/IceRpc/Internal/ServerAddressExtensions.cs
+++ b/src/IceRpc/Internal/ServerAddressExtensions.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace IceRpc.Internal;
 
-/// <summary>This class provides extension methods for <see cref="ServerAddress"/>.</summary>
+/// <summary>This class provides extension methods for <see cref="ServerAddress" />.</summary>
 internal static class ServerAddressExtensions
 {
     /// <summary>Appends the server address and all its parameters (if any) to this string builder.</summary>
@@ -16,7 +16,7 @@ internal static class ServerAddressExtensions
     /// <param name="includeScheme">When <see langword="true" />, first appends the server address protocol followed by
     /// ://.</param>
     /// <param name="paramSeparator">The character that separates parameters in the query component of the URI.</param>
-    /// <returns>The string builder <paramref name="sb"/>.</returns>
+    /// <returns>The string builder <paramref name="sb" />.</returns>
     internal static StringBuilder AppendServerAddress(
         this StringBuilder sb,
         ServerAddress serverAddress,

--- a/src/IceRpc/Internal/ServerEventSource.cs
+++ b/src/IceRpc/Internal/ServerEventSource.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Internal;
 
-/// <summary>An <see cref="EventSource"/> implementation used to log server events.</summary>
+/// <summary>An <see cref="EventSource" /> implementation used to log server events.</summary>
 internal sealed class ServerEventSource : EventSource
 {
     internal static readonly ServerEventSource Log = new("IceRpc-Server");
@@ -30,7 +30,7 @@ internal sealed class ServerEventSource : EventSource
     private long _totalFailedConnections;
     private PollingCounter? _totalFailedConnectionsCounter;
 
-    /// <summary>Creates a new instance of the <see cref="ServerEventSource"/> class with the specified name.
+    /// <summary>Creates a new instance of the <see cref="ServerEventSource" /> class with the specified name.
     /// </summary>
     /// <param name="eventSourceName">The name to apply to the event source.</param>
     internal ServerEventSource(string eventSourceName)

--- a/src/IceRpc/Internal/ServiceNotFoundDispatcher.cs
+++ b/src/IceRpc/Internal/ServiceNotFoundDispatcher.cs
@@ -4,8 +4,8 @@ using IceRpc.Slice;
 
 namespace IceRpc.Internal;
 
-/// <summary>A trivial dispatcher that always throws a <see cref="DispatchException"/> with error code
-/// <see cref="DispatchErrorCode.ServiceNotFound"/>.</summary>
+/// <summary>A trivial dispatcher that always throws a <see cref="DispatchException" /> with error code
+/// <see cref="DispatchErrorCode.ServiceNotFound" />.</summary>
 internal class ServiceNotFoundDispatcher : IDispatcher
 {
     /// <summary>Gets the unique instance of this class.</summary>

--- a/src/IceRpc/Internal/UriExtensions.cs
+++ b/src/IceRpc/Internal/UriExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace IceRpc.Internal;
 
-/// <summary>Extension methods for <see cref="Uri"/>.</summary>
+/// <summary>Extension methods for <see cref="Uri" />.</summary>
 internal static class UriExtensions
 {
     /// <summary>Parses the query portion of a URI into a dictionary of name/value. The value of the alt-server

--- a/src/IceRpc/LocalException.cs
+++ b/src/IceRpc/LocalException.cs
@@ -5,12 +5,12 @@ namespace IceRpc;
 /// <summary>This exception reports that a service address has no server address or no usable server address.</summary>
 public class NoServerAddressException : Exception
 {
-    /// <summary>Constructs a new instance of the <see cref="NoServerAddressException"/> class.</summary>
+    /// <summary>Constructs a new instance of the <see cref="NoServerAddressException" /> class.</summary>
     public NoServerAddressException()
     {
     }
 
-    /// <summary>Constructs a new instance of the <see cref="NoServerAddressException"/> class.</summary>
+    /// <summary>Constructs a new instance of the <see cref="NoServerAddressException" /> class.</summary>
     /// <param name="serviceAddress">The service address with no server address or no usable server address.</param>
     public NoServerAddressException(ServiceAddress serviceAddress)
         : base($"service address '{serviceAddress}' has no usable serverAddress")
@@ -21,7 +21,7 @@ public class NoServerAddressException : Exception
 /// <summary>This exception reports that data (bytes) received are not in an expected format.</summary>
 public class InvalidDataException : Exception
 {
-    /// <summary>Constructs a new instance of the <see cref="InvalidDataException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="InvalidDataException" /> class with a specified error
     /// message.</summary>
     /// <param name="message">The message that describes the error.</param>
     public InvalidDataException(string message)
@@ -29,7 +29,7 @@ public class InvalidDataException : Exception
     {
     }
 
-    /// <summary>Constructs a new instance of the <see cref="InvalidDataException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="InvalidDataException" /> class with a specified error
     /// message and a reference to the inner exception that is the cause of this exception.</summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
@@ -43,7 +43,7 @@ public class InvalidDataException : Exception
 /// or response with a header size greater than the remote peer's max header size.</summary>
 public class ProtocolException : Exception
 {
-    /// <summary>Constructs a new instance of the <see cref="ProtocolException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="ProtocolException" /> class with a specified error
     /// message.</summary>
     /// <param name="message">The message that describes the error.</param>
     public ProtocolException(string message)
@@ -51,7 +51,7 @@ public class ProtocolException : Exception
     {
     }
 
-    /// <summary>Constructs a new instance of the <see cref="ProtocolException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="ProtocolException" /> class with a specified error
     /// message and a reference to the inner exception that is the cause of this exception.</summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>

--- a/src/IceRpc/OutgoingFieldValue.cs
+++ b/src/IceRpc/OutgoingFieldValue.cs
@@ -9,10 +9,10 @@ namespace IceRpc;
 /// of the struct's properties can be set.</summary>
 public readonly record struct OutgoingFieldValue
 {
-    /// <summary>Gets the value of this outgoing field when <see cref="EncodeAction"/> is <c>null</c>.</summary>
+    /// <summary>Gets the value of this outgoing field when <see cref="EncodeAction" /> is <c>null</c>.</summary>
     public ReadOnlySequence<byte> ByteSequence { get; }
 
-    /// <summary>Gets the action used to encode this field or <c>null</c>, when <see cref="ByteSequence"/> holds
+    /// <summary>Gets the action used to encode this field or <c>null</c>, when <see cref="ByteSequence" /> holds
     /// the encoded value.</summary>
     /// <value>An encode action used to create a Slice2 encoded field value when the fields are about to be sent.
     /// </value>
@@ -36,7 +36,7 @@ public readonly record struct OutgoingFieldValue
 
     /// <summary>Encodes this field value using a Slice encoder.</summary>
     /// <param name="encoder">The Slice encoder.</param>
-    /// <param name="sizeLength">The number of bytes to use to encode the size when <see cref="EncodeAction"/> is
+    /// <param name="sizeLength">The number of bytes to use to encode the size when <see cref="EncodeAction" /> is
     /// not null.</param>
     public void Encode(ref SliceEncoder encoder, int sizeLength = 2)
     {

--- a/src/IceRpc/OutgoingFrame.cs
+++ b/src/IceRpc/OutgoingFrame.cs
@@ -21,8 +21,8 @@ public abstract class OutgoingFrame
     public Protocol Protocol { get; }
 
     /// <summary>Installs a payload writer interceptor in this outgoing frame. This interceptor is executed just
-    /// before sending <see cref="Payload"/>, and is typically used to compress both <see cref="Payload"/> and
-    /// <see cref="PayloadStream"/>.</summary>
+    /// before sending <see cref="Payload" />, and is typically used to compress both <see cref="Payload" /> and
+    /// <see cref="PayloadStream" />.</summary>
     /// <param name="payloadWriterInterceptor">The payload writer interceptor to install.</param>
     /// <returns>This outgoing frame.</returns>
     public OutgoingFrame Use(Func<PipeWriter, PipeWriter> payloadWriterInterceptor)

--- a/src/IceRpc/OutgoingResponse.cs
+++ b/src/IceRpc/OutgoingResponse.cs
@@ -11,8 +11,8 @@ public sealed class OutgoingResponse : OutgoingFrame
     public IDictionary<ResponseFieldKey, OutgoingFieldValue> Fields { get; set; } =
         ImmutableDictionary<ResponseFieldKey, OutgoingFieldValue>.Empty;
 
-    /// <summary>Gets or initializes the <see cref="IceRpc.ResultType"/> of this response.</summary>
-    /// <value>The result type of this response. The default is <see cref="ResultType.Success"/>.</value>
+    /// <summary>Gets or initializes the <see cref="IceRpc.ResultType" /> of this response.</summary>
+    /// <value>The result type of this response. The default is <see cref="ResultType.Success" />.</value>
     public ResultType ResultType { get; init; } = ResultType.Success;
 
     /// <summary>Constructs an outgoing response.</summary>

--- a/src/IceRpc/Pipeline.cs
+++ b/src/IceRpc/Pipeline.cs
@@ -2,9 +2,9 @@
 
 namespace IceRpc;
 
-/// <summary>A pipeline is an invoker created from zero or more interceptors installed by calling <see cref="Use"/>.
+/// <summary>A pipeline is an invoker created from zero or more interceptors installed by calling <see cref="Use" />.
 /// The last invoker of the pipeline calls the connection carried by the request or throws
-/// <see cref="ArgumentNullException"/> if this connection is null.</summary>
+/// <see cref="ArgumentNullException" /> if this connection is null.</summary>
 public sealed class Pipeline : IInvoker
 {
     private readonly Stack<Func<IInvoker, IInvoker>> _interceptorStack = new();
@@ -22,7 +22,7 @@ public sealed class Pipeline : IInvoker
     /// <param name="lastInvoker">The last invoker.</param>
     /// <returns>This pipeline.</returns>
     /// <exception cref="InvalidOperationException">Thrown if this method is called after the first call to
-    /// <see cref="InvokeAsync"/>.</exception>
+    /// <see cref="InvokeAsync" />.</exception>
     public Pipeline Into(IInvoker lastInvoker)
     {
         if (_invoker.IsValueCreated)
@@ -38,7 +38,7 @@ public sealed class Pipeline : IInvoker
     /// <param name="interceptor">The interceptor to install.</param>
     /// <returns>This pipeline.</returns>
     /// <exception cref="InvalidOperationException">Thrown if this method is called after the first call to
-    /// <see cref="InvokeAsync"/>.</exception>
+    /// <see cref="InvokeAsync" />.</exception>
     public Pipeline Use(Func<IInvoker, IInvoker> interceptor)
     {
         if (_invoker.IsValueCreated)
@@ -51,7 +51,7 @@ public sealed class Pipeline : IInvoker
     }
 
     /// <summary>Creates a pipeline of invokers by starting with the last invoker installed. This method is called
-    /// by the first call to <see cref="InvokeAsync"/>.</summary>
+    /// by the first call to <see cref="InvokeAsync" />.</summary>
     /// <returns>The pipeline of invokers.</returns>
     private IInvoker CreateInvokerPipeline()
     {

--- a/src/IceRpc/PipelineExtensions.cs
+++ b/src/IceRpc/PipelineExtensions.cs
@@ -4,7 +4,7 @@ using IceRpc.Features;
 
 namespace IceRpc;
 
-/// <summary>This class provide extension methods to add built-in interceptors to a <see cref="Pipeline"/>.
+/// <summary>This class provide extension methods to add built-in interceptors to a <see cref="Pipeline" />.
 /// </summary>
 public static class PipelineExtensions
 {

--- a/src/IceRpc/Protocol.cs
+++ b/src/IceRpc/Protocol.cs
@@ -41,14 +41,14 @@ public class Protocol
     /// <summary>Parses a string into a protocol.</summary>
     /// <param name="name">The name of the protocol.</param>
     /// <returns>A protocol with the given name in lowercase.</returns>
-    /// <exception cref="FormatException">Thrown when <paramref name="name"/> is not ice or icerpc.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="name" /> is not ice or icerpc.</exception>
     public static Protocol Parse(string name) =>
         TryParse(name, out Protocol? protocol) ? protocol : throw new FormatException($"unknown protocol '{name}'");
 
     /// <summary>Tries to parse a string into a protocol.</summary>
     /// <param name="name">The name of the protocol.</param>
     /// <param name="protocol">The protocol parsed from the name.</param>
-    /// <returns><see langword="true" /> when <paramref name="name"/> was successfully parsed into a protocol;
+    /// <returns><see langword="true" /> when <paramref name="name" /> was successfully parsed into a protocol;
     /// otherwise, <see langword="false" />.</returns>
     public static bool TryParse(string name, [NotNullWhen(true)] out Protocol? protocol)
     {

--- a/src/IceRpc/RetryPolicy.cs
+++ b/src/IceRpc/RetryPolicy.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace IceRpc;
 
-/// <summary>The retry policy can be specified when constructing a <see cref="RemoteException"/>. With the icerpc
+/// <summary>The retry policy can be specified when constructing a <see cref="RemoteException" />. With the icerpc
 /// protocol, the retry policy is transmitted as a field with the response and later decoded by the client's.</summary>
 public sealed record class RetryPolicy
 {

--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -10,7 +10,7 @@ public sealed class Router : IDispatcher
 {
     /// <summary>Gets the absolute path-prefix of this router. The absolute path of a service added to this
     /// Router is: <code>$"{AbsolutePrefix}{path}"</code> where <c>path</c> corresponds to the argument given to
-    /// <see cref="Map(string, IDispatcher)"/>.</summary>
+    /// <see cref="Map(string, IDispatcher)" />.</summary>
     /// <value>The absolute prefix of this router. It is either an empty string or a string with two or more
     /// characters starting with a <c>/</c>.</value>
     public string AbsolutePrefix { get; } = "";
@@ -32,7 +32,7 @@ public sealed class Router : IDispatcher
 
     /// <summary>Constructs a router with an absolute prefix.</summary>
     /// <param name="absolutePrefix">The absolute prefix of the new router. It must start with a <c>/</c>.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="absolutePrefix"/> is not a valid path.
+    /// <exception cref="FormatException">Thrown if <paramref name="absolutePrefix" /> is not a valid path.
     /// </exception>
     public Router(string absolutePrefix)
         : this()
@@ -50,11 +50,11 @@ public sealed class Router : IDispatcher
     /// </summary>
     /// <param name="path">The path of this route. It must match exactly the path of the request. In particular, it
     /// must start with a <c>/</c>.</param>
-    /// <param name="dispatcher">The target of this route. It is typically an <see cref="IService"/>.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="path"/> is not a valid path.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync"/> was already
+    /// <param name="dispatcher">The target of this route. It is typically an <see cref="IService" />.</param>
+    /// <exception cref="FormatException">Thrown if <paramref name="path" /> is not a valid path.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <seealso cref="Mount"/>
+    /// <seealso cref="Mount" />
     public void Map(string path, IDispatcher dispatcher)
     {
         if (_dispatcher.IsValueCreated)
@@ -71,10 +71,10 @@ public sealed class Router : IDispatcher
     /// <param name="prefix">The prefix of this route. This prefix will be compared with the start of the path of
     /// the request.</param>
     /// <param name="dispatcher">The target of this route.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix"/> is not a valid path.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync"/> was already
+    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <seealso cref="Map(string, IDispatcher)"/>
+    /// <seealso cref="Map(string, IDispatcher)" />
     public void Mount(string prefix, IDispatcher dispatcher)
     {
         if (_dispatcher.IsValueCreated)
@@ -88,10 +88,10 @@ public sealed class Router : IDispatcher
     }
 
     /// <summary>Installs a middleware in this router. A middleware must be installed before calling
-    /// <see cref="IDispatcher.DispatchAsync"/>.</summary>
+    /// <see cref="IDispatcher.DispatchAsync" />.</summary>
     /// <param name="middleware">The middleware to install.</param>
     /// <returns>This router.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync"/> was already
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
     public Router Use(Func<IDispatcher, IDispatcher> middleware)
     {

--- a/src/IceRpc/RouterExtensions.cs
+++ b/src/IceRpc/RouterExtensions.cs
@@ -5,7 +5,7 @@ using IceRpc.Slice;
 
 namespace IceRpc;
 
-/// <summary>This class provide extension methods to add built-in middleware to a <see cref="Router"/>.
+/// <summary>This class provide extension methods to add built-in middleware to a <see cref="Router" />.
 /// </summary>
 public static class RouterExtensions
 {
@@ -14,20 +14,20 @@ public static class RouterExtensions
     /// <typeparam name="TService">The service type used to get the default path.</typeparam>
     /// <param name="router">The router being configured.</param>
     /// <param name="service">The target service of this route.</param>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync"/> was already
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <seealso cref="Router.Mount(string, IDispatcher)"/>
+    /// <seealso cref="Router.Mount(string, IDispatcher)" />
     public static void Map<TService>(this Router router, IDispatcher service)
         where TService : class =>
         router.Map(typeof(TService).GetDefaultPath(), service);
 
     /// <summary>Creates a sub-router, configures this sub-router and mounts it (with
-    /// <see cref="Router.Mount(string, IDispatcher)"/>) at the given <c>prefix</c>.</summary>
+    /// <see cref="Router.Mount(string, IDispatcher)" />) at the given <c>prefix</c>.</summary>
     /// <param name="router">The router being configured.</param>
     /// <param name="prefix">The prefix of the route to the sub-router.</param>
     /// <param name="configure">A delegate that configures the new sub-router.</param>
     /// <returns>The new sub-router.</returns>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix"/> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
     public static Router Route(this Router router, string prefix, Action<Router> configure)
     {
         ServiceAddress.CheckPath(prefix);
@@ -37,7 +37,7 @@ public static class RouterExtensions
         return subRouter;
     }
 
-    /// <summary>Adds a middleware that creates and inserts the <see cref="IDispatchInformationFeature"/> feature
+    /// <summary>Adds a middleware that creates and inserts the <see cref="IDispatchInformationFeature" /> feature
     /// in all requests.</summary>
     /// <param name="router">The router being configured.</param>
     /// <returns>The router being configured.</returns>

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -12,13 +12,13 @@ namespace IceRpc;
 public sealed class Server : IAsyncDisposable
 {
     /// <summary>Gets the server address of this server.</summary>
-    /// <value>The server address of this server. Its <see cref="ServerAddress.Transport"/> property is always non-null.
-    /// When the address's host is an IP address and the port is 0, <see cref="Listen"/> replaces the port by the actual
-    /// port the server is listening on.</value>
+    /// <value>The server address of this server. Its <see cref="ServerAddress.Transport" /> property is always
+    /// non-null. When the address's host is an IP address and the port is 0, <see cref="Listen" /> replaces the port by
+    /// the actual port the server is listening on.</value>
     public ServerAddress ServerAddress => _listener?.ServerAddress ?? _serverAddress;
 
     /// <summary>Gets a task that completes when the server's shutdown is complete: see
-    /// <see cref="ShutdownAsync(string, CancellationToken)"/> This property can be retrieved before shutdown is
+    /// <see cref="ShutdownAsync(string, CancellationToken)" /> This property can be retrieved before shutdown is
     /// initiated.</summary>
     public Task ShutdownComplete => _shutdownCompleteSource.Task;
 
@@ -47,9 +47,9 @@ public sealed class Server : IAsyncDisposable
     /// <summary>Constructs a server.</summary>
     /// <param name="options">The server options.</param>
     /// <param name="duplexServerTransport">The transport used to create ice protocol connections. Null is equivalent
-    /// to <see cref="IDuplexServerTransport.Default"/>.</param>
+    /// to <see cref="IDuplexServerTransport.Default" />.</param>
     /// <param name="multiplexedServerTransport">The transport used to create icerpc protocol connections. Null is
-    /// equivalent to <see cref="IMultiplexedServerTransport.Default"/>.</param>
+    /// equivalent to <see cref="IMultiplexedServerTransport.Default" />.</param>
     public Server(
         ServerOptions options,
         IDuplexServerTransport? duplexServerTransport = null,
@@ -271,12 +271,12 @@ public sealed class Server : IAsyncDisposable
                     }
                     else
                     {
-                        // We don't wait for the connection to be activated or shutdown. This could take a while for some transports
-                        // such as TLS based transports where the handshake requires few round trips between the client and
-                        // server.
+                        // We don't wait for the connection to be activated or shutdown. This could take a while for
+                        // some transports such as TLS based transports where the handshake requires few round trips
+                        // between the client and server.
                         // Waiting could also cause a security issue if the client doesn't respond to the connection
-                        // initialization as we wouldn't be able to accept new connections in the meantime. The call will
-                        // eventually timeout if the ConnectTimeout expires.
+                        // initialization as we wouldn't be able to accept new connections in the meantime. The call
+                        // will eventually timeout if the ConnectTimeout expires.
                         _ = Task.Run(() => _ = connectionTask(connection, shutdownCancellationToken));
                     }
                 }
@@ -423,8 +423,8 @@ public sealed class Server : IAsyncDisposable
     /// <inheritdoc/>
     public override string ToString() => ServerAddress.ToString();
 
-    /// <summary>Provides a decorator that adds logging to a <see cref="IListener{T}"/> of
-    /// <see cref="IProtocolConnection"/>.</summary>
+    /// <summary>Provides a decorator that adds logging to a <see cref="IListener{T}" /> of
+    /// <see cref="IProtocolConnection" />.</summary>
     private class LogListenerDecorator : IListener<IProtocolConnection>
     {
         public ServerAddress ServerAddress => _decoratee.ServerAddress;
@@ -447,7 +447,7 @@ public sealed class Server : IAsyncDisposable
         internal LogListenerDecorator(IListener<IProtocolConnection> decoratee) => _decoratee = decoratee;
     }
 
-    /// <summary>Provides a decorator that adds EventSource-based logging to the <see cref="IProtocolConnection"/>.
+    /// <summary>Provides a decorator that adds EventSource-based logging to the <see cref="IProtocolConnection" />.
     /// </summary>
     private class LogProtocolConnectionDecorator : IProtocolConnection
     {

--- a/src/IceRpc/ServerAddress.cs
+++ b/src/IceRpc/ServerAddress.cs
@@ -15,7 +15,7 @@ namespace IceRpc;
 public readonly record struct ServerAddress
 {
     /// <summary>Gets the protocol of this server address.</summary>
-    /// <value>Either <see cref="Protocol.IceRpc"/> or <see cref="Protocol.Ice"/>.</value>
+    /// <value>Either <see cref="Protocol.IceRpc" /> or <see cref="Protocol.Ice" />.</value>
     public Protocol Protocol { get; }
 
     /// <summary>Gets or initializes the host.</summary>
@@ -80,7 +80,8 @@ public readonly record struct ServerAddress
         }
     }
 
-    /// <summary>Gets the URI used to create this server address, if this server address was created from a URI.</summary>
+    /// <summary>Gets the URI used to create this server address, if this server address was created from a URI.
+    /// </summary>
     public Uri? OriginalUri { get; private init; }
 
     private readonly string _host = "::0";
@@ -104,9 +105,9 @@ public readonly record struct ServerAddress
         OriginalUri = null;
     }
 
-    /// <summary>Constructs a server address from a <see cref="Uri"/>.</summary>
+    /// <summary>Constructs a server address from a <see cref="Uri" />.</summary>
     /// <param name="uri">An absolute URI.</param>
-    /// <exception cref="ArgumentException">Thrown if the <paramref name="uri"/> is not an absolute URI, or if its
+    /// <exception cref="ArgumentException">Thrown if the <paramref name="uri" /> is not an absolute URI, or if its
     /// scheme is not a supported protocol, or if it has a non-empty path or fragment, or if it has an empty host,
     /// or if its query can't be parsed or if it has an alt-server query parameter.</exception>
     public ServerAddress(Uri uri)
@@ -187,7 +188,7 @@ public readonly record struct ServerAddress
 
     /// <summary>Constructs a server address from a protocol, a host, a port and parsed parameters, without parameter
     /// validation.</summary>
-    /// <remarks>This constructor is used by <see cref="ServiceAddress"/> for its main server address and by the Slice
+    /// <remarks>This constructor is used by <see cref="ServiceAddress" /> for its main server address and by the Slice
     /// decoder for Slice1 server addresses.</remarks>
     internal ServerAddress(
         Protocol protocol,
@@ -205,7 +206,7 @@ public readonly record struct ServerAddress
     }
 }
 
-/// <summary>Equality comparer for <see cref="ServerAddress"/>.</summary>
+/// <summary>Equality comparer for <see cref="ServerAddress" />.</summary>
 public abstract class ServerAddressComparer : EqualityComparer<ServerAddress>
 {
     /// <summary>Gets a server address comparer that compares all server address properties, except a transport mismatch

--- a/src/IceRpc/ServerOptions.cs
+++ b/src/IceRpc/ServerOptions.cs
@@ -4,7 +4,7 @@ using System.Net.Security;
 
 namespace IceRpc;
 
-/// <summary>A property bag used to configure a <see cref="Server"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="Server" />.</summary>
 public sealed record class ServerOptions
 {
     /// <summary>Gets or sets the connection options for server connections.</summary>

--- a/src/IceRpc/ServiceAddress.cs
+++ b/src/IceRpc/ServiceAddress.cs
@@ -10,8 +10,8 @@ using System.Text;
 namespace IceRpc;
 
 /// <summary>A service address corresponds to the URI of a service, parsed and processed for easier consumption by
-/// interceptors, <see cref="ConnectionCache"/> and other elements of the invocation pipeline. It's used to construct
-/// an <see cref="OutgoingRequest"/>.</summary>
+/// interceptors, <see cref="ConnectionCache" /> and other elements of the invocation pipeline. It's used to construct
+/// an <see cref="OutgoingRequest" />.</summary>
 // The properties of this class are sorted in URI order.
 [TypeConverter(typeof(ServiceAddressTypeConverter))]
 public sealed record class ServiceAddress
@@ -118,7 +118,7 @@ public sealed record class ServiceAddress
     }
 
     /// <summary>Gets or initializes the parameters of this service address. Always empty when
-    /// <see cref="ServerAddress"/> is not null.</summary>
+    /// <see cref="ServerAddress" /> is not null.</summary>
     public ImmutableDictionary<string, string> Params
     {
         get => _params;
@@ -181,7 +181,7 @@ public sealed record class ServiceAddress
     }
 
     /// <summary>Gets the URI used to create this service address, if this service address was created from a URI and
-    /// URI-derived properties such as <see cref="ServerAddress"/> have not been updated.</summary>
+    /// URI-derived properties such as <see cref="ServerAddress" /> have not been updated.</summary>
     public Uri? OriginalUri { get; private set; }
 
     private ImmutableList<ServerAddress> _altServerAddresses = ImmutableList<ServerAddress>.Empty;
@@ -192,8 +192,8 @@ public sealed record class ServiceAddress
 
     /// <summary>Constructs a service address from a protocol.</summary>
     /// <param name="protocol">The protocol, or null for a relative service address.</param>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="protocol"/> is not null or a supported protocol.
-    /// </exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="protocol" /> is not null or a supported
+    /// protocol.</exception>
     public ServiceAddress(Protocol? protocol = null) => Protocol = protocol;
 
     /// <summary>Constructs a service address from a URI.</summary>
@@ -440,10 +440,10 @@ public sealed record class ServiceAddress
     public Uri ToUri() =>
         OriginalUri ?? (Protocol is null ? new Uri(Path, UriKind.Relative) : new Uri(ToString(), UriKind.Absolute));
 
-    /// <summary>Checks if <paramref name="params"/> contains properly escaped names and values.</summary>
+    /// <summary>Checks if <paramref name="params" /> contains properly escaped names and values.</summary>
     /// <param name="params">The dictionary to check.</param>
     /// <exception cref="FormatException">Thrown if the dictionary is not valid.</exception>
-    /// <remarks>A dictionary returned by <see cref="UriExtensions.ParseQuery"/> is properly escaped.</remarks>
+    /// <remarks>A dictionary returned by <see cref="UriExtensions.ParseQuery" /> is properly escaped.</remarks>
     internal static void CheckParams(ImmutableDictionary<string, string> @params)
     {
         foreach ((string name, string value) in @params)
@@ -459,7 +459,7 @@ public sealed record class ServiceAddress
         }
     }
 
-    /// <summary>Checks if <paramref name="path"/> is a properly escaped URI absolute path, i.e. that it starts
+    /// <summary>Checks if <paramref name="path" /> is a properly escaped URI absolute path, i.e. that it starts
     /// with a <c>/</c> and contains only unreserved characters, <c>%</c>, or reserved characters other than
     /// <c>?</c> and <c>#</c>.</summary>
     /// <param name="path">The path to check.</param>
@@ -475,10 +475,10 @@ public sealed record class ServiceAddress
         }
     }
 
-    /// <summary>Checks if <paramref name="value"/> contains only unreserved characters, <c>%</c>, or reserved
+    /// <summary>Checks if <paramref name="value" /> contains only unreserved characters, <c>%</c>, or reserved
     /// characters other than <c>#</c> and <c>&#38;</c>.</summary>
     /// <param name="value">The value to check.</param>
-    /// <returns><see langword="true" /> if <paramref name="value"/> is a valid parameter value; otherwise,
+    /// <returns><see langword="true" /> if <paramref name="value" /> is a valid parameter value; otherwise,
     /// <see langword="false" />.</returns>
     internal static bool IsValidParamValue(string value) => IsValid(value, "\"<>#&\\^`{|}");
 
@@ -500,7 +500,7 @@ public sealed record class ServiceAddress
         _fragment = fragment;
     }
 
-    /// <summary>Checks if <paramref name="fragment"/> is a properly escaped URI fragment, i.e. it contains only
+    /// <summary>Checks if <paramref name="fragment" /> is a properly escaped URI fragment, i.e. it contains only
     ///  unreserved characters, reserved characters or '%'.</summary>
     /// <param name="fragment">The fragment to check.</param>
     /// <exception cref="FormatException">Thrown if the fragment is not valid.</exception>
@@ -530,11 +530,11 @@ public sealed record class ServiceAddress
         return true;
     }
 
-    /// <summary>Checks if <paramref name="name"/> is not empty, not equal to <c>alt-server</c> nor equal to
+    /// <summary>Checks if <paramref name="name" /> is not empty, not equal to <c>alt-server</c> nor equal to
     /// <c>transport</c> and contains only unreserved characters, <c>%</c>, or reserved characters other than <c>#</c>,
     /// <c>&#38;</c> and <c>=</c>.</summary>
     /// <param name="name">The name to check.</param>
-    /// <returns><see langword="true" /> if <paramref name="name"/> is a valid parameter name; otherwise,
+    /// <returns><see langword="true" /> if <paramref name="name" /> is a valid parameter name; otherwise,
     /// <see langword="false" />.</returns>
     /// <remarks>The range of valid names is much larger than the range of names you should use. For example, you
     /// should avoid parameter names with a <c>%</c> or <c>$</c> character, even though these characters are valid

--- a/src/IceRpc/Slice/BitSequence.cs
+++ b/src/IceRpc/Slice/BitSequence.cs
@@ -83,7 +83,7 @@ public ref struct BitSequenceWriter
         _index++;
     }
 
-    /// <summary>Constructs a bit sequence writer over a bit sequence represented by a <see cref="SpanEnumerator"/>.
+    /// <summary>Constructs a bit sequence writer over a bit sequence represented by a <see cref="SpanEnumerator" />.
     /// </summary>
     internal BitSequenceWriter(
         Span<byte> firstSpan,

--- a/src/IceRpc/Slice/FieldsExtensions.cs
+++ b/src/IceRpc/Slice/FieldsExtensions.cs
@@ -14,7 +14,7 @@ public static class FieldsExtensions
     /// <param name="fields">The field dictionary.</param>
     /// <param name="key">The key to lookup in the field dictionary.</param>
     /// <param name="decodeFunc">The function used to decode the field value.</param>
-    /// <returns>The decoded field value, or default if the key was not found in <paramref name="fields"/>.
+    /// <returns>The decoded field value, or default if the key was not found in <paramref name="fields" />.
     /// </returns>
     public static TValue? DecodeValue<TKey, TValue>(
         this IDictionary<TKey, ReadOnlySequence<byte>> fields,

--- a/src/IceRpc/Slice/IActivator.cs
+++ b/src/IceRpc/Slice/IActivator.cs
@@ -9,7 +9,7 @@ public interface IActivator
     /// <summary>Creates an instance of a Slice construct based on a type ID.</summary>
     /// <param name="typeId">The Slice type ID.</param>
     /// <param name="decoder">The decoder.</param>
-    /// <returns>A new instance of the type identified by <paramref name="typeId"/>. This instance may be fully
+    /// <returns>A new instance of the type identified by <paramref name="typeId" />. This instance may be fully
     /// decoded using decoder, or only partially decoded.</returns>
     object? CreateInstance(string typeId, ref SliceDecoder decoder);
 }

--- a/src/IceRpc/Slice/ISliceFeature.cs
+++ b/src/IceRpc/Slice/ISliceFeature.cs
@@ -11,7 +11,7 @@ public interface ISliceFeature
     IActivator? Activator { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>
-    /// <value>The Slice encode options. Null is equivalent to <see cref="SliceEncodeOptions.Default"/>.</value>
+    /// <value>The Slice encode options. Null is equivalent to <see cref="SliceEncodeOptions.Default" />.</value>
     SliceEncodeOptions? EncodeOptions { get; }
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>

--- a/src/IceRpc/Slice/ITrait.cs
+++ b/src/IceRpc/Slice/ITrait.cs
@@ -5,7 +5,7 @@ namespace IceRpc.Slice;
 /// <summary>The common interface of all traits, and all Slice constructs that can implement traits.</summary>
 public interface ITrait
 {
-    /// <summary>Encodes the trait to the provided <see cref="SliceEncoder"/>.</summary>
+    /// <summary>Encodes the trait to the provided <see cref="SliceEncoder" />.</summary>
     /// <param name="encoder">The Slice encoder.</param>
     void EncodeTrait(ref SliceEncoder encoder);
 }

--- a/src/IceRpc/Slice/IncomingFrameExtensions.cs
+++ b/src/IceRpc/Slice/IncomingFrameExtensions.cs
@@ -9,11 +9,11 @@ using System.Runtime.CompilerServices;
 
 namespace IceRpc.Slice;
 
-/// <summary>Extension methods for <see cref="IncomingFrame"/>.</summary>
+/// <summary>Extension methods for <see cref="IncomingFrame" />.</summary>
 public static class IncomingFrameExtensions
 {
     /// <summary>Detaches the payload from the incoming frame. The caller takes ownership of the returned payload
-    /// pipe reader, and <see cref="IncomingFrame.Payload"/> becomes invalid.</summary>
+    /// pipe reader, and <see cref="IncomingFrame.Payload" /> becomes invalid.</summary>
     /// <param name="incoming">The incoming frame.</param>
     /// <returns>The payload pipe reader.</returns>
     public static PipeReader DetachPayload(this IncomingFrame incoming)

--- a/src/IceRpc/Slice/IncomingRequestExtensions.cs
+++ b/src/IceRpc/Slice/IncomingRequestExtensions.cs
@@ -25,14 +25,14 @@ public static class IncomingRequestExtensions
         }
     }
 
-    /// <summary>Creates an outgoing response with a <see cref="SliceResultType.ServiceFailure"/> result type.
+    /// <summary>Creates an outgoing response with a <see cref="SliceResultType.ServiceFailure" /> result type.
     /// </summary>
     /// <param name="request">The incoming request.</param>
     /// <param name="remoteException">The remote exception to encode in the payload.</param>
     /// <param name="encoding">The encoding used for the request payload.</param>
     /// <returns>The new outgoing response.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="remoteException"/> is a dispatch exception or
-    /// its <see cref="RemoteException.ConvertToUnhandled"/> property is <see langword="true" />.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="remoteException" /> is a dispatch exception or
+    /// its <see cref="RemoteException.ConvertToUnhandled" /> property is <see langword="true" />.</exception>
     public static OutgoingResponse CreateServiceFailureResponse(
         this IncomingRequest request,
         RemoteException remoteException,

--- a/src/IceRpc/Slice/IncomingResponseExtensions.cs
+++ b/src/IceRpc/Slice/IncomingResponseExtensions.cs
@@ -14,7 +14,7 @@ namespace IceRpc.Slice;
 /// Slice encoding.</summary>
 public static class IncomingResponseExtensions
 {
-    /// <summary>Decodes a response with a <see cref="ResultType.Failure"/> result type.</summary>
+    /// <summary>Decodes a response with a <see cref="ResultType.Failure" /> result type.</summary>
     /// <param name="response">The incoming response.</param>
     /// <param name="request">The outgoing request.</param>
     /// <param name="sender">The proxy that sent the request.</param>

--- a/src/IceRpc/Slice/Internal/Activator.cs
+++ b/src/IceRpc/Slice/Internal/Activator.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Slice.Internal;
 
 internal delegate object ActivateObject(ref SliceDecoder decoder);
 
-/// <summary>The default implementation of <see cref="IActivator"/>, which uses a dictionary.</summary>
+/// <summary>The default implementation of <see cref="IActivator" />, which uses a dictionary.</summary>
 internal class Activator : IActivator
 {
     internal static Activator Empty { get; } =

--- a/src/IceRpc/Slice/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc/Slice/Internal/PipeReaderExtensions.cs
@@ -13,10 +13,10 @@ internal static class PipeReaderExtensions
     /// <param name="encoding">The encoding.</param>
     /// <param name="maxSize">The maximum size of this segment.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A read result with the segment read from the reader unless <see cref="ReadResult.IsCanceled"/> is
+    /// <returns>A read result with the segment read from the reader unless <see cref="ReadResult.IsCanceled" /> is
     /// <see langword="true" />.</returns>
     /// <exception cref="InvalidDataException">Thrown when the segment size could not be decoded or the segment size
-    /// exceeds <paramref name="maxSize"/>.</exception>
+    /// exceeds <paramref name="maxSize" />.</exception>
     /// <remarks>The caller must call AdvanceTo on the reader, as usual. With Slice1, this method reads all
     /// the remaining bytes in the reader; otherwise, this method reads the segment size in the segment and returns
     /// exactly segment size bytes. This method often examines the buffer it returns as part of ReadResult,
@@ -113,14 +113,14 @@ internal static class PipeReaderExtensions
     /// <param name="encoding">The encoding.</param>
     /// <param name="maxSize">The maximum size of this segment.</param>
     /// <param name="readResult">The read result.</param>
-    /// <returns><see langword="true" /> when <paramref name="readResult"/> contains the segment read synchronously, or the
-    /// call was cancelled; otherwise, <see langword="false" />.</returns>
+    /// <returns><see langword="true" /> when <paramref name="readResult" /> contains the segment read synchronously, or
+    /// the call was cancelled; otherwise, <see langword="false" />.</returns>
     /// <exception cref="InvalidDataException">Thrown when the segment size could not be decoded or the segment size
     /// exceeds the max segment size.</exception>
-    /// <remarks>When this method returns <see langword="true" />, the caller must call AdvanceTo on the reader, as usual. This
-    /// method often examines the buffer it returns as part of ReadResult, therefore the caller should never
+    /// <remarks>When this method returns <see langword="true" />, the caller must call AdvanceTo on the reader, as
+    /// usual. This method often examines the buffer it returns as part of ReadResult, therefore the caller should never
     /// examine less than Buffer.End when the return value is <see langword="true" />. When this method returns
-    /// <see langword="false" />, the caller must call <see cref="ReadSegmentAsync"/>.</remarks>
+    /// <see langword="false" />, the caller must call <see cref="ReadSegmentAsync" />.</remarks>
     internal static bool TryReadSegment(
         this PipeReader reader,
         SliceEncoding encoding,
@@ -192,9 +192,9 @@ internal static class PipeReaderExtensions
 
     /// <summary>Checks if a read result holds a complete Slice segment and if the segment size does not exceed the
     /// maximum size.</summary>
-    /// <returns><see langword="true" /> when <paramref name="readResult"/> holds a complete segment or is canceled; otherwise,
-    /// <see langword="false" />.</returns>
-    /// <remarks><paramref name="segmentSize"/> and <paramref name="consumed"/> can be set when this method returns
+    /// <returns><see langword="true" /> when <paramref name="readResult" /> holds a complete segment or is canceled;
+    /// otherwise, <see langword="false" />.</returns>
+    /// <remarks><paramref name="segmentSize" /> and <paramref name="consumed" /> can be set when this method returns
     /// <see langword="false" />. In this case, both segmentSize and consumed are greater than 0.</remarks>
     private static bool IsCompleteSegment(
         ref ReadResult readResult,

--- a/src/IceRpc/Slice/Internal/SliceEncodingExtensions.cs
+++ b/src/IceRpc/Slice/Internal/SliceEncodingExtensions.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 
 namespace IceRpc.Slice.Internal;
 
-/// <summary>Extension methods for <see cref="SliceEncoding"/>.</summary>
+/// <summary>Extension methods for <see cref="SliceEncoding" />.</summary>
 internal static class SliceEncodingExtensions
 {
     /// <summary>Decodes a buffer.</summary>
@@ -13,7 +13,7 @@ internal static class SliceEncodingExtensions
     /// <param name="buffer">The byte buffer.</param>
     /// <param name="decodeFunc">The decode function for buffer.</param>
     /// <returns>The decoded value.</returns>
-    /// <exception cref="InvalidDataException">Thrown when <paramref name="decodeFunc"/> finds invalid data.
+    /// <exception cref="InvalidDataException">Thrown when <paramref name="decodeFunc" /> finds invalid data.
     /// </exception>
     internal static T DecodeBuffer<T>(
         this SliceEncoding encoding,

--- a/src/IceRpc/Slice/Internal/SpanEnumerator.cs
+++ b/src/IceRpc/Slice/Internal/SpanEnumerator.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Slice.Internal;
 
-/// <summary>An enumerator over one or more <see cref="Span{T}"/> of bytes. Used by <see cref="BitSequenceWriter"/>.
+/// <summary>An enumerator over one or more <see cref="Span{T}" /> of bytes. Used by <see cref="BitSequenceWriter" />.
 /// </summary>
 internal ref struct SpanEnumerator
 {

--- a/src/IceRpc/Slice/ProxyExtensions.cs
+++ b/src/IceRpc/Slice/ProxyExtensions.cs
@@ -13,7 +13,7 @@ namespace IceRpc.Slice;
 /// <param name="request">The outgoing request.</param>
 /// <param name="sender">The proxy that sent the request.</param>
 /// <param name="cancellationToken">The cancellation token.</param>
-/// <returns>A value task that contains the return value or a <see cref="RemoteException"/> when the response
+/// <returns>A value task that contains the return value or a <see cref="RemoteException" /> when the response
 /// carries a failure.</returns>
 public delegate ValueTask<T> ResponseDecodeFunc<T>(
     IncomingResponse response,
@@ -21,7 +21,7 @@ public delegate ValueTask<T> ResponseDecodeFunc<T>(
     ServiceProxy sender,
     CancellationToken cancellationToken);
 
-/// <summary>Provides extension methods for interface <see cref="IProxy"/> and generated proxy structs that implement
+/// <summary>Provides extension methods for interface <see cref="IProxy" /> and generated proxy structs that implement
 /// this interface.</summary>
 public static class ProxyExtensions
 {
@@ -32,7 +32,7 @@ public static class ProxyExtensions
         }.ToImmutableDictionary();
 
     /// <summary>Tests whether the target service implements the interface implemented by the TProxy proxy. This
-    /// method is a wrapper for <see cref="IServiceProxy.IceIsAAsync"/>.</summary>
+    /// method is a wrapper for <see cref="IServiceProxy.IceIsAAsync" />.</summary>
     /// <typeparam name="TProxy">The type of the target proxy struct.</typeparam>
     /// <param name="proxy">The source Proxy being tested.</param>
     /// <param name="features">The invocation features.</param>
@@ -54,7 +54,7 @@ public static class ProxyExtensions
     /// <param name="payload">The payload of the request. <c>null</c> is equivalent to an empty payload.</param>
     /// <param name="payloadStream">The optional payload stream of the request.</param>
     /// <param name="responseDecodeFunc">The decode function for the response payload. It decodes and throws a
-    /// <see cref="RemoteException"/> when the response payload contains a failure.</param>
+    /// <see cref="RemoteException" /> when the response payload contains a failure.</param>
     /// <param name="features">The invocation features.</param>
     /// <param name="idempotent">When <see langword="true" />, the request is idempotent.</param>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/IceRpc/Slice/RemoteException.cs
+++ b/src/IceRpc/Slice/RemoteException.cs
@@ -9,7 +9,7 @@ public abstract class RemoteException : Exception, ITrait
     public override string Message => _hasCustomMessage || DefaultMessage is null ? base.Message : DefaultMessage;
 
     /// <summary>Gets or sets a value indicating whether the exception should be converted to a <see
-    /// cref="DispatchException"/> with the <see cref="DispatchErrorCode.UnhandledException"/> error code when
+    /// cref="DispatchException" /> with the <see cref="DispatchErrorCode.UnhandledException" /> error code when
     /// thrown from a dispatcher.</summary>
     public bool ConvertToUnhandled { get; set; }
 

--- a/src/IceRpc/Slice/Service.cs
+++ b/src/IceRpc/Slice/Service.cs
@@ -13,7 +13,7 @@ public class Service : IService, IDispatcher
 {
     /// <summary>A delegate that matches the signature of the generated SliceDXxx methods. For the generated
     /// methods, the type of <c>target</c> is the type of the generated service interface, whereas for this
-    /// delegate it's <see cref="object"/>.</summary>
+    /// delegate it's <see cref="object" />.</summary>
     private delegate ValueTask<OutgoingResponse> DispatchMethod(
         object target,
         IncomingRequest request,

--- a/src/IceRpc/Slice/SliceDecoder.cs
+++ b/src/IceRpc/Slice/SliceDecoder.cs
@@ -34,9 +34,9 @@ public ref partial struct SliceDecoder
     /// <summary>Gets or creates an activator for the Slice types in the specified assembly and its referenced
     /// assemblies.</summary>
     /// <param name="assembly">The assembly.</param>
-    /// <returns>An activator that activates the Slice types defined in <paramref name="assembly"/> provided this
-    /// assembly contains generated code (as determined by the presence of the <see cref="SliceAttribute"/>
-    /// attribute). Types defined in assemblies referenced by <paramref name="assembly"/> are included as well,
+    /// <returns>An activator that activates the Slice types defined in <paramref name="assembly" /> provided this
+    /// assembly contains generated code (as determined by the presence of the <see cref="SliceAttribute" />
+    /// attribute). Types defined in assemblies referenced by <paramref name="assembly" /> are included as well,
     /// recursively. The types defined in the referenced assemblies of an assembly with no generated code are not
     /// considered.</returns>
     public static IActivator GetActivator(Assembly assembly) => ActivatorFactory.Instance.Get(assembly);
@@ -44,8 +44,8 @@ public ref partial struct SliceDecoder
     /// <summary>Gets or creates an activator for the Slice types defined in the specified assemblies and their
     /// referenced assemblies.</summary>
     /// <param name="assemblies">The assemblies.</param>
-    /// <returns>An activator that activates the Slice types defined in <paramref name="assemblies"/> and their
-    /// referenced assemblies. See <see cref="GetActivator(Assembly)"/>.</returns>
+    /// <returns>An activator that activates the Slice types defined in <paramref name="assemblies" /> and their
+    /// referenced assemblies. See <see cref="GetActivator(Assembly)" />.</returns>
     public static IActivator GetActivator(IEnumerable<Assembly> assemblies) =>
         Internal.Activator.Merge(assemblies.Select(assembly => ActivatorFactory.Instance.Get(assembly)));
 
@@ -76,7 +76,7 @@ public ref partial struct SliceDecoder
     /// <param name="encoding">The Slice encoding version.</param>
     /// <param name="activator">The activator.</param>
     /// <param name="serviceProxyFactory">The service proxy factory.</param>
-    /// <param name="templateProxy">The template proxy to give to <paramref name="serviceProxyFactory"/>.</param>
+    /// <param name="templateProxy">The template proxy to give to <paramref name="serviceProxyFactory" />.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>
@@ -118,7 +118,7 @@ public ref partial struct SliceDecoder
     /// <param name="encoding">The Slice encoding version.</param>
     /// <param name="activator">The activator.</param>
     /// <param name="serviceProxyFactory">The service proxy factory.</param>
-    /// <param name="templateProxy">The template proxy to give to <paramref name="serviceProxyFactory"/>.</param>
+    /// <param name="templateProxy">The template proxy to give to <paramref name="serviceProxyFactory" />.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>

--- a/src/IceRpc/Slice/SliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/SliceDecoderExtensions.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace IceRpc.Slice;
 
-/// <summary>Provides extension methods for <see cref="SliceDecoder"/>.</summary>
+/// <summary>Provides extension methods for <see cref="SliceDecoder" />.</summary>
 public static class SliceDecoderExtensions
 {
     /// <summary>Decodes a dictionary.</summary>

--- a/src/IceRpc/Slice/SliceEncodeOptions.cs
+++ b/src/IceRpc/Slice/SliceEncodeOptions.cs
@@ -8,12 +8,12 @@ namespace IceRpc.Slice;
 /// <summary>A property bag used to configure the encoding of payloads.</summary>
 public sealed class SliceEncodeOptions
 {
-    /// <summary>Gets the default instance of <see cref="SliceEncodeOptions"/>.</summary>
+    /// <summary>Gets the default instance of <see cref="SliceEncodeOptions" />.</summary>
     public static SliceEncodeOptions Default { get; } = new();
 
     /// <summary>Gets the pipe options that the Slice engine uses when creating pipes. The Slice engine creates a pipe
     /// when encoding a request or response payload, and when encoding an async enumerable into a
-    /// <see cref="PipeReader"/>.</summary>
+    /// <see cref="PipeReader" />.</summary>
     public PipeOptions PipeOptions { get; }
 
     /// <summary>Gets the stream flush threshold. When encoding a Slice stream (async enumerable), the Slice engine
@@ -23,11 +23,11 @@ public sealed class SliceEncodeOptions
     public int StreamFlushThreshold { get; }
 
     /// <summary>Constructs a new instance.</summary>
-    /// <param name="pool">The pool parameter for the constructor of <see cref="System.IO.Pipelines.PipeOptions"/>.
+    /// <param name="pool">The pool parameter for the constructor of <see cref="System.IO.Pipelines.PipeOptions" />.
     /// </param>
     /// <param name="minimumSegmentSize">The minimum segment size for the constructor of
-    /// <see cref="System.IO.Pipelines.PipeOptions"/>.</param>
-    /// <param name="streamFlushThreshold">The value of <see cref="StreamFlushThreshold"/>. The default value (-1) is
+    /// <see cref="System.IO.Pipelines.PipeOptions" />.</param>
+    /// <param name="streamFlushThreshold">The value of <see cref="StreamFlushThreshold" />. The default value (-1) is
     /// equivalent to 16 KB.</param>
     public SliceEncodeOptions(
         MemoryPool<byte>? pool = default,

--- a/src/IceRpc/Slice/SliceEncoder.cs
+++ b/src/IceRpc/Slice/SliceEncoder.cs
@@ -72,14 +72,14 @@ public ref partial struct SliceEncoder
     /// <summary>Computes the minimum number of bytes required to encode a long value using the Slice encoding's
     /// variable-size encoded representation.</summary>
     /// <param name="value">The long value.</param>
-    /// <returns>The minimum number of bytes required to encode <paramref name="value"/>. Can be 1, 2, 4 or 8.
+    /// <returns>The minimum number of bytes required to encode <paramref name="value" />. Can be 1, 2, 4 or 8.
     /// </returns>
     public static int GetVarInt62EncodedSize(long value) => 1 << GetVarInt62EncodedSizeExponent(value);
 
     /// <summary>Computes the minimum number of bytes required to encode a ulong value using the Slice encoding's
     /// variable-size encoded representation.</summary>
     /// <param name="value">The ulong value.</param>
-    /// <returns>The minimum number of bytes required to encode <paramref name="value"/>. Can be 1, 2, 4 or 8.
+    /// <returns>The minimum number of bytes required to encode <paramref name="value" />. Can be 1, 2, 4 or 8.
     /// </returns>
     public static int GetVarUInt62EncodedSize(ulong value) => 1 << GetVarUInt62EncodedSizeExponent(value);
 
@@ -447,7 +447,7 @@ public ref partial struct SliceEncoder
     /// <param name="tagFormat">The tag format.</param>
     /// <param name="v">The value to encode.</param>
     /// <param name="encodeAction">The delegate that encodes the value after the tag header.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="tagFormat"/> is VSize.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="tagFormat" /> is VSize.</exception>
     public void EncodeTagged<T>(
         int tag,
         TagFormat tagFormat,
@@ -563,7 +563,7 @@ public ref partial struct SliceEncoder
 
     /// <summary>Gets a placeholder to be filled-in later.</summary>
     /// <param name="size">The size of the placeholder, typically a small number like 4.</param>
-    /// <returns>A buffer of length <paramref name="size"/>.</returns>
+    /// <returns>A buffer of length <paramref name="size" />.</returns>
     /// <remarks>We make the assumption the underlying buffer writer allows rewriting memory it provided even after
     /// successive calls to GetMemory/GetSpan and Advance.</remarks>
     public Span<byte> GetPlaceholderSpan(int size)
@@ -617,7 +617,7 @@ public ref partial struct SliceEncoder
 
     /// <summary>Gets a placeholder to be filled-in later.</summary>
     /// <param name="size">The size of the placeholder, typically a small number like 4.</param>
-    /// <returns>A buffer of length <paramref name="size"/>.</returns>
+    /// <returns>A buffer of length <paramref name="size" />.</returns>
     /// <remarks>We make the assumption the underlying buffer writer allows rewriting memory it provided even after
     /// successive calls to GetMemory/GetSpan and Advance.</remarks>
     internal Memory<byte> GetPlaceholderMemory(int size)

--- a/src/IceRpc/Slice/SliceEncoderExtensions.cs
+++ b/src/IceRpc/Slice/SliceEncoderExtensions.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace IceRpc.Slice;
 
-/// <summary>Provides extension methods for <see cref="SliceEncoder"/>.</summary>
+/// <summary>Provides extension methods for <see cref="SliceEncoder" />.</summary>
 public static class SliceEncoderExtensions
 {
     /// <summary>Encodes a dictionary.</summary>
@@ -140,7 +140,7 @@ public static class SliceEncoderExtensions
     /// <summary>Encodes a span of fixed-size numeric values, such as int or ulong.</summary>
     /// <typeparam name="T">The span element type.</typeparam>
     /// <param name="encoder">The Slice encoder.</param>
-    /// <param name="v">The span of numeric values represented by a <see cref="ReadOnlySpan{T}"/>.</param>
+    /// <param name="v">The span of numeric values represented by a <see cref="ReadOnlySpan{T}" />.</param>
     public static void EncodeSpan<T>(this ref SliceEncoder encoder, ReadOnlySpan<T> v)
         where T : struct
     {

--- a/src/IceRpc/Slice/SliceEncodingExtensions.cs
+++ b/src/IceRpc/Slice/SliceEncodingExtensions.cs
@@ -5,7 +5,7 @@ using System.IO.Pipelines;
 
 namespace IceRpc.Slice;
 
-/// <summary>Extension methods for <see cref="SliceEncoding"/>.</summary>
+/// <summary>Extension methods for <see cref="SliceEncoding" />.</summary>
 public static class SliceEncodingExtensions
 {
     private static readonly ReadOnlySequence<byte> _sizeZeroPayload = new(new byte[] { 0 });

--- a/src/IceRpc/Slice/SliceFeature.cs
+++ b/src/IceRpc/Slice/SliceFeature.cs
@@ -2,10 +2,10 @@
 
 namespace IceRpc.Slice;
 
-/// <summary>The default implementation for <see cref="ISliceFeature"/>.</summary>
+/// <summary>The default implementation for <see cref="ISliceFeature" />.</summary>
 public sealed class SliceFeature : ISliceFeature
 {
-    /// <summary>Gets a <see cref="ISliceFeature"/> with default values for all properties.</summary>
+    /// <summary>Gets a <see cref="ISliceFeature" /> with default values for all properties.</summary>
     public static ISliceFeature Default { get; } = new DefaultSliceFeature();
 
     /// <inheritdoc/>
@@ -34,13 +34,13 @@ public sealed class SliceFeature : ISliceFeature
     /// <param name="activator">The activator.</param>
     /// <param name="encodeOptions">The encode options.</param>
     /// <param name="maxCollectionAllocation">The maximum collection allocation. Use <c>-1</c> to get the default value:
-    /// 8 times <paramref name="maxSegmentSize"/> if set, otherwise the value provided by
-    /// <paramref name="defaultFeature"/>.</param>
+    /// 8 times <paramref name="maxSegmentSize" /> if set, otherwise the value provided by
+    /// <paramref name="defaultFeature" />.</param>
     /// <param name="maxDepth">The maximum depth. Use <c>-1</c> to get the default value.</param>
     /// <param name="maxSegmentSize">The maximum segment size. Use <c>-1</c> to get the default value.</param>
     /// <param name="serviceProxyFactory">The service proxy factory.</param>
     /// <param name="defaultFeature">A feature that provides default values for all parameters. Null is equivalent to
-    /// <see cref="Default"/>.</param>
+    /// <see cref="Default" />.</param>
     public SliceFeature(
         IActivator? activator = null,
         SliceEncodeOptions? encodeOptions = null,

--- a/src/IceRpc/Transports/DuplexConnectionOptions.cs
+++ b/src/IceRpc/Transports/DuplexConnectionOptions.cs
@@ -4,11 +4,11 @@ using System.Buffers;
 
 namespace IceRpc.Transports;
 
-/// <summary>A property bag used to configure a <see cref="IDuplexConnection"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="IDuplexConnection" />.</summary>
 public record class DuplexConnectionOptions
 {
-    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool"/>.</summary>
-    /// <value>The minimum size of the segment requested from the <see cref="Pool"/>.</value>
+    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
+    /// <value>The minimum size of the segment requested from the <see cref="Pool" />.</value>
     public int MinSegmentSize
     {
         get => _minSegmentSize;

--- a/src/IceRpc/Transports/IDuplexClientTransport.cs
+++ b/src/IceRpc/Transports/IDuplexClientTransport.cs
@@ -13,10 +13,10 @@ public interface IDuplexClientTransport
     /// <summary>Gets the transport's name.</summary>
     string Name { get; }
 
-    /// <summary>Checks if a server address has valid <see cref="ServerAddress.Params"/> for this client transport. Only
-    /// the params are included in this check.</summary>
+    /// <summary>Checks if a server address has valid <see cref="ServerAddress.Params" /> for this client transport.
+    /// Only the params are included in this check.</summary>
     /// <param name="serverAddress">The server address to check.</param>
-    /// <returns><see langword="true" /> when all params of <paramref name="serverAddress"/> are valid for this
+    /// <returns><see langword="true" /> when all params of <paramref name="serverAddress" /> are valid for this
     /// transport; otherwise, <see langword="false" />.</returns>
     bool CheckParams(ServerAddress serverAddress);
 

--- a/src/IceRpc/Transports/IDuplexConnection.cs
+++ b/src/IceRpc/Transports/IDuplexConnection.cs
@@ -7,18 +7,18 @@ namespace IceRpc.Transports;
 /// <summary>Represents a transport connection created by a duplex transport.</summary>
 public interface IDuplexConnection : IDisposable
 {
-    /// <summary>Gets the server address of this connection. The Transport property of this server address is always non-null.
-    /// </summary>
+    /// <summary>Gets the server address of this connection. The Transport property of this server address is always
+    /// non-null.</summary>
     ServerAddress ServerAddress { get; }
 
     /// <summary>Connects this connection.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>The <see cref="TransportConnectionInformation"/>.</returns>
+    /// <returns>The <see cref="TransportConnectionInformation" />.</returns>
     /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the cancellation token was canceled.</exception>
     /// <exception cref="TransportException">Thrown if a transport error was encountered.</exception>
     /// <remarks>A transport implementation might raise other exceptions. A connection supporting SSL can for instance
-    /// raise <see cref="AuthenticationException"/> if the authentication fails while the connection is being
+    /// raise <see cref="AuthenticationException" /> if the authentication fails while the connection is being
     /// established.</remarks>
     Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken);
 
@@ -26,7 +26,7 @@ public interface IDuplexConnection : IDisposable
     /// <param name="buffer">The buffer that holds the read data.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The number of bytes read. The implementation should always return a positive and non-null number of
-    /// bytes. If it can't read bytes, it should throw <see cref="TransportException"/>.</returns>
+    /// bytes. If it can't read bytes, it should throw <see cref="TransportException" />.</returns>
     /// <exception cref="TransportException">Thrown if a transport error was encountered.</exception>
     /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the cancellation token was canceled.</exception>

--- a/src/IceRpc/Transports/IDuplexServerTransport.cs
+++ b/src/IceRpc/Transports/IDuplexServerTransport.cs
@@ -4,7 +4,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>A class to create a <see cref="IListener{T}"/> to accept incoming duplex connections.</summary>
+/// <summary>A class to create a <see cref="IListener{T}" /> to accept incoming duplex connections.</summary>
 public interface IDuplexServerTransport
 {
     /// <summary>Gets the default duplex server transport.</summary>

--- a/src/IceRpc/Transports/IMultiplexedClientTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedClientTransport.cs
@@ -13,10 +13,10 @@ public interface IMultiplexedClientTransport
     /// <summary>Gets the transport's name.</summary>
     string Name { get; }
 
-    /// <summary>Checks if a server address has valid <see cref="ServerAddress.Params"/> for this client transport. Only
-    /// the params are included in this check.</summary>
+    /// <summary>Checks if a server address has valid <see cref="ServerAddress.Params" /> for this client transport.
+    /// Only the params are included in this check.</summary>
     /// <param name="serverAddress">The server address to check.</param>
-    /// <returns><see langword="true" /> when all params of <paramref name="serverAddress"/> are valid for this
+    /// <returns><see langword="true" /> when all params of <paramref name="serverAddress" /> are valid for this
     /// transport; otherwise, <see langword="false" />.</returns>
     bool CheckParams(ServerAddress serverAddress);
 

--- a/src/IceRpc/Transports/IMultiplexedConnection.cs
+++ b/src/IceRpc/Transports/IMultiplexedConnection.cs
@@ -19,12 +19,12 @@ public interface IMultiplexedConnection : IAsyncDisposable
 
     /// <summary>Connects this connection. This method should only be called once.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>The <see cref="TransportConnectionInformation"/>.</returns>
+    /// <returns>The <see cref="TransportConnectionInformation" />.</returns>
     /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the cancellation token was canceled.</exception>
     /// <exception cref="TransportException">Thrown if a transport error was encountered.</exception>
     /// <remarks>A transport implementation might raise other exceptions. A connection supporting SSL can for instance
-    /// raise <see cref="AuthenticationException"/> if the authentication fails while the connection is being
+    /// raise <see cref="AuthenticationException" /> if the authentication fails while the connection is being
     /// established.</remarks>
     Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken);
 

--- a/src/IceRpc/Transports/IMultiplexedServerTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedServerTransport.cs
@@ -4,7 +4,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>A class to create a <see cref="IListener{T}"/> to accept incoming multiplexed connections.</summary>
+/// <summary>A class to create a <see cref="IListener{T}" /> to accept incoming multiplexed connections.</summary>
 public interface IMultiplexedServerTransport
 {
     /// <summary>Gets the default multiplexed server transport.</summary>

--- a/src/IceRpc/Transports/IMultiplexedStream.cs
+++ b/src/IceRpc/Transports/IMultiplexedStream.cs
@@ -17,7 +17,7 @@ public interface IMultiplexedStream : IDuplexPipe
 
     /// <summary>Gets a value indicating whether the stream is remote. A remote stream is a stream initiated by the peer
     /// and it's returned by <see
-    /// cref="IMultiplexedConnection.AcceptStreamAsync(CancellationToken)"/>.</summary>
+    /// cref="IMultiplexedConnection.AcceptStreamAsync(CancellationToken)" />.</summary>
     bool IsRemote { get; }
 
     /// <summary>Gets a value indicating whether the stream is started.</summary>
@@ -29,8 +29,8 @@ public interface IMultiplexedStream : IDuplexPipe
     /// <summary>Gets a task that completes when writes are closed.</summary>
     Task WritesClosed { get; }
 
-    /// <summary>Aborts the stream by completing the <see cref="IDuplexPipe.Input"/> and <see
-    /// cref="IDuplexPipe.Output"/> with the given exception.</summary>
+    /// <summary>Aborts the stream by completing the <see cref="IDuplexPipe.Input" /> and <see
+    /// cref="IDuplexPipe.Output" /> with the given exception.</summary>
     /// <param name="exception">The completion exception.</param>
     void Abort(Exception exception);
 }

--- a/src/IceRpc/Transports/IMultiplexedStreamErrorCodeConverter.cs
+++ b/src/IceRpc/Transports/IMultiplexedStreamErrorCodeConverter.cs
@@ -5,7 +5,7 @@ using System.IO.Pipelines;
 namespace IceRpc.Transports;
 
 /// <summary>A multiplexed stream implementation uses this interface to convert exceptions it receives through
-/// <see cref="PipeReader.Complete(Exception?)"/>, <see cref="PipeWriter.Complete(Exception?)"/> and similar APIs
+/// <see cref="PipeReader.Complete(Exception?)" />, <see cref="PipeWriter.Complete(Exception?)" /> and similar APIs
 /// into error codes, and to convert error codes sent by the remote peer into exceptions.</summary>
 public interface IMultiplexedStreamErrorCodeConverter
 {

--- a/src/IceRpc/Transports/Internal/AsyncQueue.cs
+++ b/src/IceRpc/Transports/Internal/AsyncQueue.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks.Sources;
 
 namespace IceRpc.Transports.Internal;
 
-/// <summary>The AsyncQueue provides queuing functionality with a <see cref="ValueTask"/> asynchronous dequeue
+/// <summary>The AsyncQueue provides queuing functionality with a <see cref="ValueTask" /> asynchronous dequeue
 /// function. This class is public even though it's in the internal namespace. It's used by the coloc transport
 /// which is implemented in another assembly.</summary>
 internal class AsyncQueue<T> : IAsyncQueueValueTaskSource<T>
@@ -45,8 +45,8 @@ internal class AsyncQueue<T> : IAsyncQueueValueTaskSource<T>
     internal bool Enqueue(T value) => _queue.Enqueue(value);
 
     /// <summary>Attempts to mark the queue as being completed, meaning no more elements will be queued. The exception
-    /// will be raised by <see cref="Enqueue"/> if it's called after this call. It will also be called by
-    /// <see cref="DequeueAsync"/> after the last element has been dequeued.</summary>
+    /// will be raised by <see cref="Enqueue" /> if it's called after this call. It will also be called by
+    /// <see cref="DequeueAsync" /> after the last element has been dequeued.</summary>
     /// <param name="exception">The exception indication why no more elements can be queued.</param>
     /// <returns><see langword="true" /> if the queue as been marked as completed, <see langword="false" /> if the queue
     /// was already completed.</returns>

--- a/src/IceRpc/Transports/Internal/AsyncQueueCore.cs
+++ b/src/IceRpc/Transports/Internal/AsyncQueueCore.cs
@@ -41,7 +41,7 @@ internal struct AsyncQueueCore<T>
         _tokenRegistration = default;
     }
 
-    /// <summary>Complete the pending <see cref="DequeueAsync"/> and discard queued items.</summary>
+    /// <summary>Complete the pending <see cref="DequeueAsync" /> and discard queued items.</summary>
     internal bool TryComplete(Exception exception)
     {
         bool lockTaken = false;

--- a/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
+++ b/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
@@ -102,8 +102,8 @@ internal class DuplexConnectionReader : IDisposable
     internal void AdvanceTo(SequencePosition consumed, SequencePosition examined) =>
         _pipe.Reader.AdvanceTo(consumed, examined);
 
-    /// <summary>Writes <paramref name="byteCount"/> bytes read from this pipe reader or its underlying connection
-    /// into <paramref name="bufferWriter"/>.</summary>
+    /// <summary>Writes <paramref name="byteCount" /> bytes read from this pipe reader or its underlying connection
+    /// into <paramref name="bufferWriter" />.</summary>
     internal ValueTask FillBufferWriterAsync(
         IBufferWriter<byte> bufferWriter,
         int byteCount,

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -10,8 +10,8 @@ using System.IO.Pipelines;
 
 namespace IceRpc.Transports.Internal;
 
-/// <summary>The Slic connection implements an <see cref="IMultiplexedConnection"/> on top of a <see
-/// cref="IDuplexConnection"/>.</summary>
+/// <summary>The Slic connection implements an <see cref="IMultiplexedConnection" /> on top of a <see
+/// cref="IDuplexConnection" />.</summary>
 internal class SlicConnection : IMultiplexedConnection
 {
     public ServerAddress ServerAddress => _duplexConnection.ServerAddress;

--- a/src/IceRpc/Transports/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeReader.cs
@@ -268,16 +268,16 @@ internal class SlicPipeReader : PipeReader
 
     /// <summary>The state enumeration is used to ensure the reader is not used after it's completed and to ensure that
     /// the internal pipe writer isn't completed concurrently when it's being used by <see
-    /// cref="ReceivedStreamFrameAsync"/>.</summary>
+    /// cref="ReceivedStreamFrameAsync" />.</summary>
     private enum State : int
     {
-        /// <summary><see cref="Complete"/> was called on this Slic pipe reader.</summary>
+        /// <summary><see cref="Complete" /> was called on this Slic pipe reader.</summary>
         Completed = 1,
 
         /// <summary>Data is being written to the internal pipe writer.</summary>
         PipeWriterInUse = 2,
 
-        /// <summary>The internal pipe writer was completed by <see cref="Abort"/>.</summary>
+        /// <summary>The internal pipe writer was completed by <see cref="Abort" />.</summary>
         PipeWriterCompleted = 4
     }
 }

--- a/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
@@ -230,13 +230,13 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     /// that the internal pipe reader isn't completed concurrently when it's being used by WriteAsync.</summary>
     private enum State : int
     {
-        /// <summary><see cref="Complete"/> was called on this Slic pipe writer.</summary>
+        /// <summary><see cref="Complete" /> was called on this Slic pipe writer.</summary>
         Completed = 1,
 
         /// <summary>Data is being read from the internal pipe reader.</summary>
         PipeReaderInUse = 2,
 
-        /// <summary>The internal pipe reader was completed either by <see cref="Abort"/>.</summary>
+        /// <summary>The internal pipe reader was completed either by <see cref="Abort" />.</summary>
         PipeReaderCompleted = 4
     }
 }

--- a/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
@@ -6,7 +6,7 @@ namespace IceRpc.Transports.Internal;
 
 internal static class SocketExceptionExtensions
 {
-    /// <summary>Converts an exception from a socket operation into a <see cref="TransportException"/>.</summary>
+    /// <summary>Converts an exception from a socket operation into a <see cref="TransportException" />.</summary>
     internal static Exception ToTransportException(this Exception exception)
     {
         SocketException socketException =

--- a/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
+++ b/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 
 namespace IceRpc.Transports;
 
-/// <summary>A property bag used to configure a <see cref="IMultiplexedConnection"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="IMultiplexedConnection" />.</summary>
 public record class MultiplexedConnectionOptions
 {
     /// <summary>Gets or sets the maximum allowed number of simultaneous remote bidirectional streams that can be
@@ -17,16 +17,16 @@ public record class MultiplexedConnectionOptions
     /// <value>The maximum number of remote unidirectional streams.</value>
     public int MaxUnidirectionalStreams { get; set; } = DefaultMaxUnidirectionalStreams;
 
-    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool"/>.</summary>
-    /// <value>The minimum size of the segment requested from the <see cref="Pool"/>.</value>
+    /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
+    /// <value>The minimum size of the segment requested from the <see cref="Pool" />.</value>
     public int MinSegmentSize { get; set; } = 4096;
 
     /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
     /// <value>A pool of memory blocks used for buffer management.</value>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
-    /// <summary>Gets or sets the <see cref="IMultiplexedStreamErrorCodeConverter"/>.</summary>
-    /// <value>The <see cref="IMultiplexedStreamErrorCodeConverter"/>.</value>
+    /// <summary>Gets or sets the <see cref="IMultiplexedStreamErrorCodeConverter" />.</summary>
+    /// <value>The <see cref="IMultiplexedStreamErrorCodeConverter" />.</value>
     public IMultiplexedStreamErrorCodeConverter? StreamErrorCodeConverter { get; set; }
 
     internal const int DefaultMaxBidirectionalStreams = 100;

--- a/src/IceRpc/Transports/ReadOnlySequencePipeWriter.cs
+++ b/src/IceRpc/Transports/ReadOnlySequencePipeWriter.cs
@@ -5,10 +5,10 @@ using System.IO.Pipelines;
 
 namespace IceRpc.Transports;
 
-/// <summary>The <see cref="ReadOnlySequencePipeWriter"/> abstract class can be extended by pipe writers to provide
-/// a <see cref="PipeWriter.WriteAsync"/> method with a <see cref="ReadOnlySequence{T}"/> source. It also provides a
+/// <summary>The <see cref="ReadOnlySequencePipeWriter" /> abstract class can be extended by pipe writers to provide
+/// a <see cref="PipeWriter.WriteAsync" /> method with a <see cref="ReadOnlySequence{T}" /> source. It also provides a
 /// boolean to notify the pipe writer implementation that no more data will be written. This class is useful for
-/// implementing multiplexed stream pipe writers and to optimize the writing of a <see cref="ReadOnlySequence{T}"/>
+/// implementing multiplexed stream pipe writers and to optimize the writing of a <see cref="ReadOnlySequence{T}" />
 /// for transports that support a gather write API.</summary>
 public abstract class ReadOnlySequencePipeWriter : PipeWriter
 {

--- a/src/IceRpc/Transports/SlicClientTransport.cs
+++ b/src/IceRpc/Transports/SlicClientTransport.cs
@@ -5,7 +5,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>Implements <see cref="IMultiplexedClientTransport"/> using Slic over a duplex client transport.</summary>
+/// <summary>Implements <see cref="IMultiplexedClientTransport" /> using Slic over a duplex client transport.</summary>
 public class SlicClientTransport : IMultiplexedClientTransport
 {
     /// <inheritdoc/>

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -5,7 +5,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>Implements <see cref="IMultiplexedServerTransport"/> using Slic over a duplex server transport.</summary>
+/// <summary>Implements <see cref="IMultiplexedServerTransport" /> using Slic over a duplex server transport.</summary>
 public class SlicServerTransport : IMultiplexedServerTransport
 {
     /// <inheritdoc/>

--- a/src/IceRpc/Transports/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/SlicTransportOptions.cs
@@ -2,8 +2,8 @@
 
 namespace IceRpc.Transports;
 
-/// <summary>A property bag used to configure a <see cref="SlicClientTransport"/> or
-/// <see cref="SlicServerTransport"/>.</summary>
+/// <summary>A property bag used to configure a <see cref="SlicClientTransport" /> or
+/// <see cref="SlicServerTransport" />.</summary>
 public sealed record class SlicTransportOptions
 {
     /// <summary>Gets or sets the idle timeout. This timeout is used to monitor the transport connection health. If no

--- a/src/IceRpc/Transports/TcpClientTransport.cs
+++ b/src/IceRpc/Transports/TcpClientTransport.cs
@@ -9,7 +9,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>Implements <see cref="IDuplexClientTransport"/> for the tcp and ssl transports.</summary>
+/// <summary>Implements <see cref="IDuplexClientTransport" /> for the tcp and ssl transports.</summary>
 public class TcpClientTransport : IDuplexClientTransport
 {
     /// <inheritdoc/>
@@ -20,13 +20,13 @@ public class TcpClientTransport : IDuplexClientTransport
 
     private readonly TcpClientTransportOptions _options;
 
-    /// <summary>Constructs a <see cref="TcpClientTransport"/>.</summary>
+    /// <summary>Constructs a <see cref="TcpClientTransport" />.</summary>
     public TcpClientTransport()
         : this(new())
     {
     }
 
-    /// <summary>Constructs a <see cref="TcpClientTransport"/>.</summary>
+    /// <summary>Constructs a <see cref="TcpClientTransport" />.</summary>
     /// <param name="options">The transport options.</param>
     public TcpClientTransport(TcpClientTransportOptions options) => _options = options;
 

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -5,7 +5,7 @@ using System.Net.Security;
 
 namespace IceRpc.Transports;
 
-/// <summary>Implements <see cref="IDuplexServerTransport"/> for the tcp and ssl transports.</summary>
+/// <summary>Implements <see cref="IDuplexServerTransport" /> for the tcp and ssl transports.</summary>
 public class TcpServerTransport : IDuplexServerTransport
 {
     /// <inheritdoc/>
@@ -13,13 +13,13 @@ public class TcpServerTransport : IDuplexServerTransport
 
     private readonly TcpServerTransportOptions _options;
 
-    /// <summary>Constructs a <see cref="TcpServerTransport"/>.</summary>
+    /// <summary>Constructs a <see cref="TcpServerTransport" />.</summary>
     public TcpServerTransport()
         : this(new())
     {
     }
 
-    /// <summary>Constructs a <see cref="TcpServerTransport"/>.</summary>
+    /// <summary>Constructs a <see cref="TcpServerTransport" />.</summary>
     /// <param name="options">The transport options.</param>
     public TcpServerTransport(TcpServerTransportOptions options) => _options = options;
 

--- a/src/IceRpc/Transports/TcpTransportOptions.cs
+++ b/src/IceRpc/Transports/TcpTransportOptions.cs
@@ -31,7 +31,7 @@ public record class TcpTransportOptions
     private int? _sendBufferSize;
 }
 
-/// <summary>The options class for configuring <see cref="TcpClientTransport"/>.</summary>
+/// <summary>The options class for configuring <see cref="TcpClientTransport" />.</summary>
 public sealed record class TcpClientTransportOptions : TcpTransportOptions
 {
     /// <summary>Gets or sets the address and port represented by a .NET IPEndPoint to use for a client
@@ -41,12 +41,12 @@ public sealed record class TcpClientTransportOptions : TcpTransportOptions
     public IPEndPoint? LocalNetworkAddress { get; set; }
 }
 
-/// <summary>The options class for configuring <see cref="TcpServerTransport"/>.</summary>
+/// <summary>The options class for configuring <see cref="TcpServerTransport" />.</summary>
 public sealed record class TcpServerTransportOptions : TcpTransportOptions
 {
     /// <summary>Gets or sets the length of the server socket queue for accepting new connections. If a new connection
     /// request arrives and the queue is full, the client connection establishment will fail with a <see
-    /// cref="TransportException"/> and the <see cref="TransportErrorCode.ConnectionRefused"/> error code.</summary>
+    /// cref="TransportException" /> and the <see cref="TransportErrorCode.ConnectionRefused" /> error code.</summary>
     /// <value>The server socket backlog size. The default is 511.</value>
     public int ListenerBackLog
     {

--- a/src/IceRpc/Transports/TransportConnectionInformation.cs
+++ b/src/IceRpc/Transports/TransportConnectionInformation.cs
@@ -17,7 +17,7 @@ public sealed record class TransportConnectionInformation
     /// <summary>Gets the certificate of the remote peer, if provided.</summary>
     public X509Certificate? RemoteCertificate { get; }
 
-    /// <summary>Constructs a new instance of <see cref="TransportConnectionInformation"/>.</summary>
+    /// <summary>Constructs a new instance of <see cref="TransportConnectionInformation" />.</summary>
     /// <param name="localNetworkAddress">The local network address.</param>
     /// <param name="remoteNetworkAddress">The remote network address.</param>
     /// <param name="remoteCertificate">The remote certificate.</param>

--- a/src/IceRpc/Transports/TransportException.cs
+++ b/src/IceRpc/Transports/TransportException.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Transports;
 
-/// <summary>The possible error codes carried by a <see cref="TransportException"/>. The error code specifies the
+/// <summary>The possible error codes carried by a <see cref="TransportException" />. The error code specifies the
 /// reason of the transport failure.</summary>
 public enum TransportErrorCode
 {
@@ -10,8 +10,8 @@ public enum TransportErrorCode
     AddressInUse,
 
     /// <summary>The peer closed the connection. With multiplexed transports, <see
-    /// cref="TransportException.ApplicationErrorCode"/> is set to the error code provided to <see
-    /// cref="IMultiplexedConnection.CloseAsync"/>.</summary>
+    /// cref="TransportException.ApplicationErrorCode" /> is set to the error code provided to <see
+    /// cref="IMultiplexedConnection.CloseAsync" />.</summary>
     ConnectionClosed,
 
     /// <summary>The connection was disposed.</summary>
@@ -42,28 +42,28 @@ public class TransportException : Exception
 {
     /// <summary>Gets the application protocol error code. It's set when this exception is triggered by the closure of a
     /// multiplexed connection by the remote peer. <see cref = "ErrorCode" /> is <see
-    /// cref="TransportErrorCode.ConnectionClosed"/> in this situation. In all other situations, this property is null.
+    /// cref="TransportErrorCode.ConnectionClosed" /> in this situation. In all other situations, this property is null.
     /// The remote peer specifies the application error code when calling <see cref=
-    /// "IMultiplexedConnection.CloseAsync"/>.</summary>
+    /// "IMultiplexedConnection.CloseAsync" />.</summary>
     public ulong? ApplicationErrorCode { get; }
 
     /// <summary>Gets the transport error code.</summary>
     public TransportErrorCode ErrorCode { get; }
 
-    /// <summary>Constructs a new instance of the <see cref="TransportException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="TransportException" /> class with a specified error
     /// code.</summary>
     /// <param name="errorCode">The error code.</param>
     public TransportException(TransportErrorCode errorCode)
         : base($"{nameof(TransportException)} {{ ErrorCode = {errorCode} }}") => ErrorCode = errorCode;
 
-    /// <summary>Constructs a new instance of the <see cref="TransportException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="TransportException" /> class with a specified error
     /// code and message.</summary>
     /// <param name="errorCode">The error code.</param>
     /// <param name="message">The message.</param>
     public TransportException(TransportErrorCode errorCode, string message)
         : base(message) => ErrorCode = errorCode;
 
-    /// <summary>Constructs a new instance of the <see cref="TransportException"/> class with a specified error
+    /// <summary>Constructs a new instance of the <see cref="TransportException" /> class with a specified error
     /// code and application error code.</summary>
     /// <param name="errorCode">The error code.</param>
     /// <param name="applicationErrorCode">The application error code.</param>
@@ -75,8 +75,8 @@ public class TransportException : Exception
         ApplicationErrorCode = applicationErrorCode;
     }
 
-    /// <summary>Constructs a new instance of the <see cref="TransportException"/> class with a specified error code and
-    /// a reference to the inner exception that is the cause of this exception.</summary>
+    /// <summary>Constructs a new instance of the <see cref="TransportException" /> class with a specified error code
+    /// and a reference to the inner exception that is the cause of this exception.</summary>
     /// <param name="errorCode">The error code.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public TransportException(TransportErrorCode errorCode, Exception innerException)

--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportConformanceTests.cs
@@ -249,7 +249,7 @@ public abstract class DuplexTransportConformanceTests
             async () => await sut.ClientConnection.ReadAsync(buffer, new CancellationToken(canceled: true)));
     }
 
-    /// <summary>Verifies that a read operation ends with <see cref="OperationCanceledException"/> if the given
+    /// <summary>Verifies that a read operation ends with <see cref="OperationCanceledException" /> if the given
     /// cancellation token is canceled.</summary>
     [Test]
     public async Task Read_cancellation()
@@ -269,7 +269,7 @@ public abstract class DuplexTransportConformanceTests
         Assert.That(async () => await readTask, Throws.InstanceOf<OperationCanceledException>());
     }
 
-    /// <summary>Verifies that calling read on a connection fails with <see cref="TransportErrorCode.ConnectionReset"/>
+    /// <summary>Verifies that calling read on a connection fails with <see cref="TransportErrorCode.ConnectionReset" />
     /// if the peer connection is disposed.</summary>
     [Test]
     public async Task Read_from_disposed_peer_connection_fails_with_transport_reset_error(
@@ -288,11 +288,11 @@ public abstract class DuplexTransportConformanceTests
 
         // Act/Assert
         TransportException? exception = Assert.ThrowsAsync<TransportException>(
-            async() => await readFrom.ReadAsync(new byte[1], default));
+            async () => await readFrom.ReadAsync(new byte[1], default));
         Assert.That(exception!.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionReset));
     }
 
-    /// <summary>Verifies that calling read on a disposed connection fails with <see cref="ObjectDisposedException"/>.
+    /// <summary>Verifies that calling read on a disposed connection fails with <see cref="ObjectDisposedException" />.
     /// </summary>
     [Test]
     public async Task Read_from_disposed_connection_fails([Values(true, false)] bool disposeServerConnection)
@@ -461,7 +461,7 @@ public abstract class DuplexTransportConformanceTests
             async () => await sut.ClientConnection.WriteAsync(buffer, new CancellationToken(canceled: true)));
     }
 
-    /// <summary>Verifies that pending write operation fails with <see cref="OperationCanceledException"/> once the
+    /// <summary>Verifies that pending write operation fails with <see cref="OperationCanceledException" /> once the
     /// cancellation token is canceled.</summary>
     [Test]
     public async Task Write_cancellation()
@@ -498,7 +498,7 @@ public abstract class DuplexTransportConformanceTests
         Assert.That(async () => await writeTask, Throws.InstanceOf<OperationCanceledException>());
     }
 
-    /// <summary>Verifies that calling write fails with <see cref="TransportErrorCode.ConnectionReset"/> when the peer
+    /// <summary>Verifies that calling write fails with <see cref="TransportErrorCode.ConnectionReset" /> when the peer
     /// connection is disposed.</summary>
     [Test]
     public async Task Write_to_disposed_peer_connection_fails_with_transport_reset_error()
@@ -532,7 +532,7 @@ public abstract class DuplexTransportConformanceTests
         Assert.That(exception.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionReset));
     }
 
-    /// <summary>Verifies that calling read on a disposed connection fails with <see cref="ObjectDisposedException"/>.
+    /// <summary>Verifies that calling read on a disposed connection fails with <see cref="ObjectDisposedException" />.
     /// </summary>
     [Test]
     public async Task Write_to_disposed_connection_fails([Values(true, false)] bool disposeServerConnection)

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -282,7 +282,7 @@ public abstract class MultiplexedTransportConformanceTests
     }
 
     /// <summary>Verifies that completing a stream with unflushed bytes fails with
-    /// <see cref="NotSupportedException"/>.</summary>
+    /// <see cref="NotSupportedException" />.</summary>
     [Test]
     public async Task Complete_stream_with_unflushed_bytes_fails()
     {
@@ -962,7 +962,7 @@ public abstract class MultiplexedTransportConformanceTests
     }
 
     /// <summary>Verifies that calling read with a canceled cancellation token fails with
-    /// <see cref="OperationCanceledException"/>.</summary>
+    /// <see cref="OperationCanceledException" />.</summary>
     [Test]
     public async Task Stream_read_with_canceled_token_fails()
     {
@@ -1030,7 +1030,7 @@ public abstract class MultiplexedTransportConformanceTests
     }
 
     /// <summary>Verifies that calling write with a canceled cancellation token fails with
-    /// <see cref="OperationCanceledException"/>.</summary>
+    /// <see cref="OperationCanceledException" />.</summary>
     [Test]
     public async Task Stream_write_with_canceled_token_fails()
     {

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -43,8 +43,8 @@ public sealed class DeadlineInterceptorTests
         Assert.That(token.Value.IsCancellationRequested, Is.True);
     }
 
-    /// <summary>Verifies that the deadline value set in the <see cref="IDeadlineFeature"/> prevails over
-    /// the default timeout value configured when installing the <see cref="DeadlineInterceptor"/>.</summary>
+    /// <summary>Verifies that the deadline value set in the <see cref="IDeadlineFeature" /> prevails over
+    /// the default timeout value configured when installing the <see cref="DeadlineInterceptor" />.</summary>
     [Test]
     [NonParallelizable]
     public async Task Deadline_feature_value_prevails_over_default_timeout()

--- a/tests/IceRpc.Locator.Tests/LocatorServerAddressFinderTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocatorServerAddressFinderTests.cs
@@ -9,7 +9,7 @@ namespace IceRpc.Locator.Tests;
 
 public class LocatorServerAddressFinderTests
 {
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly resolves an adapter ID.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly resolves an adapter ID.</summary>
     [Test]
     public async Task Find_adapter_by_id()
     {
@@ -22,8 +22,8 @@ public class LocatorServerAddressFinderTests
         Assert.That(serviceAddress, Is.EqualTo(expectedServiceAddress.ServiceAddress));
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly handles
-    /// <see cref="AdapterNotFoundException"/>.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly handles
+    /// <see cref="AdapterNotFoundException" />.</summary>
     [Test]
     public async Task Find_adapter_by_id_not_found()
     {
@@ -35,7 +35,7 @@ public class LocatorServerAddressFinderTests
         Assert.That(serviceAddress, Is.Null);
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly resolves an object ID.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly resolves an object ID.</summary>
     [Test]
     public void Find_adapter_by_id_returning_a_proxy_without_server_address_fails()
     {
@@ -48,7 +48,7 @@ public class LocatorServerAddressFinderTests
             Throws.TypeOf<InvalidDataException>());
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly resolves an object ID.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly resolves an object ID.</summary>
     [Test]
     public async Task Find_object_by_id()
     {
@@ -61,8 +61,8 @@ public class LocatorServerAddressFinderTests
         Assert.That(serviceAddress, Is.EqualTo(expectedServiceAddress.ServiceAddress));
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly handles
-    /// <see cref="ObjectNotFoundException"/>.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly handles
+    /// <see cref="ObjectNotFoundException" />.</summary>
     [Test]
     public async Task Find_object_by_id_not_found()
     {
@@ -74,7 +74,7 @@ public class LocatorServerAddressFinderTests
         Assert.That(serviceAddress, Is.Null);
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly resolves an object ID.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly resolves an object ID.</summary>
     [Test]
     public void Find_object_by_id_returning_proxy_without_server_address_fails()
     {
@@ -87,7 +87,7 @@ public class LocatorServerAddressFinderTests
             Throws.TypeOf<InvalidDataException>());
     }
 
-    /// <summary>Verifies that <see cref="LocatorServerAddressFinder"/> correctly resolves an object ID.</summary>
+    /// <summary>Verifies that <see cref="LocatorServerAddressFinder" /> correctly resolves an object ID.</summary>
     [Test]
     public void Find_object_by_id_returning_proxy_without_ice_protocol_fails()
     {
@@ -100,7 +100,7 @@ public class LocatorServerAddressFinderTests
             Throws.TypeOf<InvalidDataException>());
     }
 
-    /// <summary>Verifies that <see cref="CacheUpdateServerAddressFinderDecorator"/> adds found entries
+    /// <summary>Verifies that <see cref="CacheUpdateServerAddressFinderDecorator" /> adds found entries
     /// to the server address cache.</summary>
     [Test]
     public async Task Cache_decorator_adds_found_entries_to_the_server_address_cache()
@@ -120,7 +120,7 @@ public class LocatorServerAddressFinderTests
         Assert.That(serverAddressCache.Cache[location], Is.EqualTo(expectedServiceAddress));
     }
 
-    /// <summary>Verifies that <see cref="CacheUpdateServerAddressFinderDecorator"/> removes not found entries
+    /// <summary>Verifies that <see cref="CacheUpdateServerAddressFinderDecorator" /> removes not found entries
     /// from the server address cache.</summary>
     [Test]
     public async Task Cache_decorator_removes_not_found_entries_from_the_server_address_cache()
@@ -139,7 +139,8 @@ public class LocatorServerAddressFinderTests
         Assert.That(serverAddressCache.Cache, Is.Empty);
     }
 
-    /// <summary>Verifies that <see cref="CoalesceServerAddressFinderDecorator"/> coalesce identical requests.</summary>
+    /// <summary>Verifies that <see cref="CoalesceServerAddressFinderDecorator" /> coalesce identical requests.
+    /// </summary>
     [Test]
     public async Task Coalesce_decorator_coalesce_identical_requests()
     {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Telemetry.Tests;
 public sealed class TelemetryInterceptorTests
 {
     /// <summary>Verifies that the invocation activity is created using the activity source used to create the
-    /// <see cref="TelemetryInterceptor"/>.</summary>
+    /// <see cref="TelemetryInterceptor" />.</summary>
     [Test]
     public async Task Invocation_activity_created_from_activity_source()
     {
@@ -54,7 +54,7 @@ public sealed class TelemetryInterceptorTests
     }
 
     /// <summary>Verifies that the invocation activity context is encoded as a field with the
-    /// <see cref="RequestFieldKey.TraceContext"/> key.</summary>
+    /// <see cref="RequestFieldKey.TraceContext" /> key.</summary>
     [Test]
     public async Task Invocation_activity_encodes_trace_context_field()
     {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Telemetry.Tests;
 public sealed class TelemetryMiddlewareTests
 {
     /// <summary>Verifies that the dispatch activity is created using the activity source used to create the
-    /// <see cref="TelemetryMiddleware"/>.</summary>
+    /// <see cref="TelemetryMiddleware" />.</summary>
     [Test]
     public async Task Dispatch_activity_created_from_activity_source()
     {
@@ -53,7 +53,7 @@ public sealed class TelemetryMiddlewareTests
     }
 
     /// <summary>Verifies that the dispatch activity context is restored from the
-    /// <see cref="RequestFieldKey.TraceContext"/> field.</summary>
+    /// <see cref="RequestFieldKey.TraceContext" /> field.</summary>
     [Test]
     public async Task Dispatch_activity_decodes_trace_context_field()
     {
@@ -120,7 +120,7 @@ public sealed class TelemetryMiddlewareTests
     }
 
     /// <summary>Verifies that the dispatch activity context is restored from the
-    /// <see cref="RequestFieldKey.TraceContext"/> field.</summary>
+    /// <see cref="RequestFieldKey.TraceContext" /> field.</summary>
     [Test]
     public void Decoding_empty_trace_context_field_fails()
     {

--- a/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
+++ b/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
@@ -5,7 +5,7 @@ using System.Net;
 
 namespace IceRpc.Tests.Common;
 
-/// <summary>Provides a fake implementation of <see cref="IConnectionContext"/>.</summary>
+/// <summary>Provides a fake implementation of <see cref="IConnectionContext" />.</summary>
 public sealed class FakeConnectionContext : IConnectionContext
 {
     public static IConnectionContext Ice { get; } = new FakeConnectionContext(Protocol.Ice);

--- a/tests/IceRpc.Tests.Common/NotImplementedInvoker.cs
+++ b/tests/IceRpc.Tests.Common/NotImplementedInvoker.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Tests.Common;
 
-/// <summary>A trivial invoker that always throws <see cref="NotImplementedException"/>.</summary>
+/// <summary>A trivial invoker that always throws <see cref="NotImplementedException" />.</summary>
 public class NotImplementedInvoker : IInvoker
 {
     /// <summary>Gets the unique instance of this class.</summary>

--- a/tests/IceRpc.Tests/ClientConnectionTests.cs
+++ b/tests/IceRpc.Tests/ClientConnectionTests.cs
@@ -13,8 +13,8 @@ public class ClientConnectionTests
 {
     private static List<Protocol> Protocols => new() { Protocol.IceRpc, Protocol.Ice };
 
-    /// <summary>Verifies that <see cref="ClientConnection.ConnectAsync"/> returns a valid <see
-    /// cref="TransportConnectionInformation"/></summary>
+    /// <summary>Verifies that <see cref="ClientConnection.ConnectAsync" /> returns a valid <see
+    /// cref="TransportConnectionInformation" /></summary>
     [Test, TestCaseSource(nameof(Protocols))]
     public async Task Connect_returns_transport_connection_information(Protocol protocol)
     {

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -29,15 +29,15 @@ public sealed class IceProtocolConnectionTests
     {
         get
         {
-            // Service not found failure with a service address that has no server address gets OtherReplica retry policy response
-            // field.
+            // Service not found failure with a service address that has no server address gets OtherReplica retry
+            // policy response field.
             yield return new TestCaseData(
                 new ServiceAddress(Protocol.Ice),
                 DispatchErrorCode.ServiceNotFound,
                 RetryPolicy.OtherReplica);
 
-            // Service not found failure with a service address that has server addresses does not get a retry policy response
-            // field
+            // Service not found failure with a service address that has server addresses does not get a retry policy
+            // response field
             yield return new TestCaseData(
                 new ServiceAddress(new Uri("ice://localhost/service")),
                 DispatchErrorCode.ServiceNotFound,
@@ -52,7 +52,7 @@ public sealed class IceProtocolConnectionTests
     }
 
     /// <summary>Verifies that disposing a server connection causes the invocation to fail with <see
-    /// cref="DispatchException"/>.</summary>
+    /// cref="DispatchException" />.</summary>
     [Test]
     public async Task Disposing_server_connection_triggers_dispatch_exception([Values(false, true)] bool shutdown)
     {

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -73,7 +73,7 @@ public sealed class IceRpcProtocolConnectionTests
     }
 
     /// <summary>Verifies that disposing a server connection causes the invocation to fail with <see
-    /// cref="IceRpcProtocolStreamException"/>.</summary>
+    /// cref="IceRpcProtocolStreamException" />.</summary>
     [Test]
     public async Task Disposing_server_connection_triggers_stream_exception(
         [Values(false, true)] bool shutdown)
@@ -105,7 +105,7 @@ public sealed class IceRpcProtocolConnectionTests
     /// <summary>Verifies that exceptions thrown by the dispatcher are correctly mapped to a DispatchException with the
     /// expected error code and no retry policy.</summary>
     /// <param name="thrownException">The exception to throw by the dispatcher.</param>
-    /// <param name="errorCode">The expected <see cref="DispatchErrorCode"/>.</param>
+    /// <param name="errorCode">The expected <see cref="DispatchErrorCode" />.</param>
     [Test, TestCaseSource(nameof(ExceptionIsEncodedAsDispatchExceptionSource))]
     public async Task Exception_is_encoded_as_a_dispatch_exception(
         Exception thrownException,

--- a/tests/IceRpc.Tests/PipelineTests.cs
+++ b/tests/IceRpc.Tests/PipelineTests.cs
@@ -8,7 +8,7 @@ namespace IceRpc.Tests;
 public class PipelineTests
 {
     /// <summary>Verifies that an invoker cannot be added after
-    /// <see cref="Pipeline.InvokeAsync(OutgoingRequest, CancellationToken)"/> has been called for the first time.
+    /// <see cref="Pipeline.InvokeAsync(OutgoingRequest, CancellationToken)" /> has been called for the first time.
     /// </summary>
     [Test]
     public void Cannot_add_invoker_after_calling_invoke()

--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -212,7 +212,7 @@ public sealed class ProtocolConnectionTests
     }
 
     /// <summary>Verifies that disposing a connection that was not connected completes the
-    /// <see cref="ProtocolConnection.ShutdownComplete"/> task.</summary>
+    /// <see cref="ProtocolConnection.ShutdownComplete" /> task.</summary>
     [Test, TestCaseSource(nameof(Protocols))]
     public async Task ShutdownComplete_completes_when_disposing_not_connected_connection(Protocol protocol)
     {
@@ -432,7 +432,7 @@ public sealed class ProtocolConnectionTests
     }
 
     /// <summary>Verifies that disposing the client connection aborts pending invocations, the invocations will fail
-    /// with <see cref="ObjectDisposedException"/>.</summary>
+    /// with <see cref="ObjectDisposedException" />.</summary>
     [Test, TestCaseSource(nameof(Protocols))]
     public async Task Dispose_aborts_pending_invocations(Protocol protocol)
     {
@@ -485,7 +485,7 @@ public sealed class ProtocolConnectionTests
     }
 
     /// <summary>Ensures that the sending of a request after shutdown fails with <see
-    /// cref="ConnectionException"/>.</summary>
+    /// cref="ConnectionException" />.</summary>
     [Test, TestCaseSource(nameof(Protocols))]
     public async Task Invoke_on_shutdown_connection_fails_with_connection_closed(Protocol protocol)
     {
@@ -848,7 +848,7 @@ public sealed class ProtocolConnectionTests
         Assert.That(receivedPayload, Is.EqualTo(expectedPayload));
     }
 
-    /// <summary>Verifies that connect establishment timeouts after the <see cref="ConnectionOptions.ConnectTimeout"/>
+    /// <summary>Verifies that connect establishment timeouts after the <see cref="ConnectionOptions.ConnectTimeout" />
     /// time period.</summary>
     [Test, TestCaseSource(nameof(Protocols))]
     public async Task Connect_timeout(Protocol protocol)
@@ -1015,7 +1015,7 @@ public sealed class ProtocolConnectionTests
         Assert.That(exception!.ErrorCode, Is.EqualTo(ConnectionErrorCode.OperationAborted));
     }
 
-    /// <summary>Verifies that connection shutdown timeouts after the <see cref="ConnectionOptions.ShutdownTimeout"/>
+    /// <summary>Verifies that connection shutdown timeouts after the <see cref="ConnectionOptions.ShutdownTimeout" />
     /// time period.</summary>
     [Test, TestCaseSource(nameof(Protocols_and_client_or_server))]
     public async Task Shutdown_timeout(Protocol protocol, bool closeClientSide)

--- a/tests/IceRpc.Tests/RouterTests.cs
+++ b/tests/IceRpc.Tests/RouterTests.cs
@@ -45,7 +45,7 @@ public class RouterTests
             () => router.Mount("/foo", new InlineDispatcher((request, cancellationToken) => new(new OutgoingResponse(request)))));
     }
 
-    /// <summary>Verifies that creating a <see cref="Router"/> with an invalid prefix fails.</summary>
+    /// <summary>Verifies that creating a <see cref="Router" /> with an invalid prefix fails.</summary>
     [Test]
     public void Creating_a_router_with_invalid_prefix_fails() =>
         Assert.Throws<FormatException>(() => new Router("foo"));
@@ -83,7 +83,8 @@ public class RouterTests
         Assert.That(currentPath, Is.EqualTo(path));
     }
 
-    /// <summary>Verifies that <see cref="Router.Map(string, IDispatcher)"/> fails when using an invalid path.</summary>
+    /// <summary>Verifies that <see cref="Router.Map(string, IDispatcher)" /> fails when using an invalid path.
+    /// </summary>
     [Test]
     public void Mapping_an_invalid_path_fails()
     {
@@ -92,7 +93,7 @@ public class RouterTests
         Assert.Throws<FormatException>(() => router.Mount("foo", ServiceNotFoundDispatcher.Instance));
     }
 
-    /// <summary>Verifies that a dispatcher mounted using <see cref="Router.Mount(string, IDispatcher)"/>
+    /// <summary>Verifies that a dispatcher mounted using <see cref="Router.Mount(string, IDispatcher)" />
     /// is selected for dispatch requests with a path starting with the given prefix.</summary>
     /// <param name="prefix">The prefix to mount the dispatcher.</param>
     /// <param name="path">The path for the request.</param>
@@ -124,7 +125,7 @@ public class RouterTests
         Assert.That(currentPath, Is.EqualTo(path));
     }
 
-    /// <summary>Verifies that <see cref="Router.Mount(string, IDispatcher)"/> fails when using an invalid path.
+    /// <summary>Verifies that <see cref="Router.Mount(string, IDispatcher)" /> fails when using an invalid path.
     /// </summary>
     [Test]
     public void Mounting_an_invalid_path_fails()
@@ -135,7 +136,7 @@ public class RouterTests
     }
 
     /// <summary>Verifies that a path that doesn't match any of the registered routes throws a dispatch
-    /// exception with <see cref="DispatchErrorCode.ServiceNotFound"/> error code.</summary>
+    /// exception with <see cref="DispatchErrorCode.ServiceNotFound" /> error code.</summary>
     [Test]
     public void Path_not_found()
     {
@@ -268,7 +269,7 @@ public class RouterTests
     }
 
     /// <summary>Helper method that creates a router and calls
-    /// <see cref="IDispatcher.DispatchAsync(IncomingRequest, CancellationToken)"/> this ensures that the router
+    /// <see cref="IDispatcher.DispatchAsync(IncomingRequest, CancellationToken)" /> this ensures that the router
     /// internal dispatcher is initialized.</summary>
     /// <returns>The router.</returns>
     private static async Task<Router> CreateRouterAndCallDispatchAsync()

--- a/tests/IceRpc.Tests/ServerAddressTests.cs
+++ b/tests/IceRpc.Tests/ServerAddressTests.cs
@@ -8,8 +8,8 @@ namespace IceRpc.Tests;
 public class ServerAddressTests
 {
     /// <summary>Provides test case data for
-    /// <see cref="Create_server_address_from_valid_uri(Uri, string, ushort, string?, IDictionary{string, string})"/> test.
-    /// </summary>
+    /// <see cref="Create_server_address_from_valid_uri(Uri, string, ushort, string?, IDictionary{string, string})" />
+    /// test.</summary>
     private static IEnumerable<TestCaseData> ServerAddressUriSource
     {
         get
@@ -30,7 +30,7 @@ public class ServerAddressTests
         }
     }
 
-    /// <summary>Provides test case data for <see cref="Convert_an_server_address_into_a_string(Uri)"/> test.</summary>
+    /// <summary>Provides test case data for <see cref="Convert_an_server_address_into_a_string(Uri)" /> test.</summary>
     private static IEnumerable<TestCaseData> ServerAddressToStringSource
     {
         get
@@ -42,7 +42,8 @@ public class ServerAddressTests
         }
     }
 
-    /// <summary>A collection of valid server address strings with its expected host, port, transport and parameters.</summary>
+    /// <summary>A collection of valid server address strings with its expected host, port, transport and parameters.
+    /// </summary>
     private static readonly (Uri Uri, string Host, ushort Port, string? Transport, IDictionary<string, string>? Parameters)[] _validServerAddresss =
         new (Uri, string, ushort, string?, IDictionary<string, string>?)[]
         {
@@ -116,8 +117,8 @@ public class ServerAddressTests
         });
     }
 
-    /// <summary>Verifies that the <see cref="ServerAddress.OriginalUri"/> property is set for a server address created from an
-    /// URI.</summary>
+    /// <summary>Verifies that the <see cref="ServerAddress.OriginalUri" /> property is set for a server address created
+    /// from an URI.</summary>
     [Test]
     public void ServerAddress_original_URI()
     {
@@ -126,8 +127,8 @@ public class ServerAddressTests
         Assert.That(serverAddress.OriginalUri, Is.Not.Null);
     }
 
-    /// <summary>Verifies that the <see cref="ServerAddress.OriginalUri"/> property of a server address is set to null after
-    /// modifying the server address.</summary>
+    /// <summary>Verifies that the <see cref="ServerAddress.OriginalUri" /> property of a server address is set to null
+    /// after modifying the server address.</summary>
     [Test]
     public void ServerAddress_original_URI_is_null_after_updating_the_server_address()
     {
@@ -180,7 +181,7 @@ public class ServerAddressTests
     }
 
     /// <summary>Verifies that setting the host works with a supported host name.</summary>
-    /// <param name="host">The value to set the <see cref="ServerAddress.Host"/> property to.</param>
+    /// <param name="host">The value to set the <see cref="ServerAddress.Host" /> property to.</param>
     [TestCase("localhost")]
     [TestCase("[::0]")]
     [TestCase("::1")]
@@ -259,9 +260,9 @@ public class ServerAddressTests
         Assert.That(serverAddress.Params[name], Is.EqualTo(value));
     }
 
-    /// <summary>Verifies that trying to set the <see cref="ServerAddress.Host"/> to an invalid value throws
-    /// <see cref="ArgumentException"/> and the <see cref="ServerAddress.Host"/> property remains unchanged.</summary>
-    /// <param name="host">The invalid value for <see cref="ServerAddress.Host"/> property.</param>
+    /// <summary>Verifies that trying to set the <see cref="ServerAddress.Host" /> to an invalid value throws
+    /// <see cref="ArgumentException" /> and the <see cref="ServerAddress.Host" /> property remains unchanged.</summary>
+    /// <param name="host">The invalid value for <see cref="ServerAddress.Host" /> property.</param>
     [TestCase("")]
     [TestCase("::1.2")]
     public void Setting_invalid_server_address_host_fails(string host)
@@ -273,8 +274,8 @@ public class ServerAddressTests
         Assert.That(serverAddress.Host, Is.EqualTo("localhost"));
     }
 
-    /// <summary>Verifies that trying to add an invalid server address parameter throws <see cref="ArgumentException"/> and
-    /// the <see cref="ServerAddress.Params"/> property remains unchanged.</summary>
+    /// <summary>Verifies that trying to add an invalid server address parameter throws <see cref="ArgumentException" />
+    /// and the <see cref="ServerAddress.Params" /> property remains unchanged.</summary>
     /// <param name="name">The server address parameter name.</param>
     /// <param name="value">The server address parameter value.</param>
     [TestCase("alt-server", "x")]

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -9,8 +9,8 @@ namespace IceRpc.Tests;
 [Parallelizable(scope: ParallelScope.All)]
 public class ServerTests
 {
-    /// <summary>Verifies that calling <see cref="Server.Listen"/> more than once fails with
-    /// <see cref="InvalidOperationException"/> exception.</summary>
+    /// <summary>Verifies that calling <see cref="Server.Listen" /> more than once fails with
+    /// <see cref="InvalidOperationException" /> exception.</summary>
     [Test]
     public async Task Cannot_call_listen_twice()
     {
@@ -20,8 +20,8 @@ public class ServerTests
         Assert.Throws<InvalidOperationException>(() => server.Listen());
     }
 
-    /// <summary>Verifies that calling <see cref="Server.Listen"/> on a disposed server fails with
-    /// <see cref="ObjectDisposedException"/>.</summary>
+    /// <summary>Verifies that calling <see cref="Server.Listen" /> on a disposed server fails with
+    /// <see cref="ObjectDisposedException" />.</summary>
     [Test]
     public async Task Cannot_call_listen_on_a_disposed_server()
     {
@@ -31,8 +31,8 @@ public class ServerTests
         Assert.Throws<ObjectDisposedException>(() => server.Listen());
     }
 
-    /// <summary>Verifies that <see cref="Server.ShutdownComplete"/> task is completed after
-    /// <see cref="Server.ShutdownAsync(CancellationToken)"/> completed.</summary>
+    /// <summary>Verifies that <see cref="Server.ShutdownComplete" /> task is completed after
+    /// <see cref="Server.ShutdownAsync(CancellationToken)" /> completed.</summary>
     [Test]
     public async Task The_shutdown_complete_task_is_completed_after_shutdown()
     {

--- a/tests/IceRpc.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Tests/ServiceAddressTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Tests;
 [Parallelizable(scope: ParallelScope.All)]
 public class ServiceAddressTests
 {
-    /// <summary>Provides test case data for <see cref="Equal_service_addresses_produce_the_same_hash_code"/>
+    /// <summary>Provides test case data for <see cref="Equal_service_addresses_produce_the_same_hash_code" />
     /// test.</summary>
     private static IEnumerable<TestCaseData> ServiceAddressHashCodeSource
     {
@@ -25,7 +25,7 @@ public class ServiceAddressTests
         }
     }
 
-    /// <summary>Provides test case data for <see cref="Create_service_address_from_invalid_uri(Uri)"/>
+    /// <summary>Provides test case data for <see cref="Create_service_address_from_invalid_uri(Uri)" />
     /// test.</summary>
     private static IEnumerable<TestCaseData> ServiceAddressInvalidUriSource
     {
@@ -38,7 +38,7 @@ public class ServiceAddressTests
         }
     }
 
-    /// <summary>Provides test case data for <see cref="Create_service_address_from_uri(Uri, string, string)"/>
+    /// <summary>Provides test case data for <see cref="Create_service_address_from_uri(Uri, string, string)" />
     /// test.</summary>
     private static IEnumerable<TestCaseData> ServiceAddressUriSource
     {
@@ -51,7 +51,7 @@ public class ServiceAddressTests
         }
     }
 
-    /// <summary>Provides test case data for <see cref="Convert_a_service_address_to_a_string(ServiceAddress)"/> test.
+    /// <summary>Provides test case data for <see cref="Convert_a_service_address_to_a_string(ServiceAddress)" /> test.
     /// </summary>
     private static IEnumerable<TestCaseData> ServiceAddressToStringSource
     {
@@ -76,7 +76,7 @@ public class ServiceAddressTests
     }
 
     /// <summary>Provides test case data for
-    /// <see cref="Create_service_address_with_alt_server(ServiceAddress, ServerAddress[])"/> test.</summary>
+    /// <see cref="Create_service_address_with_alt_server(ServiceAddress, ServerAddress[])" /> test.</summary>
     private static IEnumerable<TestCaseData> AltServerAddressesSource
     {
         get
@@ -314,8 +314,8 @@ public class ServiceAddressTests
             serviceAddress = serviceAddress with { ServerAddress = serverAddress });
     }
 
-    /// <summary>Verifies that the service address server address cannot be set when the service address contains any params.
-    /// </summary>
+    /// <summary>Verifies that the service address server address cannot be set when the service address contains any
+    /// params.</summary>
     [Test]
     public void Cannot_set_server_address_on_a_service_address_with_parameters()
     {
@@ -352,8 +352,8 @@ public class ServiceAddressTests
         );
     }
 
-    /// <summary>Verifies that the service address server address cannot be null when the service address contains has alt
-    /// server addresses.</summary>
+    /// <summary>Verifies that the service address server address cannot be null when the service address contains has
+    /// alt server addresses.</summary>
     [Test]
     public void Cannot_clear_server_address_when_alt_server_is_not_empty()
     {
@@ -473,7 +473,7 @@ public class ServiceAddressTests
         });
     }
 
-    /// <summary>Verifies that an invalid URI results in an <see cref="ArgumentException"/>.</summary>
+    /// <summary>Verifies that an invalid URI results in an <see cref="ArgumentException" />.</summary>
     /// <param name="uri">The URI to parse as a service address</param>
     [Test, TestCaseSource(nameof(ServiceAddressInvalidUriSource))]
     public void Create_service_address_from_invalid_uri(Uri uri) =>
@@ -578,8 +578,8 @@ public class ServiceAddressTests
         Assert.That(result, Is.EqualTo(expected));
     }
 
-    /// <summary>Verifies that setting the alt servers containing server addresses that uses a protocol different than the
-    /// proxy protocol throws <see cref="ArgumentException"/>.</summary>
+    /// <summary>Verifies that setting the alt servers containing server addresses that uses a protocol different than
+    /// the proxy protocol throws <see cref="ArgumentException" />.</summary>
     [Test]
     public void Setting_alt_server_with_a_different_protocol_fails()
     {
@@ -604,7 +604,7 @@ public class ServiceAddressTests
     }
 
     /// <summary>Verifies that setting a server address that uses a protocol different than the service address protocol
-    /// throws <see cref="ArgumentException"/>.</summary>
+    /// throws <see cref="ArgumentException" />.</summary>
     [Test]
     public void Setting_server_address_with_a_different_protocol_fails()
     {

--- a/tests/IceRpc.Tests/Slice/BitSequenceWriterTests.cs
+++ b/tests/IceRpc.Tests/Slice/BitSequenceWriterTests.cs
@@ -11,7 +11,7 @@ namespace IceRpc.Tests.Slice;
 [Parallelizable(scope: ParallelScope.All)]
 public class BitSequenceWriterTests
 {
-    /// <summary>Provides test case data for <see cref="Write_fails(byte[], byte[], IList{Memory{byte}}?)"/> test.
+    /// <summary>Provides test case data for <see cref="Write_fails(byte[], byte[], IList{Memory{byte}}?)" /> test.
     /// </summary>
     private static IEnumerable<TestCaseData> WriteFailsDataSource
     {
@@ -31,7 +31,7 @@ public class BitSequenceWriterTests
     }
 
     /// <summary>Provides test case data for
-    /// <see cref="Write_bit_sequence_clears_memory(byte[], byte[], IList{Memory{byte}}?, int)"/> test.</summary>
+    /// <see cref="Write_bit_sequence_clears_memory(byte[], byte[], IList{Memory{byte}}?, int)" /> test.</summary>
     private static IEnumerable<TestCaseData> WriteClearsDataSource
     {
         get
@@ -84,7 +84,7 @@ public class BitSequenceWriterTests
         pipe.Reader.Complete();
     }
 
-    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write"/> correctly writes the specified bit
+    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write" /> correctly writes the specified bit
     /// sequence to the provided spans and memory.</summary>
     /// <param name="pattern">The byte pattern to write.</param>
     [TestCase(0)]
@@ -120,7 +120,7 @@ public class BitSequenceWriterTests
         }
     }
 
-    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write"/> correctly zeros the provided spans
+    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write" /> correctly zeros the provided spans
     /// and additional memory.</summary>
     /// <param name="firstBytes">The bytes that will be used to create the first span.</param>
     /// <param name="secondBytes">The bytes that will be used to create the second span. (Can be empty)</param>
@@ -153,7 +153,7 @@ public class BitSequenceWriterTests
         Assert.That(current.ToArray().All(o => o == 0), Is.True);
     }
 
-    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write"/> on a BitSequenceWriter that has already
+    /// <summary>Verifies that calling <see cref="BitSequenceWriter.Write" /> on a BitSequenceWriter that has already
     /// enumerated fully through its spans throws an invalid operation exception.</summary>
     /// <param name="firstBytes">The bytes that will be used to create the first span.</param>
     /// <param name="secondBytes">The bytes that will be used to create the second span. (Can be empty)</param>

--- a/tests/IceRpc.Tests/Slice/NumericTypesDecodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/NumericTypesDecodingTests.cs
@@ -66,7 +66,7 @@ public class NumericTypesDecodingTests
     }
 
     /// <summary>Tests that attempting to decode a variable size int that is out of bound throws
-    /// an <see cref="InvalidDataException"/>.</summary>
+    /// an <see cref="InvalidDataException" />.</summary>
     /// <param name="encodedBytes">An encoded long that will fail to be decoded into an int.</param>
     [TestCase(new byte[] { 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00 })]
     [TestCase(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFD, 0xFF, 0xFF, 0xFF })]
@@ -99,7 +99,7 @@ public class NumericTypesDecodingTests
     }
 
     /// <summary>Tests that attempting to decode a variable length unisgned int that that is out of bound throws
-    /// an <see cref="InvalidDataException"/>.</summary>
+    /// an <see cref="InvalidDataException" />.</summary>
     /// <param name="value">A long to encode into a byte array that will fail to be decoded into an uint.</param>
     [TestCase((ulong)UInt32.MaxValue + 1)]
     public void Decode_varuint_invalid_data_fails(ulong value)

--- a/tests/IceRpc.Tests/Slice/NumericTypesEncodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/NumericTypesEncodingTests.cs
@@ -69,7 +69,7 @@ public class NumericTypesEncodingTests
         Assert.That(buffer[0..bufferWriter.WrittenMemory.Length], Is.EqualTo(expected));
     }
 
-    /// <summary>Tests that <see cref="SliceEncoder.EncodeVarInt62"/> will throw an ArgumentOutOfRangeException
+    /// <summary>Tests that <see cref="SliceEncoder.EncodeVarInt62" /> will throw an ArgumentOutOfRangeException
     /// if the parameter is larger than the max value of a varlong or smaller than the min value of a varlong.</summary>
     /// <param name="value">The varlong to be encoded.</param>
     [TestCase(SliceEncoder.VarInt62MinValue - 1)]
@@ -109,7 +109,7 @@ public class NumericTypesEncodingTests
         Assert.That(buffer[0..bufferWriter.WrittenMemory.Length], Is.EqualTo(expected));
     }
 
-    /// <summary>Tests that <see cref="SliceEncoder.EncodeVarUInt62(ulong)"/> will throw an ArgumentOutOfRangeException
+    /// <summary>Tests that <see cref="SliceEncoder.EncodeVarUInt62(ulong)" /> will throw an ArgumentOutOfRangeException
     /// if the parameter is larger than the max value of a varulong.</summary>
     /// <param name="value">The value to be encoded.</param>
     [TestCase(SliceEncoder.VarUInt62MaxValue + 1)]

--- a/tests/IceRpc.Tests/Slice/OperationTests.cs
+++ b/tests/IceRpc.Tests/Slice/OperationTests.cs
@@ -294,7 +294,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that sequence of fixed size numeric values outgoing parameter is mapped to
-    /// <see cref="ReadOnlyMemory{T}"/> the mapping for the incoming parameter is not affected.</summary>
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming parameter is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_param()
     {
@@ -314,7 +314,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that sequence of fixed size numeric values outgoing return value is mapped to
-    /// <see cref="ReadOnlyMemory{T}"/> the mapping for the incoming return value is not affected.</summary>
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming return value is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_return()
     {
@@ -340,7 +340,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that an optional sequence of fixed size numeric values outgoing parameter is mapped to a
-    /// <see cref="ReadOnlyMemory{T}"/> the mapping for the incoming parameter is not affected.</summary>
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming parameter is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_optional_param(
         [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
@@ -359,7 +359,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that sequence of fixed size numeric values outgoing optional return value is mapped to
-    /// <see cref="ReadOnlyMemory{T}"/> the mapping for the optional incoming return value is not affected.</summary>
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the optional incoming return value is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_optional_return(
         [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
@@ -386,7 +386,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that an optional sequence of fixed size numeric values outgoing tagged parameter is mapped to
-    /// a <see cref="ReadOnlyMemory{T}"/> the mapping for the incoming parameter is not affected.</summary>
+    /// a <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming parameter is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_tagged_param(
         [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
@@ -405,7 +405,7 @@ public class OperationTests
     }
 
     /// <summary>Verifies that sequence of fixed size numeric values outgoing tagged return value is mapped to
-    /// <see cref="ReadOnlyMemory{T}"/> the mapping for the optional incoming return value is not affected.</summary>
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the optional incoming return value is not affected.</summary>
     [Test]
     public void Slice2_operation_encode_with_readonly_memory_tagged_return(
         [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
@@ -452,7 +452,7 @@ public class OperationTests
         Assert.That(service.Z, Is.EqualTo(10));
     }
 
-    /// <summary>Verifies that a tagged sequence parameter that uses the <see cref="ReadOnlyMemory{T}"/> mapping has a
+    /// <summary>Verifies that a tagged sequence parameter that uses the <see cref="ReadOnlyMemory{T}" /> mapping has a
     /// default value that is equivalent to a non set tagged parameter.</summary>
     [Test]
     public async Task Proxy_tagged_default_values_with_readonly_memory_params()
@@ -592,7 +592,7 @@ public class OperationTests
             int[]? p1,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new(p1);
-        
+
         public ValueTask OpWithProxyParameterAsync(
             ServiceProxy service,
             IFeatureCollection features,

--- a/tests/IceRpc.Tests/Slice/ProxyTests.cs
+++ b/tests/IceRpc.Tests/Slice/ProxyTests.cs
@@ -12,8 +12,8 @@ namespace IceRpc.Tests.Slice;
 [Parallelizable(scope: ParallelScope.All)]
 public class ProxyTests
 {
-    /// <summary>Provides test case data for <see cref="Decode_proxy(ServiceAddress, ServiceAddress, SliceEncoding)"/> test.
-    /// </summary>
+    /// <summary>Provides test case data for <see cref="Decode_proxy(ServiceAddress, ServiceAddress, SliceEncoding)" />
+    /// test.</summary>
     private static IEnumerable<TestCaseData> DecodeProxyDataSource
     {
         get
@@ -68,7 +68,7 @@ public class ProxyTests
         Assert.That(decoded?.ServiceAddress, Is.EqualTo(expected));
     }
 
-    /// <summary>Verifies that calling <see cref="SliceDecoder.DecodeProxy"/> correctly decodes a proxy.</summary>
+    /// <summary>Verifies that calling <see cref="SliceDecoder.DecodeProxy" /> correctly decodes a proxy.</summary>
     /// <param name="value">The service address of the proxy to encode.</param>
     /// <param name="expected">The expected URI string of the service address.</param>
     /// <param name="encoding">The encoding used to decode the service address.</param>

--- a/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/SequenceDecodingTests.cs
@@ -11,9 +11,9 @@ namespace IceRpc.Tests.Slice;
 [Parallelizable(scope: ParallelScope.All)]
 public class SequenceDecodingTests
 {
-    /// <summary>Tests <see cref="SliceDecoderExtensions.DecodeSequence{T}(ref SliceDecoder, Action{T}?)"/> with a
+    /// <summary>Tests <see cref="SliceDecoderExtensions.DecodeSequence{T}(ref SliceDecoder, Action{T}?)" /> with a
     /// fixed-size numeric value type.</summary>
-    /// <param name="encoding">The <see cref="SliceEncoding"/> to use for the decoding.</param>
+    /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the decoding.</param>
     [Test]
     public void Decode_fixed_sized_numeric_sequence(
         [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
@@ -34,9 +34,9 @@ public class SequenceDecodingTests
         Assert.That(sut.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
-    /// <summary>Tests <see cref="SliceDecoderExtensions.DecodeSequence{T}(ref SliceDecoder, Action{T}?)"/> with a
+    /// <summary>Tests <see cref="SliceDecoderExtensions.DecodeSequence{T}(ref SliceDecoder, Action{T}?)" /> with a
     /// string sequence.</summary>
-    /// <param name="encoding">The <see cref="SliceEncoding"/> to use for the decoding.</param>
+    /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the decoding.</param>
     [Test]
     public void Decode_string_sequence(
         [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)

--- a/tests/IceRpc.Tests/Slice/SequenceEncodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/SequenceEncodingTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Tests.Slice;
 public class SequenceEncodingTests
 {
     /// <summary>Provides test case data for
-    /// <see cref="Encode_fixed_sized_numeric_sequence(SliceEncoding, IEnumerable{int})"/> test.</summary>
+    /// <see cref="Encode_fixed_sized_numeric_sequence(SliceEncoding, IEnumerable{int})" /> test.</summary>
     private static IEnumerable<TestCaseData> SequenceLongData
     {
         get
@@ -32,9 +32,9 @@ public class SequenceEncodingTests
         }
     }
 
-    /// <summary>Tests <see cref="SliceEncoderExtensions.EncodeSequence{T}(ref SliceEncoder, IEnumerable{T})"/> with a
+    /// <summary>Tests <see cref="SliceEncoderExtensions.EncodeSequence{T}(ref SliceEncoder, IEnumerable{T})" /> with a
     /// value type.</summary>
-    /// <param name="encoding">The <see cref="SliceEncoding"/> to use for the encoding.</param>
+    /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the encoding.</param>
     /// <param name="expected">The enumerable to be encoded.</param>
     [Test, TestCaseSource(nameof(SequenceLongData))]
     public void Encode_fixed_sized_numeric_sequence(SliceEncoding encoding, IEnumerable<int> expected)
@@ -56,9 +56,9 @@ public class SequenceEncodingTests
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
-    /// <summary>Tests <see cref="SliceEncoderExtensions.EncodeSequence{T}(ref SliceEncoder, IEnumerable{T}, EncodeAction{T})"/>
+    /// <summary>Tests <see cref="SliceEncoderExtensions.EncodeSequence{T}(ref SliceEncoder, IEnumerable{T}, EncodeAction{T})" />
     /// with a sequence of non numeric types.</summary>
-    /// <param name="encoding">The <see cref="SliceEncoding"/> to use for the encoding.</param>
+    /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the encoding.</param>
     [Test]
     public void Encode_string_sequence(
         [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)

--- a/tests/IceRpc.Tests/Slice/SpanEnumeratorTests.cs
+++ b/tests/IceRpc.Tests/Slice/SpanEnumeratorTests.cs
@@ -9,7 +9,7 @@ namespace IceRpc.Tests.Slice;
 public class SpanEnumeratorTests
 {
     /// <summary>Provides test case data for
-    /// <see cref="Move_to_next_span(byte[], byte[], IList{Memory{byte}}?, int, byte[])"/> test.
+    /// <see cref="Move_to_next_span(byte[], byte[], IList{Memory{byte}}?, int, byte[])" /> test.
     /// </summary>
     private static IEnumerable<TestCaseData> EnumeratorCurrentUpdatesSuccessfullySource
     {
@@ -50,7 +50,7 @@ public class SpanEnumeratorTests
     }
 
     /// <summary>Provides test case data for
-    /// <see cref="Move_past_the_end_fails(byte[], byte[], IList{Memory{byte}}?, int)"/> test.
+    /// <see cref="Move_past_the_end_fails(byte[], byte[], IList{Memory{byte}}?, int)" /> test.
     /// </summary>
     private static IEnumerable<TestCaseData> EnumeratorNextFailsSource
     {
@@ -86,7 +86,7 @@ public class SpanEnumeratorTests
         }
     }
 
-    /// <summary>Verifies that calling <see cref="SpanEnumerator.MoveNext"/> correctly enumerates through the spans
+    /// <summary>Verifies that calling <see cref="SpanEnumerator.MoveNext" /> correctly enumerates through the spans
     /// held by the enumerator. </summary>
     /// <param name="firstBytes">The bytes that will be used to create the first span.</param>
     /// <param name="secondBytes">The bytes that will be used to create the second span. (Can be empty)</param>
@@ -113,7 +113,7 @@ public class SpanEnumeratorTests
         Assert.That(enumerator.Current.ToArray(), Is.EqualTo(expected.ToArray()));
     }
 
-    /// <summary>Verifies that calling <see cref="SpanEnumerator.MoveNext"/> will not enumerate past the final
+    /// <summary>Verifies that calling <see cref="SpanEnumerator.MoveNext" /> will not enumerate past the final
     /// span or memory provided to the enumerator.</summary>
     /// <param name="firstBytes">The bytes that will be used to create the first span.</param>
     /// <param name="secondBytes">The bytes that will be used to create the second span. (Can be empty)</param>

--- a/tests/IceRpc.Tests/Slice/StreamTests.cs
+++ b/tests/IceRpc.Tests/Slice/StreamTests.cs
@@ -224,8 +224,8 @@ public class StreamTests
         }
     }
 
-    /// <summary>Test that the payload of an incoming request is completed with <see cref="InvalidDataException"/> after
-    /// the async enumerable decoding action throws <see cref="InvalidDataException"/>.</summary>
+    /// <summary>Test that the payload of an incoming request is completed with <see cref="InvalidDataException" />
+    /// after the async enumerable decoding action throws <see cref="InvalidDataException" />.</summary>
     [Test]
     public async Task Decode_stream_of_variable_size_elements_containing_invalid_data_completes_payload_with_an_exception()
     {
@@ -258,8 +258,8 @@ public class StreamTests
         }
     }
 
-    /// <summary>Test that the payload of an incoming request is completed with <see cref="InvalidDataException"/> after
-    /// the async enumerable decoding action throws <see cref="InvalidDataException"/>.</summary>
+    /// <summary>Test that the payload of an incoming request is completed with <see cref="InvalidDataException" />
+    /// after  the async enumerable decoding action throws <see cref="InvalidDataException" />.</summary>
     [Test]
     public async Task Decode_stream_of_fixed_size_elements_containing_invalid_data_completes_payload_with_an_exception()
     {

--- a/tests/IceRpc.Tests/Slice/TraitEncodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/TraitEncodingTests.cs
@@ -8,7 +8,7 @@ namespace IceRpc.Tests.Slice;
 
 public sealed class TraitEncodingTests
 {
-    /// <summary>Verifies that decoding a trait with a mismatched type fails with <see cref="InvalidDataException"/>.
+    /// <summary>Verifies that decoding a trait with a mismatched type fails with <see cref="InvalidDataException" />.
     /// </summary>
     [Test]
     public void Decoding_a_mismatched_type_fails()
@@ -29,7 +29,7 @@ public sealed class TraitEncodingTests
             Throws.TypeOf<InvalidDataException>());
     }
 
-    /// <summary>Verify that <see cref="SliceDecoder.DecodeTrait{T}"/> method correctly decodes a trait into a concrete
+    /// <summary>Verify that <see cref="SliceDecoder.DecodeTrait{T}" /> method correctly decodes a trait into a concrete
     /// type.</summary>
     [Test]
     public void Decoding_a_trait_as_a_struct()
@@ -49,7 +49,7 @@ public sealed class TraitEncodingTests
         Assert.That(traitStructB2, Is.EqualTo(traitStructB1));
     }
 
-    /// <summary>Verify that <see cref="SliceDecoder.DecodeTrait{T}"/> method correctly decodes a trait as an
+    /// <summary>Verify that <see cref="SliceDecoder.DecodeTrait{T}" /> method correctly decodes a trait as an
     /// interface.</summary>
     [Test]
     public void Decoding_a_trait_as_an_interface()
@@ -69,7 +69,7 @@ public sealed class TraitEncodingTests
         Assert.That(decodedTrait.GetString(), Is.EqualTo("Bar"));
     }
 
-    /// <summary>Verifies that decoding a trait with an unknown type ID fails with <see cref="InvalidDataException"/>.
+    /// <summary>Verifies that decoding a trait with an unknown type ID fails with <see cref="InvalidDataException" />.
     /// </summary>
     [Test]
     public void Decoding_an_unknown_type_id_fails()
@@ -91,7 +91,7 @@ public sealed class TraitEncodingTests
             Throws.TypeOf<InvalidDataException>());
     }
 
-    /// <summary>Verifies that nested trait decoding fails with <see cref="InvalidDataException"/> after reaching
+    /// <summary>Verifies that nested trait decoding fails with <see cref="InvalidDataException" /> after reaching
     /// the decoder max depth.</summary>
     /// <param name="depth">The decoder max depth.</param>
     [TestCase(100)]

--- a/tests/IceRpc.Tests/Slice/TypeIdAttributeTests.cs
+++ b/tests/IceRpc.Tests/Slice/TypeIdAttributeTests.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Tests.Slice.TypeIdAttributeTestNamespace;
 
 public sealed class TypeIdAttributeTests
 {
-    /// <summary>Provides test case data for <see cref="Get_default_path(Type, string)"/> test.</summary>
+    /// <summary>Provides test case data for <see cref="Get_default_path(Type, string)" /> test.</summary>
     private static IEnumerable<TestCaseData> GetDefaultPathSource
     {
         get
@@ -19,7 +19,7 @@ public sealed class TypeIdAttributeTests
         }
     }
 
-    /// <summary>Provides test case data for <see cref="Get_typeId(Type, string?)"/> test.</summary>
+    /// <summary>Provides test case data for <see cref="Get_typeId(Type, string?)" /> test.</summary>
     private static IEnumerable<TestCaseData> GetSliceTypeIdSource
     {
         get
@@ -65,7 +65,7 @@ public sealed class TypeIdAttributeTests
     };
 
     /// <summary>Verifies that types generated from Slice definitions have the expected type ID.</summary>
-    /// <param name="type">The <see cref="Type"/> of the generated type to test.</param>
+    /// <param name="type">The <see cref="Type" /> of the generated type to test.</param>
     /// <param name="expected">The expected type ID.</param>
     [Test, TestCaseSource(nameof(GetSliceTypeIdSource))]
     public void Get_typeId(Type type, string? expected)
@@ -76,7 +76,7 @@ public sealed class TypeIdAttributeTests
     }
 
     /// <summary>Verifies that types generated from Slice definitions have the expected default path.</summary>
-    /// <param name="type">The <see cref="Type"/> of the generated type to test.</param>
+    /// <param name="type">The <see cref="Type" /> of the generated type to test.</param>
     /// <param name="expected">The expected type ID.</param>
     [Test, TestCaseSource(nameof(GetDefaultPathSource))]
     public void Get_default_path(Type type, string? expected)

--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -35,8 +35,8 @@ public class TcpTransportTests
             ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password")
         };
 
-    /// <summary>Verifies that setting <see cref="TcpTransportOptions.ReceiveBufferSize"/> and
-    /// <see cref="TcpTransportOptions.SendBufferSize"/> configures the respective socket properties.</summary>
+    /// <summary>Verifies that setting <see cref="TcpTransportOptions.ReceiveBufferSize" /> and
+    /// <see cref="TcpTransportOptions.SendBufferSize" /> configures the respective socket properties.</summary>
     /// <param name="bufferSize">The buffer size to test with.</param>
     [TestCase(16 * 1024)]
     [TestCase(64 * 1024)]
@@ -83,7 +83,7 @@ public class TcpTransportTests
         }
     }
 
-    /// <summary>Verifies that setting the <see cref="TcpClientTransportOptions.LocalNetworkAddress"/> properties, sets
+    /// <summary>Verifies that setting the <see cref="TcpClientTransportOptions.LocalNetworkAddress" /> properties, sets
     /// the socket local server address.</summary>
     [Test]
     public void Configure_client_connection_local_network_address()
@@ -100,8 +100,8 @@ public class TcpTransportTests
         Assert.That(connection.Socket.LocalEndPoint, Is.EqualTo(localNetworkAddress));
     }
 
-    /// <summary>Verifies that setting <see cref="TcpTransportOptions.ReceiveBufferSize"/> and
-    /// <see cref="TcpTransportOptions.SendBufferSize"/> configures the respective socket properties.</summary>
+    /// <summary>Verifies that setting <see cref="TcpTransportOptions.ReceiveBufferSize" /> and
+    /// <see cref="TcpTransportOptions.SendBufferSize" /> configures the respective socket properties.</summary>
     /// <param name="bufferSize">The buffer size to test with.</param>
     [TestCase(16 * 1024)]
     [TestCase(64 * 1024)]
@@ -167,7 +167,7 @@ public class TcpTransportTests
         }
     }
 
-    /// <summary>Verifies that setting the <see cref="TcpServerTransportOptions.ListenerBackLog"/> configures the
+    /// <summary>Verifies that setting the <see cref="TcpServerTransportOptions.ListenerBackLog" /> configures the
     /// socket listen backlog.</summary>
     [Test]
     public async Task Configure_server_connection_listen_backlog()
@@ -231,7 +231,7 @@ public class TcpTransportTests
     }
 
     /// <summary>Verifies that using a DNS name for a TCP listener server address fails with <see
-    /// cref="NotSupportedException"/> exception.</summary>
+    /// cref="NotSupportedException" /> exception.</summary>
     [Test]
     public void DNS_name_cannot_be_used_in_a_tcp_listener_server_address()
     {
@@ -243,7 +243,7 @@ public class TcpTransportTests
     }
 
     /// <summary>Verifies that the client connect call on a tls connection fails with
-    /// <see cref="OperationCanceledException"/> when the cancellation token is canceled.</summary>
+    /// <see cref="OperationCanceledException" /> when the cancellation token is canceled.</summary>
     [Test]
     public async Task Tls_client_connect_operation_canceled_exception()
     {
@@ -331,7 +331,7 @@ public class TcpTransportTests
     }
 
     /// <summary>Verifies that the server connect call on a tls connection fails with
-    /// <see cref="OperationCanceledException"/> when the cancellation token is canceled.</summary>
+    /// <see cref="OperationCanceledException" /> when the cancellation token is canceled.</summary>
     [Test]
     public async Task Tls_server_connect_operation_canceled_exception()
     {

--- a/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
+++ b/tests/IceRpc.Tests/Transports/TlsConfigurationTests.cs
@@ -12,7 +12,7 @@ namespace IceRpc.Tests.Transports;
 [Parallelizable(scope: ParallelScope.All)]
 public class TlsConfigurationTests
 {
-    /// <summary>Verifies that the server connection establishment will fail with <see cref="AuthenticationException"/>
+    /// <summary>Verifies that the server connection establishment will fail with <see cref="AuthenticationException" />
     /// when the client certificate is not trusted.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Security",
@@ -157,7 +157,7 @@ public class TlsConfigurationTests
         Assert.That(clientCertificateValidationCallback, Is.True);
     }
 
-    /// <summary>Verifies that the client connection establishment fail with <see cref="AuthenticationException"/> when
+    /// <summary>Verifies that the client connection establishment fail with <see cref="AuthenticationException" /> when
     /// the server certificate is not trusted.</summary>
     [Test]
     public async Task Tls_server_certificate_not_trusted()

--- a/tests/IntegrationTests/ServiceTests.cs
+++ b/tests/IntegrationTests/ServiceTests.cs
@@ -10,7 +10,7 @@ namespace IceRpc.IntegrationTests;
 [Parallelizable(ParallelScope.All)]
 public class ServiceTests
 {
-    /// <summary>Verifies the operations of <see cref="Service"/>.</summary>
+    /// <summary>Verifies the operations of <see cref="Service" />.</summary>
     [Test]
     public async Task Service_operations([Values("ice", "icerpc")] string protocol)
     {

--- a/tools/slicec-cs/src/class_visitor.rs
+++ b/tools/slicec-cs/src/class_visitor.rs
@@ -91,7 +91,7 @@ impl Visitor for ClassVisitor<'_> {
             );
         }
 
-        let constructor_summary = format!(r#"Constructs a new instance of <see cref="{}"/>."#, class_name);
+        let constructor_summary = format!(r#"Constructs a new instance of <see cref="{}" />."#, class_name);
 
         // One-shot ctor (may be parameterless)
         class_builder.add_block(constructor(

--- a/tools/slicec-cs/src/comment_patcher.rs
+++ b/tools/slicec-cs/src/comment_patcher.rs
@@ -72,7 +72,7 @@ impl CommentPatcher {
                     Err(_) => s.to_owned(), // TODO log a warning
                 };
 
-                format!("<see cref=\"{identifier}\"/>")
+                format!("<see cref=\"{identifier}\" />")
             });
 
             Some(comment)

--- a/tools/slicec-cs/src/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/dispatch_visitor.rs
@@ -26,7 +26,7 @@ impl Visitor for DispatchVisitor<'_> {
         let mut interface_builder = ContainerBuilder::new(&format!("{} partial interface", access), &interface_name);
 
         let summary_comment = format!(
-            r#"Interface used to implement services for Slice interface {}. <seealso cref="{}"/>.
+            r#"Interface used to implement services for Slice interface {}. <seealso cref="{}" />.
 {}"#,
             interface_def.identifier(),
             interface_def.proxy_name(),

--- a/tools/slicec-cs/src/encoded_result.rs
+++ b/tools/slicec-cs/src/encoded_result.rs
@@ -40,7 +40,7 @@ pub fn encoded_result_struct(operation: &Operation) -> CodeBlock {
     constructor_builder.add_comment(
         "summary",
         &format!(
-            r#"Constructs a new <see cref="{struct_name}"/> instance that
+            r#"Constructs a new <see cref="{struct_name}" /> instance that
 immediately encodes the return value of operation {operation_name}."#,
             struct_name = struct_name,
             operation_name = operation_name

--- a/tools/slicec-cs/src/enum_visitor.rs
+++ b/tools/slicec-cs/src/enum_visitor.rs
@@ -70,7 +70,7 @@ fn enum_underlying_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_comment(
         "summary",
         &format!(
-            r#"Provides an extension method for creating a <see cref="{enum_name}"/> from a <see cref="{underlying_type}"/>"#,
+            r#"Provides an extension method for creating a <see cref="{enum_name}" /> from a <see cref="{underlying_type}" />"#,
             enum_name = escaped_identifier,
             underlying_type = cs_type
         ),
@@ -124,7 +124,7 @@ private static readonly global::System.Collections.Generic.HashSet<{underlying}>
             "summary",
             format!(
                 r#"
-Converts a <see cref="{underlying_type}"/> into the corresponding <see cref="{escaped_identifier}"/>
+Converts a <see cref="{underlying_type}" /> into the corresponding <see cref="{escaped_identifier}" />
 enumerator."#,
                 underlying_type = cs_type,
                 escaped_identifier = escaped_identifier
@@ -180,7 +180,7 @@ fn enum_encoder_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_comment(
         "summary",
         &format!(
-            r#"Provide extension methods for encoding <see cref="{}"/>."#,
+            r#"Provide extension methods for encoding <see cref="{}" />."#,
             escaped_identifier
         ),
     );
@@ -189,9 +189,9 @@ fn enum_encoder_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_block(
         format!(
             r#"
-/// <summary>Encodes a <see cref="{escaped_identifier}"/> enum.</summary>
+/// <summary>Encodes a <see cref="{escaped_identifier}" /> enum.</summary>
 /// <param name="encoder">The Slice encoder.</param>
-/// <param name="value">The <see cref="{escaped_identifier}"/> enumerator value to encode.</param>
+/// <param name="value">The <see cref="{escaped_identifier}" /> enumerator value to encode.</param>
 {access} static void Encode{identifier}(this ref SliceEncoder encoder, {escaped_identifier} value) =>
     {encode_enum}(({underlying_type})value);"#,
             access = access,
@@ -221,7 +221,7 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_comment(
         "summary",
         &format!(
-            r#"Provide extension methods for encoding <see cref="{}"/>."#,
+            r#"Provide extension methods for encoding <see cref="{}" />."#,
             escaped_identifier
         ),
     );
@@ -236,9 +236,9 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_block(
         format!(
             r#"
-/// <summary>Decodes a <see cref="{escaped_identifier}"/> enum.</summary>
+/// <summary>Decodes a <see cref="{escaped_identifier}" /> enum.</summary>
 /// <param name="decoder">The Slice decoder.</param>
-/// <returns>The decoded <see cref="{escaped_identifier}"/> enumerator value.</returns>
+/// <returns>The decoded <see cref="{escaped_identifier}" /> enumerator value.</returns>
 {access} static {escaped_identifier} Decode{identifier}(this ref SliceDecoder decoder) =>
     {underlying_extensions_class}.As{identifier}({decode_enum});"#,
             access = access,

--- a/tools/slicec-cs/src/exception_visitor.rs
+++ b/tools/slicec-cs/src/exception_visitor.rs
@@ -230,7 +230,7 @@ fn one_shot_constructor(exception_def: &Exception, add_message_and_exception_par
 
     ctor_builder.add_comment(
         "summary",
-        &format!(r#"Constructs a new instance of <see cref="{}"/>."#, &exception_name),
+        &format!(r#"Constructs a new instance of <see cref="{}" />."#, &exception_name),
     );
 
     if add_message_and_exception_parameters {

--- a/tools/slicec-cs/src/proxy_visitor.rs
+++ b/tools/slicec-cs/src/proxy_visitor.rs
@@ -39,7 +39,7 @@ impl Visitor for ProxyVisitor<'_> {
         let proxy_bases: Vec<String> = bases.into_iter().map(|b| b.scoped_proxy_name(&namespace)).collect();
 
         let summary_message = format!(
-            r#"The client-side interface for Slice interface {}. <seealso cref="{}"/>.
+            r#"The client-side interface for Slice interface {}. <seealso cref="{}" />.
 {}"#,
             interface_def.identifier(),
             interface_def.interface_name(),
@@ -61,7 +61,7 @@ impl Visitor for ProxyVisitor<'_> {
             ContainerBuilder::new(&format!("{} readonly partial record struct", access), &proxy_impl);
 
         proxy_impl_builder.add_bases(&proxy_impl_bases)
-            .add_comment("summary", &format!(r#"Proxy record struct. It implements <see cref="{}"/> by sending requests to a remote IceRPC service."#, proxy_interface))
+            .add_comment("summary", &format!(r#"Proxy record struct. It implements <see cref="{}" /> by sending requests to a remote IceRPC service."#, proxy_interface))
             .add_type_id_attribute(interface_def)
             .add_container_attributes(interface_def)
             .add_block(request_class(interface_def))
@@ -91,7 +91,7 @@ public IceRpc.ServiceAddress ServiceAddress {{ get; init; }} = DefaultServiceAdd
             proxy_impl_builder.add_block(
                 format!(
                     r#"
-/// <summary>Implicit conversion to <see cref="{base_impl}"/>.</summary>
+/// <summary>Implicit conversion to <see cref="{base_impl}" />.</summary>
 public static implicit operator {base_impl}({proxy_impl} proxy) =>
     new() {{ EncodeOptions = proxy.EncodeOptions, Invoker = proxy.Invoker, ServiceAddress = proxy.ServiceAddress }};"#,
                     base_impl = base_impl,
@@ -126,7 +126,7 @@ public static {proxy_impl} FromPath(string path) => new() {{ ServiceAddress = ne
 
 /// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>
 /// <param name="invoker">The invocation pipeline of the proxy.</param>
-/// <param name="serviceAddress">The service address. Null is equivalent to <see cref="DefaultServiceAddress"/>.</param>
+/// <param name="serviceAddress">The service address. Null is equivalent to <see cref="DefaultServiceAddress" />.</param>
 /// <param name="encodeOptions">The encode options, used to customize the encoding of request payloads.</param>
 public {proxy_impl}(
     IceRpc.IInvoker invoker,
@@ -389,7 +389,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
         builder.add_comment(
             "returns",
             &format!(
-                "The payload encoded with <see cref=\"{}\"/>.",
+                "The payload encoded with <see cref=\"{}\" />.",
                 operation.encoding.to_cs_encoding()
             ),
         );
@@ -420,7 +420,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
     class_builder.add_comment(
         "summary",
         &format!(
-            r#"Holds a <see cref="IceRpc.Slice.ResponseDecodeFunc{{T}}"/> for each non-void remote operation defined in <see cref="{}Proxy"/>."#,
+            r#"Holds a <see cref="IceRpc.Slice.ResponseDecodeFunc{{T}}" /> for each non-void remote operation defined in <see cref="{}Proxy" />."#,
             interface_def.interface_name()));
 
     for operation in operations {
@@ -450,7 +450,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         builder.add_comment(
             "summary",
             &format!(
-                r#"The <see cref="ResponseDecodeFunc{{T}}"/> for the return value type of operation {}."#,
+                r#"The <see cref="ResponseDecodeFunc{{T}}" /> for the return value type of operation {}."#,
                 operation.identifier()
             ),
         );

--- a/tools/slicec-cs/src/struct_visitor.rs
+++ b/tools/slicec-cs/src/struct_visitor.rs
@@ -62,7 +62,10 @@ impl<'a> Visitor for StructVisitor<'a> {
         );
         main_constructor.add_comment(
             "summary",
-            &format!(r#"Constructs a new instance of <see cref="{}"/>."#, &escaped_identifier),
+            &format!(
+                r#"Constructs a new instance of <see cref="{}" />."#,
+                &escaped_identifier
+            ),
         );
 
         for member in &members {
@@ -117,7 +120,7 @@ impl<'a> Visitor for StructVisitor<'a> {
             .add_comment(
                 "summary",
                 &format!(
-                    r#"Constructs a new instance of <see cref="{}"/> from a decoder."#,
+                    r#"Constructs a new instance of <see cref="{}" /> from a decoder."#,
                     &escaped_identifier
                 ),
             )


### PR DESCRIPTION
As mentioned in PR https://github.com/zeroc-ice/icerpc-csharp/pull/1826, Microsoft includes a whitespace character after the string literal end character `"` and before the closing of the xml tag `/>` for XML doc comments.

This PR updates our doc comments to follow the same convention.