### PR TITLE
Add Enumerator Attribute Validation

### DIFF
--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -253,4 +253,11 @@ impl Visitor for CsValidator<'_> {
             }
         }
     }
+
+    fn visit_enumerator(&mut self, enumerator: &Enumerator) {
+        validate_repeated_attributes(enumerator, self.diagnostic_reporter);
+        for (attribute, span) in &cs_attributes(&enumerator.attributes(false)) {
+            validate_common_attributes(attribute, span, self.diagnostic_reporter)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds validation for attributes on enumerators to the cs_validator.
If there's a reason we don't have this (like we're performing this somewhere else) let me know and I'll close this.
But I imagine this is just a case that we missed.