### PR TITLE
Fixes Quic and Slic errors, #2620

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
@@ -32,6 +32,7 @@ internal static class QuicExceptionExtensions
                     new IceRpcException(IceRpcError.ConnectionAborted, exception), // TODO: does this ever happen?
             QuicError.ConnectionRefused => new IceRpcException(IceRpcError.ConnectionRefused, exception),
             QuicError.ConnectionTimeout => new IceRpcException(IceRpcError.ConnectionAborted, exception),
+            QuicError.HostUnreachable => new IceRpcException(IceRpcError.ServerUnreachable, exception),
             QuicError.OperationAborted => new IceRpcException(IceRpcError.OperationAborted, exception),
             QuicError.StreamAborted => new IceRpcException(IceRpcError.TruncatedData, exception),
 

--- a/src/IceRpc/IceRpcError.cs
+++ b/src/IceRpc/IceRpcError.cs
@@ -48,6 +48,9 @@ public enum IceRpcError
     /// </summary>
     ServerBusy,
 
+    /// <summary>The server is unreachable.</summary>
+    ServerUnreachable,
+
     /// <summary>The reading of a transport stream completed with incomplete data.</summary>
     TruncatedData,
 }

--- a/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
+++ b/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
@@ -255,9 +255,9 @@ internal class DuplexConnectionReader : IAsyncDisposable
                     }
                     else
                     {
-                        // The peer gracefully shut down the connection but returned less data than expected, it's
-                        // considered as an error.
-                        throw new InvalidDataException("Received less data than expected.");
+                        // The connection was aborted or the peer gracefully shut down the connection but returned less
+                        // data than expected.
+                        throw new IceRpcException(IceRpcError.ConnectionAborted);
                     }
                 }
             }

--- a/src/IceRpc/Transports/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Internal/SlicConnection.cs
@@ -1345,7 +1345,9 @@ internal class SlicConnection : IMultiplexedConnection
                     }
                     else
                     {
-                        throw new IceRpcException(IceRpcError.TruncatedData);
+                        // The duplex transport ReadAsync call returned an empty buffer. This indicates a peer
+                        // connection abort.
+                        throw new IceRpcException(IceRpcError.ConnectionAborted);
                     }
                 }
             }

--- a/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SocketExceptionExtensions.cs
@@ -18,6 +18,8 @@ internal static class SocketExceptionExtensions
             // non-gracefully the connection. EPIPE is returned if the socket is closed and the send buffer is empty
             // while ECONNRESET is returned if the send buffer is not empty.
             SocketError.ConnectionReset => IceRpcError.ConnectionAborted,
+            SocketError.HostUnreachable => IceRpcError.ServerUnreachable,
+            SocketError.NetworkUnreachable => IceRpcError.ServerUnreachable,
             SocketError.Shutdown => IceRpcError.ConnectionAborted,
             SocketError.ConnectionRefused => IceRpcError.ConnectionRefused,
             SocketError.OperationAborted => IceRpcError.OperationAborted,


### PR DESCRIPTION
This PR fixes #2620 by adding the `ServerUnreachable` error code. For `ConnectionRefused`, I kept the native transport mapping as is.