### PR TITLE
Fix Invoke_cancellation_on_duplex_transport_hang

### DIFF
--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -289,7 +289,9 @@ public sealed class IceProtocolConnectionTests
     public async Task Invoke_cancellation_on_duplex_transport_hang([Values] bool oneway)
     {
         // Arrange
-        using var dispatcher = new TestDispatcher(holdDispatchCount: 1);
+
+        // Make sure the dispatcher does not return the response immediately when oneway is false.
+        using var dispatcher = new TestDispatcher(holdDispatchCount: oneway ? 0 : 1);
         await using ServiceProvider provider = new ServiceCollection()
             .AddProtocolTest(Protocol.Ice, dispatcher)
             .AddTestDuplexTransport(clientHoldOperation: DuplexTransportOperation.Write)


### PR DESCRIPTION
A fix for #2643

I think the test fails on Linux because we can get the response fast enough and response tcs is completed by the time we call WaitAsync

https://github.com/zeroc-ice/icerpc-csharp/blob/1f56a78b069f56ea3616747025e2b1cdc4ce2d13/src/IceRpc/Internal/IceProtocolConnection.cs#L401-L425