### PR TITLE
Update LogAndRetryConnectorListenerDecorator

### DIFF
--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -21,9 +21,19 @@ internal static partial class ProtocolLoggerExtensions
     [LoggerMessage(
         EventId = (int)ProtocolEventIds.ConnectionAcceptFailed,
         EventName = nameof(ProtocolEventIds.ConnectionAcceptFailed),
-        Level = LogLevel.Trace,
+        Level = LogLevel.Error,
         Message = "Listener '{ServerAddress}' failed to accept a new connection")]
     internal static partial void LogConnectionAcceptFailed(
+        this ILogger logger,
+        ServerAddress serverAddress,
+        Exception exception);
+
+    [LoggerMessage(
+        EventId = (int)ProtocolEventIds.ConnectionAcceptFailedAndContinue,
+        EventName = nameof(ProtocolEventIds.ConnectionAcceptFailedAndContinue),
+        Level = LogLevel.Trace,
+        Message = "Listener '{ServerAddress}' failed to accept a new connection but continues accepting connections")]
+    internal static partial void LogConnectionAcceptFailedAndContinue(
         this ILogger logger,
         ServerAddress serverAddress,
         Exception exception);

--- a/src/IceRpc/ProtocolEventIds.cs
+++ b/src/IceRpc/ProtocolEventIds.cs
@@ -8,8 +8,12 @@ public enum ProtocolEventIds
     /// <summary>The protocol listener accepted a new connection.</summary>
     ConnectionAccepted,
 
-    /// <summary>The protocol listener failed to accept a new connection.</summary>
+    /// <summary>The protocol listener failed to accept a new connection. This is a fatal error.</summary>
     ConnectionAcceptFailed,
+
+    /// <summary>The protocol listener failed to accept a new connection but continues accepting more connections.
+    /// </summary>
+    ConnectionAcceptFailedAndContinue,
 
     /// <summary>The connection connect attempt succeed.</summary>
     ConnectionConnected,


### PR DESCRIPTION
This PR updates the LogAndRetryConnectorListenerDecorator to:

 - log "other" fatal exceptions at the error level
This decorator is the best spot to log such accept failures, even if it does not handle them otherwise.

 - split Accept failures in 2: AcceptFailed (error) and AcceptFailedAndContinue (trace)