### PR TITLE
Simplified dispatch cancellation on writes closed

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -986,14 +986,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
 
             async Task CancelDispatchOnWritesClosedAsync()
             {
-                try
-                {
-                    await stream.WritesClosed.WaitAsync(dispatchCts.Token).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // ignored.
-                }
+                await stream.WritesClosed.ConfigureAwait(false);
                 dispatchCts.Cancel();
             }
         }
@@ -1099,7 +1092,6 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
         {
             if (cancelDispatchOnWritesClosedTask is not null)
             {
-                dispatchCts.Cancel();
                 await cancelDispatchOnWritesClosedTask.ConfigureAwait(false);
             }
 


### PR DESCRIPTION
This PR simplifies the dispatch cancellation on stream writes closed. This simplification also allows to workaround the Quic bug and failure from #2694.