### PR TITLE
Simplify write coalescing in QuicPipeWriter

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
@@ -117,7 +117,7 @@ internal class QuicPipeWriter : ReadOnlySequencePipeWriter
                     {
                         source.CopyTo(pipeMemory.Span);
                         _pipe.Writer.Advance((int)source.Length);
-                        source = default;
+                        source = ReadOnlySequence<byte>.Empty;
                     }
                     else
                     {


### PR DESCRIPTION
This PR simplifies the write coalescing in QuicPipeWriter and reuses _pipe.Writer for this coalescing.

With this PR: when source (= payload) fits in the remaining bytes of the last segment of _pipe.Writer (= buffered bytes, typically the icerpc header), we copy source into _pipe.Writer. Otherwise we do nothing.

Fixes #1884.