### PR TITLE
Added custom assert message for transport `IceRpcError` tests

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs
@@ -103,11 +103,15 @@ public abstract class DuplexConnectionConformanceTests
         {
             Assert.That(
                 exception?.IceRpcError,
-                Is.Null.Or.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError));
+                Is.Null.Or.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError),
+                $"The test failed with an unexpected IceRpcError {exception}");
         }
         else
         {
-            Assert.That(exception?.IceRpcError, Is.Null.Or.EqualTo(IceRpcError.ConnectionAborted));
+            Assert.That(
+                exception?.IceRpcError,
+                Is.Null.Or.EqualTo(IceRpcError.ConnectionAborted),
+                $"The test failed with an unexpected IceRpcError {exception}");
         }
     }
 
@@ -232,7 +236,10 @@ public abstract class DuplexConnectionConformanceTests
         // Act/Assert
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
             async () => await readFrom.ReadAsync(new byte[1], default));
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -427,7 +434,10 @@ public abstract class DuplexConnectionConformanceTests
             exception = ex;
         }
 
-        Assert.That(exception.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     /// <summary>Creates the service collection used for the duplex transport conformance tests.</summary>

--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexListenerConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexListenerConformanceTests.cs
@@ -72,7 +72,10 @@ public abstract class DuplexListenerConformanceTests
 
         // Assert
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptTask);
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.OperationAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -141,7 +144,8 @@ public abstract class DuplexListenerConformanceTests
         // otherwise it fails with ConnectionRefused.
         Assert.That(
             exception!.IceRpcError,
-            Is.EqualTo(IceRpcError.ConnectionRefused).Or.EqualTo(IceRpcError.ConnectionAborted));
+            Is.EqualTo(IceRpcError.ConnectionRefused).Or.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
         clientConnection.Dispose();
     }
 
@@ -156,7 +160,10 @@ public abstract class DuplexListenerConformanceTests
         // Act/Assert
         IceRpcException? exception = Assert.Throws<IceRpcException>(
             () => serverTransport.Listen(listener.ServerAddress, new DuplexConnectionOptions(), null));
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.AddressInUse));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.AddressInUse),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]

--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportSslAuthenticationConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexTransportSslAuthenticationConformanceTests.cs
@@ -42,14 +42,17 @@ public abstract class DuplexTransportSslAuthenticationConformanceTests
         Assert.That(async () => await clientConnectTask, Throws.TypeOf<AuthenticationException>());
 
         // The client will typically close the transport connection after receiving AuthenticationException
-        var ex = Assert.ThrowsAsync<IceRpcException>(
+        var exception = Assert.ThrowsAsync<IceRpcException>(
             async () =>
             {
                 sut.Client.Dispose();
                 await serverConnectTask;
                 await sut.Server.ReadAsync(new byte[1], CancellationToken.None);
             });
-        Assert.That(ex!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -196,9 +196,12 @@ public abstract class MultiplexedConnectionConformanceTests
         await Task.Delay(TimeSpan.FromMilliseconds(50));
         Assert.That(createStreamTask.IsCompleted, Is.False);
         await sut.Client.CloseAsync(MultiplexedConnectionCloseError.NoError, default);
+
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await createStreamTask);
         Assert.That(
-            async () => await createStreamTask,
-            Throws.TypeOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.OperationAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     /// <summary>Verify streams cannot be created after closing down the connection.</summary>
@@ -268,7 +271,10 @@ public abstract class MultiplexedConnectionConformanceTests
                 }
             });
 
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -375,12 +381,18 @@ public abstract class MultiplexedConnectionConformanceTests
         await sut.Client.CloseAsync(MultiplexedConnectionCloseError.NoError, default);
 
         // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await streams.Local.Output.WriteAsync(_oneBytePayload));
         Assert.That(
-            async () => await streams.Local.Output.WriteAsync(_oneBytePayload),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
+
+        exception = Assert.ThrowsAsync<IceRpcException>(async () => await streams.Local.Input.ReadAsync());
         Assert.That(
-            async () => await streams.Local.Input.ReadAsync(),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -399,15 +411,24 @@ public abstract class MultiplexedConnectionConformanceTests
         Assert.That(
             async () => await sut.Client.CreateStreamAsync(true, default),
             Throws.InstanceOf<ObjectDisposedException>());
+
         Assert.That(
             async () => await sut.Client.AcceptStreamAsync(default),
             Throws.InstanceOf<ObjectDisposedException>());
+
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await streams.Local.Output.WriteAsync(_oneBytePayload));
         Assert.That(
-            async () => await streams.Local.Output.WriteAsync(_oneBytePayload),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
+
+        exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await streams.Local.Input.ReadAsync());
         Assert.That(
-            async () => await streams.Local.Input.ReadAsync(),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -431,15 +452,23 @@ public abstract class MultiplexedConnectionConformanceTests
 
         // Assert
 
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
         Assert.That(
-            async () => await acceptStreamTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.OperationAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
+
+        exception = Assert.ThrowsAsync<IceRpcException>(async () => await createStreamTask);
         Assert.That(
-            async () => await createStreamTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.OperationAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
+
+        exception = Assert.ThrowsAsync<IceRpcException>(async () => await readTask);
         Assert.That(
-            async () => await readTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.OperationAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -454,9 +483,12 @@ public abstract class MultiplexedConnectionConformanceTests
         await sut.Client.DisposeAsync();
 
         // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await sut.Server.AcceptStreamAsync(default));
         Assert.That(
-            async () => _ = await sut.Server.AcceptStreamAsync(default),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -721,9 +753,8 @@ public abstract class MultiplexedConnectionConformanceTests
         await sut.Server.CloseAsync(closeError, CancellationToken.None);
 
         // Assert
-        Assert.That(
-            async () => await acceptStreamTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(expectedIceRpcError));
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+        Assert.That(exception?.IceRpcError, Is.EqualTo(expectedIceRpcError));
     }
 
     /// <summary>Verify streams cannot be created after closing down the connection.</summary>
@@ -756,9 +787,8 @@ public abstract class MultiplexedConnectionConformanceTests
         await sut.Server.CloseAsync(closeError, CancellationToken.None);
 
         // Assert
-        Assert.That(
-            async () => await stream2CreateStreamTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(expectedIceRpcError));
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await stream2CreateStreamTask);
+        Assert.That(exception?.IceRpcError, Is.EqualTo(expectedIceRpcError));
 
         stream1.Input.Complete();
         stream1.Output.Complete();

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
@@ -81,7 +81,10 @@ public abstract class MultiplexedListenerConformanceTests
 
         // Assert
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptTask);
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.OperationAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.OperationAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]
@@ -162,7 +165,8 @@ public abstract class MultiplexedListenerConformanceTests
         // BUGFIX with Quic this throws an internal error https://github.com/dotnet/runtime/issues/78573
         Assert.That(
             exception!.IceRpcError,
-            Is.EqualTo(IceRpcError.AddressInUse).Or.EqualTo(IceRpcError.IceRpcError));
+            Is.EqualTo(IceRpcError.AddressInUse).Or.EqualTo(IceRpcError.IceRpcError),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedStreamConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedStreamConformanceTests.cs
@@ -116,9 +116,8 @@ public abstract class MultiplexedStreamConformanceTests
         await clientServerConnection.Server.CloseAsync(closeError, default);
 
         // Assert
-        Assert.That(
-            async () => await readTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(expectedIceRpcError));
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await readTask);
+        Assert.That(exception?.IceRpcError, Is.EqualTo(expectedIceRpcError));
     }
 
     [Test]
@@ -165,9 +164,12 @@ public abstract class MultiplexedStreamConformanceTests
         await Task.Delay(TimeSpan.FromMilliseconds(50));
 
         // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await sut.Remote.Input.ReadAsync());
         Assert.That(
-            async () => await sut.Remote.Input.ReadAsync(),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.TruncatedData));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.TruncatedData),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     /// <summary>Verifies that we can read and write concurrently to multiple streams.</summary>

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportSslAuthenticationConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedTransportSslAuthenticationConformanceTests.cs
@@ -63,10 +63,11 @@ public abstract class MultiplexedTransportSslAuthenticationConformanceTests
         {
             // The client will typically close the transport connection after receiving AuthenticationException
             await sut.Client.DisposeAsync();
-            var ex = Assert.ThrowsAsync<IceRpcException>(async () => await serverConnectTask!);
+            var exception = Assert.ThrowsAsync<IceRpcException>(async () => await serverConnectTask!);
             Assert.That(
-                ex!.IceRpcError,
-                Is.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError));
+                exception?.IceRpcError,
+                Is.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError),
+                $"The test failed with an unexpected IceRpcError {exception}");
             await serverConnection.DisposeAsync();
         }
     }

--- a/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/SlicTransportTests.cs
@@ -177,9 +177,11 @@ public class SlicTransportTests
         }
 
         // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await connectTask);
         Assert.That(
-            () => connectTask,
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
 
         if (clientConnectTask is not null)
         {
@@ -392,9 +394,12 @@ public class SlicTransportTests
         _ = await stream.Output.WriteAsync(new byte[1], default);
 
         // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await sut.Server.AcceptStreamAsync(default));
         Assert.That(
-            () => sut.Server.AcceptStreamAsync(default),
-            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+            exception?.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     [Test]

--- a/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/TcpTransportTests.cs
@@ -292,7 +292,10 @@ public class TcpTransportTests
         // Act/Assert
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
             async () => await serverConnection.ConnectAsync(default));
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception!.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted),
+            $"The test failed with an unexpected IceRpcError {exception}");
     }
 
     /// <summary>Verifies that the server connect call on a tls connection fails with


### PR DESCRIPTION
This PR adds a custom message with the IceRpcException when an IceRpcError doesn't match the expected error. I changed this only for the transport tests. The goal is to get more information for transport related sporadic failures such as #2579. 

The output of the test failure is:
```
  Échoué IceRpc:Tests:Transports:SslConnectionConformanceTests:Read_from_disposed_peer_connection_fails_with_connection_aborted(False) [352 ms]
  Message d'erreur :
     The test failed with an unexpected IceRpcError IceRpc.IceRpcException: An IceRpc call failed with error 'ConnectionAborted'.
 ---> System.IO.IOException: Unable to read data from the transport connection: Connection reset by peer.
 ---> System.Net.Sockets.SocketException (54): Connection reset by peer
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ReceiveAsync(Socket socket, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.ReceiveAsync(Memory`1 buffer, SocketFlags socketFlags, Boolean fromNetworkStream, CancellationToken cancellationToken)
   at System.Net.Sockets.NetworkStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
   at IceRpc.Transports.Internal.TcpConnection.<>c__DisplayClass12_0.<<ReadAsync>g__PerformReadAsync|0>d.MoveNext() in /Users/benoit/Devel/GitHub/icerpc-csharp/src/IceRpc/Transports/Internal/TcpConnection.cs:line 71
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at IceRpc.Transports.Internal.TcpConnection.<>c__DisplayClass12_0.<ReadAsync>g__PerformReadAsync|0()
   at IceRpc.Transports.Internal.TcpConnection.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken) in /Users/benoit/Devel/GitHub/icerpc-csharp/src/IceRpc/Transports/Internal/TcpConnection.cs:line 64
   at IceRpc.Conformance.Tests.DuplexConnectionConformanceTests.<>c__DisplayClass7_0.<<Read_from_disposed_peer_connection_fails_with_connection_aborted>b__0>d.MoveNext() in /Users/benoit/Devel/GitHub/icerpc-csharp/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs:line 238
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at IceRpc.Conformance.Tests.DuplexConnectionConformanceTests.<>c__DisplayClass7_0.<Read_from_disposed_peer_connection_fails_with_connection_aborted>b__0()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, String message, Object[] args)
   at NUnit.Framework.Assert.ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, String message, Object[] args)
   at NUnit.Framework.Assert.ThrowsAsync[TActual](AsyncTestDelegate code, String message, Object[] args)
   at NUnit.Framework.Assert.ThrowsAsync[TActual](AsyncTestDelegate code)
   at IceRpc.Conformance.Tests.DuplexConnectionConformanceTests.Read_from_disposed_peer_connection_fails_with_connection_aborted(Boolean readFromServer) in /Users/benoit/Devel/GitHub/icerpc-csharp/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs:line 237
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Threading.Tasks.Task.WhenAllPromise`1.Invoke(Task ignored)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at IceRpc.Transports.Internal.TcpClientConnection.ConnectAsyncCore(CancellationToken cancellationToken) in /Users/benoit/Devel/GitHub/icerpc-csharp/src/IceRpc/Transports/Internal/TcpConnection.cs:line 367
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()
   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at System.Net.Security.SslStream.ReceiveBlobAsync[TIOAdapter](CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.MoveNext()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.InvokeContinuation(Action`1 continuation, Object state, Boolean forceAsync, Boolean requiresExecutionContextFlow)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs _)
   at System.Net.Sockets.SocketAsyncEngine.System.Threading.IThreadPoolWorkItem.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
--- End of stack trace from previous location ---

   --- End of inner exception stack trace ---
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
   at IceRpc.Transports.Internal.TcpConnection.<>c__DisplayClass12_0.<<ReadAsync>g__PerformReadAsync|0>d.MoveNext() in /Users/benoit/Devel/GitHub/icerpc-csharp/src/IceRpc/Transports/Internal/TcpConnection.cs:line 71
   --- End of inner exception stack trace ---
   at IceRpc.Transports.Internal.TcpConnection.<>c__DisplayClass12_0.<<ReadAsync>g__PerformReadAsync|0>d.MoveNext() in /Users/benoit/Devel/GitHub/icerpc-csharp/src/IceRpc/Transports/Internal/TcpConnection.cs:line 77
--- End of stack trace from previous location ---
   at IceRpc.Conformance.Tests.DuplexConnectionConformanceTests.<>c__DisplayClass7_0.<<Read_from_disposed_peer_connection_fails_with_connection_aborted>b__0>d.MoveNext() in /Users/benoit/Devel/GitHub/icerpc-csharp/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs:line 238
--- End of stack trace from previous location ---
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, String message, Object[] args)
  Expected: IceRpcError
  But was:  ConnectionAborted
```