### PR TITLE
Cleanup RunContinuationsAsynchronously usage

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocListener.cs
@@ -119,6 +119,8 @@ internal class ColocListener : IListener<IDuplexConnection>
     {
         // Create a tcs that is completed by AcceptAsync when accepts the corresponding connection, at which point
         // the client side connect operation will complete.
+        // We use RunContinuationsAsynchronously to avoid the ConnectAsync continuation end up running in the AcceptAsync
+        // loop that completes this tcs.
         var tcs = new TaskCompletionSource<PipeReader>(TaskCreationOptions.RunContinuationsAsynchronously);
         if (_channel.Writer.TryWrite((tcs, clientPipeReader)))
         {

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -27,8 +27,7 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     // _pendingConnections.
     private int _detachedConnectionCount;
 
-    private readonly TaskCompletionSource _detachedConnectionsTcs =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _detachedConnectionsTcs = new();
 
     // A cancellation token source that is canceled when DisposeAsync is called.
     private readonly CancellationTokenSource _disposedCts = new();

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -29,6 +29,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
     private Task? _connectTask;
     private readonly IDispatcher _dispatcher;
     private int _dispatchCount;
+    // We don't want the continuation to run from the dispatch or invocation thread.
     private readonly TaskCompletionSource _dispatchesAndInvocationsCompleted =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -27,8 +27,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
     private IMultiplexedStream? _controlStream;
     private int _dispatchCount;
     private readonly IDispatcher? _dispatcher;
-    private readonly TaskCompletionSource _dispatchesCompleted =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _dispatchesCompleted = new();
 
     private readonly SemaphoreSlim? _dispatchSemaphore;
 
@@ -76,7 +75,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
     private Task? _shutdownTask;
 
     private int _streamCount;
-    private readonly TaskCompletionSource _streamsClosed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _streamsClosed = new();
 
     private readonly IMultiplexedConnection _transportConnection;
 

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -25,8 +25,7 @@ public sealed class Server : IAsyncDisposable
     // in _connections.
     private int _detachedConnectionCount;
 
-    private readonly TaskCompletionSource _detachedConnectionsTcs =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _detachedConnectionsTcs = new();
 
     // A cancellation token source that is canceled by DisposeAsync.
     private readonly CancellationTokenSource _disposedCts = new();


### PR DESCRIPTION
This PR cleanups RunContinuationsAsynchronously usage, I didn't change its usage in SlicStream because it is not clear to me why it is needed there.