### PR TITLE
Remove "context" error message from ToIceRpcException

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
@@ -7,26 +7,29 @@ namespace IceRpc.Transports.Internal;
 internal static class QuicExceptionExtensions
 {
     /// <summary>Converts a <see cref="QuicException"/> into an <see cref="IceRpcException"/>.</summary>
-    internal static IceRpcException ToIceRpcException(this QuicException exception, string? message = null) =>
+    internal static IceRpcException ToIceRpcException(this QuicException exception) =>
         exception.QuicError switch
         {
-            QuicError.AddressInUse => new IceRpcException(IceRpcError.AddressInUse, message, exception),
+            QuicError.AddressInUse => new IceRpcException(IceRpcError.AddressInUse, exception),
             QuicError.ConnectionAborted =>
                 exception.ApplicationErrorCode is long applicationErrorCode ?
                     applicationErrorCode switch
                     {
                         (long)MultiplexedConnectionCloseError.NoError =>
-                            new IceRpcException(IceRpcError.ConnectionClosedByPeer, message),
+                            new IceRpcException(IceRpcError.ConnectionClosedByPeer),
                         (long)MultiplexedConnectionCloseError.ServerBusy =>
-                            new IceRpcException(IceRpcError.ServerBusy, message),
-                        _ => new IceRpcException(IceRpcError.ConnectionAborted, message, exception),
+                            new IceRpcException(IceRpcError.ServerBusy),
+                        _ => new IceRpcException(
+                            IceRpcError.ConnectionAborted,
+                            $"The connection was closed by the peer with an unknown application error code: '{applicationErrorCode}'",
+                            exception),
                     } :
-                    new IceRpcException(IceRpcError.ConnectionAborted, message, exception),
-            QuicError.ConnectionRefused => new IceRpcException(IceRpcError.ConnectionRefused, message, exception),
-            QuicError.ConnectionTimeout => new IceRpcException(IceRpcError.ConnectionAborted, message, exception),
-            QuicError.OperationAborted => new IceRpcException(IceRpcError.OperationAborted, message, exception),
-            QuicError.StreamAborted => new IceRpcException(IceRpcError.TruncatedData, message, exception),
+                    new IceRpcException(IceRpcError.ConnectionAborted, exception), // TODO: does this ever happen?
+            QuicError.ConnectionRefused => new IceRpcException(IceRpcError.ConnectionRefused, exception),
+            QuicError.ConnectionTimeout => new IceRpcException(IceRpcError.ConnectionAborted, exception),
+            QuicError.OperationAborted => new IceRpcException(IceRpcError.OperationAborted, exception),
+            QuicError.StreamAborted => new IceRpcException(IceRpcError.TruncatedData, exception),
 
-            _ => new IceRpcException(IceRpcError.IceRpcError, message, exception)
+            _ => new IceRpcException(IceRpcError.IceRpcError, exception)
         };
 }

--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedConnection.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedConnection.cs
@@ -35,7 +35,7 @@ internal abstract class QuicMultiplexedConnection : IMultiplexedConnection
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The accept operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 
@@ -52,7 +52,7 @@ internal abstract class QuicMultiplexedConnection : IMultiplexedConnection
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The close operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 
@@ -62,7 +62,7 @@ internal abstract class QuicMultiplexedConnection : IMultiplexedConnection
     {
         if (_connection is null)
         {
-            throw new InvalidOperationException("The Quic connection is not connected.");
+            throw new InvalidOperationException();
         }
 
         QuicStream stream;
@@ -74,7 +74,7 @@ internal abstract class QuicMultiplexedConnection : IMultiplexedConnection
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The stream creation failed.");
+            throw exception.ToIceRpcException();
         }
 
         return new QuicMultiplexedStream(
@@ -102,7 +102,7 @@ internal class QuicMultiplexedClientConnection : QuicMultiplexedConnection
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The connect operation failed.");
+            throw exception.ToIceRpcException();
         }
 
         return new TransportConnectionInformation(

--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -91,7 +91,7 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The listener creation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 }

--- a/src/IceRpc.Quic/Transports/Internal/QuicPipeReader.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicPipeReader.cs
@@ -54,7 +54,7 @@ internal class QuicPipeReader : PipeReader
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The read operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch (ObjectDisposedException)
         {

--- a/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicPipeWriter.cs
@@ -151,7 +151,7 @@ internal class QuicPipeWriter : ReadOnlySequencePipeWriter
         }
         catch (QuicException exception)
         {
-            throw exception.ToIceRpcException("The write operation failed.");
+            throw exception.ToIceRpcException();
         }
         // We don't wrap other exceptions
 

--- a/src/IceRpc/Transports/Internal/IOExceptionExtensions.cs
+++ b/src/IceRpc/Transports/Internal/IOExceptionExtensions.cs
@@ -7,8 +7,8 @@ namespace IceRpc.Transports.Internal;
 internal static class IOExceptionExtensions
 {
     /// <summary>Converts an IOException into an <see cref="IceRpcException" />.</summary>
-    internal static IceRpcException ToIceRpcException(this IOException exception, string? message = null) =>
+    internal static IceRpcException ToIceRpcException(this IOException exception) =>
         exception.InnerException is SocketException socketException ?
-            socketException.ToIceRpcException(message, exception) :
-            new IceRpcException(IceRpcError.IceRpcError, message, exception);
+            socketException.ToIceRpcException(exception) :
+            new IceRpcException(IceRpcError.IceRpcError, exception);
 }

--- a/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Transports.Internal;
 internal static class SocketExceptionExtensions
 {
     /// <summary>Converts a SocketException into an <see cref="IceRpcException" />.</summary>
-    internal static IceRpcException ToIceRpcException(this SocketException exception, string? message = null, Exception? innerException = null)
+    internal static IceRpcException ToIceRpcException(this SocketException exception, Exception? innerException = null)
     {
         innerException ??= exception;
         IceRpcError errorCode = exception.SocketErrorCode switch
@@ -23,6 +23,7 @@ internal static class SocketExceptionExtensions
             SocketError.OperationAborted => IceRpcError.OperationAborted,
             _ => IceRpcError.IceRpcError
         };
-        return new IceRpcException(errorCode, message, innerException);
+
+        return new IceRpcException(errorCode, innerException);
     }
 }

--- a/src/IceRpc/Transports/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpConnection.cs
@@ -79,11 +79,11 @@ internal abstract class TcpConnection : IDuplexConnection
         }
         catch (IOException exception)
         {
-            throw exception.ToIceRpcException("The read operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch (SocketException exception)
         {
-            throw exception.ToIceRpcException("The read operation failed.");
+            throw exception.ToIceRpcException();
         }
 
         return received;
@@ -206,11 +206,11 @@ internal abstract class TcpConnection : IDuplexConnection
         }
         catch (IOException exception)
         {
-            throw exception.ToIceRpcException("The write operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch (SocketException exception)
         {
-            throw exception.ToIceRpcException("The write operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 
@@ -270,11 +270,11 @@ internal class TcpClientConnection : TcpConnection
         }
         catch (IOException exception)
         {
-            throw exception.ToIceRpcException("The connect operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch (SocketException exception)
         {
-            throw exception.ToIceRpcException("The connect operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 
@@ -319,7 +319,7 @@ internal class TcpClientConnection : TcpConnection
         catch (SocketException exception)
         {
             Socket.Dispose();
-            throw exception.ToIceRpcException("The bind operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch
         {
@@ -363,11 +363,11 @@ internal class TcpServerConnection : TcpConnection
         }
         catch (IOException exception)
         {
-            throw exception.ToIceRpcException("The connect operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch (SocketException exception)
         {
-            throw exception.ToIceRpcException("The connect operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -33,7 +33,7 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
         }
         catch (SocketException exception)
         {
-            throw exception.ToIceRpcException("The accept operation failed.");
+            throw exception.ToIceRpcException();
         }
     }
 
@@ -98,7 +98,7 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
         catch (SocketException exception)
         {
             _socket.Dispose();
-            throw exception.ToIceRpcException("The bind operation failed.");
+            throw exception.ToIceRpcException();
         }
         catch
         {


### PR DESCRIPTION
This PR fixes #2363.

This context message is not that helpful since you can see the context from the stack trace of your IceRpcException.
Then, having this message in ToIceRpcException makes it difficult/impossible for ToIceRpcException to specify an error message when appropriate. This is the case when processing a ConnectionAborted "application error code" from Quic.

We have the application error code processing logic in Slic but we don't use a ToIceRpcException extension method for Slic since Slic does not have its own exception type to convert.