### PR TITLE
Reject cs::attribute for operation and operation parameters

### DIFF
--- a/tests/IceRpc.Tests/Slice/OperationTests.cs
+++ b/tests/IceRpc.Tests/Slice/OperationTests.cs
@@ -237,23 +237,6 @@ public class OperationTests
             Throws.Nothing);
     }
 
-    // TODO check that the parameter has the expected attributes or reject cs::attribute for operation parameters.
-    [Test]
-    public async Task Operation_with_cs_attribute()
-    {
-        // Arrange
-        await using ServiceProvider provider = new ServiceCollection()
-            .AddClientServerColocTest(new MyOperationsA())
-            .AddIceRpcProxy<IMyOperationsAProxy, MyOperationsAProxy>()
-            .BuildServiceProvider(validateScopes: true);
-
-        IMyOperationsAProxy proxy = provider.GetRequiredService<IMyOperationsAProxy>();
-        provider.GetRequiredService<Server>().Listen();
-
-        // Act
-        Assert.That(async () => await proxy.OpWithCsAttributeAsync(10), Throws.Nothing);
-    }
-
     [Test]
     public async Task Operation_with_single_return_value_and_encoded_result_attribute()
     {
@@ -592,11 +575,6 @@ public class OperationTests
             int features,
             IFeatureCollection features_,
             CancellationToken cancellationToken_) => default;
-
-        public ValueTask<int> OpWithCsAttributeAsync(
-            int p,
-            IFeatureCollection features,
-            CancellationToken cancellationToken) => default;
 
         public ValueTask<IMyOperationsA.OpWithSingleReturnValueAndEncodedResultAttributeEncodedResult> OpWithSingleReturnValueAndEncodedResultAttributeAsync(
             IFeatureCollection features,

--- a/tests/IceRpc.Tests/Slice/OperationTests.slice
+++ b/tests/IceRpc.Tests/Slice/OperationTests.slice
@@ -31,9 +31,6 @@ interface MyOperationsA
     // cancel and features as regular parameter names
     opWithSpecialParameterNames(cancel: int32, features: int32);
 
-    // Parameter with cs::attribute
-    opWithCsAttribute(p: [cs::attribute("MyAttribute")] int32) -> int32;
-
     // Encoded result
     [cs::encodedResult] opWithSingleReturnValueAndEncodedResultAttribute() -> sequence<int32>;
     [cs::encodedResult] opWithMultipleReturnValuesAndEncodedResultAttribute() -> (r1: sequence<int32>, r2: sequence<int32>);

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -7,7 +7,7 @@ use crate::cs_attributes::match_cs_attribute;
 use crate::member_util::escape_parameter_name;
 use crate::slicec_ext::*;
 use slice::code_block::CodeBlock;
-use slice::grammar::{Attributable, Class, Commentable, Encoding, Entity, Operation};
+use slice::grammar::{Class, Commentable, Encoding, Entity, Operation};
 use slice::supported_encodings::SupportedEncodings;
 use slice::utils::code_gen_util::TypeContext;
 
@@ -320,17 +320,6 @@ impl FunctionBuilder {
         let parameters = operation.parameters();
 
         for parameter in &parameters {
-            // The attributes are a space separated list of attributes.
-            // eg. [attribute1] [attribute2]
-
-            let parameter_attributes = parameter
-                .attributes(false)
-                .into_iter()
-                .filter_map(match_cs_attribute)
-                .map(|attribute| format!("[{}]", attribute))
-                .collect::<Vec<_>>()
-                .join("\n");
-
             let parameter_type = parameter.cs_type_string(&operation.namespace(), context, false);
             let parameter_name = parameter.parameter_name();
 
@@ -339,7 +328,7 @@ impl FunctionBuilder {
             let parameter_comment = operation_parameter_doc_comment(operation, &parameter.cs_identifier(None));
 
             self.add_parameter(
-                &format!("{}{}", parameter_attributes, &parameter_type),
+                &format!("{}", &parameter_type),
                 &parameter_name,
                 if context == TypeContext::Encode && parameter.tag.is_some() {
                     Some("default")

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -80,7 +80,7 @@ fn validate_collection_attributes<T: Attributable>(attributable: &T, diagnostic_
 
 fn validate_common_attributes(attribute: &CsAttributeKind, span: &Span, diagnostic_reporter: &mut DiagnosticReporter) {
     match attribute {
-        CsAttributeKind::Attribute { .. } | CsAttributeKind::Identifier { .. } => {}
+        CsAttributeKind::Identifier { .. } => {}
         _ => report_unexpected_attribute(attribute, span, diagnostic_reporter),
     }
 }
@@ -123,7 +123,7 @@ impl Visitor for CsValidator<'_> {
     fn visit_struct_start(&mut self, struct_def: &Struct) {
         for (attribute, span) in &cs_attributes(&struct_def.attributes(false)) {
             match attribute {
-                CsAttributeKind::Readonly | CsAttributeKind::Internal => {}
+                CsAttributeKind::Readonly | CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
@@ -132,7 +132,7 @@ impl Visitor for CsValidator<'_> {
     fn visit_class_start(&mut self, class_def: &Class) {
         for (attribute, span) in &cs_attributes(&class_def.attributes(false)) {
             match attribute {
-                CsAttributeKind::Internal => {}
+                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
@@ -141,7 +141,7 @@ impl Visitor for CsValidator<'_> {
     fn visit_exception_start(&mut self, exception_def: &Exception) {
         for (attribute, span) in &cs_attributes(&exception_def.attributes(false)) {
             match attribute {
-                CsAttributeKind::Internal => {}
+                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
@@ -159,7 +159,7 @@ impl Visitor for CsValidator<'_> {
     fn visit_enum_start(&mut self, enum_def: &Enum) {
         for (attribute, span) in &cs_attributes(&enum_def.attributes(false)) {
             match attribute {
-                CsAttributeKind::Internal => {}
+                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
@@ -215,7 +215,7 @@ impl Visitor for CsValidator<'_> {
     fn visit_data_member(&mut self, data_member: &DataMember) {
         for (attribute, ..) in &cs_attributes(&data_member.attributes(false)) {
             match attribute {
-                CsAttributeKind::Identifier { .. } => {}
+                CsAttributeKind::Identifier { .. } | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_data_type_attributes(&data_member.data_type, self.diagnostic_reporter),
             }
         }


### PR DESCRIPTION
This PR updates the allowed targets for "cs::attribute", it is no longer allowed for operation, parameter, or interface declaration.

It can be used for struct, class, and enum declarations, it is also valid for fields of struct and classes.
