### PR TITLE
Remove bogus protocol check - Fix #2249

### DIFF
--- a/src/IceRpc.Quic/Transports/QuicClientTransport.cs
+++ b/src/IceRpc.Quic/Transports/QuicClientTransport.cs
@@ -29,8 +29,7 @@ public class QuicClientTransport : IMultiplexedClientTransport
     }
 
     /// <inheritdoc/>
-    public bool CheckParams(ServerAddress serverAddress) =>
-        serverAddress.Protocol == Protocol.IceRpc && serverAddress.Params.Count == 0;
+    public bool CheckParams(ServerAddress serverAddress) => serverAddress.Params.Count == 0;
 
     /// <inheritdoc/>
     public IMultiplexedConnection CreateConnection(


### PR DESCRIPTION
We don't need to check the protocol here, that is not the job of CheckParams.