### PR TITLE
Update IProtocolConnection.ShutdownComplete

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -381,17 +381,13 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
         {
             try
             {
-                await connection.ShutdownComplete.WaitAsync(shutdownCancellationToken).ConfigureAwait(false);
+                _ = await connection.ShutdownComplete.WaitAsync(shutdownCancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException exception) when (exception.CancellationToken == shutdownCancellationToken)
             {
                 // The connection cache is being shut down or disposed and cache's DisposeAsync is responsible to
                 // DisposeAsync this connection.
                 return;
-            }
-            catch
-            {
-                // ignore and continue: the connection was aborted
             }
 
             lock (_mutex)

--- a/src/IceRpc/IConnectionContext.cs
+++ b/src/IceRpc/IConnectionContext.cs
@@ -15,10 +15,12 @@ public interface IConnectionContext
     /// non-null.</value>
     ServerAddress ServerAddress { get; }
 
-    /// <summary>Gets a task that completes when the connection is shut down or aborted.</summary>
-    /// <value>A task that completes when the connection is successfully shut down. It completes with an exception when
-    /// the connection is aborted.</value>
-    Task ShutdownComplete { get; }
+    /// <summary>Gets a task that completes when the underlying transport connection is closed.</summary>
+    /// <value>A task that completes successfully with a null exception when the connection is shut down gracefully.
+    /// When this connection is aborted, this task completes successfully with the exception that caused the abort.
+    /// This task is never faulted.</value>
+    // TODO: rename property
+    Task<Exception?> ShutdownComplete { get; }
 
     /// <summary>Gets the transport connection information.</summary>
     TransportConnectionInformation TransportConnectionInformation { get; }

--- a/src/IceRpc/IProtocolConnection.cs
+++ b/src/IceRpc/IProtocolConnection.cs
@@ -15,18 +15,21 @@ public interface IProtocolConnection : IInvoker, IAsyncDisposable
     /// non-null.</value>
     ServerAddress ServerAddress { get; }
 
-    /// <summary>Gets a task that completes when the connection is shut down or fails. The connection shutdown is
-    /// initiated by any of the following events:
+    /// <summary>Gets a task that completes when the underlying transport connection is closed or the underlying
+    /// transport connection cannot be established.</summary>
+    /// <value>A task that completes successfully with a null exception when this connection is shut down gracefully
+    /// or disposed before a call to <see cref="ConnectAsync" />. When this connection is aborted, this task completes
+    /// successfully with the exception that caused the abort. This task is never faulted.</value>
+    /// <remarks>The graceful shutdown of the connection is initiated by any of the following events:
     /// <list type="bullet">
     /// <item><description>The application calls <see cref="ShutdownAsync" /> on the connection.</description></item>
     /// <item><description>The connection shuts down itself because it remained idle for longer than its configured idle
     /// timeout.</description></item>
     /// <item><description>The peer shuts down the connection.</description></item>
     /// </list>
-    /// </summary>
-    /// <value>A task that completes when the connection is successfully shut down. It completes with an exception when
-    /// the connection fails.</value>
-    Task ShutdownComplete { get; }
+    /// </remarks>
+    // TODO: rename property to 'Closed'.
+    Task<Exception?> ShutdownComplete { get; }
 
     /// <summary>Establishes the connection to the peer.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>

--- a/src/IceRpc/Internal/ConnectionContext.cs
+++ b/src/IceRpc/Internal/ConnectionContext.cs
@@ -11,7 +11,7 @@ internal sealed class ConnectionContext : IConnectionContext
 
     public ServerAddress ServerAddress => _protocolConnection.ServerAddress;
 
-    public Task ShutdownComplete => _protocolConnection.ShutdownComplete;
+    public Task<Exception?> ShutdownComplete => _protocolConnection.ShutdownComplete;
 
     public TransportConnectionInformation TransportConnectionInformation { get; }
 

--- a/src/IceRpc/Internal/MetricsProtocolConnectionDecorator.cs
+++ b/src/IceRpc/Internal/MetricsProtocolConnectionDecorator.cs
@@ -9,7 +9,7 @@ internal class MetricsProtocolConnectionDecorator : IProtocolConnection
 {
     public ServerAddress ServerAddress => _decoratee.ServerAddress;
 
-    public Task ShutdownComplete => _decoratee.ShutdownComplete;
+    public Task<Exception?> ShutdownComplete => _decoratee.ShutdownComplete;
 
     private readonly IProtocolConnection _decoratee;
     private readonly Task _shutdownAsync;
@@ -52,11 +52,7 @@ internal class MetricsProtocolConnectionDecorator : IProtocolConnection
         // This task executes exactly once per decorated connection.
         async Task ShutdownAsync()
         {
-            try
-            {
-                await ShutdownComplete.ConfigureAwait(false);
-            }
-            catch (Exception)
+            if (await ShutdownComplete.ConfigureAwait(false) is not null)
             {
                 ClientMetrics.Instance.ConnectionFailure();
             }

--- a/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
+++ b/tests/IceRpc.Tests.Common/FakeConnectionContext.cs
@@ -15,7 +15,7 @@ public sealed class FakeConnectionContext : IConnectionContext
 
     public ServerAddress ServerAddress { get; }
 
-    public Task ShutdownComplete => _shutdownCompletionSource.Task;
+    public Task<Exception?> ShutdownComplete => _shutdownCompletionSource.Task;
 
     public TransportConnectionInformation TransportConnectionInformation =>
         new(IPEndPoint.Parse(LocalAddress), IPEndPoint.Parse(RemoteAddress), null);
@@ -23,7 +23,7 @@ public sealed class FakeConnectionContext : IConnectionContext
     private const string LocalAddress = "192.168.7.7:10000";
     private const string RemoteAddress = "10.10.10.10:11000";
 
-    private readonly TaskCompletionSource _shutdownCompletionSource = new(); // never completed
+    private readonly TaskCompletionSource<Exception?> _shutdownCompletionSource = new(); // never completed
 
     public static IConnectionContext FromProtocol(Protocol protocol) =>
         protocol == Protocol.Ice ? Ice :

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -205,11 +205,13 @@ public sealed class IceProtocolConnectionTests
         };
 
         // Act/Assert
-        var exception = Assert.ThrowsAsync<IceRpcException>(
-            async () => await sut.Client.InvokeAsync(request, default));
-        Assert.That(exception, Is.Not.Null);
-        exception = Assert.ThrowsAsync<IceRpcException>(async () => await sut.Server.ShutdownComplete);
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
+        Assert.That(
+            async () => await sut.Client.InvokeAsync(request, default),
+            Throws.InstanceOf<IceRpcException>());
+
+        Assert.That(
+            async () => await sut.Server.ShutdownComplete,
+            Is.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.IceRpcError));
     }
 
     /// <summary>This test verifies that responses that are received after a request has been discarded are ignored,


### PR DESCRIPTION
This PR changes IProtocolConnection.ShutdownComplete to be a never-faulted task as proposed in #2341.

It also updates ProtocolConnection.ConnectAsync to no longer throw IceRpcException(ConnectionClosed). It's now ClientConnection that throws IceRpcException(ConnectionClosed) when a previous always completed ConnectAsync call was unsuccessful.