### PR TITLE
Fixed ShutdownComplete to always raise a ConnectionException

### DIFF
--- a/src/IceRpc/ConnectionException.cs
+++ b/src/IceRpc/ConnectionException.cs
@@ -74,4 +74,12 @@ public class ConnectionException : Exception
     public ConnectionException(ConnectionErrorCode errorCode, Exception? innerException)
         : base($"{nameof(ConnectionException)} {{ ErrorCode = {errorCode} }}", innerException) =>
         ErrorCode = errorCode;
+
+    /// <summary>Constructs a new instance of the <see cref="ConnectionException" /> class with a specified error
+    /// code, message and inner exception.</summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public ConnectionException(ConnectionErrorCode errorCode, string message, Exception? innerException)
+        : base(message, innerException) => ErrorCode = errorCode;
 }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -270,7 +270,10 @@ internal sealed class IceProtocolConnection : ProtocolConnection
                 }
                 catch (Exception exception)
                 {
-                    ConnectionClosedException = new(ConnectionErrorCode.ClosedByAbort, "the connection was lost");
+                    ConnectionClosedException = new(
+                        ConnectionErrorCode.ClosedByAbort,
+                        "the connection was lost",
+                        exception);
 
                     // Notify the ConnectionLost callback.
                     ConnectionLost(exception);

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -207,7 +207,10 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
                             return; // already closing or closed
                         }
 
-                        ConnectionClosedException = new(ConnectionErrorCode.ClosedByAbort, "the connection was lost");
+                        ConnectionClosedException = new(
+                            ConnectionErrorCode.ClosedByAbort,
+                            "the connection was lost",
+                            exception);
                     }
 
                     ConnectionLost(exception);

--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -118,14 +118,16 @@ internal abstract class ProtocolConnection : IProtocolConnection
                 {
                     ConnectionClosedException = new(
                         ConnectionErrorCode.ClosedByAbort,
-                        "the connection establishment failed");
+                        "the connection establishment failed",
+                        exception);
                     throw new ConnectionException(ConnectionErrorCode.TransportError, exception);
                 }
                 catch (Exception exception)
                 {
                     ConnectionClosedException = new(
                         ConnectionErrorCode.ClosedByAbort,
-                        "the connection establishment failed");
+                        "the connection establishment failed",
+                        exception);
                     throw new ConnectionException(ConnectionErrorCode.Unspecified, exception);
                 }
             }
@@ -327,7 +329,10 @@ internal abstract class ProtocolConnection : IProtocolConnection
         CancellationToken cancellationToken);
 
     private protected void ConnectionLost(Exception exception) =>
-        _ = _shutdownCompleteSource.TrySetException(exception);
+        _ = _shutdownCompleteSource.TrySetException(new ConnectionException(
+            ConnectionErrorCode.ClosedByAbort,
+            "the connection was lost",
+            exception));
 
     private protected void DisableIdleCheck() =>
         _idleTimeoutTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);

--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -371,9 +371,9 @@ public sealed class ProtocolConnectionTests
         await sut.Client.DisposeAsync();
 
         // Assert
-        TransportException? exception = Assert.ThrowsAsync<TransportException>(
+        ConnectionException? exception = Assert.ThrowsAsync<ConnectionException>(
             async () => await sut.Server.ShutdownComplete);
-        Assert.That(exception!.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionReset));
+        Assert.That(exception!.ErrorCode, Is.EqualTo(ConnectionErrorCode.ClosedByAbort));
     }
 
     /// <summary>Verifies that a ConnectAsync failure completes ShutdownComplete.</summary>


### PR DESCRIPTION
This PR ensures ShutdownComplete raises `ConnectionException(ConnectionErrorCode.ClosedByAbort)` if the connection with the peer is lost. It also fixes other spots where this error code is used to provide the cause of the abort with the inner exception.