### PR TITLE
Don't log listener OCE as a failure

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -31,7 +31,7 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
             }
             catch (QuicException exception) when (exception.QuicError == QuicError.OperationAborted)
             {
-                // Listener was disposed while accept was in progress.
+                // Listener was disposed while the accept operation was in progress.
                 throw new IceRpcException(IceRpcError.OperationAborted, exception);
             }
             catch (OperationCanceledException exception) when (exception.CancellationToken != cancellationToken)

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -125,13 +125,13 @@ internal static partial class ProtocolLoggerExtensions
         EventId = (int)ProtocolEventIds.StartAcceptingConnections,
         EventName = nameof(ProtocolEventIds.StartAcceptingConnections),
         Level = LogLevel.Trace,
-        Message = "Listener '{ServerAddress}' start accepting connections")]
+        Message = "Listener '{ServerAddress}' has started accepting connections")]
     internal static partial void LogStartAcceptingConnections(this ILogger logger, ServerAddress serverAddress);
 
     [LoggerMessage(
         EventId = (int)ProtocolEventIds.StopAcceptingConnections,
         EventName = nameof(ProtocolEventIds.StopAcceptingConnections),
         Level = LogLevel.Trace,
-        Message = "Listener '{ServerAddress}' stop accepting connections")]
+        Message = "Listener '{ServerAddress}' has stopped accepting connections")]
     internal static partial void LogStopAcceptingConnections(this ILogger logger, ServerAddress serverAddress);
 }

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -534,6 +534,15 @@ public sealed class Server : IAsyncDisposable
             {
                 throw;
             }
+            catch (ObjectDisposedException)
+            {
+                throw;
+            }
+            catch (IceRpcException exception) when (exception.IceRpcError == IceRpcError.OperationAborted)
+            {
+                // Listener was disposed while the accept operation was in progress.
+                throw;
+            }
             catch (Exception exception)
             {
                 _logger.LogConnectionAcceptFailed(ServerAddress, exception);

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -39,6 +39,7 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
             }
             catch (SocketException exception) when (exception.SocketErrorCode == SocketError.OperationAborted)
             {
+                // Listener was disposed while the accept operation was in progress.
                 throw new IceRpcException(IceRpcError.OperationAborted, exception);
             }
             catch (SocketException)


### PR DESCRIPTION
Just a fix for #2278,  the server no longer logs OCE as a failure

```
C:\Users\jose\source\repos\icerpc-csharp\examples\GenericHost>dotnet run --project Server\Server.csproj
dbug: Microsoft.Extensions.Hosting.Internal.Host[1]
      Hosting starting
trce: IceRpc.Server[6]
      Listener 'icerpc://127.0.0.1:10000?transport=tcp' start accepting connections
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\Users\jose\source\repos\icerpc-csharp\examples\GenericHost\Server\bin\Any CPU\Debug\net7.0\
dbug: Microsoft.Extensions.Hosting.Internal.Host[2]
      Hosting started
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
dbug: Microsoft.Extensions.Hosting.Internal.Host[3]
      Hosting stopping
trce: IceRpc.Server[7]
      Listener 'icerpc://127.0.0.1:10000?transport=tcp' stop accepting connections
dbug: Microsoft.Extensions.Hosting.Internal.Host[4]
      Hosting stopped
```