### PR TITLE
Clean up Ssl transport conformance tests configuration - See #2055

### DIFF
--- a/tests/IceRpc.Tests/Transports/SslTransportConformanceTests.cs
+++ b/tests/IceRpc.Tests/Transports/SslTransportConformanceTests.cs
@@ -22,16 +22,11 @@ public class SslTransportConformanceTests : TcpTransportConformanceTests
         services.AddSingleton(provider =>
             new SslClientAuthenticationOptions
             {
-                ClientCertificates = new X509CertificateCollection()
-                    {
-                        new X509Certificate2("../../../certs/client.p12", "password")
-                    },
                 RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true
             });
 
         services.AddSingleton(provider => new SslServerAuthenticationOptions
         {
-            ClientCertificateRequired = false,
             ServerCertificate = new X509Certificate2("../../../certs/server.p12", "password")
         });
 


### PR DESCRIPTION
This PR clean up the configuration for SSL transport conformance tests, a client certificate is not required. This can be the cause of #2055 the documentation is not clear whether or not the certificate is always sent even if server options set `ClientCertificateRequired` to false.

I also remove the setting of `ClientCertificateRequired` to false because this is the default.