### PR TITLE
Connect Async minor fix

### DIFF
--- a/src/IceRpc/Internal/ProtocolConnection.cs
+++ b/src/IceRpc/Internal/ProtocolConnection.cs
@@ -140,7 +140,7 @@ internal abstract class ProtocolConnection : IProtocolConnection
             }
             catch
             {
-                Debug.Assert(ConnectionClosedException != null);
+                Debug.Assert(ConnectionClosedException is not null);
                 _shutdownCompleteSource.TrySetException(ConnectionClosedException);
                 throw;
             }


### PR DESCRIPTION
Minor fix for ConnectAsync, don't need for exception here, `ConnectionClosedException` is always set by the try/catch above