### PR TITLE
Program.CancelKeyPressed

### DIFF
--- a/examples/Hello/Server/Program.cs
+++ b/examples/Hello/Server/Program.cs
@@ -4,15 +4,23 @@ using HelloExample;
 using IceRpc;
 
 await using var server = new Server(new Hello());
-
-// Create a task completion source to keep running until Ctrl+C is pressed.
-var cancelKeyPressed = new TaskCompletionSource();
-Console.CancelKeyPress += (sender, eventArgs) =>
-{
-    eventArgs.Cancel = true;
-    _ = cancelKeyPressed.TrySetResult();
-};
-
 server.Listen();
-await cancelKeyPressed.Task;
+
+// Wait until the console receives a Ctrl+C.
+await CancelKeyPressed;
 await server.ShutdownAsync();
+
+// The implementation of CancelKeyPressed.
+public static partial class Program
+{
+    public static Task CancelKeyPressed => _cancelKeyPressedTcs.Task;
+
+    private static readonly TaskCompletionSource _cancelKeyPressedTcs = new();
+
+    static Program() =>
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            eventArgs.Cancel = true;
+            _ = _cancelKeyPressedTcs.TrySetResult();
+        };
+}


### PR DESCRIPTION
This PR shows how we can add a `Program.CancelKeyPressed` property and await it. With this property, our server boilerplate is simply:

```
await using var server = new Server(new Hello());
server.Listen();

// Wait until the console receives a Ctrl+C.
await CancelKeyPressed;
await server.ShutdownAsync();
```

and we "factor out" the TaskCompletionSource / Ctrl+C handling distraction.

In this PR, I put the partial Program directly in Server/Program.cs. 
However, I propose to actually put this code in:
examples/Common/Program.CancelKeyPressed.cs and include this file in projects that need it.

Naturally, I'll wait until there is a consensus before doing that!
