### PR TITLE
Show Quic hang

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -437,17 +437,18 @@ public abstract class MultiplexedTransportConformanceTests
 
         IMultiplexedStream disposedStream = disposeServer ? remoteStream : localStream;
         IMultiplexedStream peerStream = disposeServer ? localStream : remoteStream;
+        await disposedStream.Output.CompleteAsync(); // TODO: try also without, Quic doesn't hang in this case
+        await peerStream.Output.CompleteAsync();
+        await Task.Delay(100); // TODO: temporary
 
         // Act
         await disposedConnection.DisposeAsync();
 
         // Assert
 
-        Assert.ThrowsAsync<TransportException>(async () => await disposedStream.Input.ReadAsync());
-        Assert.ThrowsAsync<TransportException>(async () => await disposedStream.Output.WriteAsync(_oneBytePayload));
-
-        Assert.ThrowsAsync<TransportException>(async () => await peerStream.Input.ReadAsync());
-        Assert.ThrowsAsync<TransportException>(async () => await peerStream.Output.WriteAsync(_oneBytePayload));
+        // TODO: Quic hangs here.
+        await disposedStream.ReadsClosed;
+        await disposedStream.WritesClosed;
 
         await CompleteStreamAsync(localStream);
         await CompleteStreamAsync(remoteStream);


### PR DESCRIPTION
This draft PR modifies a test to show a hang with Quic: we dispose the connection and yet disposedStream.ReadsClosed does not complete.