### PR TITLE
Fixes #2492

### DIFF
--- a/tests/IceRpc.Tests/ConnectionCacheTests.cs
+++ b/tests/IceRpc.Tests/ConnectionCacheTests.cs
@@ -220,8 +220,8 @@ public sealed class ConnectionCacheTests
             multiplexedClientTransport: multiplexedClientTransport);
         await new ServiceProxy(cache, new Uri("icerpc://foo")).IcePingAsync();
 
-        TestMultiplexedConnectionDecorator connection = multiplexedClientTransport.LastConnection!;
-        connection.HoldOperation = MultiplexedTransportOperation.DisposeAsync;
+        TestMultiplexedConnectionDecorator clientConnection = multiplexedClientTransport.LastConnection!;
+        clientConnection.HoldOperation = MultiplexedTransportOperation.DisposeAsync;
 
         // Shutdown the server to trigger the background client connection shutdown and disposal.
         await server.ShutdownAsync();
@@ -230,10 +230,10 @@ public sealed class ConnectionCacheTests
         ValueTask disposeTask = cache.DisposeAsync();
 
         // Assert
-        await connection.DisposeCalled;
+        await clientConnection.DisposeCalled;
         using var cts = new CancellationTokenSource(100);
         Assert.That(() => disposeTask.AsTask().WaitAsync(cts.Token), Throws.InstanceOf<OperationCanceledException>());
-        connection.HoldOperation = MultiplexedTransportOperation.None; // Release dispose
+        clientConnection.HoldOperation = MultiplexedTransportOperation.None; // Release dispose
         await disposeTask;
     }
 }

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -265,20 +265,20 @@ public class ServerTests
         using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
         await clientConnection.InvokeAsync(request);
 
-        TestMultiplexedConnectionDecorator connection = multiplexedServerTransport.LastAcceptedConnection!;
-        connection.HoldOperation = MultiplexedTransportOperation.DisposeAsync;
+        TestMultiplexedConnectionDecorator serverConnection = multiplexedServerTransport.LastAcceptedConnection!;
+        serverConnection.HoldOperation = MultiplexedTransportOperation.DisposeAsync;
 
         // Shutdown the client connection to trigger the background server connection disposal.
-        await server.ShutdownAsync();
+        await clientConnection.ShutdownAsync();
 
         // Act
         ValueTask disposeTask = server.DisposeAsync();
 
         // Assert
-        await connection.DisposeCalled;
+        await serverConnection.DisposeCalled;
         using var cts = new CancellationTokenSource(100);
         Assert.That(() => disposeTask.AsTask().WaitAsync(cts.Token), Throws.InstanceOf<OperationCanceledException>());
-        connection.HoldOperation = MultiplexedTransportOperation.None; // Release dispose
+        serverConnection.HoldOperation = MultiplexedTransportOperation.None; // Release dispose
         await disposeTask;
     }
 }

--- a/tests/IceRpc.Tests/TestMultiplexedTransportDecorator.cs
+++ b/tests/IceRpc.Tests/TestMultiplexedTransportDecorator.cs
@@ -230,7 +230,7 @@ public sealed class TestMultiplexedConnectionDecorator : IMultiplexedConnection
                 _holdCloseTcs.TrySetResult();
             }
 
-            if (_holdOperation.HasFlag(MultiplexedTransportOperation.Close))
+            if (_holdOperation.HasFlag(MultiplexedTransportOperation.DisposeAsync))
             {
                 _holdDisposeTcs = new();
             }


### PR DESCRIPTION
This PR fixes the connection cache `Dispose_waits_for_background_connection_dispose` test. It also aligns the same test for `Server` on this one. It's simpler and doesn't check for all kinds of things.