### PR TITLE
Removed _waitForConnectionFailure task

### DIFF
--- a/src/IceRpc/ClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/ClientProtocolConnectionFactory.cs
@@ -40,6 +40,9 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
         };
 
         _multiplexedClientTransport = multiplexedClientTransport ?? IMultiplexedClientTransport.Default;
+
+        // If the dispatcher is null, we don't allow the peer to open streams for incoming requests. The only stream
+        // which is accepted locally is the peer remote control stream.
         _multiplexedConnectionOptions = new MultiplexedConnectionOptions
         {
             MaxBidirectionalStreams = connectionOptions.Dispatcher is null ? 0 :

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -202,6 +202,9 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
 
                         try
                         {
+                            // If _dispatcher is null, this call will be block indefinitely until the connection is
+                            // closed because the multiplexed connection MaxUnidirectionalStreams and
+                            // MaxBidirectionalStreams options don't allow the peer to open streams.
                             stream = await _transportConnection.AcceptStreamAsync(_tasksCts.Token)
                                 .ConfigureAwait(false);
                         }


### PR DESCRIPTION
This PR removes the `_waitForConnectionFailure` task. It also fixes the exception handling from the reading of the `GoAway` frame on the remote control stream. Bogus GoAway frames now trigger the connection closure.