### PR TITLE
Wait for dispatch completion before disposing transport connection with `icerpc`

### DIFF
--- a/tests/IceRpc.Tests/ProtocolLoggerTests.cs
+++ b/tests/IceRpc.Tests/ProtocolLoggerTests.cs
@@ -189,7 +189,8 @@ public sealed class ProtocolLoggerTests
         Assert.That(
             entry.State["RemoteNetworkAddress"],
             Is.EqualTo(clientConnectionInformation.RemoteNetworkAddress));
-        Assert.That(entry.Exception, Is.InstanceOf<IceRpcException>());
+
+        Assert.That(entry.Exception, Is.InstanceOf<ObjectDisposedException>());
     }
 
     [Test]


### PR DESCRIPTION
This PR updates IceRpcProtocolConnection as follows:

- DisposeAsync waits for dispatches to complete before disposing its transport connection; this way, a dispatch task can't fail with OperationAborted
- DisposeAsync sets the Closed exception to ObjectDisposedException and not IceRpcException(OperationAborted)

For invocations, it's not practical and also pointless to try to "wait for invocations to complete" before disposing the transport connection. An InvokeAsync should naturally throw IceRpcException(OperationAborted) when the protocol connection is disposed while it's running.