### PR TITLE
Small reshuffling of the dispatch implementation

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1061,13 +1061,11 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
 
             try
             {
-                OutgoingResponse response = await PerformDispatchRequestAsync(
-                    request,
-                    dispatchCts.Token).ConfigureAwait(false);
+                OutgoingResponse response = await PerformDispatchRequestAsync(request, dispatchCts.Token)
+                    .ConfigureAwait(false);
 
                 if (!request.IsOneway)
                 {
-                    // Send the response.
                     Debug.Assert(streamOutput is not null);
                     EncodeHeader(response);
 


### PR DESCRIPTION
This PR updates the icerpc dispatch implementation. In the existing code, we have a the local function `PerformDispatchRequestAsync` that uses both its cancellationToken parameter and the _dispatchCts.Token... and this looks odd to me.

A side effect of this PR is if an oneway dispatch fails, we now create a response and then ignore this response. It's an un-optimization. I don't think it's a big deal since oneway dispatch should rarely fails and creating a failure response from an exception is not that expensive.