### PR TITLE
Fixed UTE caused by non-disposed connection, fixes #2757

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
@@ -31,7 +31,7 @@ public abstract class MultiplexedListenerConformanceTests
         await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
         IListener<IMultiplexedConnection> listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
         var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
-        var clientConnection = clientTransport.CreateConnection(
+        await using var clientConnection = clientTransport.CreateConnection(
             listener.ServerAddress,
             provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
             provider.GetService<SslClientAuthenticationOptions>());


### PR DESCRIPTION
This PR fixes #2757 by adding a missing dispose for a Slic connection.