### PR TITLE
Use DisposeAsync for wait for timer callbacks to finish

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -287,8 +287,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
             _duplexConnection.Dispose();
 
             // It's safe to dispose the reader/writer since no more threads are sending/receiving data.
-            _duplexConnectionReader.Dispose();
-            _duplexConnectionWriter.Dispose();
+            await _duplexConnectionReader.DisposeAsync().ConfigureAwait(false);
+            await _duplexConnectionWriter.DisposeAsync().ConfigureAwait(false);
 
             _disposedCts.Dispose();
             _readFramesCts.Dispose();

--- a/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
+++ b/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
@@ -9,7 +9,7 @@ namespace IceRpc.Transports.Internal;
 
 /// <summary>A helper class to efficiently read data from a duplex connection. It provides a PipeReader-like API but is
 /// not a PipeReader.</summary>
-internal class DuplexConnectionReader : IDisposable
+internal class DuplexConnectionReader : IAsyncDisposable
 {
     private readonly IDuplexConnection _connection;
     private TimeSpan _idleTimeout = Timeout.InfiniteTimeSpan;
@@ -18,11 +18,11 @@ internal class DuplexConnectionReader : IDisposable
     private TimeSpan _nextIdleTime;
     private readonly Pipe _pipe;
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         _pipe.Writer.Complete();
         _pipe.Reader.Complete();
-        _idleTimeoutTimer.Dispose();
+        await _idleTimeoutTimer.DisposeAsync().ConfigureAwait(false);
     }
 
     internal DuplexConnectionReader(

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -435,8 +435,8 @@ internal class SlicConnection : IMultiplexedConnection
             }
 
             _duplexConnection.Dispose();
-            _duplexConnectionReader.Dispose();
-            _duplexConnectionWriter.Dispose();
+            await _duplexConnectionReader.DisposeAsync().ConfigureAwait(false);
+            await _duplexConnectionWriter.DisposeAsync().ConfigureAwait(false);
 
             _disposedCts.Dispose();
             _writeSemaphore.Dispose();

--- a/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
+++ b/tests/IceRpc.Tests/Transports/DuplexConnectionReaderTests.cs
@@ -33,7 +33,7 @@ public class DuplexConnectionReaderTests
         await Task.WhenAll(clientConnectTask, serverConnectTask);
 
         var tcs = new TaskCompletionSource<TimeSpan>();
-        using var reader = new DuplexConnectionReader(
+        await using var reader = new DuplexConnectionReader(
             clientConnection,
             MemoryPool<byte>.Shared,
             4096,
@@ -66,7 +66,7 @@ public class DuplexConnectionReaderTests
         await Task.WhenAll(clientConnectTask, serverConnectTask);
 
         var tcs = new TaskCompletionSource<TimeSpan>();
-        using var reader = new DuplexConnectionReader(
+        await using var reader = new DuplexConnectionReader(
             clientConnection,
             MemoryPool<byte>.Shared,
             4096,

--- a/tests/IceRpc.Tests/Transports/DuplexConnectionWriterTests.cs
+++ b/tests/IceRpc.Tests/Transports/DuplexConnectionWriterTests.cs
@@ -33,7 +33,7 @@ public class DuplexConnectionWriterTests
         await Task.WhenAll(clientConnectTask, serverConnectTask);
 
         int pingCount = 0;
-        using var writer = new DuplexConnectionWriter(
+        await using var writer = new DuplexConnectionWriter(
             clientConnection,
             MemoryPool<byte>.Shared,
             4096,

--- a/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
@@ -119,12 +119,12 @@ public class SlicTransportTests
             clientAuthenticationOptions: null);
         await duplexClientConnection.ConnectAsync(default);
 
-        using var writer = new DuplexConnectionWriter(
+        await using var writer = new DuplexConnectionWriter(
             duplexClientConnection,
             MemoryPool<byte>.Shared,
             4096,
             keepAliveAction: null);
-        using var reader = new DuplexConnectionReader(
+        await using var reader = new DuplexConnectionReader(
             duplexClientConnection,
             MemoryPool<byte>.Shared,
             4096,


### PR DESCRIPTION
This PR makes duplex connection reader & writer async disposable, to async dispose timers and ensures we wait for timer callbacks to finish.

see #2540