### PR TITLE
Fix UTE in TcpConnection.WriteAsync

### DIFF
--- a/src/IceRpc/Transports/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Internal/TcpConnection.cs
@@ -183,7 +183,6 @@ internal abstract class TcpConnection : IDuplexConnection
                         }
                     }
 
-                    // We ignore the number of bytes actually sent.
                     Task sendTask = Socket.SendAsync(_segments, SocketFlags.None);
 
                     try
@@ -201,7 +200,7 @@ internal abstract class TcpConnection : IDuplexConnection
                         }
                         catch
                         {
-                            // expected, most likely a OperationAborted
+                            // expected, most likely OperationAborted
                         }
                         throw;
                     }


### PR DESCRIPTION
This PR fixes a UTE in TpcConnection.WriteAsync.

Upon cancellation, we no longer let a "send task" continue (and typically fail) in the background.

Related to proposal 1 in #2590.