### PR TITLE
Fix for test nullable warnings with VSCode

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportSslAuthenticationConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportSslAuthenticationConformanceTests.cs
@@ -52,7 +52,7 @@ public abstract class DuplexTransportSslAuthenticationConformanceTests
                 await serverConnectTask;
                 await serverConnection.ReadAsync(new byte[1], CancellationToken.None);
             });
-        Assert.That(ex.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionAborted));
+        Assert.That(ex!.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionAborted));
     }
 
     [Test]

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportSslAuthenticationConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportSslAuthenticationConformanceTests.cs
@@ -59,7 +59,7 @@ public abstract class MultiplexedTransportSslAuthenticationConformanceTests
             // The client will typically close the transport connection after receiving AuthenticationException
             await clientConnection.DisposeAsync();
             var ex = Assert.ThrowsAsync<TransportException>(async () => await serverConnectTask);
-            Assert.That(ex.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionAborted));
+            Assert.That(ex!.ErrorCode, Is.EqualTo(TransportErrorCode.ConnectionAborted));
         }
     }
 

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -39,7 +39,7 @@ public sealed class DeadlineInterceptorTests
         // Assert
         Assert.That(hasDeadline, Is.True);
         Assert.That(token, Is.Not.Null);
-        Assert.That(token.Value.CanBeCanceled, Is.True);
+        Assert.That(token!.Value.CanBeCanceled, Is.True);
         Assert.That(token.Value.IsCancellationRequested, Is.True);
     }
 
@@ -133,7 +133,7 @@ public sealed class DeadlineInterceptorTests
 
         // Assert
         Assert.That(token, Is.Not.Null);
-        Assert.That(token.Value, Is.EqualTo(cts.Token));
+        Assert.That(token!.Value, Is.EqualTo(cts.Token));
     }
 
     [Test]

--- a/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
@@ -42,14 +42,14 @@ public sealed class DeadlineMiddlewareTests
         };
 
         // Act
-        DispatchException exception =
+        DispatchException? exception =
             Assert.ThrowsAsync<DispatchException>(async () => await sut.DispatchAsync(request, CancellationToken.None));
 
         // Assert
-        Assert.That(exception.StatusCode, Is.EqualTo(StatusCode.DeadlineExpired));
+        Assert.That(exception!.StatusCode, Is.EqualTo(StatusCode.DeadlineExpired));
         Assert.That(hasDeadline, Is.True);
         Assert.That(token, Is.Not.Null);
-        Assert.That(token.Value.CanBeCanceled, Is.True);
+        Assert.That(token!.Value.CanBeCanceled, Is.True);
         Assert.That(token.Value.IsCancellationRequested, Is.True);
 
         // Cleanup

--- a/tests/IceRpc.Locator.Tests/LocatorInterceptorTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocatorInterceptorTests.cs
@@ -47,7 +47,7 @@ public class LocatorInterceptorTests
 
         IServerAddressFeature? serverAddressFeature = request.Features.Get<IServerAddressFeature>();
         Assert.That(serverAddressFeature, Is.Not.Null);
-        Assert.That(serverAddressFeature.ServerAddress, Is.EqualTo(expected.ServerAddress));
+        Assert.That(serverAddressFeature!.ServerAddress, Is.EqualTo(expected.ServerAddress));
     }
 
     /// <summary>Verifies that the locator interceptor correctly resolves a well-known proxy using the given
@@ -67,7 +67,7 @@ public class LocatorInterceptorTests
 
         IServerAddressFeature? serverAddressFeature = request.Features.Get<IServerAddressFeature>();
         Assert.That(serverAddressFeature, Is.Not.Null);
-        Assert.That(serverAddressFeature.ServerAddress, Is.EqualTo(expected.ServerAddress));
+        Assert.That(serverAddressFeature!.ServerAddress, Is.EqualTo(expected.ServerAddress));
     }
 
     /// <summary>Verifies that the locator interceptor set the refresh cache parameter on the second attempt to resolve

--- a/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
@@ -21,7 +21,7 @@ public sealed class LoggerInterceptorTests
         await sut.InvokeAsync(request, default);
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
-        List<TestLoggerEntry> entries = loggerFactory.Logger.Entries;
+        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
 
         Assert.That(entries.Count, Is.EqualTo(1));
         Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.Invoke));
@@ -55,7 +55,7 @@ public sealed class LoggerInterceptorTests
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
 
-        List<TestLoggerEntry> entries = loggerFactory.Logger.Entries;
+        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
 
         Assert.That(entries.Count, Is.EqualTo(1));
         Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeException));

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -22,7 +22,7 @@ public sealed class LoggerMiddlewareTests
 
         // Assert
         Assert.That(loggerFactory.Logger, Is.Not.Null);
-        List<TestLoggerEntry> entries = loggerFactory.Logger.Entries;
+        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
 
         Assert.That(entries.Count, Is.EqualTo(1));
         Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.Dispatch));
@@ -57,7 +57,7 @@ public sealed class LoggerMiddlewareTests
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
 
-        List<TestLoggerEntry> entries = loggerFactory.Logger.Entries;
+        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
 
         Assert.That(entries.Count, Is.EqualTo(1));
         Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchException));

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -40,7 +40,7 @@ public sealed class TelemetryInterceptorTests
 
         // Assert
         Assert.That(invocationActivity, Is.Not.Null);
-        Assert.That(invocationActivity.Kind, Is.EqualTo(ActivityKind.Client));
+        Assert.That(invocationActivity!.Kind, Is.EqualTo(ActivityKind.Client));
         Assert.That(invocationActivity.OperationName, Is.EqualTo($"{request.ServiceAddress.Path}/{request.Operation}"));
         Assert.That(invocationActivity.Tags, Is.Not.Null);
         var tags = invocationActivity.Tags.ToDictionary(entry => entry.Key, entry => entry.Value);
@@ -94,7 +94,7 @@ public sealed class TelemetryInterceptorTests
         Assert.That(invocationActivity, Is.Not.Null);
         Assert.That(decodedActivity, Is.Not.Null);
         // The decode activity parent is the invocation activity
-        Assert.That(decodedActivity.ParentId, Is.EqualTo(invocationActivity.Id));
+        Assert.That(decodedActivity!.ParentId, Is.EqualTo(invocationActivity!.Id));
         Assert.That(decodedActivity.ParentSpanId, Is.EqualTo(invocationActivity.SpanId));
         Assert.That(decodedActivity.Baggage, Is.Not.Null);
         Assert.That(decodedActivity.ActivityTraceFlags, Is.EqualTo(invocationActivity.ActivityTraceFlags));

--- a/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
@@ -40,7 +40,7 @@ public sealed class TelemetryMiddlewareTests
 
         // Assert
         Assert.That(dispatchActivity, Is.Not.Null);
-        Assert.That(dispatchActivity.Kind, Is.EqualTo(ActivityKind.Server));
+        Assert.That(dispatchActivity!.Kind, Is.EqualTo(ActivityKind.Server));
         Assert.That(dispatchActivity.OperationName, Is.EqualTo($"{request.Path}/{request.Operation}"));
         Assert.That(dispatchActivity.Tags, Is.Not.Null);
         var tags = dispatchActivity.Tags.ToDictionary(entry => entry.Key, entry => entry.Value);
@@ -66,7 +66,7 @@ public sealed class TelemetryMiddlewareTests
         });
 
         string? encodedActivityId;
-        ActivitySpanId? parentSpandId;
+        ActivitySpanId? parentSpanId;
         ReadOnlySequence<byte>? encodedTraceContext = EncodeTraceContext();
 
         ReadOnlySequence<byte> EncodeTraceContext()
@@ -77,7 +77,7 @@ public sealed class TelemetryMiddlewareTests
             encodedActivity.AddBaggage("foo", "bar");
             encodedActivity.Start();
             encodedActivityId = encodedActivity.Id;
-            parentSpandId = encodedActivity.SpanId;
+            parentSpanId = encodedActivity.SpanId;
 
             var buffer = new byte[1024];
             var bufferWriter = new MemoryBufferWriter(buffer);
@@ -110,8 +110,8 @@ public sealed class TelemetryMiddlewareTests
         // Assert
         Assert.That(dispatchActivity, Is.Not.Null);
         // The dispatch activity parent matches the activity context encoded in the TraceContext field
-        Assert.That(dispatchActivity.ParentId, Is.EqualTo(encodedActivityId));
-        Assert.That(dispatchActivity.ParentSpanId, Is.EqualTo(parentSpandId));
+        Assert.That(dispatchActivity!.ParentId, Is.EqualTo(encodedActivityId));
+        Assert.That(dispatchActivity.ParentSpanId, Is.EqualTo(parentSpanId));
         Assert.That(dispatchActivity.ActivityTraceFlags, Is.EqualTo(ActivityTraceFlags.None));
         Assert.That(dispatchActivity.Baggage, Is.Not.Null);
         var baggage = dispatchActivity.Baggage.ToDictionary(x => x.Key, x => x.Value);

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -200,9 +200,9 @@ public sealed class IceProtocolConnectionTests
         // Act/Assert
         var exception = Assert.ThrowsAsync<ConnectionException>(
             async () => await sut.Client.InvokeAsync(request, default));
-        Assert.That(exception.ErrorCode, Is.EqualTo(ConnectionErrorCode.TransportError));
+        Assert.That(exception!.ErrorCode, Is.EqualTo(ConnectionErrorCode.TransportError));
         exception = Assert.ThrowsAsync<ConnectionException>(async () => await sut.Server.ShutdownComplete);
-        Assert.That(exception.ErrorCode, Is.EqualTo(ConnectionErrorCode.ClosedByAbort));
+        Assert.That(exception!.ErrorCode, Is.EqualTo(ConnectionErrorCode.ClosedByAbort));
     }
 
     private static string GetErrorMessage(string Message, Exception innerException) =>

--- a/tests/IceRpc.Tests/RouterTests.cs
+++ b/tests/IceRpc.Tests/RouterTests.cs
@@ -136,10 +136,10 @@ public class RouterTests
     {
         var router = new Router();
 
-        DispatchException ex = Assert.ThrowsAsync<DispatchException>(
+        DispatchException? ex = Assert.ThrowsAsync<DispatchException>(
             async () => await router.DispatchAsync(new IncomingRequest(FakeConnectionContext.IceRpc)));
 
-        Assert.That(ex.StatusCode, Is.EqualTo(StatusCode.ServiceNotFound));
+        Assert.That(ex!.StatusCode, Is.EqualTo(StatusCode.ServiceNotFound));
     }
 
     /// <summary>Verifies that the router middleware are called in the expected order. That corresponds
@@ -201,14 +201,14 @@ public class RouterTests
     /// <summary>Verifies that the middleware are called in the expected order before dispatching the request to the
     /// inner most router.</summary>
     /// <param name="prefix">The prefix for the sub-router.</param>
-    /// <param name="subprefix">The prefix for the sub-sub-router</param>
+    /// <param name="subPrefix">The prefix for the sub-sub-router</param>
     /// <param name="path">The path for the request.</param>
     /// <param name="subpath">The path for the dispatcher in the inner most router.</param>
     [TestCase("/foo", "/bar", "/foo/bar/abc", "/abc")]
     [TestCase("/foo/", "/bar/", "/foo/bar/abc", "/abc")]
-    public async Task Router_with_middleware_and_nested_subrouters(
+    public async Task Router_with_middleware_and_nested_sub_routers(
         string prefix,
-        string subprefix,
+        string subPrefix,
         string path,
         string subpath)
     {
@@ -234,7 +234,7 @@ public class RouterTests
                     return next.DispatchAsync(request, cancellationToken);
                 }));
 
-            r.Route(subprefix, r =>
+            r.Route(subPrefix, r =>
             {
                 r.Use(next => new InlineDispatcher(
                    (request, cancellationToken) =>

--- a/tests/IceRpc.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Tests/ServiceAddressTests.cs
@@ -217,6 +217,7 @@ public class ServiceAddressTests
     /// </summary>
     private static readonly (string uriString, string Path, string Fragment)[] _validServiceAddressUris = new (string, string, string)[]
         {
+            /* spellchecker:disable */
             ("icerpc://host.zeroc.com/path?encoding=foo", "/path", ""),
             ("ice://host.zeroc.com/identity#facet", "/identity", "facet"),
             ("ice://host.zeroc.com/identity#facet#?!$x", "/identity", "facet#?!$x"),
@@ -268,6 +269,7 @@ public class ServiceAddressTests
             ("/foo/bar", "/foo/bar", ""),
             ("//foo/bar", "//foo/bar", ""),
             ("/foo:bar", "/foo:bar", ""),
+            /* spellchecker:enable */
         };
 
     private static readonly Dictionary<string, ServerAddress[]> _altServerAddresses = new()
@@ -499,7 +501,7 @@ public class ServiceAddressTests
         await proxy.SendProxyAsync(proxy);
 
         Assert.That(service.ReceivedProxy, Is.Not.Null);
-        Assert.That(service.ReceivedProxy.Value.Invoker, Is.EqualTo(pipeline));
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(pipeline));
     }
 
     /// <summary>Verifies that a proxy received over an incoming connection has a null invoker by default.</summary>
@@ -517,7 +519,7 @@ public class ServiceAddressTests
         await proxy.SendProxyAsync(proxy);
 
         Assert.That(service.ReceivedProxy, Is.Not.Null);
-        Assert.That(service.ReceivedProxy.Value.Invoker, Is.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.Null);
     }
 
     /// <summary>Verifies that a service address received over an outgoing connection inherits the callers invoker.

--- a/tests/IceRpc.Tests/Slice/ActivatorTests.cs
+++ b/tests/IceRpc.Tests/Slice/ActivatorTests.cs
@@ -110,7 +110,7 @@ public class ActivatorTests
         object? instance = sut.CreateClassInstance(typeId, ref decoder);
 
         Assert.That(instance, Is.Not.Null);
-        Assert.That(instance.GetType(), Is.EqualTo(expectedType));
+        Assert.That(instance!.GetType(), Is.EqualTo(expectedType));
     }
 
     [Test, TestCaseSource(nameof(ReferencedAssembliesExceptionTypeIdsWithType))]
@@ -125,6 +125,6 @@ public class ActivatorTests
         object? instance = sut.CreateExceptionInstance(typeId, ref decoder, message: null);
 
         Assert.That(instance, Is.Not.Null);
-        Assert.That(instance.GetType(), Is.EqualTo(expectedType));
+        Assert.That(instance!.GetType(), Is.EqualTo(expectedType));
     }
 }

--- a/tests/IceRpc.Tests/Slice/ClassTests.cs
+++ b/tests/IceRpc.Tests/Slice/ClassTests.cs
@@ -506,13 +506,13 @@ public sealed class ClassTests
         // Assert
         Assert.That(theA.TheB, Is.Not.Null);
         Assert.That(theA.TheB, Is.TypeOf<MyClassB>());
-        Assert.That(theA.TheB.TheA, Is.Null);
+        Assert.That(theA.TheB!.TheA, Is.Null);
         Assert.That(theA.TheB.TheB, Is.Null);
         Assert.That(theA.TheB.TheC, Is.Null);
 
         Assert.That(theA.TheC, Is.Not.Null);
         Assert.That(theA.TheC, Is.TypeOf<MyClassC>());
-        Assert.That(theA.TheC.TheB, Is.Null);
+        Assert.That(theA.TheC!.TheB, Is.Null);
 
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
@@ -586,13 +586,13 @@ public sealed class ClassTests
         // Assert
         Assert.That(theA.TheB, Is.Not.Null);
         Assert.That(theA.TheB, Is.TypeOf<MyClassB>());
-        Assert.That(theA.TheB.TheA, Is.Null);
+        Assert.That(theA.TheB!.TheA, Is.Null);
         Assert.That(theA.TheB.TheB, Is.Null);
         Assert.That(theA.TheB.TheC, Is.Null);
 
         Assert.That(theA.TheC, Is.Not.Null);
         Assert.That(theA.TheC, Is.TypeOf<MyClassC>());
-        Assert.That(theA.TheC.TheB, Is.Null);
+        Assert.That(theA.TheC!.TheB, Is.Null);
 
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
@@ -649,13 +649,13 @@ public sealed class ClassTests
         // Assert
         Assert.That(theA.TheB, Is.Not.Null);
         Assert.That(theA.TheB, Is.TypeOf<MyClassB>());
-        Assert.That(theA.TheB.TheA, Is.Null);
+        Assert.That(theA.TheB!.TheA, Is.Null);
         Assert.That(theA.TheB.TheB, Is.Null);
         Assert.That(theA.TheB.TheC, Is.Not.Null);
 
         Assert.That(theA.TheC, Is.Not.Null);
         Assert.That(theA.TheC, Is.TypeOf<MyClassC>());
-        Assert.That(theA.TheC.TheB, Is.Not.Null);
+        Assert.That(theA.TheC!.TheB, Is.Not.Null);
 
         Assert.That(theA.TheB.TheC, Is.EqualTo(theA.TheC));
         Assert.That(theA.TheC.TheB, Is.EqualTo(theA.TheB));
@@ -741,13 +741,13 @@ public sealed class ClassTests
         // Assert
         Assert.That(theA.TheB, Is.Not.Null);
         Assert.That(theA.TheB, Is.TypeOf<MyClassB>());
-        Assert.That(theA.TheB.TheA, Is.Null);
+        Assert.That(theA.TheB!.TheA, Is.Null);
         Assert.That(theA.TheB.TheB, Is.Null);
         Assert.That(theA.TheB.TheC, Is.Not.Null);
 
         Assert.That(theA.TheC, Is.Not.Null);
         Assert.That(theA.TheC, Is.TypeOf<MyClassC>());
-        Assert.That(theA.TheC.TheB, Is.Not.Null);
+        Assert.That(theA.TheC!.TheB, Is.Not.Null);
 
         Assert.That(theA.TheB.TheC, Is.EqualTo(theA.TheC));
         Assert.That(theA.TheC.TheB, Is.EqualTo(theA.TheB));

--- a/tests/IceRpc.Tests/Slice/ExceptionTests.cs
+++ b/tests/IceRpc.Tests/Slice/ExceptionTests.cs
@@ -143,7 +143,7 @@ public sealed class ExceptionTests
         var value = decoder.DecodeUserException() as MyDerivedException;
 
         Assert.That(value, Is.Not.Null);
-        Assert.That(value.I, Is.EqualTo(10));
+        Assert.That(value!.I, Is.EqualTo(10));
         Assert.That(value.J, Is.EqualTo(20));
         Assert.That(value.K, Is.EqualTo(30));
         Assert.That(value.L, Is.EqualTo(40));
@@ -176,7 +176,7 @@ public sealed class ExceptionTests
         var value = decoder.DecodeUserException() as MyException;
 
         Assert.That(value, Is.Not.Null);
-        Assert.That(value.I, Is.EqualTo(10));
+        Assert.That(value!.I, Is.EqualTo(10));
         Assert.That(value.J, Is.EqualTo(20));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
@@ -216,7 +216,7 @@ public sealed class ExceptionTests
         var value = decoder.DecodeUserException() as MyExceptionWithTaggedMembers;
 
         Assert.That(value, Is.Not.Null);
-        Assert.That(value.I, Is.EqualTo(10));
+        Assert.That(value!.I, Is.EqualTo(10));
         Assert.That(value.J, Is.EqualTo(20));
         Assert.That(value.K, Is.EqualTo(k));
         Assert.That(value.L, Is.EqualTo(l));
@@ -339,7 +339,7 @@ public sealed class ExceptionTests
         // TODO how we test this without using DecodeUserException?
         var decoded = decoder.DecodeUserException() as MyDerivedException;
         Assert.That(decoded, Is.Not.Null);
-        Assert.That(decoded.I, Is.EqualTo(expected.I));
+        Assert.That(decoded!.I, Is.EqualTo(expected.I));
         Assert.That(decoded.J, Is.EqualTo(expected.J));
         Assert.That(decoded.K, Is.EqualTo(expected.K));
         Assert.That(decoded.L, Is.EqualTo(expected.L));
@@ -361,7 +361,7 @@ public sealed class ExceptionTests
             activator: SliceDecoder.GetActivator(typeof(MyException).Assembly));
         var value = decoder.DecodeUserException() as MyException;
         Assert.That(value, Is.Not.Null);
-        Assert.That(value.I, Is.EqualTo(expected.I));
+        Assert.That(value!.I, Is.EqualTo(expected.I));
         Assert.That(value.J, Is.EqualTo(expected.J));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
@@ -384,7 +384,7 @@ public sealed class ExceptionTests
             activator: SliceDecoder.GetActivator(typeof(MyExceptionWithTaggedMembers).Assembly));
         var value = decoder.DecodeUserException() as MyExceptionWithTaggedMembers;
         Assert.That(value, Is.Not.Null);
-        Assert.That(value.I, Is.EqualTo(10));
+        Assert.That(value!.I, Is.EqualTo(10));
         Assert.That(value.J, Is.EqualTo(20));
         Assert.That(value.K, Is.EqualTo(k));
         Assert.That(value.L, Is.EqualTo(l));

--- a/tests/IceRpc.Tests/Slice/OperationTests.cs
+++ b/tests/IceRpc.Tests/Slice/OperationTests.cs
@@ -505,7 +505,7 @@ public class OperationTests
         await proxy.OpWithProxyParameterAsync(ServiceProxy.FromPath("/hello"));
 
         Assert.That(service.ReceivedProxy, Is.Not.Null);
-        Assert.That(service.ReceivedProxy.Value.Invoker, Is.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.Null);
     }
 
     class MyOperationsA : Service, IMyOperationsA


### PR DESCRIPTION
This PR fixes some warnings that only show up in VSCode

```
Assert.That(token, Is.Not.Null);
Assert.That(token.Value.CanBeCanceled, Is.True);
```
Given the above code, Visual Studio knows the token is not null, MSBuild doesn't complain either, but it doesn't work with VSCode, seems the NUnit analyzer doesn't fully work with VSCode.