### PR TITLE
Fix LogAndRetryConnectorListenerDecorator

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -590,7 +590,7 @@ public sealed class Server : IAsyncDisposable
 
         public ValueTask DisposeAsync()
         {
-            _logger?.LogStopAcceptingConnections(ServerAddress);
+            _logger.LogStopAcceptingConnections(ServerAddress);
             return _decoratee.DisposeAsync();
         }
 


### PR DESCRIPTION
This is a small fix to the LogAndRetryConnectorListenerDecorator. The behavior should be identical when logger is null or equal to NullLogger.Instance, and we should never see `_logger?.LogXxx`.

In general, a nullable ILogger parameter (in particular constructor parameter) is fine when defaulted to null, however the corresponding field should be non-nullable.