### PR TITLE
Add comments, regarding cs:generic testing

### DIFF
--- a/tests/IceRpc.Tests/Slice/DictionaryTests.slice
+++ b/tests/IceRpc.Tests/Slice/DictionaryTests.slice
@@ -3,9 +3,9 @@
 module IceRpc::Tests::Slice
 
 interface DictionaryMappingOperations {
-    // Don't need to add tests for different cs::generic arguments, there is a single code path, the given argument
-    // must be a generic type that implements IDictionary<TKey, TValue> and provides a constructor that allows to initialize the
-    // dictionary with a given initial capacity.
+    // We don't need to add tests for other cs::generic arguments because the code path is always the same. The argument
+    // must be a non-abstract generic type that implements IDictionary<TKey, TValue> and provides a constructor with an
+    // initial capacity parameter.
     opReturnTuple() ->
         (r1: [cs::generic("CustomDictionary")] dictionary<int32, int32>
          r2: [cs::generic("CustomDictionary")] dictionary<int32, int32>)

--- a/tests/IceRpc.Tests/Slice/SequenceMappingTests.slice
+++ b/tests/IceRpc.Tests/Slice/SequenceMappingTests.slice
@@ -3,9 +3,9 @@
 module IceRpc::Tests::Slice
 
 interface SequenceMappingOperations {
-    // Don't need to add tests for different cs::generic arguments, there is a single code path, the given argument
-    // must be a generic type that implements IEnumerable<T> and provides a constructor that allows to initialize the
-    // sequence class from an IEnumerable<T>.
+    // We don't need to add tests for other cs::generic arguments because the code path is always the same. The argument
+    // must be a non-abstract generic type that implements IEnumerable<T> and provides a constructor that allows to
+    // initialize the sequence contents from an IEnumerable<T>.
     opReturnTuple() ->
         (r1: [cs::generic("CustomSequence")] sequence<int32>
          r2: [cs::generic("CustomSequence")] sequence<int32>)


### PR DESCRIPTION
Added a comment explaining why we don't need additional tests for `cs:generic`, fix #2729