### PR TITLE
Fixed Slic to close the connection on duplex transport idle timeout

### DIFF
--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -534,8 +534,10 @@ internal class SlicConnection : IMultiplexedConnection
             duplexConnection,
             options.Pool,
             options.MinSegmentSize,
-            connectionIdleAction: () => _acceptStreamChannel.Writer.TryComplete(
-                new IceRpcException(IceRpcError.ConnectionIdle)));
+            connectionIdleAction: () =>
+                Close(
+                    new IceRpcException(IceRpcError.ConnectionIdle),
+                    "The Slic connection was aborted because it did not receive any byte for too long."));
 
         // Initially set the peer packet max size to the local max size to ensure we can receive the first
         // initialize frame.


### PR DESCRIPTION
This PR fixes Slic to close the connection if the underlying duplex connection is idle (which indicates a connection issue). Previously, only `AcceptStreamAsync` was failing under this condition and as a result it didn't abort the connection if `AcceptStreamAsync` wasn't called.