### PR TITLE
Implement CancelPendingFlush by throwing NotSupportedException and

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
@@ -27,7 +27,9 @@ internal class QuicPipeWriter : ReadOnlySequencePipeWriter
 
     public override void Advance(int bytes) => _pipe.Writer.Advance(bytes);
 
-    public override void CancelPendingFlush() => _pipe.Writer.CancelPendingFlush();
+    // QuicPipeWriter does not support this method: the IceRPC core does not need it. And when the application code
+    // installs a payload writer interceptor, this interceptor should never call it on "next".
+    public override void CancelPendingFlush() => throw new NotSupportedException();
 
     public override void Complete(Exception? exception = null)
     {

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -1437,44 +1437,6 @@ public abstract class MultiplexedTransportConformanceTests
     }
 
     [Test]
-    [Ignore("see issue #1939")]
-    public async Task Stream_write_returns_canceled_flush_result_after_cancel_pending_flush()
-    {
-        // Arrange
-        await using ServiceProvider provider = CreateServiceCollection()
-            .AddMultiplexedTransportTest()
-            .BuildServiceProvider(validateScopes: true);
-        var clientConnection = provider.GetRequiredService<IMultiplexedConnection>();
-        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
-        await using IMultiplexedConnection serverConnection =
-            await ConnectAndAcceptConnectionAsync(listener, clientConnection);
-
-        var sut = await CreateAndAcceptStreamAsync(clientConnection, serverConnection);
-
-        Memory<byte> _ = sut.LocalStream.Output.GetMemory();
-        sut.LocalStream.Output.Advance(1);
-
-        // Act
-        sut.LocalStream.Output.CancelPendingFlush();
-
-        // Assert
-        FlushResult flushResult1 = await sut.LocalStream.Output.FlushAsync();
-        FlushResult flushResult2 = await sut.LocalStream.Output.FlushAsync();
-        ReadResult readResult = await sut.RemoteStream.Input.ReadAsync();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(flushResult1.IsCanceled, Is.True);
-            Assert.That(flushResult1.IsCompleted, Is.False);
-            Assert.That(flushResult2.IsCanceled, Is.False);
-            Assert.That(flushResult2.IsCompleted, Is.False);
-            Assert.That(readResult.Buffer, Has.Length.EqualTo(1));
-        });
-
-        CompleteStreams(sut);
-    }
-
-    [Test]
     public async Task Stream_write_empty_buffer_is_noop()
     {
         // Arrange


### PR DESCRIPTION
removeCancelPendingFlush test.

We don't need a test for an API that is never called (here: CancelPendingFlush).

Fixes #1939.
See also #1948.