### PR TITLE
Simplify generated code for single stream parameter

### DIFF
--- a/tools/slicec-cs/src/visitors/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/visitors/dispatch_visitor.rs
@@ -242,7 +242,7 @@ fn request_decode_body(operation: &Operation) -> CodeBlock {
             writeln!(
                 code,
                 "await request.DecodeEmptyArgsAsync({encoding}, cancellationToken).ConfigureAwait(false);",
-                encoding = operation.encoding.to_cs_encoding()
+                encoding = operation.encoding.to_cs_encoding(),
             );
             match stream_member.data_type().concrete_type() {
                 Types::Primitive(primitive) if matches!(primitive, Primitive::UInt8) => {


### PR DESCRIPTION
This avoids some generated tmp references

```
            await request.DecodeEmptyArgsAsync(SliceEncoding.Slice2, cancellationToken).ConfigureAwait(false);
            var payloadContinuation = request.DetachPayload();
            return payloadContinuation.ToAsyncEnumerable<string>(
                SliceEncoding.Slice2,
                (ref SliceDecoder decoder) => decoder.DecodeString(),
                sliceFeature: request.Features.Get<IceRpc.Slice.ISliceFeature>());
```

Instead of

```
           var sliceP_p = payloadContinuation.ToAsyncEnumerable<string>(
                SliceEncoding.Slice2,
                (ref SliceDecoder decoder) => decoder.DecodeString(),
                sliceFeature: request.Features.Get<IceRpc.Slice.ISliceFeature>());

            return sliceP_p;
```

No need for `sliceP_p` we directly return the `ToAsyncEnumerable` result
