### PR TITLE
Fixed icerpc test to depend on the multiplexed test transport

### DIFF
--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -1202,15 +1202,15 @@ public sealed class IceRpcProtocolConnectionTests
 
         await using ServiceProvider provider = new ServiceCollection()
             .AddProtocolTest(Protocol.IceRpc)
-            .AddTestDuplexTransport()
+            .AddTestMultiplexedTransport()
             .BuildServiceProvider(validateScopes: true);
 
-        var serverTransport = provider.GetRequiredService<TestDuplexServerTransportDecorator>();
+        var serverTransport = provider.GetRequiredService<TestMultiplexedServerTransportDecorator>();
 
         ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
         (_, Task serverShutdownRequested) = await sut.ConnectAsync();
-        // Hold server reads after the connection is established to prevent shutdown to proceed.
-        serverTransport.LastAcceptedConnection.HoldOperation = DuplexTransportOperation.Read;
+        // Hold the remote control stream reads after the connection is established to prevent shutdown to proceed.
+        serverTransport.LastAcceptedConnection.LastStream.HoldOperation = MultiplexedTransportOperation.StreamRead;
         _ = sut.Server.ShutdownWhenRequestedAsync(serverShutdownRequested);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));


### PR DESCRIPTION
This PR fixes an icerpc test to depend on the multiplexed test transport instead of the duplex test transport. This is mostly useful when running the protocol tests with Quic.