### PR TITLE
Make IncomingRequest disposable

### DIFF
--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -7,7 +7,7 @@ using System.Collections.Immutable;
 namespace IceRpc;
 
 /// <summary>Represents a request frame received by the application.</summary>
-public sealed class IncomingRequest : IncomingFrame
+public sealed class IncomingRequest : IncomingFrame, IDisposable
 {
     /// <summary>Gets or sets the features of this request.</summary>
     public IFeatureCollection Features { get; set; } = FeatureCollection.Empty;
@@ -66,16 +66,15 @@ public sealed class IncomingRequest : IncomingFrame
     {
     }
 
-    /// <summary>Completes the payload of this request, and the response associated with this request (if
-    /// any).</summary>
-    /// <param name="exception">The exception that caused this completion.</param>
-    public void Complete(Exception? exception = null)
+    /// <summary>Disposes this incoming request. This completes the payload of this request and the payload(s) of the
+    /// response associated with this request (if set).</summary>
+    public void Dispose()
     {
-        Payload.Complete(exception);
+        Payload.Complete();
         if (_response is not null)
         {
-            _response.Payload.Complete(exception);
-            _response.PayloadStream?.Complete(exception);
+            _response.Payload.Complete();
+            _response.PayloadStream?.Complete();
         }
     }
 }

--- a/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
@@ -33,7 +33,7 @@ public sealed class DeadlineMiddlewareTests
         PipeReader pipeReader = WriteDeadline(deadline);
         pipeReader.TryRead(out var readResult);
 
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>
             {
@@ -74,7 +74,7 @@ public sealed class DeadlineMiddlewareTests
         PipeReader pipeReader = WriteDeadline(expectedDeadline);
         pipeReader.TryRead(out var readResult);
 
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>
             {

--- a/tests/IceRpc.Deflate.Tests/DeflateMiddlewareTests.cs
+++ b/tests/IceRpc.Deflate.Tests/DeflateMiddlewareTests.cs
@@ -35,9 +35,10 @@ public class CompressorMiddlewareTests
         var sut = new DeflateMiddleware(dispatcher);
         var outStream = new MemoryStream();
         var output = PipeWriter.Create(outStream);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
 
         // Act
-        OutgoingResponse response = await sut.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc));
+        OutgoingResponse response = await sut.DispatchAsync(request);
 
         // Assert
         PipeWriter payloadWriter = response.GetPayloadWriter(output);
@@ -59,8 +60,9 @@ public class CompressorMiddlewareTests
     {
         var dispatcher = new InlineDispatcher((request, cancellationToken) => new(new OutgoingResponse(request)));
         var sut = new DeflateMiddleware(dispatcher);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
 
-        OutgoingResponse response = await sut.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc));
+        OutgoingResponse response = await sut.DispatchAsync(request);
 
         var pipe = new Pipe();
         Assert.That(response.GetPayloadWriter(pipe.Writer), Is.EqualTo(pipe.Writer));
@@ -83,8 +85,9 @@ public class CompressorMiddlewareTests
             return new(response);
         });
         var sut = new DeflateMiddleware(dispatcher);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
 
-        var response = await sut.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc), default);
+        var response = await sut.DispatchAsync(request, default);
 
         var pipe = new Pipe();
         Assert.That(response.GetPayloadWriter(pipe.Writer), Is.EqualTo(pipe.Writer));
@@ -104,7 +107,7 @@ public class CompressorMiddlewareTests
             return new(new OutgoingResponse(request));
         });
         var sut = new DeflateMiddleware(dispatcher);
-        IncomingRequest request = CreateRequestWitCompressionFormatField(_unknownEncodedCompressionFormatValue);
+        using IncomingRequest request = CreateRequestWitCompressionFormatField(_unknownEncodedCompressionFormatValue);
 
         await sut.DispatchAsync(request, default);
 
@@ -118,7 +121,7 @@ public class CompressorMiddlewareTests
     {
         var dispatcher = new InlineDispatcher((request, cancellationToken) => new(new OutgoingResponse(request)));
         var sut = new DeflateMiddleware(dispatcher);
-        IncomingRequest request = CreateRequestWitCompressionFormatField(_deflateEncodedCompressionFormatValue);
+        using IncomingRequest request = CreateRequestWitCompressionFormatField(_deflateEncodedCompressionFormatValue);
         request.Payload = PipeReader.Create(CreateCompressedPayload(_payload));
 
         OutgoingResponse response = await sut.DispatchAsync(request, default);

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/DispatcherBuilderTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/DispatcherBuilderTests.cs
@@ -23,7 +23,8 @@ public sealed class DispatcherBuilderTests
         builder.Map<ITestService>("/foo");
         IDispatcher dispatcher = builder.Build();
 
-        _ = await dispatcher.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" });
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" };
+        _ = await dispatcher.DispatchAsync(request);
 
         Assert.That(provider.GetRequiredService<ICallTracker>().Count, Is.EqualTo(1));
     }
@@ -40,8 +41,9 @@ public sealed class DispatcherBuilderTests
         var builder = new DispatcherBuilder(provider);
         builder.Mount<ITestService>("/");
         IDispatcher dispatcher = builder.Build();
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" };
 
-        _ = await dispatcher.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" });
+        _ = await dispatcher.DispatchAsync(request);
 
         Assert.That(provider.GetRequiredService<ICallTracker>().Count, Is.EqualTo(1));
     }
@@ -62,8 +64,9 @@ public sealed class DispatcherBuilderTests
         builder.UseMiddleware<UserMiddleware, IUser>();
         builder.Map<ITestService>("/foo");
         IDispatcher dispatcher = builder.Build();
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" };
 
-        _ = await dispatcher.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" });
+        _ = await dispatcher.DispatchAsync(request);
 
         Assert.That(provider.GetRequiredService<ICallTracker>().Count, Is.EqualTo(1));
         Assert.That(provider.GetRequiredService<IPathTracker>().Path, Is.EqualTo("/foo"));
@@ -87,8 +90,9 @@ public sealed class DispatcherBuilderTests
         builder.UseMiddleware<TripleMiddleware, IUser, IDep2, IDep3>();
         builder.Map<ITestService>("/foo");
         IDispatcher dispatcher = builder.Build();
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" };
 
-        _ = await dispatcher.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/foo" });
+        _ = await dispatcher.DispatchAsync(request);
 
         Assert.That(provider.GetRequiredService<ICallTracker>().Count, Is.EqualTo(3));
         Assert.That(provider.GetRequiredService<IPathTracker>().Path, Is.EqualTo("/foo"));

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -14,7 +14,7 @@ public sealed class LoggerMiddlewareTests
         var dispatcher = new InlineDispatcher((request, cancellationToken) => new(new OutgoingResponse(request)));
         using var loggerFactory = new TestLoggerFactory();
         await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/path", Operation = "doIt" };
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/path", Operation = "doIt" };
         var sut = new LoggerMiddleware(dispatcher, loggerFactory.CreateLogger<LoggerMiddleware>());
 
         // Act
@@ -44,7 +44,7 @@ public sealed class LoggerMiddlewareTests
         var dispatcher = new InlineDispatcher((request, cancellationToken) => throw new InvalidOperationException());
         using var loggerFactory = new TestLoggerFactory();
         await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/path", Operation = "doIt" };
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = "/path", Operation = "doIt" };
         var sut = new LoggerMiddleware(dispatcher, loggerFactory.CreateLogger<LoggerMiddleware>());
 
         try

--- a/tests/IceRpc.Metrics.Tests/DispatchEventSourceTests.cs
+++ b/tests/IceRpc.Metrics.Tests/DispatchEventSourceTests.cs
@@ -16,7 +16,7 @@ public sealed class DispatchEventSourceTests
         using var eventSource = new DispatchEventSource(Guid.NewGuid().ToString());
         using var eventListener = new TestEventListener(expectedEventId);
         eventListener.EnableEvents(eventSource, EventLevel.Verbose);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Path = "/test",
             Operation = "Op"
@@ -41,7 +41,7 @@ public sealed class DispatchEventSourceTests
         using var eventListener = new TestEventListener(expectedEventId);
         using var eventSource = new DispatchEventSource(Guid.NewGuid().ToString());
         eventListener.EnableEvents(eventSource, EventLevel.Verbose);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Path = "/test",
             Operation = "Op"
@@ -67,7 +67,7 @@ public sealed class DispatchEventSourceTests
         using var eventListener = new TestEventListener(expectedEventId);
         using var eventSource = new DispatchEventSource(Guid.NewGuid().ToString());
         eventListener.EnableEvents(eventSource, EventLevel.Verbose);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Path = "/test",
             Operation = "Op"
@@ -92,7 +92,7 @@ public sealed class DispatchEventSourceTests
         using var eventListener = new TestEventListener(expectedEventId);
         using var eventSource = new DispatchEventSource(Guid.NewGuid().ToString());
         eventListener.EnableEvents(eventSource, EventLevel.Verbose);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Path = "/test",
             Operation = "Op"

--- a/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
@@ -21,7 +21,7 @@ public sealed class MetricsMiddlewareTests
             ("canceled-requests", "1"),
             ("current-requests", "0"));
         using var eventSource = new DispatchEventSource(name);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
         var sut = new MetricsMiddleware(dispatcher, eventSource);
 
         try
@@ -50,7 +50,7 @@ public sealed class MetricsMiddlewareTests
             ("failed-requests", "1"),
             ("current-requests", "0"));
         using var eventSource = new DispatchEventSource(name);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
         var sut = new MetricsMiddleware(dispatcher, eventSource);
 
         try
@@ -77,7 +77,7 @@ public sealed class MetricsMiddlewareTests
             ("total-requests", "1"),
             ("current-requests", "0"));
         using var eventSource = new DispatchEventSource(name);
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
         var sut = new MetricsMiddleware(dispatcher, eventSource);
 
         await sut.DispatchAsync(request, default);

--- a/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
+++ b/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
@@ -22,7 +22,7 @@ public sealed class RequestContextMiddlewareTests
         {
             encoded = readResult.Buffer;
         }
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>()
             {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
@@ -29,7 +29,7 @@ public sealed class TelemetryMiddlewareTests
         using ActivityListener mockActivityListener = CreateMockActivityListener(activitySource);
         var sut = new TelemetryMiddleware(dispatcher, activitySource);
 
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Operation = "Op",
             Path = "/"
@@ -94,7 +94,7 @@ public sealed class TelemetryMiddlewareTests
         var sut = new TelemetryMiddleware(dispatcher, activitySource);
 
         // Create an incoming request that carries the encoded trace context
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>()
             {
@@ -138,7 +138,7 @@ public sealed class TelemetryMiddlewareTests
         var sut = new TelemetryMiddleware(dispatcher, activitySource);
 
         // Create an incoming request that carries an empty trace context field
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>()
             {

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -167,7 +167,7 @@ public sealed class IceProtocolConnectionTests
         _ = sut.Client.InvokeAsync(request);
 
         // Assert
-        Assert.That(await payloadStreamDecorator.Completed, Is.InstanceOf<NotSupportedException>());
+        Assert.That(async () => await payloadStreamDecorator.Completed, Throws.Nothing);
     }
 
     /// <summary>Shutting down a non-connected server connection disposes the underlying transport connection.

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -429,7 +429,7 @@ public sealed class IceRpcProtocolConnectionTests
         _ = sut.Client.InvokeAsync(request);
 
         // Assert
-        Assert.That(await payloadDecorator.Completed, Is.InstanceOf<NotSupportedException>());
+        Assert.That(async () => await payloadDecorator.Completed, Throws.Nothing);
     }
 
     /// <summary>Ensures that the request payload stream is completed on valid request.</summary>

--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -668,7 +668,7 @@ public sealed class ProtocolConnectionTests
         _ = sut.Client.InvokeAsync(request);
 
         // Assert
-        Assert.That(await payloadDecorator.Completed, Is.InstanceOf<NotSupportedException>());
+        Assert.That(async () => await payloadDecorator.Completed, Throws.Nothing);
     }
 
     /// <summary>Ensures that the response payload is completed on an invalid response payload writer.</summary>
@@ -697,7 +697,7 @@ public sealed class ProtocolConnectionTests
         _ = sut.Client.InvokeAsync(request);
 
         // Assert
-        Assert.That(await payloadDecorator.Completed, Is.InstanceOf<NotSupportedException>());
+        Assert.That(async () => await payloadDecorator.Completed, Throws.Nothing);
     }
 
     /// <summary>Ensures that the request payload writer is completed on valid request.</summary>

--- a/tests/IceRpc.Tests/RouterTests.cs
+++ b/tests/IceRpc.Tests/RouterTests.cs
@@ -71,13 +71,10 @@ public class RouterTests
             }));
 
         router.Mount(path, new InlineDispatcher((current, cancellationToken) => new(new OutgoingResponse(current))));
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = path };
 
         // Act
-        _ = await router.DispatchAsync(
-            new IncomingRequest(FakeConnectionContext.IceRpc)
-            {
-                Path = path
-            });
+        _ = await router.DispatchAsync(request);
 
         // Assert
         Assert.That(currentPath, Is.EqualTo(path));
@@ -113,13 +110,10 @@ public class RouterTests
                 currentPath = current.Path;
                 return new(new OutgoingResponse(current));
             }));
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = path };
 
         // Act
-        _ = await router.DispatchAsync(
-            new IncomingRequest(FakeConnectionContext.IceRpc)
-            {
-                Path = path
-            });
+        _ = await router.DispatchAsync(request);
 
         // Assert
         Assert.That(currentPath, Is.EqualTo(path));
@@ -181,9 +175,10 @@ public class RouterTests
                     calls.Add("middleware-4");
                     return new(new OutgoingResponse(request));
                 }));
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
 
         // Act
-        _ = await router.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc));
+        _ = await router.DispatchAsync(request);
 
         // Assert
         Assert.That(calls, Is.EqualTo(expectedCalls));
@@ -256,13 +251,10 @@ public class RouterTests
                     }));
             });
         });
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc) { Path = path };
 
         // Act
-        _ = await router.DispatchAsync(
-            new IncomingRequest(FakeConnectionContext.IceRpc)
-            {
-                Path = path
-            });
+        _ = await router.DispatchAsync(request);
 
         // Assert
         Assert.That(calls, Is.EqualTo(expectedCalls));
@@ -277,8 +269,9 @@ public class RouterTests
         var dispatcher = new InlineDispatcher((request, cancellationToken) => new(new OutgoingResponse(request)));
         var router = new Router();
         router.Mount("/", dispatcher);
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc);
 
-        _ = await router.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc));
+        _ = await router.DispatchAsync(request);
         return router;
     }
 }

--- a/tests/IceRpc.Tests/Slice/OperationEncodingTests.cs
+++ b/tests/IceRpc.Tests/Slice/OperationEncodingTests.cs
@@ -31,7 +31,7 @@ public class OperationEncodingTests
     public async Task Slice2_operation_decode_with_single_parameter()
     {
         // Arrange
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Payload = Encode(10)
         };
@@ -110,7 +110,7 @@ public class OperationEncodingTests
     [Test]
     public async Task Slice2_operation_decode_with_multiple_parameters()
     {
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Payload = Encode(10, "hello world!")
         };
@@ -230,7 +230,7 @@ public class OperationEncodingTests
     {
         const int p1 = 10;
         const string p2 = "hello world!";
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Payload = Encode(p1, p2, p3, p4)
         };
@@ -402,7 +402,7 @@ public class OperationEncodingTests
     {
         const int p1 = 10;
         const string p2 = "hello world!";
-        var request = new IncomingRequest(FakeConnectionContext.IceRpc)
+        using var request = new IncomingRequest(FakeConnectionContext.IceRpc)
         {
             Payload = Encode(p1, p2, p3, p4)
         };


### PR DESCRIPTION
This PR makes IncomingRequest disposable and removes its Complete method.

Fixes #1973.