### PR TITLE
Update to use new Error and Warning builder API

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -371,9 +371,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linux-raw-sys"
@@ -611,9 +611,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -643,18 +643,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,7 +692,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/zeroc-ice/icerpc#0a0cd5fabf307a87a5adf21f6c42aad22c47bf50"
+source = "git+ssh://git@github.com/zeroc-ice/icerpc#56e4b3b051be7fcb581941b69ef98405d4938b99"
 dependencies = [
  "clap",
  "console",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"

--- a/tools/slicec-cs/src/attribute_patcher.rs
+++ b/tools/slicec-cs/src/attribute_patcher.rs
@@ -117,10 +117,9 @@ impl AttributePatcher<'_> {
                 .single_argument(attribute)
                 .map(|argument| CsAttributeKind::Type { name: argument }),
             _ => {
-                self.reporter.report_error(Error::new(
-                    ErrorKind::UnexpectedAttribute(attribute.directive.to_owned()),
-                    Some(attribute.span),
-                ));
+                Error::new(ErrorKind::UnexpectedAttribute(attribute.directive.to_owned()))
+                    .set_span(attribute.span)
+                    .report(self.reporter);
                 None
             }
         }
@@ -153,14 +152,14 @@ impl AttributePatcher<'_> {
     }
 
     fn error_missing(&mut self, required_argument: String, span: &Span) {
-        self.reporter.report_error(Error::new(
-            ErrorKind::MissingRequiredArgument(required_argument),
-            Some(span),
-        ));
+        Error::new(ErrorKind::MissingRequiredArgument(required_argument))
+            .set_span(span)
+            .report(self.reporter);
     }
 
     fn error_too_many(&mut self, expected: String, span: &Span) {
-        self.reporter
-            .report_error(Error::new(ErrorKind::TooManyArguments(expected), Some(span)));
+        Error::new(ErrorKind::TooManyArguments(expected))
+            .set_span(span)
+            .report(self.reporter);
     }
 }

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -328,7 +328,7 @@ impl FunctionBuilder {
             let parameter_comment = operation_parameter_doc_comment(operation, &parameter.cs_identifier(None));
 
             self.add_parameter(
-                &format!("{}", &parameter_type),
+                &parameter_type.to_string(),
                 &parameter_name,
                 if context == TypeContext::Encode && parameter.tag.is_some() {
                     Some("default")

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -117,10 +117,7 @@ fn try_main() -> CompilationResult {
                 match write_file(&path, &code_string) {
                     Ok(_) => (),
                     Err(err) => {
-                        compilation_data
-                            .diagnostic_reporter
-                            .report_error(Error::new(ErrorKind::IO(err), None));
-
+                        Error::new(ErrorKind::IO(err)).report(&mut compilation_data.diagnostic_reporter);
                         continue;
                     }
                 }

--- a/tools/slicec-cs/src/validators/tests.rs
+++ b/tools/slicec-cs/src/validators/tests.rs
@@ -33,10 +33,9 @@ fn identifier_attribute_no_args() {
         .diagnostic_reporter;
 
     // Assert
-    let expected = [Error::new(
-        ErrorKind::MissingRequiredArgument(cs_attributes::IDENTIFIER.to_owned() + r#"("<argument>")"#),
-        None,
-    )];
+    let expected = [Error::new(ErrorKind::MissingRequiredArgument(
+        cs_attributes::IDENTIFIER.to_owned() + r#"("<argument>")"#,
+    ))];
     std::iter::zip(expected, diagnostic_reporter.into_diagnostics())
         .for_each(|(expected, actual)| assert_eq!(expected.to_string(), actual.to_string()));
 }
@@ -60,10 +59,9 @@ fn identifier_attribute_multiple_args() {
         .diagnostic_reporter;
 
     // Assert
-    let expected = [Error::new(
-        ErrorKind::TooManyArguments(cs_attributes::IDENTIFIER.to_owned() + r#"("<argument>")"#),
-        None,
-    )];
+    let expected = [Error::new(ErrorKind::TooManyArguments(
+        cs_attributes::IDENTIFIER.to_owned() + r#"("<argument>")"#,
+    ))];
     std::iter::zip(expected, diagnostic_reporter.into_diagnostics())
         .for_each(|(expected, actual)| assert_eq!(expected.to_string(), actual.to_string()));
 }
@@ -106,10 +104,10 @@ fn identifier_attribute_invalid_on_modules() {
         .unwrap_err()
         .diagnostic_reporter;
     // Assert
-    let expected = [Error::new(
-        ErrorKind::InvalidAttribute(cs_attributes::IDENTIFIER.to_owned(), "module".to_owned()),
-        None,
-    )];
+    let expected = [Error::new(ErrorKind::InvalidAttribute(
+        cs_attributes::IDENTIFIER.to_owned(),
+        "module".to_owned(),
+    ))];
     std::iter::zip(expected, diagnostic_reporter.into_diagnostics())
         .for_each(|(expected, actual)| assert_eq!(expected.to_string(), actual.to_string()));
 }


### PR DESCRIPTION
This is the sister PR to https://github.com/zeroc-ice/icerpc/pull/370. The slicec PR cleaned up the error and warning API by using the builder pattern and resulted in a much cleaner API.