### PR TITLE
Replace min_wire_size with new fixed_wire_size

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/zeroc-ice/icerpc#e26d870910c10cbc63059b2129b3af5bb1cb647f"
+source = "git+ssh://git@github.com/zeroc-ice/icerpc#4ee0543c71122ed8869e67a5f322d9a160a282cf"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/src/visitors/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/visitors/dispatch_visitor.rs
@@ -316,8 +316,9 @@ fn request_decode_func(operation: &Operation) -> CodeBlock {
     let parameters = operation.non_streamed_parameters();
     assert!(!parameters.is_empty());
 
-    let use_default_decode_func =
-        parameters.len() == 1 && get_bit_sequence_size(&parameters) == 0 && parameters.first().unwrap().tag.is_none();
+    let use_default_decode_func = parameters.len() == 1
+        && get_bit_sequence_size(operation.encoding, &parameters) == 0
+        && parameters.first().unwrap().tag.is_none();
 
     if use_default_decode_func {
         let param = parameters.first().unwrap();
@@ -579,7 +580,7 @@ fn payload_continuation(operation: &Operation, encoding: &str) -> CodeBlock {
     {encode_options})",
                     encode_action =
                         encode_action(stream_type, TypeContext::Encode, namespace, operation.encoding, false).indent(),
-                    use_segments = !stream_type.is_fixed_size(),
+                    use_segments = stream_type.fixed_wire_size().is_none(),
                     encode_options = "request.Features.Get<ISliceFeature>()?.EncodeOptions",
                 )
                 .into(),

--- a/tools/slicec-cs/src/visitors/proxy_visitor.rs
+++ b/tools/slicec-cs/src/visitors/proxy_visitor.rs
@@ -245,7 +245,7 @@ if ({features_parameter}?.Get<IceRpc.Features.ICompressFeature>() is null)
                     .add_argument(
                         encode_action(stream_type, TypeContext::Encode, namespace, operation.encoding, false).indent(),
                     )
-                    .add_argument(!stream_type.is_fixed_size())
+                    .add_argument(stream_type.fixed_wire_size().is_none())
                     .add_argument(encoding)
                     .add_argument("this.EncodeOptions")
                     .build(),
@@ -600,7 +600,10 @@ fn return_value_decode_func(operation: &Operation) -> CodeBlock {
     let members = operation.non_streamed_return_members();
     assert!(!members.is_empty());
 
-    if members.len() == 1 && get_bit_sequence_size(&members) == 0 && members.first().unwrap().tag.is_none() {
+    if members.len() == 1
+        && get_bit_sequence_size(operation.encoding, &members) == 0
+        && members.first().unwrap().tag.is_none()
+    {
         decode_func(members.first().unwrap().data_type(), namespace, operation.encoding)
     } else {
         format!(


### PR DESCRIPTION
This PR updates `slicec-cs` to use the new `fixed_wire_size` which replaces `min_wire_size` and `is_fixed_size` 