### PR TITLE
Don't need to await write stream frame task

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -678,9 +678,6 @@ internal class SlicConnection : IMultiplexedConnection
                     stream.TrySetWritesClosed();
                 }
 
-                // Make sure the previous stream frame write completed successfully.
-                await _writeStreamFrameTask.ConfigureAwait(false);
-
                 EncodeStreamFrameHeader(stream.Id, sendSource1.Length + sendSource2.Length, lastStreamFrame);
             }
             catch


### PR DESCRIPTION
We don't need to await this task, the write semaphore is only released after the previous frame was sent and we already hold the write semaphore here. Fix #2387 