### PR TITLE
Remove Server.ServerAddress

### DIFF
--- a/tests/IceRpc.Tests/ClientConnectionTests.cs
+++ b/tests/IceRpc.Tests/ClientConnectionTests.cs
@@ -30,10 +30,10 @@ public class ClientConnectionTests
             },
             multiplexedServerTransport: new SlicServerTransport(new TcpServerTransport()),
             duplexServerTransport: new TcpServerTransport());
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         await using var connection = new ClientConnection(
-            new ClientConnectionOptions() { ServerAddress = server.ServerAddress },
+            new ClientConnectionOptions() { ServerAddress = serverAddress },
             duplexClientTransport: new TcpClientTransport(),
             multiplexedClientTransport: new SlicClientTransport(new TcpClientTransport()));
 
@@ -50,8 +50,7 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri("icerpc://127.0.0.1:0"));
-        server.Listen();
-        ServerAddress serverAddress = server.ServerAddress;
+        ServerAddress serverAddress = server.Listen();
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
         await server.DisposeAsync();
@@ -69,8 +68,7 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri("icerpc://127.0.0.1:0"));
-        server.Listen();
-        ServerAddress serverAddress = server.ServerAddress;
+        ServerAddress serverAddress = server.Listen();
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
 
@@ -98,8 +96,7 @@ public class ClientConnectionTests
     {
         // Arrange
         var server = new Server(ServiceNotFoundDispatcher.Instance, new Uri($"{protocol.Name}://127.0.0.1:0"));
-        server.Listen();
-        ServerAddress serverAddress = server.ServerAddress;
+        ServerAddress serverAddress = server.Listen();
         await using var connection = new ClientConnection(serverAddress);
         await connection.ConnectAsync();
         await server.DisposeAsync();

--- a/tests/IceRpc.Tests/ProtocolLoggerTests.cs
+++ b/tests/IceRpc.Tests/ProtocolLoggerTests.cs
@@ -25,10 +25,10 @@ public sealed class ProtocolLoggerTests
             serverAddress,
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
             logger: serverLoggerFactory.CreateLogger("IceRpc"));
-        server.Listen();
+        serverAddress = server.Listen();
 
         await using var clientConnection = new ClientConnection(
-            server.ServerAddress,
+            serverAddress,
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
             logger: clientLoggerFactory.CreateLogger("IceRpc"));
         using var request = new OutgoingRequest(
@@ -47,11 +47,11 @@ public sealed class ProtocolLoggerTests
         TestLoggerEntry entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StartAcceptingConnections));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
 
         entry = await serverLoggerFactory.Logger!.Entries.Reader.ReadAsync();
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionAccepted));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
         Assert.That(
             entry.State["RemoteNetworkAddress"]?.ToString(),
             Is.EqualTo(clientConnectionInformation.LocalNetworkAddress.ToString()));
@@ -93,10 +93,10 @@ public sealed class ProtocolLoggerTests
             multiplexedServerTransport: new ConnectFailMultiplexedServerTransportDecorator(
                 new SlicServerTransport(colocTransport.ServerTransport)),
             logger: serverLoggerFactory.CreateLogger("IceRpc"));
-        server.Listen();
+        serverAddress = server.Listen();
 
         await using var clientConnection = new ClientConnection(
-            server.ServerAddress,
+            serverAddress,
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
             logger: clientLoggerFactory.CreateLogger("IceRpc"));
 
@@ -113,14 +113,14 @@ public sealed class ProtocolLoggerTests
         while (entry.EventId != (int)ProtocolEventIds.ConnectionConnectFailed);
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnectFailed));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
         Assert.That(entry.Exception, Is.InstanceOf<InvalidOperationException>());
 
         Assert.That(clientLoggerFactory.Logger, Is.Not.Null);
         entry = await clientLoggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.ConnectionConnectFailed));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
         Assert.That(entry.Exception, Is.InstanceOf<IceRpcException>());
     }
 
@@ -138,10 +138,10 @@ public sealed class ProtocolLoggerTests
             serverAddress,
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
             logger: serverLoggerFactory.CreateLogger("IceRpc"));
-        server.Listen();
+        serverAddress = server.Listen();
 
         await using var clientConnection = new ClientConnection(
-            server.ServerAddress,
+            serverAddress,
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
             logger: clientLoggerFactory.CreateLogger("IceRpc"));
         using var request = new OutgoingRequest(
@@ -214,7 +214,7 @@ public sealed class ProtocolLoggerTests
             logger: loggerFactory.CreateLogger("IceRpc"));
 
         // Act
-        server.Listen();
+        serverAddress = server.Listen();
         await server.DisposeAsync();
 
         // Assert
@@ -222,11 +222,11 @@ public sealed class ProtocolLoggerTests
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StartAcceptingConnections));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
 
         entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
         Assert.That(entry.EventId.Id, Is.EqualTo((int)ProtocolEventIds.StopAcceptingConnections));
-        Assert.That(entry.State["ServerAddress"], Is.EqualTo(server.ServerAddress));
+        Assert.That(entry.State["ServerAddress"], Is.EqualTo(serverAddress));
     }
 
     [Test]
@@ -243,10 +243,10 @@ public sealed class ProtocolLoggerTests
             serverAddress,
             multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport),
             logger: serverLoggerFactory.CreateLogger("IceRpc"));
-        server.Listen();
+        serverAddress = server.Listen();
 
         await using var clientConnection = new ClientConnection(
-            server.ServerAddress,
+            serverAddress,
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport),
             logger: clientLoggerFactory.CreateLogger("IceRpc"));
 

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -33,19 +33,6 @@ public class ServerTests
         Assert.Throws<ObjectDisposedException>(() => server.Listen());
     }
 
-    /// <summary>Verifies that Server.ServerAddress.Transport property is set.</summary>
-    [Test]
-    public async Task Server_server_address_transport_property_is_set([Values("ice", "icerpc")] string protocol)
-    {
-        // Arrange/Act
-        await using var server = new Server(
-            ServiceNotFoundDispatcher.Instance,
-            new ServerAddress(Protocol.Parse(protocol)));
-
-        // Assert
-        Assert.That(server.ServerAddress.Transport, Is.Not.Null);
-    }
-
     [Test]
     public async Task Connection_refused_after_max_connections_is_reached()
     {
@@ -60,18 +47,18 @@ public class ServerTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://127.0.0.1:0")),
             });
 
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         await using var connection1 = new ClientConnection(
             new ClientConnectionOptions
             {
-                ServerAddress = server.ServerAddress,
+                ServerAddress = serverAddress,
             });
 
         await using var connection2 = new ClientConnection(
             new ClientConnectionOptions
             {
-                ServerAddress = server.ServerAddress,
+                ServerAddress = serverAddress,
             });
 
         await connection1.ConnectAsync();
@@ -98,11 +85,11 @@ public class ServerTests
            },
            multiplexedServerTransport: serverTransport);
 
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         var clientConnectionOptions = new ClientConnectionOptions()
         {
-            ServerAddress = server.ServerAddress
+            ServerAddress = serverAddress
         };
 
         await using var clientConnection1 = new ClientConnection(
@@ -157,21 +144,21 @@ public class ServerTests
            },
            multiplexedServerTransport: serverTransport);
 
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         // The listener is now available
         DelayDisposeConnectionListener serverListener = serverTransport.Listener!;
 
         await using var clientConnection1 = new ClientConnection(
-            new ClientConnectionOptions { ServerAddress = server.ServerAddress },
+            new ClientConnectionOptions { ServerAddress = serverAddress },
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport));
 
         await using var clientConnection2 = new ClientConnection(
-            new ClientConnectionOptions { ServerAddress = server.ServerAddress },
+            new ClientConnectionOptions { ServerAddress = serverAddress },
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport));
 
         await using var clientConnection3 = new ClientConnection(
-            new ClientConnectionOptions { ServerAddress = server.ServerAddress },
+            new ClientConnectionOptions { ServerAddress = serverAddress },
             multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport));
 
         // No need to delay the disposal of any connections (the default behavior)
@@ -217,13 +204,13 @@ public class ServerTests
                 ServerAddress = new ServerAddress(new Uri("icerpc://127.0.0.1:0")),
             });
 
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         await using var clientConnection = new ClientConnection(
            new ClientConnectionOptions
            {
                ShutdownTimeout = TimeSpan.FromMilliseconds(500),
-               ServerAddress = server.ServerAddress,
+               ServerAddress = serverAddress,
            });
 
         using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));

--- a/tests/IntegrationTests/CustomTransportTests.cs
+++ b/tests/IntegrationTests/CustomTransportTests.cs
@@ -84,12 +84,12 @@ public class CustomTransportTests
             },
             multiplexedServerTransport: new CustomServerTransport());
 
-        server.Listen();
+        ServerAddress serverAddress = server.Listen();
 
         await using var connection = new ClientConnection(
             new ClientConnectionOptions
             {
-                ServerAddress = server.ServerAddress
+                ServerAddress = serverAddress
             },
             multiplexedClientTransport: new CustomClientTransport());
 
@@ -111,16 +111,16 @@ public class CustomTransportTests
                 }
             },
                 multiplexedServerTransport: new CustomServerTransport());
-            server.Listen();
+            ServerAddress serverAddress = server.Listen();
 
             await using var connection1 = new ClientConnection(
                 new ClientConnectionOptions
                 {
                     // We add the custom server address here because listen updates the server address and the custom transport
                     // removes the parameter
-                    ServerAddress = server.ServerAddress with
+                    ServerAddress = serverAddress with
                     {
-                        Params = server.ServerAddress.Params.Add("custom-p", "bar")
+                        Params = serverAddress.Params.Add("custom-p", "bar")
                     }
                 },
                 multiplexedClientTransport: new CustomClientTransport());


### PR DESCRIPTION
This PR removes Server.ServerAddress and returns the "actual" server address from Server.Listen.

Fixes #2353.

