### PR TITLE
Move listener tests to the corresponding conformance test class

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Quic;
 using System.Net.Security;
-using System.Security.Authentication;
 
 namespace IceRpc.Transports.Internal;
 

--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using IceRpc.Slice;
-using System.Diagnostics;
 
 namespace IceRpc;
 

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Net.Security;
-using System.Security.Authentication;
 
 namespace IceRpc.Conformance.Tests;
 
@@ -345,54 +344,6 @@ public abstract partial class MultiplexedConnectionConformanceTests
 
         // Assert
         Assert.That(async () => await connectTask, Throws.InstanceOf<OperationCanceledException>());
-    }
-
-    /// <summary>Verifies that connect fails if the listener is disposed.</summary>
-    [Test]
-    public async Task Connect_fails_if_listener_is_disposed()
-    {
-        // Arrange
-        await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
-        IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
-        var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
-
-        Task connectTask = ConnectAsync(clientTransport);
-
-        // Act
-        await listener.DisposeAsync();
-
-        // Assert
-
-        // If using Quic and the listener is disposed during the ssl handshake this can fail
-        // with AuthenticationException otherwise it fails with TransportException.
-        Assert.That(
-            async () => await connectTask,
-            Throws.InstanceOf<IceRpcException>().Or.TypeOf<AuthenticationException>());
-
-        async Task ConnectAsync(IMultiplexedClientTransport clientTransport)
-        {
-            // Establish connections until we get a failure.
-            var connections = new List<IMultiplexedConnection>();
-            try
-            {
-                while (true)
-                {
-                    IMultiplexedConnection connection = clientTransport.CreateConnection(
-                        listener.ServerAddress,
-                        provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-                        provider.GetService<SslClientAuthenticationOptions>());
-                    connections.Add(connection);
-
-                    await connection.ConnectAsync(default);
-
-                    // Continue until connect fails.
-                }
-            }
-            finally
-            {
-                await Task.WhenAll(connections.Select(c => c.DisposeAsync().AsTask()));
-            }
-        }
     }
 
     /// <summary>Verifies that disabling the idle timeout doesn't abort the connection if it's idle.</summary>
@@ -847,40 +798,6 @@ public abstract partial class MultiplexedConnectionConformanceTests
 
             stream.Input.Complete();
         }
-    }
-
-    [Test]
-    public async Task Listen_twice_on_the_same_address_fails_with_a_transport_exception()
-    {
-        // Arrange
-        await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
-        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
-        var serverTransport = provider.GetRequiredService<IMultiplexedServerTransport>();
-
-        // Act/Assert
-        IceRpcException? exception = Assert.Throws<IceRpcException>(
-            () => serverTransport.Listen(
-                listener.ServerAddress,
-                new MultiplexedConnectionOptions(),
-                provider.GetService<SslServerAuthenticationOptions>()));
-        // BUGFIX with Quic this throws an internal error https://github.com/dotnet/runtime/issues/78573
-        Assert.That(
-            exception!.IceRpcError,
-            Is.EqualTo(IceRpcError.AddressInUse).Or.EqualTo(IceRpcError.IceRpcError));
-    }
-
-    [Test]
-    public async Task Listener_server_address_transport_property_is_set()
-    {
-        // Arrange
-        await using ServiceProvider provider = CreateServiceCollection()
-            .AddMultiplexedTransportTest()
-            .BuildServiceProvider(validateScopes: true);
-        var transport = provider.GetRequiredService<IMultiplexedClientTransport>().Name;
-        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
-
-        // Act/Assert
-        Assert.That(listener.ServerAddress.Transport, Is.EqualTo(transport));
     }
 
     /// <summary>Creates the service collection used for multiplexed transport conformance tests.</summary>

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -867,7 +867,7 @@ public sealed class IceRpcProtocolConnectionTests
             async () => await sut.Client.InvokeAsync(request),
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.TruncatedData));
         Assert.That(
-            async() => await tcs.Task,
+            async () => await tcs.Task,
             Is.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.LimitExceeded));
     }
 


### PR DESCRIPTION
This PR just moves a few tests that are specific to transport listeners to the new class for listener conformance tests.