### PR TITLE
No longer white list LimitExceeded

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -287,12 +287,9 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
                                     }
                                     catch (IceRpcException exception) when (
                                         exception.IceRpcError is
-                                            IceRpcError.LimitExceeded or
                                             IceRpcError.OperationAborted or
                                             IceRpcError.TruncatedData)
                                     {
-                                        // LimitExceeded is expected when attempting to encode a response header larger
-                                        // than the peer's max header size.
                                         // OperationAborted is expected when the connection is disposed (and aborted)
                                         // while we're receiving a request header or sending a response.
                                         // TruncatedData is expected when reading a request header. It can also be


### PR DESCRIPTION
This PR removes LimitExceeded from the errors tolerated by the dispatch task. As a result, if we can't encode a response header because its size exceeds the peer's max header size, we execute the faulted task action.

The rationale is "faulted task action" (and unobserved task exception) are the only way for the user to be notified that this limit is exceeded. If we just eat the exception (current code), it's going to be really hard to figure out why IceRpc doesn't send a response.

This PR also adds a test for responses whose header exceeds this limit.

Note: if we no longer catch IceRpcError.LimitExceeded in the core (like in the current code), we could (and should) just merge in into "other errors" (IceRpcError.IceRpcError). That's for a follow-up PR.
