### PR TITLE
Constants for CS Attributes

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use crate::comments::{operation_parameter_doc_comment, CommentTag};
+use crate::cs_attributes;
 use crate::member_util::escape_parameter_name;
 use crate::slicec_ext::*;
 use slice::code_block::CodeBlock;

--- a/tools/slicec-cs/src/cs_attributes.rs
+++ b/tools/slicec-cs/src/cs_attributes.rs
@@ -1,0 +1,9 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+pub const ATTRIBUTE: &str = "cs::attribute";
+pub const ENCODED_RESULT: &str = "cs::encodedResult";
+pub const GENERIC: &str = "cs::generic";
+pub const INTERNAL: &str = "cs::internal";
+pub const NAMESPACE: &str = "cs::namespace";
+pub const READONLY: &str = "cs::readonly";
+pub const TYPE: &str = "cs::type";

--- a/tools/slicec-cs/src/cs_validator.rs
+++ b/tools/slicec-cs/src/cs_validator.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use crate::slicec_ext::cs_attributes;
+use crate::cs_attributes;
 use slice::diagnostics::{DiagnosticReporter, Error, ErrorKind};
 use slice::grammar::*;
 use slice::parse_result::{ParsedData, ParserResult};

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 use crate::builders::{Builder, FunctionCallBuilder};
+use crate::cs_attributes;
 use crate::cs_util::*;
 use crate::slicec_ext::*;
 use slice::code_block::CodeBlock;

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 use crate::builders::{Builder, FunctionCallBuilder};
+use crate::cs_attributes;
 use crate::cs_util::*;
 use crate::slicec_ext::*;
 use slice::code_block::CodeBlock;

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -4,6 +4,7 @@ mod builders;
 mod class_visitor;
 mod comment_patcher;
 mod comments;
+mod cs_attributes;
 mod cs_options;
 mod cs_util;
 mod cs_validator;

--- a/tools/slicec-cs/src/module_visitor.rs
+++ b/tools/slicec-cs/src/module_visitor.rs
@@ -1,8 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 use crate::builders::{Builder, ContainerBuilder};
+use crate::cs_attributes;
 use crate::generated_code::GeneratedCode;
-use crate::slicec_ext::cs_attributes;
 use slice::code_block::CodeBlock;
 
 use slice::grammar::*;

--- a/tools/slicec-cs/src/slicec_ext/attribute_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/attribute_ext.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use crate::slicec_ext::cs_attributes;
+use crate::cs_attributes;
 use slice::grammar::Attributable;
 
 pub trait AttributeExt {

--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+use crate::cs_attributes;
 use crate::cs_util::escape_keyword;
-use crate::slicec_ext::cs_attributes;
 
 use slice::convert_case::{Case, Casing};
 use slice::grammar::Entity;

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -19,13 +19,3 @@ pub use operation_ext::OperationExt;
 pub use primitive_ext::PrimitiveExt;
 pub use slice_encoding_ext::EncodingExt;
 pub use type_ref_ext::TypeRefExt;
-
-pub mod cs_attributes {
-    pub const ATTRIBUTE: &str = "cs::attribute";
-    pub const ENCODED_RESULT: &str = "cs::encodedResult";
-    pub const GENERIC: &str = "cs::generic";
-    pub const INTERNAL: &str = "cs::internal";
-    pub const NAMESPACE: &str = "cs::namespace";
-    pub const READONLY: &str = "cs::readonly";
-    pub const TYPE: &str = "cs::type";
-}

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use super::{cs_attributes, EntityExt, ParameterExt, ParameterSliceExt};
+use super::{EntityExt, ParameterExt, ParameterSliceExt};
+use crate::cs_attributes;
 
 use slice::grammar::{Attributable, ClassFormat, Contained, Operation};
 use slice::utils::code_gen_util::TypeContext;

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -3,7 +3,7 @@
 use super::entity_ext::EntityExt;
 use super::interface_ext::InterfaceExt;
 use super::primitive_ext::PrimitiveExt;
-use crate::slicec_ext::cs_attributes;
+use crate::cs_attributes;
 
 use slice::grammar::*;
 use slice::utils::code_gen_util::TypeContext;


### PR DESCRIPTION
Closes #1834

This PR cleanups the csharp attributes in `slicec-cs` by adding a sub module to `attribute_ext.rs`. This submodule contains constant ref strings referening to each cs attribute.