### PR TITLE
Fixed Quic tests to only run on Quic supported platforms

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -10,7 +10,6 @@ namespace IceRpc.Transports.Internal;
 [System.Runtime.Versioning.SupportedOSPlatform("macOS")]
 [System.Runtime.Versioning.SupportedOSPlatform("linux")]
 [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-
 internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
 {
     public ServerAddress ServerAddress { get; }

--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedStream.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedStream.cs
@@ -10,7 +10,6 @@ namespace IceRpc.Transports.Internal;
 [System.Runtime.Versioning.SupportedOSPlatform("macOS")]
 [System.Runtime.Versioning.SupportedOSPlatform("linux")]
 [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-
 internal class QuicMultiplexedStream : IMultiplexedStream
 {
     public ulong Id => (ulong)_stream.Id;

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
@@ -6,15 +6,27 @@ using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 namespace IceRpc.Tests.Transports;
 
-[Platform(Exclude = "MacOsX")]
 [Parallelizable(ParallelScope.All)]
+[System.Runtime.Versioning.SupportedOSPlatform("macOS")]
+[System.Runtime.Versioning.SupportedOSPlatform("linux")]
+[System.Runtime.Versioning.SupportedOSPlatform("windows")]
 public class QuicTransportConformanceTests : MultiplexedTransportConformanceTests
 {
+    [OneTimeSetUp]
+    public void FixtureSetUp()
+    {
+        if (!QuicConnection.IsSupported)
+        {
+            Assert.Ignore("Quic is not supported on this platform");
+        }
+    }
+
     /// <summary>Creates the service collection used for Quic multiplexed transports for conformance testing.</summary>
     protected override IServiceCollection CreateServiceCollection()
     {


### PR DESCRIPTION
This PR fixes that Quic conformance tests to only run on Quic supported platforms.