### PR TITLE
SlicPipeWriter.CancelPendingFlush is not supported, fixes #1969

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Internal/SlicPipeWriter.cs
@@ -102,7 +102,7 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
             {
                 // Flush the internal pipe. It can be completed if the peer sent the stop sending frame.
                 FlushResult flushResult = await _pipe.Writer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
-                Debug.Assert(!flushResult.IsCanceled); // CancelPendingFlush never called on _pipe.Writer
+                Debug.Assert(!flushResult.IsCanceled); // CancelPendingFlush is never called on _pipe.Writer
                 if (flushResult.IsCompleted)
                 {
                     return new FlushResult(isCanceled: false, isCompleted: true);


### PR DESCRIPTION
This PR removes the support for `SlicPipeWriter.CancelPendingFlush` which was only partially implemented since it didn't cancel the sending from the Slic frame.