### PR TITLE
Add test for MaxIceFrameSize

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -280,8 +280,12 @@ internal sealed class IceProtocolConnection : ProtocolConnection
 
                     // Notify the ConnectionLost callback.
                     ConnectionLost(exception);
-                    // Initiate the shutdown if not already done.
-                    InitiateShutdown(ConnectionErrorCode.ClosedByAbort);
+                    // Don't wait for DisposeAsync to be called to cancel dispatches and invocations which might still
+                    // be running.
+                    CancelDispatchesAndInvocations();
+
+                    // Also kill the transport connection right away instead of waiting Dispose to be called.
+                    _duplexConnection.Dispose();
                 }
                 finally
                 {

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -182,7 +182,7 @@ public sealed class IceProtocolConnectionTests
         // Act/Assert
         var exception = Assert.ThrowsAsync<ConnectionException>(
             async () => await sut.Client.InvokeAsync(request, default));
-        Assert.That(exception.ErrorCode, Is.EqualTo(ConnectionErrorCode.OperationAborted));
+        Assert.That(exception.ErrorCode, Is.EqualTo(ConnectionErrorCode.TransportError));
         exception = Assert.ThrowsAsync<ConnectionException>(async () => await sut.Server.ShutdownComplete);
         Assert.That(exception.ErrorCode, Is.EqualTo(ConnectionErrorCode.ClosedByAbort));
     }


### PR DESCRIPTION
This PR adds a test to ensure that the connection is aborted when receiving a frame larger than the max ice frame size, it also fixes the Ice protocol connection to ensure the connection is aborted upon getting an exception from reading a frame.