### PR TITLE
Fix Bogus assert in ProtocolConnection ConnectionAsync

### DIFF
--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -94,7 +94,6 @@ internal abstract class ProtocolConnection : IProtocolConnection
                 {
                     lock (_mutex)
                     {
-                        Debug.Assert(_disposeTask is null); // DisposeAsync doesn't cancel ConnectAsync.
                         if (_connectCts.IsCancellationRequested)
                         {
                             ConnectionClosedException = new(ConnectionErrorCode.ClosedByAbort);

--- a/src/IceRpc/Transports/Internal/AsyncQueueCore.cs
+++ b/src/IceRpc/Transports/Internal/AsyncQueueCore.cs
@@ -121,15 +121,7 @@ internal struct AsyncQueueCore<T>
         _tokenRegistration = default;
 
         // Get the result.
-        T? result;
-        try
-        {
-            result = _source.GetResult(token);
-        }
-        catch (Exception ex)
-        {
-            throw ExceptionUtil.Throw(ex);
-        }
+        T result = _source.GetResult(token);
 
         bool lockTaken = false;
         try


### PR DESCRIPTION
See  #2075

This PR also includes a fix for an unrelated try/catch block in `AsyncQueueCore` which results in better stack traces.