### PR TITLE
Fix #1982

### DIFF
--- a/tests/IceRpc.Deadline.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Deadline.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Deflate.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Deflate.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Locator.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Locator.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Logger.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Logger.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Metrics.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Metrics.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.RequestContext.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.RequestContext.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Retry.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Retry.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Telemetry.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Telemetry.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]

--- a/tests/IceRpc.Tests/ClientConnectionTests.cs
+++ b/tests/IceRpc.Tests/ClientConnectionTests.cs
@@ -106,10 +106,14 @@ public class ClientConnectionTests
         server = new Server(ServiceNotFoundDispatcher.Instance, serverAddress);
         server.Listen();
 
-        using var request = new OutgoingRequest(new ServiceAddress(protocol));
+        {
+            // Create a separate scope to ensure the call to DisposeAsync runs after
+            // request is disposed by the using directive.
+            using var request = new OutgoingRequest(new ServiceAddress(protocol));
 
-        // Act/Assert
-        Assert.That(async () => await connection.InvokeAsync(request), Throws.Nothing);
+            // Act/Assert
+            Assert.That(async () => await connection.InvokeAsync(request), Throws.Nothing);
+        }
 
         await server.DisposeAsync();
     }

--- a/tests/IntegrationTests/AssemblyInfo.cs
+++ b/tests/IntegrationTests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-[assembly: NUnit.Framework.Timeout(15000)]
+[assembly: NUnit.Framework.Timeout(8000)]


### PR DESCRIPTION
The request was disposed of after the Server, so the server Shutdown hung, that is because we have `using request` but manually dispose of the server.