### PR TITLE
Refactor IceRpc connection accept stream loop

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -322,7 +322,7 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
 
     private protected override async ValueTask DisposeAsyncCore()
     {
-        // Cancel dispatches and invocations. This also set _isReadOnly to true.
+        // Cancel dispatches and invocations. This also sets _isReadOnly to true.
         CancelDispatchesAndInvocations();
 
         // Before disposing the transport connection, cancel pending tasks which are using the transport connection and


### PR DESCRIPTION
This PR refactors the IceRPC protocol connection accept stream loop:

- all the stream processing - including the reading of the header - is now in the dispatch thread

- the previous logic for setting the _lastRemoteXxxStreamId was buggy and is now fixed; it assumed stream.Id keep increasing which cannot be true

- if we accept a stream AND the dispatches have not completed AND the stream ID is < _lastRemoteXxxStreamId, we proceed and dispatch it, even if we're shutting down. That's the most logical behavior.

- we wait until the dispatches is completely done (including response sent) to decrease the _dispatchCount / signal _dispatchesCompleted. We didn't with the previous code which was incorrect: there was a chance we'd dispose the connection of a "completed dispatch" still sending its response to the peer.