### PR TITLE
Fix deprecated dotnet new commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,9 +70,9 @@ install_templates()
     run_command dotnet "pack" "-c" "$dotnet_config"
     dotnet_templates=$(dotnet new -l)
     if [[ "$dotnet_templates" == *"icerpc-client"* ]]; then
-        run_command "dotnet" 'new' '-u' 'IceRpc.ProjectTemplates'
+        run_command "dotnet" 'new' 'uninstall' 'IceRpc.ProjectTemplates'
     fi
-    run_command "dotnet" 'new' '-i' "bin/$dotnet_config/IceRpc.ProjectTemplates.$version.nupkg"
+    run_command "dotnet" 'new' 'install' "bin/$dotnet_config/IceRpc.ProjectTemplates.$version.nupkg"
     popd
 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -89,10 +89,10 @@ function InstallTemplates($config) {
     RunCommand "dotnet" @('pack', '--configuration', $dotnetConfiguration)
     $dotnet_templates = dotnet new -l
     if ($dotnet_templates.Where({$_.Contains("icerpc-client")}).count -gt 0) {
-        RunCommand "dotnet" @('new', '--uninstall', 'IceRpc.ProjectTemplates')
+        RunCommand "dotnet" @('new', 'uninstall', 'IceRpc.ProjectTemplates')
     }
 
-    RunCommand "dotnet" @('new', '--install', "bin\Any CPU\$dotnetConfiguration\IceRpc.ProjectTemplates.$version.nupkg")
+    RunCommand "dotnet" @('new', 'install', "bin\Any CPU\$dotnetConfiguration\IceRpc.ProjectTemplates.$version.nupkg")
     Pop-Location
 }
 


### PR DESCRIPTION
dotnet new --(un)install is now dotnet new (un)install

Got these messages when running build.sh

```
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
```
```
Warning: use of 'dotnet new --uninstall' is deprecated. Use 'dotnet new uninstall' instead.
```