### PR TITLE
Write outgoing ice request in the background upon invocation cancellation

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -1640,6 +1640,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
         // _writeTask is protected by the write semaphore
         _writeTask = PerformSendControlFrameAsync(semaphoreLock); // does not throw synchronously
 
+        // _writeTask owns the write semaphore
         await _writeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         // PerformSendControlFrameAsync keeps running in the background when cancellation token is canceled and possibly


### PR DESCRIPTION
This PR ensures that invocation cancellation, shutdown cancellation etc. does not cancel writes to the duplex connection writer. Upon cancellation, the write keeps going in the background and will release the semaphore when done.

Fixes #2472.

This PR also converts a bunch of static local functions into private static method for readability. The contents of these methods was not changed at all.

TODO: add  tests!