### PR TITLE
Make hello client non-interactive

### DIFF
--- a/examples/Hello/Client/Program.cs
+++ b/examples/Hello/Client/Program.cs
@@ -5,7 +5,7 @@ using IceRpc;
 
 await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
 
-var hello = new HelloProxy(connection);
-string greeting = await hello.SayHelloAsync(Environment.UserName);
+var helloProxy = new HelloProxy(connection);
+string greeting = await helloProxy.SayHelloAsync(Environment.UserName);
 
 Console.WriteLine(greeting);


### PR DESCRIPTION
This PR make the hello client non-interactive (and simpler).

A non-interactive client is easier to run and I think it's also easier to explain. We'll use this hello example in our very first IceRPC tutorial. With an interactive example, the execution has to include the user interaction (enter string, press enter), which distracts from our RPC focus.

Typical execution with this PR:
```
Bernards-MBP:Hello bernard$ dotnet run --project Server/Server.csproj
bernard says hello!
^CAttempting to cancel the build...
```

```
Bernards-MBP:Hello bernard$ dotnet run --project Client/Client.csproj
Hello, bernard!
```

TODO: look into the server message.