### PR TITLE
Test: Dispose stream without calling Input.Complete / Output.Complete

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportConformanceTests.cs
@@ -534,7 +534,9 @@ public abstract partial class MultiplexedTransportConformanceTests
             provider.GetService<SslServerAuthenticationOptions>()));
     }
 
+    /// <summary>Verifies we can dispose a stream without calling Complete on its Input or Output.</summary>
     [Test]
+    [Ignore("fails with Slic, see #2297")]
     public async Task Dispose_stream_without_complete()
     {
         // Arrange


### PR DESCRIPTION
This is a test case-case for #2297.