### PR TITLE
Fixes #2747

### DIFF
--- a/src/IceRpc/Slice/PipeReaderExtensions.cs
+++ b/src/IceRpc/Slice/PipeReaderExtensions.cs
@@ -2,7 +2,9 @@
 
 using IceRpc.Slice.Internal;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 
 namespace IceRpc.Slice;
 
@@ -114,5 +116,86 @@ public static class PipeReaderExtensions
 
         ValueTask<ReadResult> ReadAsync(PipeReader reader, CancellationToken cancellationToken) =>
             reader.ReadSegmentAsync(encoding, sliceFeature.MaxSegmentSize, cancellationToken);
+    }
+
+    /// <summary>Decodes an async enumerable from a pipe reader.</summary>
+    /// <param name="reader">The pipe reader.</param>
+    /// <param name="readFunc">The function used to read enough data to decode elements returned by the
+    /// enumerable.</param>
+    /// <param name="decodeBufferFunc">The function used to decode an element.</param>
+    /// <param name="cancellationToken">The cancellation token which is provided to <see
+    /// cref="IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)" />.</param>
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(
+        this PipeReader reader,
+        Func<PipeReader, CancellationToken, ValueTask<ReadResult>> readFunc,
+        Func<ReadOnlySequence<byte>, IEnumerable<T>> decodeBufferFunc,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            ReadResult readResult;
+
+            try
+            {
+                readResult = await readFunc(reader, cancellationToken).ConfigureAwait(false);
+
+                if (readResult.IsCanceled)
+                {
+                    // We never call CancelPendingRead; an interceptor or middleware can but it's not correct.
+                    throw new InvalidOperationException("Unexpected call to CancelPendingRead.");
+                }
+                if (readResult.Buffer.IsEmpty)
+                {
+                    Debug.Assert(readResult.IsCompleted);
+                    reader.Complete();
+                    yield break;
+                }
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
+            {
+                // Canceling the cancellation token is a normal way to complete an iteration.
+                reader.Complete();
+                yield break;
+            }
+            catch
+            {
+                reader.Complete();
+                throw;
+            }
+
+            IEnumerable<T> items;
+
+            try
+            {
+                items = decodeBufferFunc(readResult.Buffer);
+                reader.AdvanceTo(readResult.Buffer.End);
+            }
+            catch
+            {
+                reader.Complete();
+                throw;
+            }
+
+            if (readResult.IsCompleted)
+            {
+                reader.Complete();
+            }
+
+            foreach (T item in items)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    reader.Complete();
+                    yield break;
+                }
+                yield return item;
+            }
+
+            if (readResult.IsCompleted)
+            {
+                // The corresponding payload.Complete is just before the foreach
+                yield break;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR moves `ToAsyncEnumerable` pipe reader extension to the right class, fixes #2747.