### PR TITLE
Log transport accept failures

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Net.Security;
 
@@ -18,7 +19,8 @@ internal class ColocServerTransport : IDuplexServerTransport
     public IListener<IDuplexConnection> Listen(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger)
     {
         if (serverAuthenticationOptions is not null)
         {

--- a/src/IceRpc.Quic/Transports/Internal/QuicTransportLoggerExtensions.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicTransportLoggerExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+
+namespace IceRpc.Transports;
+
+/// <summary>This class contains ILogger extension methods for logging calls to the transport connection APIs.</summary>
+internal static partial class TransportLoggerExtensions
+{
+    [LoggerMessage(
+        EventId = (int)QuicTransportEventId.ConnectionAcceptFailed,
+        EventName = nameof(QuicTransportEventId.ConnectionAcceptFailed),
+        Level = LogLevel.Trace,
+        Message = "Listener '{ServerAddress}' failed to accept a new connection")]
+    internal static partial void LogQuicConnectionAcceptFailed(
+        this ILogger logger,
+        ServerAddress serverAddress,
+        Exception exception);
+}

--- a/src/IceRpc.Quic/Transports/QuicServerTransport.cs
+++ b/src/IceRpc.Quic/Transports/QuicServerTransport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
+using Microsoft.Extensions.Logging;
 using System.Net.Security;
 
 namespace IceRpc.Transports;
@@ -30,7 +31,8 @@ public class QuicServerTransport : IMultiplexedServerTransport
     public IListener<IMultiplexedConnection> Listen(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger)
     {
         if (serverAddress.Params.Count > 0)
         {
@@ -51,6 +53,6 @@ public class QuicServerTransport : IMultiplexedServerTransport
             serverAddress = serverAddress with { Transport = Name };
         }
 
-        return new QuicMultiplexedListener(serverAddress, options, _quicOptions, serverAuthenticationOptions);
+        return new QuicMultiplexedListener(serverAddress, options, _quicOptions, serverAuthenticationOptions, logger);
     }
 }

--- a/src/IceRpc.Quic/Transports/QuicTransportEventId.cs
+++ b/src/IceRpc.Quic/Transports/QuicTransportEventId.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+namespace IceRpc.Transports;
+
+/// <summary>This enum contains event ID constants used for transport connection related logging.</summary>
+public enum QuicTransportEventId
+{
+    /// <summary>The transport listener failed to accept a new connection.</summary>
+    ConnectionAcceptFailed,
+}

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -9,8 +9,8 @@ namespace IceRpc.Internal;
 internal static partial class ProtocolLoggerExtensions
 {
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionAccepted,
-        EventName = nameof(ProtocolEventIds.ConnectionAccepted),
+        EventId = (int)ProtocolEventId.ConnectionAccepted,
+        EventName = nameof(ProtocolEventId.ConnectionAccepted),
         Level = LogLevel.Trace,
         Message = "Listener '{ServerAddress}' accepted connection from '{RemoteNetworkAddress}'")]
     internal static partial void LogConnectionAccepted(
@@ -19,8 +19,8 @@ internal static partial class ProtocolLoggerExtensions
         EndPoint remoteNetworkAddress);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionAcceptFailed,
-        EventName = nameof(ProtocolEventIds.ConnectionAcceptFailed),
+        EventId = (int)ProtocolEventId.ConnectionAcceptFailed,
+        EventName = nameof(ProtocolEventId.ConnectionAcceptFailed),
         Level = LogLevel.Trace,
         Message = "Listener '{ServerAddress}' failed to accept a new connection")]
     internal static partial void LogConnectionAcceptFailed(
@@ -29,8 +29,8 @@ internal static partial class ProtocolLoggerExtensions
         Exception exception);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionConnected,
-        EventName = nameof(ProtocolEventIds.ConnectionConnected),
+        EventId = (int)ProtocolEventId.ConnectionConnected,
+        EventName = nameof(ProtocolEventId.ConnectionConnected),
         Level = LogLevel.Trace,
         Message = "{Kind} connection from '{LocalNetworkAddress}' to '{RemoteNetworkAddress}' connected")]
     internal static partial void LogConnectionConnected(
@@ -53,8 +53,8 @@ internal static partial class ProtocolLoggerExtensions
     // Multiple logging methods are using same event id.
 #pragma warning disable SYSLIB1006
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionConnectFailed,
-        EventName = nameof(ProtocolEventIds.ConnectionConnectFailed),
+        EventId = (int)ProtocolEventId.ConnectionConnectFailed,
+        EventName = nameof(ProtocolEventId.ConnectionConnectFailed),
         Level = LogLevel.Trace,
         Message = "Client|Server connection connect to '{ServerAddress}' failed")]
     internal static partial void LogConnectionConnectFailed(
@@ -63,8 +63,8 @@ internal static partial class ProtocolLoggerExtensions
         Exception exception);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionConnectFailed,
-        EventName = nameof(ProtocolEventIds.ConnectionConnectFailed),
+        EventId = (int)ProtocolEventId.ConnectionConnectFailed,
+        EventName = nameof(ProtocolEventId.ConnectionConnectFailed),
         Level = LogLevel.Trace,
         Message = "Server|Client connection connect from '{ServerAddress}' to '{RemoteNetworkAddress}' failed")]
     internal static partial void LogConnectionConnectFailed(
@@ -75,8 +75,8 @@ internal static partial class ProtocolLoggerExtensions
 #pragma warning restore SYSLIB1006
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionFailed,
-        EventName = nameof(ProtocolEventIds.ConnectionFailed),
+        EventId = (int)ProtocolEventId.ConnectionFailed,
+        EventName = nameof(ProtocolEventId.ConnectionFailed),
         Level = LogLevel.Trace,
         Message = "{Kind} connection from '{LocalNetworkAddress}' to '{RemoteNetworkAddress}' failed")]
     internal static partial void LogConnectionFailed(
@@ -100,8 +100,8 @@ internal static partial class ProtocolLoggerExtensions
             exception);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.ConnectionShutdown,
-        EventName = nameof(ProtocolEventIds.ConnectionShutdown),
+        EventId = (int)ProtocolEventId.ConnectionShutdown,
+        EventName = nameof(ProtocolEventId.ConnectionShutdown),
         Level = LogLevel.Trace,
         Message = "{Kind} connection from '{LocalNetworkAddress}' to '{RemoteNetworkAddress}' shutdown")]
     internal static partial void LogConnectionShutdown(
@@ -122,15 +122,15 @@ internal static partial class ProtocolLoggerExtensions
             remoteNetworkAddress);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.StartAcceptingConnections,
-        EventName = nameof(ProtocolEventIds.StartAcceptingConnections),
+        EventId = (int)ProtocolEventId.StartAcceptingConnections,
+        EventName = nameof(ProtocolEventId.StartAcceptingConnections),
         Level = LogLevel.Trace,
         Message = "Listener '{ServerAddress}' start accepting connections")]
     internal static partial void LogStartAcceptingConnections(this ILogger logger, ServerAddress serverAddress);
 
     [LoggerMessage(
-        EventId = (int)ProtocolEventIds.StopAcceptingConnections,
-        EventName = nameof(ProtocolEventIds.StopAcceptingConnections),
+        EventId = (int)ProtocolEventId.StopAcceptingConnections,
+        EventName = nameof(ProtocolEventId.StopAcceptingConnections),
         Level = LogLevel.Trace,
         Message = "Listener '{ServerAddress}' stop accepting connections")]
     internal static partial void LogStopAcceptingConnections(this ILogger logger, ServerAddress serverAddress);

--- a/src/IceRpc/ProtocolEventId.cs
+++ b/src/IceRpc/ProtocolEventId.cs
@@ -3,7 +3,7 @@
 namespace IceRpc;
 
 /// <summary>This enum contains event ID constants used for protocol connection related logging.</summary>
-public enum ProtocolEventIds
+public enum ProtocolEventId
 {
     /// <summary>The protocol listener accepted a new connection.</summary>
     ConnectionAccepted,

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -3,6 +3,7 @@
 using IceRpc.Internal;
 using IceRpc.Transports;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Net;
 using System.Net.Security;
 
@@ -99,7 +100,8 @@ public sealed class Server : IAsyncDisposable
                         MinSegmentSize = options.ConnectionOptions.MinSegmentSize,
                         Pool = options.ConnectionOptions.Pool,
                     },
-                    options.ServerAuthenticationOptions);
+                    options.ServerAuthenticationOptions,
+                    logger ?? NullLogger.Instance);
                 listener = new IceConnectorListener(transportListener, options.ConnectionOptions);
             }
             else
@@ -114,7 +116,8 @@ public sealed class Server : IAsyncDisposable
                         MinSegmentSize = options.ConnectionOptions.MinSegmentSize,
                         Pool = options.ConnectionOptions.Pool
                     },
-                    options.ServerAuthenticationOptions);
+                    options.ServerAuthenticationOptions,
+                    logger ?? NullLogger.Instance);
                 listener = new IceRpcConnectorListener(transportListener, options.ConnectionOptions);
             }
 

--- a/src/IceRpc/Transports/IDuplexServerTransport.cs
+++ b/src/IceRpc/Transports/IDuplexServerTransport.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using Microsoft.Extensions.Logging;
 using System.Net.Security;
 
 namespace IceRpc.Transports;
@@ -17,9 +18,11 @@ public interface IDuplexServerTransport
     /// <param name="serverAddress">The server address of the listener.</param>
     /// <param name="options">The duplex connection options.</param>
     /// <param name="serverAuthenticationOptions">The SSL server authentication options.</param>
+    /// <param name="logger">The logger.</param>
     /// <returns>The new listener.</returns>
     IListener<IDuplexConnection> Listen(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions);
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger);
 }

--- a/src/IceRpc/Transports/IMultiplexedServerTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedServerTransport.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using Microsoft.Extensions.Logging;
 using System.Net.Security;
 
 namespace IceRpc.Transports;
@@ -17,9 +18,11 @@ public interface IMultiplexedServerTransport
     /// <param name="serverAddress">The server address of the listener.</param>
     /// <param name="options">The multiplexed connection options.</param>
     /// <param name="serverAuthenticationOptions">The SSL server authentication options.</param>
+    /// <param name="logger">The logger.</param>
     /// <returns>The new listener.</returns>
     IListener<IMultiplexedConnection> Listen(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions);
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger);
 }

--- a/src/IceRpc/Transports/Internal/TcpTransportLoggerExtensions.cs
+++ b/src/IceRpc/Transports/Internal/TcpTransportLoggerExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+
+namespace IceRpc.Transports;
+
+/// <summary>This class contains ILogger extension methods for logging calls to the transport connection APIs.</summary>
+internal static partial class TcpTransportLoggerExtensions
+{
+    [LoggerMessage(
+        EventId = (int)TcpTransportEventId.ConnectionAcceptFailed,
+        EventName = nameof(TcpTransportEventId.ConnectionAcceptFailed),
+        Level = LogLevel.Trace,
+        Message = "Listener '{ServerAddress}' failed to accept a new connection")]
+    internal static partial void LogTcpConnectionAcceptFailed(
+        this ILogger logger,
+        ServerAddress serverAddress,
+        Exception exception);
+}

--- a/src/IceRpc/Transports/SlicServerTransport.cs
+++ b/src/IceRpc/Transports/SlicServerTransport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
+using Microsoft.Extensions.Logging;
 using System.Net.Security;
 
 namespace IceRpc.Transports;
@@ -34,7 +35,8 @@ public class SlicServerTransport : IMultiplexedServerTransport
     public IListener<IMultiplexedConnection> Listen(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions) =>
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger) =>
         new SlicListener(
             _duplexServerTransport.Listen(
                 serverAddress,
@@ -43,7 +45,8 @@ public class SlicServerTransport : IMultiplexedServerTransport
                     MinSegmentSize = options.MinSegmentSize,
                     Pool = options.Pool
                 },
-                serverAuthenticationOptions),
+                serverAuthenticationOptions,
+                logger),
             options,
             _slicTransportOptions);
 }

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Transports.Internal;
+using Microsoft.Extensions.Logging;
 using System.Net.Security;
 
 namespace IceRpc.Transports;
@@ -27,7 +28,8 @@ public class TcpServerTransport : IDuplexServerTransport
     public IListener<IDuplexConnection> Listen(
         ServerAddress serverAddress,
         DuplexConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger)
     {
         // This is the composition root of the tcp server transport, where we install log decorators when logging
         // is enabled.
@@ -50,6 +52,6 @@ public class TcpServerTransport : IDuplexServerTransport
                 $"The {nameof(serverAuthenticationOptions)} argument cannot be null when using the ssl transport.");
         }
 
-        return new TcpListener(serverAddress, options, serverAuthenticationOptions, _options);
+        return new TcpListener(serverAddress, options, serverAuthenticationOptions, _options, logger);
     }
 }

--- a/src/IceRpc/Transports/TcpTransportEventId.cs
+++ b/src/IceRpc/Transports/TcpTransportEventId.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+namespace IceRpc.Transports;
+
+/// <summary>This enum contains event ID constants used for tcp transport connection related logging.</summary>
+public enum TcpTransportEventId
+{
+    /// <summary>The transport listener failed to accept a new connection.</summary>
+    ConnectionAcceptFailed,
+}

--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportConformanceTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Net;
@@ -244,7 +245,11 @@ public abstract class DuplexTransportConformanceTests
 
         // Act/Assert
         IceRpcException? exception = Assert.Throws<IceRpcException>(
-            () => serverTransport.Listen(listener.ServerAddress, new DuplexConnectionOptions(), null));
+            () => serverTransport.Listen(
+                listener.ServerAddress,
+                new DuplexConnectionOptions(),
+                null,
+                NullLogger.Instance));
         Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.AddressInUse));
     }
 
@@ -347,7 +352,12 @@ public abstract class DuplexTransportConformanceTests
         var serverAddress = new ServerAddress(new Uri("icerpc://foo?unknown-parameter=foo"));
 
         // Act/Asserts
-        Assert.Throws<ArgumentException>(() => serverTransport.Listen(serverAddress, new DuplexConnectionOptions(), null));
+        Assert.Throws<ArgumentException>(
+            () => serverTransport.Listen(
+                serverAddress,
+                new DuplexConnectionOptions(),
+                null,
+                NullLogger.Instance));
     }
 
     [Test]

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Internal;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Buffers;
@@ -531,7 +533,8 @@ public abstract partial class MultiplexedTransportConformanceTests
         Assert.Throws<ArgumentException>(() => serverTransport.Listen(
             serverAddress,
             new MultiplexedConnectionOptions(),
-            provider.GetService<SslServerAuthenticationOptions>()));
+            provider.GetService<SslServerAuthenticationOptions>(),
+            provider.GetService<ILogger>() ?? NullLogger.Instance));
     }
 
     [Test]
@@ -870,7 +873,8 @@ public abstract partial class MultiplexedTransportConformanceTests
             () => serverTransport.Listen(
                 listener.ServerAddress,
                 new MultiplexedConnectionOptions(),
-                provider.GetService<SslServerAuthenticationOptions>()));
+                provider.GetService<SslServerAuthenticationOptions>(),
+                provider.GetService<ILogger>() ?? NullLogger.Instance));
         // BUGFIX with Quic this throws an internal error https://github.com/dotnet/runtime/issues/78573
         Assert.That(
             exception!.IceRpcError,

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Conformance.Tests;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Net.Quic;
@@ -38,7 +40,8 @@ public class QuicTransportConformanceTests : MultiplexedTransportConformanceTest
                 provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
                     new ServerAddress(Protocol.IceRpc) { Host = "127.0.0.1", Port = 0 },
                     provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-                    provider.GetRequiredService<SslServerAuthenticationOptions>()))
+                    provider.GetRequiredService<SslServerAuthenticationOptions>(),
+                    provider.GetRequiredService<ILogger>() ?? NullLogger.Instance))
             .AddSingleton(provider =>
                 new SslClientAuthenticationOptions
                 {

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.Net.Security;
 
@@ -22,7 +24,8 @@ public static class QuicTransportServiceCollectionExtensions
                 provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
                     new ServerAddress(Protocol.IceRpc) { Host = "127.0.0.1", Port = 0 },
                     provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-                    provider.GetRequiredService<SslServerAuthenticationOptions>()))
+                    provider.GetRequiredService<SslServerAuthenticationOptions>(),
+                    provider.GetRequiredService<ILogger>() ?? NullLogger.Instance))
             .AddSingleton(provider =>
                 (QuicMultiplexedConnection)provider.GetRequiredService<IMultiplexedClientTransport>().CreateConnection(
                     provider.GetRequiredService<IListener<IMultiplexedConnection>>().ServerAddress,

--- a/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using IceRpc.Builder;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -56,7 +57,8 @@ public static class ServiceCollectionExtensions
                 provider.GetRequiredService<IDuplexServerTransport>().Listen(
                     new ServerAddress(serverAddressUri),
                     provider.GetService<IOptions<DuplexConnectionOptions>>()?.Value ?? new(),
-                    provider.GetService<SslServerAuthenticationOptions>()))
+                    provider.GetService<SslServerAuthenticationOptions>(),
+                    provider.GetService<ILogger>() ?? NullLogger.Instance))
             .AddSingleton(provider =>
                 provider.GetRequiredService<IDuplexClientTransport>().CreateConnection(
                     provider.GetRequiredService<IListener<IDuplexConnection>>().ServerAddress,
@@ -72,7 +74,8 @@ public static class ServiceCollectionExtensions
                 provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
                     new ServerAddress(serverAddressUri),
                     provider.GetService<IOptions<MultiplexedConnectionOptions>>()?.Value ?? new(),
-                    provider.GetService<SslServerAuthenticationOptions>()))
+                    provider.GetService<SslServerAuthenticationOptions>(),
+                    provider.GetService<ILogger>() ?? NullLogger.Instance))
             .AddSingleton(provider =>
                 provider.GetRequiredService<IMultiplexedClientTransport>().CreateConnection(
                     provider.GetRequiredService<IListener<IMultiplexedConnection>>().ServerAddress,

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -5,6 +5,7 @@ using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using System.Buffers;
 using System.Diagnostics;
@@ -928,9 +929,10 @@ public sealed class IceRpcProtocolConnectionTests
         public IListener<IMultiplexedConnection> Listen(
             ServerAddress serverAddress,
             MultiplexedConnectionOptions options,
-            SslServerAuthenticationOptions? serverAuthenticationOptions) =>
+            SslServerAuthenticationOptions? serverAuthenticationOptions,
+            ILogger logger) =>
             _listener = new HoldMultiplexedListener(
-                _decoratee.Listen(serverAddress, options, serverAuthenticationOptions));
+                _decoratee.Listen(serverAddress, options, serverAuthenticationOptions, logger));
 
         internal HoldMultiplexedServerTransport(IMultiplexedServerTransport decoratee) => _decoratee = decoratee;
 

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Security;
@@ -275,8 +276,9 @@ public class ServerTests
         public IListener<IDuplexConnection> Listen(
             ServerAddress serverAddress,
             DuplexConnectionOptions options,
-            SslServerAuthenticationOptions? serverAuthenticationOptions) =>
-            new HoldListener(_serverTransport.Listen(serverAddress, options, serverAuthenticationOptions));
+            SslServerAuthenticationOptions? serverAuthenticationOptions,
+            ILogger logger) =>
+            new HoldListener(_serverTransport.Listen(serverAddress, options, serverAuthenticationOptions, logger));
 
         internal HoldServerTransport(IDuplexServerTransport serverTransport) => _serverTransport = serverTransport;
     }
@@ -348,10 +350,11 @@ public class ServerTests
         public IListener<IMultiplexedConnection> Listen(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger)
         {
             Listener = new DelayDisposeConnectionListener(
-                _serverTransport.Listen(serverAddress, options, serverAuthenticationOptions));
+                _serverTransport.Listen(serverAddress, options, serverAuthenticationOptions, logger));
             return Listener;
         }
     }

--- a/tests/IceRpc.Tests/Transports/ColocTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/ColocTransportTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace IceRpc.Tests.Transports;
@@ -17,7 +18,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -50,7 +52,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
 
         // Fill the pending connection queue.
         var connections = new List<(IDuplexConnection, Task)>();
@@ -87,7 +90,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -112,7 +116,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -135,7 +140,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -156,7 +162,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -184,7 +191,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -207,7 +215,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -238,7 +247,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -269,7 +279,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -296,7 +307,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),
@@ -319,7 +331,8 @@ public class ColocTransportTests
         await using IListener<IDuplexConnection> listener = colocTransport.ServerTransport.Listen(
             serverAddress,
             new DuplexConnectionOptions(),
-            null);
+            null,
+            NullLogger.Instance);
         using IDuplexConnection clientConnection = colocTransport.ClientTransport.CreateConnection(
             serverAddress,
             new DuplexConnectionOptions(),

--- a/tests/IceRpc.Tests/Transports/SlicTransportConformanceTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportConformanceTests.cs
@@ -4,6 +4,8 @@ using IceRpc.Conformance.Tests;
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Net.Security;
@@ -30,7 +32,8 @@ public class SlicTransportConformanceTests : MultiplexedTransportConformanceTest
                 provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
                     new ServerAddress(Protocol.IceRpc) { Host = "colochost" },
                     provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-                    serverAuthenticationOptions: provider.GetService<SslServerAuthenticationOptions>()));
+                    serverAuthenticationOptions: provider.GetService<SslServerAuthenticationOptions>(),
+                    provider.GetService<ILogger>() ?? NullLogger.Instance));
 
         services.AddOptions<SlicTransportOptions>("client");
         services.AddOptions<SlicTransportOptions>("server");

--- a/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.Net.Security;
 
@@ -19,7 +21,8 @@ public static class SlicTransportServiceCollectionExtensions
                 provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
                     new ServerAddress(Protocol.IceRpc) { Host = "colochost" },
                     provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-                    provider.GetService<SslServerAuthenticationOptions>()))
+                    provider.GetService<SslServerAuthenticationOptions>(),
+                    provider.GetService<ILogger>() ?? NullLogger.Instance))
             .AddSingleton(provider =>
                 (SlicConnection)provider.GetRequiredService<IMultiplexedClientTransport>().CreateConnection(
                     provider.GetRequiredService<IListener<IMultiplexedConnection>>().ServerAddress,

--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Transports;
 using IceRpc.Transports.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Security;
@@ -328,7 +329,8 @@ public class TcpTransportTests
         return serverTransport.Listen(
             serverAddress ?? new ServerAddress(Protocol.IceRpc) { Host = "::1", Port = 0 },
             new DuplexConnectionOptions(),
-            authenticationOptions);
+            authenticationOptions,
+            NullLogger.Instance);
     }
 
     private static TcpClientConnection CreateTcpClientConnection(

--- a/tests/IntegrationTests/CustomTransportTests.cs
+++ b/tests/IntegrationTests/CustomTransportTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Slice;
 using IceRpc.Transports;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using System.Net.Security;
 
@@ -51,7 +52,8 @@ public class CustomServerTransport : IMultiplexedServerTransport
     public IListener<IMultiplexedConnection> Listen(
         ServerAddress serverAddress,
         MultiplexedConnectionOptions options,
-        SslServerAuthenticationOptions? serverAuthenticationOptions)
+        SslServerAuthenticationOptions? serverAuthenticationOptions,
+        ILogger logger)
     {
         if (serverAddress.Transport is string transport && transport != "tcp" && transport != "custom")
         {
@@ -64,7 +66,7 @@ public class CustomServerTransport : IMultiplexedServerTransport
             Transport = "tcp"
         };
 
-        return _transport.Listen(serverAddress, options, serverAuthenticationOptions);
+        return _transport.Listen(serverAddress, options, serverAuthenticationOptions, logger);
     }
 }
 


### PR DESCRIPTION
This is a possible fix for #1959 to log exceptions that are retried by the listener.