### PR TITLE
Fixed how `ice` connection are rejected by `Server`, fixes #2407

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -869,8 +869,11 @@ public sealed class Server : IAsyncDisposable
             return new();
         }
 
-        public Task RefuseTransportConnectionAsync(CancellationToken cancel) =>
-            _transportConnection!.ShutdownAsync(cancel);
+        public Task RefuseTransportConnectionAsync(CancellationToken cancel)
+        {
+            _transportConnection!.Dispose();
+            return Task.CompletedTask;
+        }
 
         internal IceConnector(IDuplexConnection transportConnection, ConnectionOptions options)
         {


### PR DESCRIPTION
This PR fixes #2407 and the `ice` connection refusal by the server when `MaxConnections` is reached. The server now disposes of the connection instead of shutting it down. It also fixes the matching test to verify the expected error code when a connection is rejected.