### PR TITLE
DuplexConnectionReader test fixes

### DIFF
--- a/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
+++ b/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
@@ -32,13 +32,13 @@ public class DuplexConnectionReaderTests
         Task<TransportConnectionInformation> serverConnectTask = serverConnection.ConnectAsync(default);
         await Task.WhenAll(clientConnectTask, serverConnectTask);
 
-        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
         var tcs = new TaskCompletionSource<TimeSpan>();
         using var reader = new DuplexConnectionReader(
             clientConnection,
             MemoryPool<byte>.Shared,
             4096,
             connectionLostAction: _ => tcs.SetResult(TimeSpan.FromMilliseconds(Environment.TickCount64)));
+        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
         reader.EnableAliveCheck(TimeSpan.FromMilliseconds(500));
 
         // Act
@@ -65,13 +65,13 @@ public class DuplexConnectionReaderTests
         Task<TransportConnectionInformation> serverConnectTask = serverConnection.ConnectAsync(default);
         await Task.WhenAll(clientConnectTask, serverConnectTask);
 
-        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
         var tcs = new TaskCompletionSource<TimeSpan>();
         using var reader = new DuplexConnectionReader(
             clientConnection,
             MemoryPool<byte>.Shared,
             4096,
             connectionLostAction: _ => tcs.SetResult(TimeSpan.FromMilliseconds(Environment.TickCount64)));
+        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
         reader.EnableAliveCheck(TimeSpan.FromMilliseconds(500));
 
         // Write and read data to defer the idle timeout


### PR DESCRIPTION
This fixes the DuplexConnectionReader  tests to correctly measure the elapsed time, the test was comparing the expected duration with the milliseconds from TickCount64.

I also replace the delay with a TCS that waits for the connection lost action call.

From #2367 seems the callback was not called within the delay, so this should fix it or if the callback is never called it will hang until NUnit timeout kicks in.