### PR TITLE
Set MaxBidirectionalStreams etc. in tests

### DIFF
--- a/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
@@ -44,7 +44,23 @@ public static class ProtocolServiceCollectionExtensions
                 listener: provider.GetRequiredService<IListener<IMultiplexedConnection>>()));
 
         services.AddOptions<MultiplexedConnectionOptions>().Configure(
-            options => options.StreamErrorCodeConverter = IceRpcProtocol.Instance.MultiplexedStreamErrorCodeConverter);
+            options =>
+            {
+                options.StreamErrorCodeConverter = IceRpcProtocol.Instance.MultiplexedStreamErrorCodeConverter;
+
+                // TODO: this affects the client and the server connection, which is not good since we only check the
+                // serverConnectionOptions.
+                if (serverConnectionOptions.Dispatcher is null)
+                {
+                    options.MaxBidirectionalStreams = 0;
+                    options.MaxUnidirectionalStreams = 1;
+                }
+                else
+                {
+                    options.MaxBidirectionalStreams = serverConnectionOptions.MaxIceRpcBidirectionalStreams;
+                    options.MaxUnidirectionalStreams = serverConnectionOptions.MaxIceRpcUnidirectionalStreams + 1;
+                }
+            });
 
         return services;
     }


### PR DESCRIPTION
This is a partial/attempted fix for #2009.

Several tests hang with this update and would need to be updated. Maybe there is a better approach?

```
 Failed IceRpc:Tests:IceRpcProtocolConnectionTests:PayloadStream_completed_on_invalid_request_payload(False) [8 s]
  Failed IceRpc:Tests:IceRpcProtocolConnectionTests:PayloadStream_completed_on_invalid_request_payload(True) [8 s]
  Failed IceRpc:Tests:IceRpcProtocolConnectionTests:PayloadStream_completed_on_valid_request(False) [8 s]
  Failed IceRpc:Tests:IceRpcProtocolConnectionTests:PayloadStream_completed_on_valid_request(True) [8 s]
  Failed IceRpc:Tests:ProtocolConnectionTests:Payload_completed_on_valid_request(icerpc,True) [8 s]
  Failed IceRpc:Tests:ProtocolConnectionTests:Payload_completed_on_valid_request(icerpc,False) [8 s]
  Failed IceRpc:Tests:ProtocolConnectionTests:PayloadWriter_completed_with_valid_request(icerpc) [8 s]
```
