### PR TITLE
Use ObjectDisposedException.ThrowIf when possible

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocConnection.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocConnection.cs
@@ -25,10 +25,8 @@ internal abstract class ColocConnection : IDuplexConnection
 
     public async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
     {
-        if (_state.HasFlag(State.Disposed))
-        {
-            throw new ObjectDisposedException($"{typeof(ColocConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_state.HasFlag(State.Disposed), this);
+
         if (_reader is null)
         {
             throw new InvalidOperationException("Reading is not allowed before connection is connected.");
@@ -99,10 +97,8 @@ internal abstract class ColocConnection : IDuplexConnection
 
     public Task ShutdownAsync(CancellationToken cancellationToken)
     {
-        if (_state.HasFlag(State.Disposed))
-        {
-            throw new ObjectDisposedException($"{typeof(ColocConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_state.HasFlag(State.Disposed), this);
+
         if (_reader is null)
         {
             throw new InvalidOperationException("Shutdown is not allowed before the connection is connected.");
@@ -122,10 +118,8 @@ internal abstract class ColocConnection : IDuplexConnection
 
     public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancellationToken)
     {
-        if (_state.HasFlag(State.Disposed))
-        {
-            throw new ObjectDisposedException($"{typeof(ColocConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_state.HasFlag(State.Disposed), this);
+
         if (_reader is null)
         {
             throw new InvalidOperationException("Writing is not allowed before the connection is connected.");
@@ -227,10 +221,8 @@ internal class ClientColocConnection : ColocConnection
 
     public override async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken)
     {
-        if (_state.HasFlag(State.Disposed))
-        {
-            throw new ObjectDisposedException($"{typeof(ColocConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_state.HasFlag(State.Disposed), this);
+
         if (_reader is not null)
         {
             throw new InvalidOperationException("Connection establishment cannot be called twice.");

--- a/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
@@ -26,10 +26,7 @@ internal class ColocListener : IListener<IDuplexConnection>
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
-        if (_disposeCts.IsCancellationRequested)
-        {
-            throw new ObjectDisposedException(nameof(ColocListener));
-        }
+        ObjectDisposedException.ThrowIf(_disposeCts.IsCancellationRequested, this);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
         try

--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -142,10 +142,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
         IProtocolConnection connection;
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(ClientConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_isShutdown)
             {
                 throw new InvalidOperationException("Cannot connect a client connection after shutting it down.");
@@ -214,10 +212,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
         IProtocolConnection connection;
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(ClientConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_isShutdown)
             {
                 throw new IceRpcException(IceRpcError.InvocationRefused, "The client connection is shut down.");
@@ -295,10 +291,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
 
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(ClientConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_isShutdown)
             {
                 throw new InvalidOperationException("The client connection is already shut down or shutting down.");
@@ -514,10 +508,9 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
                 // tries again with a refreshed connection.
                 // Note: this works fine because ClientConnection does not use ObjectDisposedException to mean "there is
                 // no need to dispose this connection".
-                if (_isDisposed || (_connectTask is not null && (_connectTask.IsFaulted || _connectTask.IsCanceled)))
-                {
-                    throw new ObjectDisposedException($"{typeof(ConnectProtocolConnectionDecorator)}");
-                }
+                ObjectDisposedException.ThrowIf(
+                    _isDisposed || (_connectTask is not null && (_connectTask.IsFaulted || _connectTask.IsCanceled)),
+                    this);
 
                 if (_connectTask is null)
                 {

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -172,10 +172,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
 
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(ConnectionCache)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new IceRpcException(IceRpcError.InvocationRefused, "The connection cache is shut down.");
@@ -325,10 +323,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(ConnectionCache)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new InvalidOperationException("The connection cache is already shut down or shutting down.");

--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -46,10 +46,7 @@ public sealed class IncomingRequest : IncomingFrame, IDisposable
         get => _response;
         set
         {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(IncomingRequest));
-            }
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
 
             _response?.Payload.Complete();
             _response?.PayloadContinuation?.Complete();

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -85,10 +85,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is not null)
             {
                 throw new InvalidOperationException("Cannot call connect more than once.");
@@ -318,10 +316,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
 
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceRpcProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_refuseInvocations)
             {
                 throw new IceRpcException(IceRpcError.InvocationRefused, _invocationRefusedMessage);
@@ -544,10 +540,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new InvalidOperationException("Cannot call ShutdownAsync more than once.");

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -92,10 +92,8 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceRpcProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is not null)
             {
                 throw new InvalidOperationException("Cannot call connect more than once.");
@@ -330,10 +328,8 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
         CancellationToken shutdownCancellationToken;
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceRpcProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_refuseInvocations)
             {
                 throw new IceRpcException(IceRpcError.InvocationRefused, _invocationRefusedMessage);
@@ -637,10 +633,8 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(IceRpcProtocolConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new InvalidOperationException("Cannot call ShutdownAsync more than once.");

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -34,10 +34,7 @@ public sealed class OutgoingRequest : OutgoingFrame, IDisposable
         get => _response;
         set
         {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(OutgoingRequest));
-            }
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
 
             _response?.Dispose();
             _response = value;

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -286,10 +286,8 @@ public sealed class Server : IAsyncDisposable
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(Server)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new InvalidOperationException($"Server '{this}' is shut down or shutting down.");
@@ -542,10 +540,8 @@ public sealed class Server : IAsyncDisposable
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(Server)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_shutdownTask is not null)
             {
                 throw new InvalidOperationException($"Server '{this}' is shut down or shutting down.");

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -72,10 +72,8 @@ internal class SlicConnection : IMultiplexedConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(SlicConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is null || !_connectTask.IsCompleted)
             {
                 throw new InvalidOperationException("Cannot accept stream before connecting the Slic connection.");
@@ -104,10 +102,8 @@ internal class SlicConnection : IMultiplexedConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(SlicConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is not null)
             {
                 throw new InvalidOperationException("Cannot connect twice a Slic connection.");
@@ -313,10 +309,8 @@ internal class SlicConnection : IMultiplexedConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(SlicConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is null || !_connectTask.IsCompleted)
             {
                 throw new InvalidOperationException("Cannot close a Slic connection before connecting it.");
@@ -369,10 +363,8 @@ internal class SlicConnection : IMultiplexedConnection
     {
         lock (_mutex)
         {
-            if (_disposeTask is not null)
-            {
-                throw new ObjectDisposedException($"{typeof(SlicConnection)}");
-            }
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+
             if (_connectTask is null || !_connectTask.IsCompleted)
             {
                 throw new InvalidOperationException("Cannot create stream before connecting the Slic connection.");

--- a/src/IceRpc/Transports/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpConnection.cs
@@ -52,10 +52,8 @@ internal abstract class TcpConnection : IDuplexConnection
 
     public async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
     {
-        if (_isDisposed)
-        {
-            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
         if (buffer.Length == 0)
         {
             throw new ArgumentException($"The {nameof(buffer)} cannot be empty.", nameof(buffer));
@@ -113,10 +111,7 @@ internal abstract class TcpConnection : IDuplexConnection
 
     public async ValueTask WriteAsync(IReadOnlyList<ReadOnlyMemory<byte>> buffers, CancellationToken cancellationToken)
     {
-        if (_isDisposed)
-        {
-            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         Debug.Assert(buffers.Count > 0);
 
@@ -239,10 +234,7 @@ internal class TcpClientConnection : TcpConnection
 
     public override async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken)
     {
-        if (_isDisposed)
-        {
-            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         try
         {
@@ -341,10 +333,7 @@ internal class TcpServerConnection : TcpConnection
 
     public override async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken)
     {
-        if (_isDisposed)
-        {
-            throw new ObjectDisposedException($"{typeof(TcpConnection)}");
-        }
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         try
         {


### PR DESCRIPTION
This is a small cleanup to prefer using `ObjectDisposedException.ThrowIf` when throwing ODE