### PR TITLE
Rename BackLog to Backlog

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -94,7 +94,7 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
             new QuicListenerOptions
             {
                 ListenEndPoint = new IPEndPoint(ipAddress, serverAddress.Port),
-                ListenBacklog = quicTransportOptions.ListenerBacklog,
+                ListenBacklog = quicTransportOptions.ListenBacklog,
                 ApplicationProtocols = authenticationOptions.ApplicationProtocols,
                 ConnectionOptionsCallback = GetConnectionOptionsAsync
             },

--- a/src/IceRpc.Quic/Transports/QuicTransportOptions.cs
+++ b/src/IceRpc.Quic/Transports/QuicTransportOptions.cs
@@ -37,12 +37,12 @@ public sealed record class QuicServerTransportOptions : QuicTransportOptions
     /// request arrives and the queue is full, the client connection establishment will fail with a <see
     /// cref="TransportException"/> and the <see cref="TransportErrorCode.ConnectionRefused"/> error code.</summary>
     /// <value>The server listen backlog size. The default is 511.</value>
-    public int ListenerBacklog
+    public int ListenBacklog
     {
-        get => _listenerBacklog;
-        set => _listenerBacklog = value > 0 ? value :
-            throw new ArgumentException($"{nameof(ListenerBacklog)} can't be less than 1", nameof(value));
+        get => _listenBacklog;
+        set => _listenBacklog = value > 0 ? value :
+            throw new ArgumentException($"{nameof(ListenBacklog)} can't be less than 1", nameof(value));
     }
 
-    private int _listenerBacklog = 511;
+    private int _listenBacklog = 511;
 }

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -113,7 +113,7 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
 
             _socket.Bind(address);
             address = (IPEndPoint)_socket.LocalEndPoint!;
-            _socket.Listen(tcpOptions.ListenerBacklog);
+            _socket.Listen(tcpOptions.ListenBacklog);
         }
         catch (Exception exception)
         {

--- a/src/IceRpc/Transports/TcpTransportOptions.cs
+++ b/src/IceRpc/Transports/TcpTransportOptions.cs
@@ -48,12 +48,12 @@ public sealed record class TcpServerTransportOptions : TcpTransportOptions
     /// request arrives and the queue is full, the client connection establishment will fail with a <see
     /// cref="TransportException" /> and the <see cref="TransportErrorCode.ConnectionRefused" /> error code.</summary>
     /// <value>The server socket backlog size. The default is 511.</value>
-    public int ListenerBacklog
+    public int ListenBacklog
     {
-        get => _listenerBacklog;
-        set => _listenerBacklog = value > 0 ? value :
-            throw new ArgumentException($"{nameof(ListenerBacklog)} can't be less than 1", nameof(value));
+        get => _listenBacklog;
+        set => _listenBacklog = value > 0 ? value :
+            throw new ArgumentException($"{nameof(ListenBacklog)} can't be less than 1", nameof(value));
     }
 
-    private int _listenerBacklog = 511;
+    private int _listenBacklog = 511;
 }

--- a/tests/IceRpc.Tests/Transports/TcpTransportConformanceTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportConformanceTests.cs
@@ -17,7 +17,7 @@ public class TcpTransportConformanceTests : DuplexTransportConformanceTests
         .AddDuplexTransportClientServerTest(new Uri("icerpc://127.0.0.1:0/"))
         .AddSingleton<IDuplexServerTransport>(provider => new TcpServerTransport(new TcpServerTransportOptions
             {
-                ListenerBacklog = 1
+                ListenBacklog = 1
             }))
         .AddSingleton<IDuplexClientTransport>(provider => new TcpClientTransport());
 }

--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -146,7 +146,7 @@ public class TcpTransportTests
         }
     }
 
-    /// <summary>Verifies that setting the <see cref="TcpServerTransportOptions.ListenerBacklog" /> configures the
+    /// <summary>Verifies that setting the <see cref="TcpServerTransportOptions.ListenBacklog" /> configures the
     /// socket listen backlog.</summary>
     [Test]
     public async Task Configure_server_connection_listen_backlog()
@@ -155,7 +155,7 @@ public class TcpTransportTests
         await using IListener<IDuplexConnection> listener = CreateTcpListener(
             options: new TcpServerTransportOptions
             {
-                ListenerBacklog = 18
+                ListenBacklog = 18
             });
 
         IDuplexClientTransport clientTransport = new TcpClientTransport(new TcpClientTransportOptions());


### PR DESCRIPTION
Just rename BackLog to Backlog for consistency with Microsoft Quic fixes #2019