### PR TITLE
Fixed protocol logging levels

### DIFF
--- a/src/IceRpc/Internal/LogTaskExceptionObserver.cs
+++ b/src/IceRpc/Internal/LogTaskExceptionObserver.cs
@@ -45,7 +45,7 @@ internal class LogTaskExceptionObserver : ITaskExceptionObserver
 
             // expected and somewhat common (peer aborts connection)
             IceRpcException rpcException when rpcException.IceRpcError is IceRpcError.ConnectionAborted =>
-                LogLevel.Trace,
+                LogLevel.Debug,
 
             // rare, for example a protocol error
             IceRpcException => LogLevel.Debug,

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -23,7 +23,7 @@ internal static partial class ProtocolLoggerExtensions
         EventId = (int)ProtocolEventIds.ConnectionAcceptFailed,
         EventName = nameof(ProtocolEventIds.ConnectionAcceptFailed),
         Level = LogLevel.Critical,
-        Message = "Listener '{ServerAddress}' failed to accept a new connection and stops accepting connections")]
+        Message = "Listener '{ServerAddress}' failed to accept a new connection and stopped accepting connections")]
     internal static partial void LogConnectionAcceptFailed(
         this ILogger logger,
         ServerAddress serverAddress,


### PR DESCRIPTION
This fixes #2711. I've upgraded the logging at trace level to debug level. I've also bumped the accept failure logging to critical (from error). A server that stops accepting connections is really a critical issue to me.