### PR TITLE
Assign _nextIdleTime before changing the timer

### DIFF
--- a/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
+++ b/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
@@ -81,8 +81,8 @@ internal class DuplexConnectionReader : IAsyncDisposable
             }
             else
             {
-                // Update _nextIdleTime before changing the timer, the idle action is considered
-                // postponed when _nextIdleTime is greater than the current time.
+                // Update _nextIdleTime before changing the timer, the idle action is considered postponed when
+                // _nextIdleTime is greater than the current time.
                 _nextIdleTime = TimeSpan.FromMilliseconds(Environment.TickCount64) + idleTimeout;
                 _idleTimeoutTimer.Change(idleTimeout, Timeout.InfiniteTimeSpan);
             }
@@ -204,8 +204,8 @@ internal class DuplexConnectionReader : IAsyncDisposable
             }
             else
             {
-                // Update _nextIdleTime before changing the timer, the idle action is considered
-                // postponed when _nextIdleTime is greater than the current time.
+                // Update _nextIdleTime before changing the timer, the idle action is considered postponed when
+                // _nextIdleTime is greater than the current time.
                 _nextIdleTime = TimeSpan.FromMilliseconds(Environment.TickCount64) + _idleTimeout;
                 _idleTimeoutTimer.Change(_idleTimeout, Timeout.InfiniteTimeSpan);
             }


### PR DESCRIPTION
Fix #2575

I was not able to reproduce the failure, but I think the problem was that we assign _nextIdleTime after changing the timer, with this setup there is a chance that the callback is not called.

https://github.com/zeroc-ice/icerpc-csharp/blob/05f4051eec5f73a0158570878f2d3c0b365482d2/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs#L48-L53

