### PR TITLE
Replace 127.0.0.1 in examples

### DIFF
--- a/examples/Authorization/Client/Program.cs
+++ b/examples/Authorization/Client/Program.cs
@@ -3,7 +3,7 @@
 using AuthorizationExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 // A `Hello` proxy that doesn't use any authentication. An authentication token is not needed to call `SayHello`.
 var unauthenticatedHelloProxy = new HelloProxy(connection, new Uri("icerpc:/hello"));

--- a/examples/Compress/Client/Program.cs
+++ b/examples/Compress/Client/Program.cs
@@ -3,7 +3,7 @@
 using CompressExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 // Add the compressor interceptor to the invocation pipeline.
 IInvoker pipeline = new Pipeline().UseCompressor(CompressionFormat.Brotli).Into(connection);

--- a/examples/Download/Client/Program.cs
+++ b/examples/Download/Client/Program.cs
@@ -4,7 +4,7 @@ using DownloadExample;
 using IceRpc;
 using System.IO.Pipelines;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 var downloader = new DownloaderProxy(connection);
 
 // Receive the stream from the server.

--- a/examples/GenericHost/Client/appsettings.json
+++ b/examples/GenericHost/Client/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Client": {
-    "ServerAddress": "icerpc://127.0.0.1:10000",
+    "ServerAddress": "icerpc://localhost:10000",
     "ConnectTimeout": "00:00:05"
   },
   "CertificateAuthoritiesFile": "../../certs/cacert.der"

--- a/examples/GenericHost/Server/appsettings.json
+++ b/examples/GenericHost/Server/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Server": {
-    "ServerAddress": "icerpc://127.0.0.1:10000",
+    "ServerAddress": "icerpc://[::0]:10000",
     "ConnectionOptions": {
       "CloseTimeout": "00:00:05"
     }

--- a/examples/Hello/Client/Program.cs
+++ b/examples/Hello/Client/Program.cs
@@ -3,7 +3,7 @@
 using HelloExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 var helloProxy = new HelloProxy(connection);
 string greeting = await helloProxy.SayHelloAsync(Environment.UserName);

--- a/examples/HelloCore/Client/Program.cs
+++ b/examples/HelloCore/Client/Program.cs
@@ -3,7 +3,7 @@
 using HelloCoreExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 // Construct an outgoing request for the icerpc protocol.
 using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc))

--- a/examples/HelloLog/Client/Program.cs
+++ b/examples/HelloLog/Client/Program.cs
@@ -12,7 +12,7 @@ using ILoggerFactory loggerFactory = LoggerFactory.Create(
 ILogger logger = loggerFactory.CreateLogger<ClientConnection>();
 
 // Create a client connection that logs messages using logger.
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"), logger: logger);
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"), logger: logger);
 
 var helloProxy = new HelloProxy(connection);
 string greeting = await helloProxy.SayHelloAsync(Environment.UserName);

--- a/examples/HelloQuic/Client/Program.cs
+++ b/examples/HelloQuic/Client/Program.cs
@@ -21,7 +21,7 @@ var clientAuthenticationOptions = new SslClientAuthenticationOptions
 };
 
 await using var connection = new ClientConnection(
-    new Uri("icerpc://127.0.0.1"),
+    new Uri("icerpc://localhost"),
     clientAuthenticationOptions,
     multiplexedClientTransport: new QuicClientTransport());
 

--- a/examples/Interop/Minimal/Client/Program.cs
+++ b/examples/Interop/Minimal/Client/Program.cs
@@ -4,7 +4,7 @@ using Demo;
 using IceRpc;
 
 // Use the ice protocol for compatibility with ZeroC Ice.
-await using var connection = new ClientConnection(new Uri("ice://127.0.0.1:10000"));
+await using var connection = new ClientConnection(new Uri("ice://localhost:10000"));
 
 // The service address URI includes the protocol to use (ice).
 var hello = new HelloProxy(connection, new Uri("ice:/hello"));

--- a/examples/Metrics/Client/Program.cs
+++ b/examples/Metrics/Client/Program.cs
@@ -3,7 +3,7 @@
 using MetricsExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 var hello = new HelloProxy(connection);
 

--- a/examples/MultipleInterfaces/Client/Program.cs
+++ b/examples/MultipleInterfaces/Client/Program.cs
@@ -3,7 +3,7 @@
 using MultipleInterfacesExample;
 using IceRpc;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 var helloProxy = new HelloProxy(connection);
 var requestCounterProxy = new RequestCounterProxy(connection);

--- a/examples/OpenTelemetry/Client/Program.cs
+++ b/examples/OpenTelemetry/Client/Program.cs
@@ -21,7 +21,7 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
    .AddZipkinExporter()
    .Build();
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 pipeline.Into(connection);
 

--- a/examples/OpenTelemetry/CrmServer/Program.cs
+++ b/examples/OpenTelemetry/CrmServer/Program.cs
@@ -23,7 +23,7 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 router.Map<ICrm>(new Crm());
 
-await using var server = new Server(router, new Uri("icerpc://127.0.0.1:20001"));
+await using var server = new Server(router, new Uri("icerpc://[::0]:20001"));
 server.Listen();
 
 // Wait until the console receives a Ctrl+C.

--- a/examples/OpenTelemetry/HelloServer/Program.cs
+++ b/examples/OpenTelemetry/HelloServer/Program.cs
@@ -24,7 +24,7 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
    .AddZipkinExporter()
    .Build();
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1:20001"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost:20001"));
 pipeline.Into(connection);
 
 var proxy = new CrmProxy(pipeline);

--- a/examples/RequestContext/Client/Program.cs
+++ b/examples/RequestContext/Client/Program.cs
@@ -5,7 +5,7 @@ using IceRpc.Features;
 using IceRpc.RequestContext;
 using RequestContextExample;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 
 // Add the request context interceptor to the invocation pipeline.
 Pipeline pipeline = new Pipeline().UseRequestContext().Into(connection);

--- a/examples/Retry/Client/Program.cs
+++ b/examples/Retry/Client/Program.cs
@@ -45,10 +45,10 @@ Pipeline pipeline = new Pipeline()
 // We use a logger to ensure proper ordering of the messages on the console.
 ILogger logger = loggerFactory.CreateLogger("IceRpc.RetryExample");
 
-string helloServiceAddress = "icerpc://127.0.0.1:10000/hello?alt-server=127.0.0.1:10001";
+string helloServiceAddress = "icerpc://localhost:10000/hello?alt-server=localhost:10001";
 for (int i = 2; i < serverInstances; i++)
 {
-    helloServiceAddress += $"&alt-server=127.0.0.1:{10000 + i}";
+    helloServiceAddress += $"&alt-server=localhost:{10000 + i}";
 }
 var hello = new HelloProxy(pipeline, new Uri(helloServiceAddress));
 

--- a/examples/Retry/Server/Program.cs
+++ b/examples/Retry/Server/Program.cs
@@ -16,7 +16,7 @@ if (!int.TryParse(args[0], out number))
     return;
 }
 
-var serverAddress = new ServerAddress(new Uri($"icerpc://127.0.0.1:{10000 + number}/"));
+var serverAddress = new ServerAddress(new Uri($"icerpc://[::0]:{10000 + number}/"));
 
 await using var server = new Server(new Chatbot(number), serverAddress);
 server.Listen();

--- a/examples/Secure/Client/Program.cs
+++ b/examples/Secure/Client/Program.cs
@@ -22,7 +22,7 @@ var clientAuthenticationOptions = new SslClientAuthenticationOptions()
     }
 };
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"), clientAuthenticationOptions);
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"), clientAuthenticationOptions);
 
 var hello = new HelloProxy(connection);
 

--- a/examples/Stream/Client/Program.cs
+++ b/examples/Stream/Client/Program.cs
@@ -4,7 +4,7 @@ using IceRpc;
 using StreamExample;
 
 // Establish the connection to the server
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 var randomGeneratorProxy = new GeneratorProxy(connection);
 
 IAsyncEnumerable<int> randomNumbers = await randomGeneratorProxy.GenerateNumbersAsync();

--- a/examples/Upload/Client/Program.cs
+++ b/examples/Upload/Client/Program.cs
@@ -4,7 +4,7 @@ using IceRpc;
 using System.IO.Pipelines;
 using UploadExample;
 
-await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+await using var connection = new ClientConnection(new Uri("icerpc://localhost"));
 var uploader = new UploaderProxy(connection);
 
 Console.WriteLine("Uploading image of the Earth...");


### PR DESCRIPTION
This PR replaces `127.0.0.1` by localhost in clients and `[::0]` in servers.

Fixes #2793
Fixes #2802 
