### PR TITLE
Fix client connection test TODO

### DIFF
--- a/tests/IceRpc.Tests/ClientConnectionTests.cs
+++ b/tests/IceRpc.Tests/ClientConnectionTests.cs
@@ -119,7 +119,7 @@ public class ClientConnectionTests
     }
 
     [Test, TestCaseSource(nameof(Protocols))]
-    public async Task Connection_can_connect_after_connection_refused(Protocol protocol)
+    public async Task Connection_can_connect_after_connect_failure(Protocol protocol)
     {
         // Arrange
         var colocTransport = new ColocTransport();
@@ -137,7 +137,6 @@ public class ClientConnectionTests
         // Act/Assert
         IceRpcException exception =
             Assert.ThrowsAsync<IceRpcException>(async () => await connection.ConnectAsync());
-        Assert.That(exception.IceRpcError, Is.EqualTo(IceRpcError.ConnectionRefused));
         server.Listen();
         Assert.That(async () => await connection.ConnectAsync(), Throws.Nothing);
     }


### PR DESCRIPTION
This fixes a TODO in `Connection_can_connect_after_connection_refused` renamed as `Connection_can_connect_after_connect_failure` 

I think the reason for the connection connect failure is not important here,  the point is the connection can still retry after connect failed.