### PR TITLE
Change FaultedTaskAction

### DIFF
--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Transports;
 using System.Buffers;
-using System.Diagnostics;
 
 namespace IceRpc;
 
@@ -23,14 +22,14 @@ public record class ConnectionOptions
     /// not accept requests.</value>
     public IDispatcher? Dispatcher { get; set; }
 
-    /// <summary>Gets or sets the action to execute when a task that IceRPC starts and does not await completes due to
-    /// an unhandled exception. This unhandled exception can correspond to a bug in IceRPC itself or to an exception
-    /// thrown by the application code called by IceRPC. For example, when a dispatch task sends a response provided by
-    /// the application and the reading of this response throws <c>MyException</c>, this action will be called with this
-    /// exception instance.</summary>
-    /// <value>The default action calls Assert and includes the exception in the Assert message.</value>
-    /// <seealso cref="TaskScheduler.UnobservedTaskException" />
-    public Action<Exception> FaultedTaskAction { get; set; } = _defaultFaultedTaskAction;
+    /// <summary>Gets or sets the action to execute when a task that IceRPC starts and does not await is about to
+    /// complete with an unhandled exception. This unhandled exception can correspond to a bug in IceRPC itself or to an
+    /// exception thrown by the application code called by IceRPC. For example, when a dispatch task sends a response
+    /// provided by the application and the reading of this response throws <c>MyException</c>, this action will be
+    /// called with this exception instance.</summary>
+    /// <value>The default action is null which means no-op.</value>
+    /// <remarks>If the registered action throws an exception, the task will complete with this exception.</remarks>
+    public Action<Exception>? FaultedTaskAction { get; set; }
 
     /// <summary>Gets or sets the idle timeout. This timeout is used to gracefully shutdown the connection if it's
     /// idle for longer than this timeout. A connection is considered idle when there's no invocations or dispatches
@@ -138,8 +137,6 @@ public record class ConnectionOptions
     internal const int DefaultMaxIceRpcHeaderSize = 16_383;
 
     private const int IceMinFrameSize = 256;
-    private static readonly Action<Exception> _defaultFaultedTaskAction =
-        exception => Debug.Fail($"IceRpc task completed due to an unhandled exception: {exception}");
 
     private TimeSpan _connectTimeout = TimeSpan.FromSeconds(10);
     private TimeSpan _idleTimeout = TimeSpan.FromSeconds(60);

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -33,7 +33,7 @@ internal sealed class IceProtocolConnection : ProtocolConnection
     private readonly IDuplexConnection _duplexConnection;
     private readonly DuplexConnectionReader _duplexConnectionReader;
     private readonly DuplexConnectionWriter _duplexConnectionWriter;
-    private readonly Action<Exception> _faultedTaskAction;
+    private readonly Action<Exception>? _faultedTaskAction;
     private readonly TimeSpan _idleTimeout;
     private int _invocationCount;
     private bool _isClosedByPeer;
@@ -973,10 +973,9 @@ internal sealed class IceProtocolConnection : ProtocolConnection
                         {
                             await DispatchRequestAsync(request, contextReader).ConfigureAwait(false);
                         }
-                        catch (Exception exception)
+                        catch (Exception exception) when (_faultedTaskAction is not null)
                         {
                             _faultedTaskAction(exception);
-                            throw;
                         }
                     },
                     CancellationToken.None);

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -28,7 +28,7 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly SemaphoreSlim? _dispatchSemaphore;
-    private readonly Action<Exception> _faultedTaskAction;
+    private readonly Action<Exception>? _faultedTaskAction;
     // The number of bytes we need to encode a size up to _maxRemoteHeaderSize. It's 2 for DefaultMaxHeaderSize.
     private int _headerSizeLength = 2;
 
@@ -309,11 +309,10 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
                                 {
                                     // This occurs during shutdown.
                                 }
-                                catch (Exception exception)
+                                catch (Exception exception) when (_faultedTaskAction is not null)
                                 {
                                     // not expected
                                     _faultedTaskAction(exception);
-                                    throw;
                                 }
                                 finally
                                 {
@@ -842,10 +841,9 @@ internal sealed class IceRpcProtocolConnection : ProtocolConnection
                         // TruncatedData is expected when the payloadContinuation comes from an incoming IceRPC payload
                         // and the peer's Output is completed with an exception.
                     }
-                    catch (Exception exception)
+                    catch (Exception exception) when (_faultedTaskAction is not null)
                     {
                         _faultedTaskAction(exception);
-                        throw;
                     }
                     finally
                     {

--- a/tests/IceRpc.Tests.Common/AssertTraceListener.cs
+++ b/tests/IceRpc.Tests.Common/AssertTraceListener.cs
@@ -23,5 +23,11 @@ public class AssertTraceListener : DefaultTraceListener
         }
     }
 
-    public static void Setup() => Trace.Listeners[0] = _instance;
+    public static void Setup()
+    {
+        Trace.Listeners[0] = _instance;
+
+        TaskScheduler.UnobservedTaskException +=
+            (_, eventArgs) => Assert.Fail($"Unobserved exception: {eventArgs.Exception}");
+    }
 }

--- a/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests/ProtocolServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using IceRpc.Internal;
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics;
 
 namespace IceRpc.Tests;
 
@@ -12,8 +13,15 @@ public static class ProtocolServiceCollectionExtensions
     public static IServiceCollection AddIceProtocolTest(
         this IServiceCollection services,
         ConnectionOptions clientConnectionOptions,
-        ConnectionOptions serverConnectionOptions) =>
-        services.AddSingleton(provider =>
+        ConnectionOptions serverConnectionOptions)
+    {
+        clientConnectionOptions.Dispatcher ??= ServiceNotFoundDispatcher.Instance;
+        clientConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
+
+        serverConnectionOptions.Dispatcher ??= ServiceNotFoundDispatcher.Instance;
+        serverConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
+
+        return services.AddSingleton(provider =>
             new ClientServerProtocolConnection(
                 clientProtocolConnection: new IceProtocolConnection(
                     provider.GetRequiredService<IDuplexConnection>(),
@@ -34,12 +42,19 @@ public static class ProtocolServiceCollectionExtensions
                             serverConnectionOptions);
                     },
                 listener: provider.GetRequiredService<IListener<IDuplexConnection>>()));
+    }
 
     public static IServiceCollection AddIceRpcProtocolTest(
         this IServiceCollection services,
         ConnectionOptions clientConnectionOptions,
         ConnectionOptions serverConnectionOptions)
     {
+        clientConnectionOptions.Dispatcher ??= ServiceNotFoundDispatcher.Instance;
+        clientConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
+
+        serverConnectionOptions.Dispatcher ??= ServiceNotFoundDispatcher.Instance;
+        serverConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
+
         services.AddSingleton(provider =>
             new ClientServerProtocolConnection(
                 clientProtocolConnection: new IceRpcProtocolConnection(
@@ -74,8 +89,11 @@ public static class ProtocolServiceCollectionExtensions
     {
         clientConnectionOptions ??= new();
         clientConnectionOptions.Dispatcher ??= ServiceNotFoundDispatcher.Instance;
+        clientConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
+
         serverConnectionOptions ??= new();
         serverConnectionOptions.Dispatcher ??= dispatcher ?? ServiceNotFoundDispatcher.Instance;
+        serverConnectionOptions.FaultedTaskAction ??= ServiceCollectionExtensions.DefaultFaultedTaskAction;
 
         if (protocol == Protocol.Ice)
         {


### PR DESCRIPTION
This PR changes faulted task action as proposed on my blog:
https://zeroc.atlassian.net/wiki/spaces/~bernard/blog/2022/12/12/1202749441/December+12+2022

It also added an UnobversedTaskException event which unfortunately fires a number of times (don't know how many), which suggests bug in our code or in the test suite.

I can't figure out how to get more information out of NUnit to pinpoint the actual problem. Is there a way to display the test name? Run the tests one by one?