### PR TITLE
(ice) don't dispatch when cancellation token is canceled

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -953,6 +953,10 @@ internal sealed class IceProtocolConnection : IProtocolConnection
             // The dispatcher can complete the incoming request payload to release its memory as soon as possible.
             try
             {
+                // _dispatcher.DispatchAsync may very well ignore the cancellation token and we don't want to keep
+                // dispatching when the cancellation token is canceled.
+                cancellationToken.ThrowIfCancellationRequested();
+
                 response = await _dispatcher.DispatchAsync(request, cancellationToken).ConfigureAwait(false);
             }
             finally


### PR DESCRIPTION
This tiny PR makes sure we stop dispatching requests when the dispatch cancellation token is canceled.

Note: shortly because this code executes we check _shutdownTask: as soon as shutdown starts, we no longer dispatch anything.

This check is for the situation where _twowayDispatchesCts is canceled but we're not shutting down, e.g. we've failed to write to the connection but we're not shutdown or disposed yet.