### PR TITLE
Update accept requests loop

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -213,14 +213,15 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
                 try
                 {
                     // We check the cancellation token for each iteration because we want to exit the accept requests
-                    // loop at soon as ShutdownAsyncCore requests this cancellation, even when one or more streams can
+                    // loop as soon as ShutdownAsyncCore requests this cancellation, even when one or more streams can
                     // be accepted without waiting.
                     while (!_acceptStreamCts.Token.IsCancellationRequested)
                     {
-                        // If _dispatcher is null, this call will block indefinitely until the transport connection is
-                        // closed or disposed, or until the cancellation token is canceled. This is because the
-                        // multiplexed connection MaxUnidirectionalStreams and MaxBidirectionalStreams options don't
-                        // allow this peer to accept streams.
+                        // When _dispatcher is null, the multiplexed connection MaxUnidirectionalStreams and
+                        // MaxBidirectionalStreams options are configured to not accept any request-stream from the
+                        // peer. As a result, when _dispatcher is null, this call will block indefinitely until the
+                        // transport connection is closed or disposed, or until the cancellation token is canceled by
+                        // ShutdownAsyncCore.
                         IMultiplexedStream stream = await _transportConnection.AcceptStreamAsync(_acceptStreamCts.Token)
                             .ConfigureAwait(false);
 


### PR DESCRIPTION
This PR updates the icerpc accept requests loop to check the token before each iteration.

Without this check, a legitimate implementation of AcceptStreamsAsync may not check the token when streams (requests from the clients) are readily available and delay a shutdown.