### PR TITLE
Protocol logger tests

### DIFF
--- a/src/IceRpc/Internal/LogClientProtocolConnectionFactoryDecorator.cs
+++ b/src/IceRpc/Internal/LogClientProtocolConnectionFactoryDecorator.cs
@@ -90,14 +90,17 @@ internal class LogClientProtocolConnectionFactoryDecorator : IClientProtocolConn
                             _connectionInformation.RemoteNetworkAddress);
                     }
                 }
-                catch (Exception exception) when (_connectionInformation is not null)
+                catch (Exception exception)
                 {
                     // We only log Shutdown exceptions when ConnectAsync completed successfully.
-                    _logger.LogConnectionFailed(
-                        isServer: false,
-                        _connectionInformation.LocalNetworkAddress,
-                        _connectionInformation.RemoteNetworkAddress,
-                        exception);
+                    if (_connectionInformation is not null)
+                    {
+                        _logger.LogConnectionFailed(
+                            isServer: false,
+                            _connectionInformation.LocalNetworkAddress,
+                            _connectionInformation.RemoteNetworkAddress,
+                            exception);
+                    }
                 }
             }
         }

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
 using System.Net;
 

--- a/src/IceRpc/ProtocolEventIds.cs
+++ b/src/IceRpc/ProtocolEventIds.cs
@@ -17,9 +17,6 @@ public enum ProtocolEventIds
     /// <summary>The connection connect attempt failed.</summary>
     ConnectionConnectFailed,
 
-    /// <summary>A client connection has been created.</summary>
-    ConnectionCreated,
-
     /// <summary>A connection has been terminated because a failure.</summary>
     ConnectionFailed,
 

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -539,6 +539,7 @@ public sealed class Server : IAsyncDisposable
 
         public ValueTask DisposeAsync()
         {
+            _logger.LogStopAcceptingConnections(ServerAddress);
             return _decoratee.DisposeAsync();
         }
 

--- a/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
@@ -21,18 +21,17 @@ public sealed class LoggerInterceptorTests
         await sut.InvokeAsync(request, default);
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
-        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
-        Assert.That(entries.Count, Is.EqualTo(1));
-        Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.Invoke));
-        Assert.That(entries[0].State["ServiceAddress"], Is.EqualTo(serviceAddress));
-        Assert.That(entries[0].State["Operation"], Is.EqualTo("doIt"));
-        Assert.That(entries[0].State["StatusCode"], Is.EqualTo(StatusCode.Success));
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.Invoke));
+        Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.Success));
         Assert.That(
-            entries[0].State["LocalNetworkAddress"],
+            entry.State["LocalNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.IceRpc.TransportConnectionInformation.LocalNetworkAddress));
         Assert.That(
-            entries[0].State["RemoteNetworkAddress"],
+            entry.State["RemoteNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.IceRpc.TransportConnectionInformation.RemoteNetworkAddress));
     }
 
@@ -55,12 +54,11 @@ public sealed class LoggerInterceptorTests
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
 
-        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
-        Assert.That(entries.Count, Is.EqualTo(1));
-        Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeException));
-        Assert.That(entries[0].State["ServiceAddress"], Is.EqualTo(serviceAddress));
-        Assert.That(entries[0].State["Operation"], Is.EqualTo("doIt"));
-        Assert.That(entries[0].Exception, Is.InstanceOf<InvalidOperationException>());
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeException));
+        Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.Exception, Is.InstanceOf<InvalidOperationException>());
     }
 }

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -22,18 +22,17 @@ public sealed class LoggerMiddlewareTests
 
         // Assert
         Assert.That(loggerFactory.Logger, Is.Not.Null);
-        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
-        Assert.That(entries.Count, Is.EqualTo(1));
-        Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.Dispatch));
-        Assert.That(entries[0].State["Operation"], Is.EqualTo("doIt"));
-        Assert.That(entries[0].State["Path"], Is.EqualTo("/path"));
-        Assert.That(entries[0].State["StatusCode"], Is.EqualTo(StatusCode.Success));
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.Dispatch));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.State["Path"], Is.EqualTo("/path"));
+        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.Success));
         Assert.That(
-            entries[0].State["LocalNetworkAddress"],
+            entry.State["LocalNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.IceRpc.TransportConnectionInformation.LocalNetworkAddress));
         Assert.That(
-            entries[0].State["RemoteNetworkAddress"],
+            entry.State["RemoteNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.IceRpc.TransportConnectionInformation.RemoteNetworkAddress));
 
     }
@@ -57,12 +56,11 @@ public sealed class LoggerMiddlewareTests
 
         Assert.That(loggerFactory.Logger, Is.Not.Null);
 
-        List<TestLoggerEntry> entries = loggerFactory.Logger!.Entries;
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
-        Assert.That(entries.Count, Is.EqualTo(1));
-        Assert.That(entries[0].EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchException));
-        Assert.That(entries[0].State["Path"], Is.EqualTo("/path"));
-        Assert.That(entries[0].State["Operation"], Is.EqualTo("doIt"));
-        Assert.That(entries[0].Exception, Is.InstanceOf<InvalidOperationException>());
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchException));
+        Assert.That(entry.State["Path"], Is.EqualTo("/path"));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.Exception, Is.InstanceOf<InvalidOperationException>());
     }
 }

--- a/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
+++ b/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
@@ -56,8 +56,12 @@ public sealed class RetryInterceptorTests
         Assert.That(attempts, Is.EqualTo(2));
 
         Assert.That(loggerFactory.Logger!.Category, Is.EqualTo("IceRpc.Logger.LoggerInterceptor"));
-        Assert.That(loggerFactory.Logger!.Entries.Count, Is.EqualTo(2));
-        TestLoggerEntry entry = loggerFactory.Logger!.Entries[1];
+
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
+        // The first entry doesn't correspond to a retry and has an empty scope
+        Assert.That(entry.Scope, Is.Empty);
+
+        entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
         Assert.That(entry.Scope["Attempt"], Is.EqualTo(2));
         Assert.That(entry.Scope["MaxAttempts"], Is.EqualTo(2));
         Assert.That(entry.LogLevel, Is.EqualTo(LogLevel.Information));

--- a/tests/IceRpc.Tests.Common/TestLogger.cs
+++ b/tests/IceRpc.Tests.Common/TestLogger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using Microsoft.Extensions.Logging;
+using System.Threading.Channels;
 
 namespace IceRpc.Tests.Common;
 
@@ -18,7 +19,7 @@ public class TestLogger : ILogger
 
     public Dictionary<string, object?> CurrentScope { get; internal set; } = new();
 
-    public List<TestLoggerEntry> Entries = new();
+    public Channel<TestLoggerEntry> Entries = Channel.CreateUnbounded<TestLoggerEntry>();
 
     public TestLogger(string category) => Category = category;
 
@@ -29,7 +30,7 @@ public class TestLogger : ILogger
         Exception? exception,
         Func<TState, Exception?, string> formatter)
     {
-        Entries.Add(new(
+        Entries.Writer.TryWrite(new(
             logLevel,
             eventId,
             new Dictionary<string, object?>(

--- a/tests/IceRpc.Tests/ProtocolLoggerTests.cs
+++ b/tests/IceRpc.Tests/ProtocolLoggerTests.cs
@@ -1,0 +1,367 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using IceRpc.Internal;
+using IceRpc.Tests.Common;
+using IceRpc.Transports;
+using NUnit.Framework;
+using System.Net;
+using System.Net.Security;
+
+namespace IceRpc.Tests;
+
+[Parallelizable(ParallelScope.All)]
+public sealed class ProtocolLoggerTests
+{
+    [Test]
+    public async Task Log_connection_accepted_and_connection_connected()
+    {
+        // Arrange
+        var serverAddress = new ServerAddress(new Uri($"icerpc://colochost-{Guid.NewGuid()}"));
+        using var serverLoggerFactory = new TestLoggerFactory();
+        using var clientLoggerFactory = new TestLoggerFactory();
+        var colocTransport = new ColocTransport();
+        await using var server = new Server(
+            dispatcher: ServiceNotFoundDispatcher.Instance,
+            serverAddress,
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
+            logger: serverLoggerFactory.CreateLogger("IceRpc"));
+        server.Listen();
+
+        await using var clientConnection = new ClientConnection(
+            server.ServerAddress,
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
+            logger: clientLoggerFactory.CreateLogger("IceRpc"));
+        using var request = new OutgoingRequest(
+            new ServiceAddress(Protocol.IceRpc)
+            {
+                ServerAddress = serverAddress
+            });
+
+        // Act
+        var clientConnectionInformation = await clientConnection.ConnectAsync();
+        // Send a request to ensure the server side is connected before than we inspect the log
+        _ = await clientConnection.InvokeAsync(request);
+
+        // Assert
+        Assert.That(serverLoggerFactory.Logger, Is.Not.Null);
+        TestLoggerEntry entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StartAcceptingConnections));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+
+        entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionAccepted));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress.ToString()));
+
+        entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnected));
+        Assert.That(entry.State["Kind"], Is.EqualTo("Server|Client"));
+        Assert.That(
+            entry.State["LocalNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress.ToString()));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress.ToString()));
+
+        Assert.That(clientLoggerFactory.Logger, Is.Not.Null);
+        entry = await clientLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnected));
+        Assert.That(entry.State["Kind"], Is.EqualTo("Client|Server"));
+        Assert.That(
+            entry.State["LocalNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress));
+    }
+
+    [Test]
+    public async Task Log_connection_connected_failed()
+    {
+        // Arrange
+        var serverAddress = new ServerAddress(new Uri($"icerpc://colochost-{Guid.NewGuid()}"));
+        using var serverLoggerFactory = new TestLoggerFactory();
+        using var clientLoggerFactory = new TestLoggerFactory();
+        var colocTransport = new ColocTransport();
+        await using var server = new Server(
+            dispatcher: ServiceNotFoundDispatcher.Instance,
+            serverAddress,
+            multiplexedServerTransport: new ConnectFailMultiplexedServerTransportDecorator(
+                new SlicServerTransport(colocTransport.ServerTransport)),
+            logger: serverLoggerFactory.CreateLogger("IceRpc"));
+        server.Listen();
+
+        await using var clientConnection = new ClientConnection(
+            server.ServerAddress,
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
+            logger: clientLoggerFactory.CreateLogger("IceRpc"));
+
+        // Act
+        Assert.ThrowsAsync<IceRpcException>(async () => await clientConnection.ConnectAsync(default));
+
+        // Assert
+        Assert.That(serverLoggerFactory.Logger, Is.Not.Null);
+        TestLoggerEntry? entry;
+        do
+        {
+            entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+        }
+        while (entry.EventId != (int)ProtocolEventIds.ConnectionConnectFailed);
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnectFailed));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.Exception, Is.InstanceOf<InvalidOperationException>());
+
+        Assert.That(clientLoggerFactory.Logger, Is.Not.Null);
+        entry = await clientLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnectFailed));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.Exception, Is.InstanceOf<IceRpcException>());
+    }
+
+    [Test]
+    public async Task Log_connection_failed()
+    {
+        // Arrange
+        var serverAddress = new ServerAddress(new Uri($"icerpc://colochost-{Guid.NewGuid()}"));
+        using var serverLoggerFactory = new TestLoggerFactory();
+        using var clientLoggerFactory = new TestLoggerFactory();
+        using var dispatcher = new TestDispatcher();
+        var colocTransport = new ColocTransport();
+        await using var server = new Server(
+            dispatcher,
+            serverAddress,
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
+            logger: serverLoggerFactory.CreateLogger("IceRpc"));
+        server.Listen();
+
+        await using var clientConnection = new ClientConnection(
+            server.ServerAddress,
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
+            logger: clientLoggerFactory.CreateLogger("IceRpc"));
+        using var request = new OutgoingRequest(
+            new ServiceAddress(Protocol.IceRpc)
+            {
+                ServerAddress = serverAddress
+            });
+        // Act
+        var clientConnectionInformation = await clientConnection.ConnectAsync();
+        var invokeTask = clientConnection.InvokeAsync(request, default);
+        await dispatcher.DispatchStart;
+        try
+        {
+            await clientConnection.ShutdownAsync(new CancellationToken(canceled: true));
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await clientConnection.DisposeAsync();
+
+        // Assert
+        Assert.ThrowsAsync<IceRpcException>(async () => await invokeTask);
+        Assert.That(serverLoggerFactory.Logger, Is.Not.Null);
+
+        TestLoggerEntry? entry;
+        do
+        {
+            entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+        }
+        while (entry.EventId != (int)ProtocolEventIds.ConnectionFailed);
+
+        Assert.That(entry, Is.Not.Null);
+        Assert.That(entry.State["Kind"], Is.EqualTo("Server|Client"));
+        Assert.That(entry.State["LocalNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress.ToString()));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress.ToString()));
+        Assert.That(entry.Exception, Is.InstanceOf<IceRpcException>());
+
+        Assert.That(clientLoggerFactory.Logger, Is.Not.Null);
+        do
+        {
+            entry = await clientLoggerFactory.Logger!.Entries.Reader.ReadAsync();
+        }
+        while (entry.EventId != (int)ProtocolEventIds.ConnectionFailed);
+
+        Assert.That(entry.State["Kind"], Is.EqualTo("Client|Server"));
+        Assert.That(
+            entry.State["LocalNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress));
+        Assert.That(entry.Exception, Is.InstanceOf<IceRpcException>());
+    }
+
+    [Test]
+    public async Task Log_start_stop_accept()
+    {
+        // Arrange
+        var serverAddress = new ServerAddress(new Uri($"icerpc://colochost-{Guid.NewGuid()}"));
+        using var loggerFactory = new TestLoggerFactory();
+        var colocTransport = new ColocTransport();
+        var server = new Server(
+            dispatcher: ServiceNotFoundDispatcher.Instance,
+            serverAddress,
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
+            logger: loggerFactory.CreateLogger("IceRpc"));
+
+        // Act
+        server.Listen();
+        await server.DisposeAsync();
+
+        // Assert
+        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StartAcceptingConnections));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+
+        entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StopAcceptingConnections));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+    }
+
+    [Test]
+    public async Task Log_connection_shutdown()
+    {
+        // Arrange
+        var colocTransport = new ColocTransport();
+        var serverAddress = new ServerAddress(new Uri($"icerpc://colochost-{Guid.NewGuid()}"));
+        using var serverLoggerFactory = new TestLoggerFactory();
+        using var clientLoggerFactory = new TestLoggerFactory();
+
+        await using var server = new Server(
+            dispatcher: ServiceNotFoundDispatcher.Instance,
+            serverAddress,
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
+            logger: serverLoggerFactory.CreateLogger("IceRpc"));
+        server.Listen();
+
+        await using var clientConnection = new ClientConnection(
+            server.ServerAddress,
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
+            logger: clientLoggerFactory.CreateLogger("IceRpc"));
+
+        using var request = new OutgoingRequest(
+            new ServiceAddress(Protocol.IceRpc)
+            {
+                ServerAddress = serverAddress
+            });
+        var clientConnectionInformation = await clientConnection.ConnectAsync(default);
+        // Send a request to ensure the server side is connected before than we shutdown the connection
+        _ = await clientConnection.InvokeAsync(request);
+
+        // Act
+        await clientConnection.ShutdownAsync();
+
+        // Assert
+        Assert.That(serverLoggerFactory.Logger, Is.Not.Null);
+        var entries = serverLoggerFactory.Logger!.Entries;
+        TestLoggerEntry? entry = null;
+        do
+        {
+            entry = await serverLoggerFactory.Logger.Entries.Reader.ReadAsync();
+        }
+        while (entry.EventId.Id != (int)ProtocolEventIds.ConnectionShutdown);
+
+        Assert.That(entry.State["Kind"], Is.EqualTo("Server|Client"));
+        Assert.That(
+            entry.State["LocalNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress.ToString()));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"]?.ToString(),
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress.ToString()));
+
+        Assert.That(clientLoggerFactory.Logger, Is.Not.Null);
+        entries = clientLoggerFactory.Logger!.Entries;
+
+        do
+        {
+            entry = await clientLoggerFactory.Logger.Entries.Reader.ReadAsync();
+        }
+        while (entry.EventId.Id != (int)ProtocolEventIds.ConnectionShutdown);
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionShutdown));
+        Assert.That(entry.State["Kind"], Is.EqualTo("Client|Server"));
+        Assert.That(
+            entry.State["LocalNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"],
+            Is.EqualTo(clientConnectionInformation.LocalNetworkAddress));
+    }
+
+    // A multiplexed server transport decorators that wraps the listeners it creates with a listener
+    // that creates multiplexed connections that will fail during connect.
+    internal class ConnectFailMultiplexedServerTransportDecorator : IMultiplexedServerTransport
+    {
+        public string Name => _decoratee.Name;
+
+        private readonly IMultiplexedServerTransport _decoratee;
+
+        internal ConnectFailMultiplexedServerTransportDecorator(IMultiplexedServerTransport decoratee) => _decoratee = decoratee;
+
+        public IListener<IMultiplexedConnection> Listen(
+            ServerAddress serverAddress,
+            MultiplexedConnectionOptions options,
+            SslServerAuthenticationOptions? serverAuthenticationOptions)
+        {
+            IListener<IMultiplexedConnection> listener =
+                _decoratee.Listen(serverAddress, options, serverAuthenticationOptions);
+            return new ConnectFailMultiplexedConnectionListenerDecorator(listener);
+        }
+    }
+
+    // A multiplexed listener decorator that wraps the connections it creates with a connection decorator
+    // that will fail to connect
+    private class ConnectFailMultiplexedConnectionListenerDecorator : IListener<IMultiplexedConnection>
+    {
+        public ServerAddress ServerAddress => _decoratee.ServerAddress;
+
+        private readonly IListener<IMultiplexedConnection> _decoratee;
+
+
+        public async Task<(IMultiplexedConnection Connection, EndPoint RemoteNetworkAddress)> AcceptAsync(
+            CancellationToken cancellationToken)
+        {
+            (IMultiplexedConnection connection, EndPoint remoteNetworkAddress) =
+                await _decoratee.AcceptAsync(cancellationToken);
+            return (new ConnectFailMultiplexedConnectionDecorator(connection), remoteNetworkAddress);
+        }
+
+        public ValueTask DisposeAsync() => _decoratee.DisposeAsync();
+
+        internal ConnectFailMultiplexedConnectionListenerDecorator(IListener<IMultiplexedConnection> decoratee) =>
+            _decoratee = decoratee;
+    }
+
+    // A multiplexed connection decorator that always fail to connect
+    private class ConnectFailMultiplexedConnectionDecorator : IMultiplexedConnection
+    {
+        public ServerAddress ServerAddress => _decoratee.ServerAddress;
+
+        private readonly IMultiplexedConnection _decoratee;
+
+        public Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Connect failed.");
+
+        public ValueTask DisposeAsync() => _decoratee.DisposeAsync();
+        public ValueTask<IMultiplexedStream> AcceptStreamAsync(CancellationToken cancellationToken) =>
+            _decoratee.AcceptStreamAsync(cancellationToken);
+
+        public Task CloseAsync(MultiplexedConnectionCloseError closeError, CancellationToken cancellationToken) =>
+            _decoratee.CloseAsync(closeError, cancellationToken);
+
+        public ValueTask<IMultiplexedStream> CreateStreamAsync(bool bidirectional, CancellationToken cancellationToken) =>
+            _decoratee.CreateStreamAsync(bidirectional, cancellationToken);
+
+        internal ConnectFailMultiplexedConnectionDecorator(IMultiplexedConnection decoratee) => _decoratee = decoratee;
+    }
+}


### PR DESCRIPTION
A few fixes in this PR:

- Adds a few tests for protocol logging
- Fixes a bug in LogProtocolConnectionDecorator.ShutdownAsync that resulted in DisposeAsync throwing the ShutdownComplete exceptions.
- Removed ConnectionCreated - Fixes #2208
- Adds a missing call to `LogStopAcceptingConnections`