### PR TITLE
Improve Accept_stream_cancellation test

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -53,7 +53,7 @@ public abstract partial class MultiplexedTransportConformanceTests
 
         using var cts = new CancellationTokenSource();
         ValueTask<IMultiplexedStream> acceptTask = serverConnection.AcceptStreamAsync(cts.Token);
-        await Task.Delay(10); // give a few ms for acceptTask to start
+        await Task.Delay(TimeSpan.FromMilliseconds(10)); // give a few ms for acceptTask to start
 
         // Act
         cts.Cancel();


### PR DESCRIPTION
This PR updates the Accept_stream_cancellation test to show the connection will accept new streams after an AcceptAsync is canceled. This is not obvious with QUIC where cancellation is fatal for stream operations.