### PR TITLE
Quic reject client connection

### DIFF
--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportTests.cs
@@ -80,7 +80,6 @@ public class QuicTransportTests
             {
                 new X509Certificate2("../../../certs/client.p12", "password")
             },
-            // First connection is rejected, the following connections are accepted.
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true,
         };
         await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);


### PR DESCRIPTION
This PR adds a test that shows that Quic connection connect calls success, even when the server certificate validation callback rejects the client certificate. I would expect a TransportException or AuthenticationException see #1958