### PR TITLE
Display full qualified name when running tests

### DIFF
--- a/build/icerpc.tests.props
+++ b/build/icerpc.tests.props
@@ -9,5 +9,6 @@
     <!-- Missing XML comment for publicly visible type or member, we disable this warning because we don't care about
          public elements not being documented, we just want to ensure that bogus doc elments are detected. -->
     <NoWarn>CS1591</NoWarn>
+    <RunSettingsFilePath>$(MSbuildThisFileDirectory)\tests.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 </Project>

--- a/build/tests.runsettings
+++ b/build/tests.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <NUnit>
+      <DisplayName>FullNameSep</DisplayName>
+    </NUnit>
+</RunSettings>


### PR DESCRIPTION
Fix #1873 for NUnit the behavior can be configured in the test run settings using the DisplayName property

see https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#displayname
```
Skipped IceRpc:Tests:Transports:QuicTransportConformanceTests:Stream_full_duplex_communication(5,16,32,1) [65 ms]
Skipped IceRpc:Tests:Transports:QuicTransportConformanceTests:Stream_full_duplex_communication(5,16,32,16384) [65 ms]
Skipped IceRpc:Tests:Transports:QuicTransportConformanceTests:Stream_output_completes_after_completing_peer_input [65 ms]
```