### PR TITLE
Fix bugs in MultiplexedStream conformance tests

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -1084,7 +1084,7 @@ public abstract class MultiplexedTransportConformanceTests
         sut.LocalStream.Input.Complete();
 
         // Assert
-        await Task.Delay(TimeSpan.FromMilliseconds(50)); // give time for frame to reach Output
+        await Task.Delay(TimeSpan.FromMilliseconds(50)); // give time to StopSending frame to reach Output
         FlushResult flushResult = await sut.RemoteStream.Output.WriteAsync(new byte[1]);
         Assert.That(flushResult.IsCompleted, Is.True);
 
@@ -1110,7 +1110,7 @@ public abstract class MultiplexedTransportConformanceTests
         sut.LocalStream.Input.Complete();
 
         // Assert
-        await Task.Delay(TimeSpan.FromMilliseconds(50)); // give time for frame to reach Output
+        await Task.Delay(TimeSpan.FromMilliseconds(50)); // give time to StopSending frame to reach Output
         FlushResult flushResult = await sut.RemoteStream.Output.FlushAsync();
         Assert.That(flushResult.IsCompleted, Is.True);
 


### PR DESCRIPTION
This PR fixes #1986 and various bugs in the conformance tests. Somehow several tests had their description reversed.

The issue with #1986 is we called FlushAsync in a loop but only had something to Flush the first time around (!). With Quic, FlushAsync with nothing to flush is no-op.