### PR TITLE
Transport server address validation fixes

### DIFF
--- a/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocClientTransport.cs
@@ -33,7 +33,7 @@ internal class ColocClientTransport : IDuplexClientTransport
             !CheckParams(serverAddress))
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Coloc transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Coloc client transport.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Coloc/Transports/Internal/ColocServerTransport.cs
@@ -29,7 +29,7 @@ internal class ColocServerTransport : IDuplexServerTransport
             !ColocTransport.CheckParams(serverAddress))
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Coloc transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Coloc server transport.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicMultiplexedListener.cs
@@ -48,7 +48,7 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
         if (!IPAddress.TryParse(serverAddress.Host, out IPAddress? ipAddress))
         {
             throw new ArgumentException(
-                $"The Quic transport can't listen on '{serverAddress.Host}' because it requires an IP address.",
+                $"Listening on the DNS name '{serverAddress.Host}' is not allowed; an IP address is required.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc.Quic/Transports/QuicClientTransport.cs
+++ b/src/IceRpc.Quic/Transports/QuicClientTransport.cs
@@ -16,7 +16,7 @@ public class QuicClientTransport : IMultiplexedClientTransport
     private readonly QuicClientTransportOptions _quicTransportOptions;
 
     /// <summary>Constructs a Quic client transport.</summary>
-    /// <param name="options">The options to configure the Quic transport.</param>
+    /// <param name="options">The options to configure the Quic client transport.</param>
     public QuicClientTransport(QuicClientTransportOptions options) => _quicTransportOptions = options;
 
     /// <summary>Constructs a Quic client transport.</summary>
@@ -36,13 +36,13 @@ public class QuicClientTransport : IMultiplexedClientTransport
     {
         if (!QuicConnection.IsSupported)
         {
-            throw new NotSupportedException("The Quic transport is not supported on this platform.");
+            throw new NotSupportedException("The Quic client transport is not supported on this platform.");
         }
 
         if ((serverAddress.Transport is string transport && transport != Name) || !CheckParams(serverAddress))
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Quic transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Quic client transport.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc.Quic/Transports/QuicServerTransport.cs
+++ b/src/IceRpc.Quic/Transports/QuicServerTransport.cs
@@ -32,13 +32,13 @@ public class QuicServerTransport : IMultiplexedServerTransport
     {
         if (!QuicConnection.IsSupported)
         {
-            throw new NotSupportedException("The Quic transport is not supported on this platform.");
+            throw new NotSupportedException("The Quic server transport is not supported on this platform.");
         }
 
         if ((serverAddress.Transport is string transport && transport != Name) || serverAddress.Params.Count > 0)
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Quic transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Quic server transport.",
                 nameof(serverAddress));
         }
 
@@ -46,7 +46,7 @@ public class QuicServerTransport : IMultiplexedServerTransport
         {
             throw new ArgumentNullException(
                 nameof(serverAuthenticationOptions),
-                "The Quic transport requires the Ssl server authentication options to be set.");
+                "The Quic server transport requires the Ssl server authentication options to be set.");
         }
 
         if (serverAddress.Transport is null)

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -302,8 +302,8 @@ public sealed class Server : IAsyncDisposable
     /// <exception cref="InvalidOperationException">Thrown when the server is already listening, shut down or shutting
     /// down.</exception>
     /// <exception cref="ObjectDisposedException">Throw when the server is disposed.</exception>
-    /// <remarks><see cref="Listen" /> can also throw exceptions from the transport if it doesn't support the server
-    /// address.</remarks>
+    /// <remarks><see cref="Listen" /> can also throw exceptions from the transport; for example, the transport can
+    /// reject the server address.</remarks>
     public ServerAddress Listen()
     {
         lock (_mutex)

--- a/src/IceRpc/Transports/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Internal/TcpListener.cs
@@ -51,7 +51,7 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
         if (!IPAddress.TryParse(serverAddress.Host, out IPAddress? ipAddress))
         {
             throw new ArgumentException(
-                $"The Tcp transport can't listen on '{serverAddress.Host}' because it requires an IP address.",
+                $"Listening on the DNS name '{serverAddress.Host}' is not allowed; an IP address is required.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc/Transports/TcpClientTransport.cs
+++ b/src/IceRpc/Transports/TcpClientTransport.cs
@@ -68,7 +68,7 @@ public class TcpClientTransport : IDuplexClientTransport
             !CheckParams(serverAddress))
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Tcp transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Tcp client transport.",
                 nameof(serverAddress));
         }
 

--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -35,7 +35,7 @@ public class TcpServerTransport : IDuplexServerTransport
             serverAddress.Params.Count > 0)
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains parameters that are not valid for the Tcp transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Tcp server transport.",
                 nameof(serverAddress));
         }
 
@@ -47,7 +47,7 @@ public class TcpServerTransport : IDuplexServerTransport
         {
             throw new ArgumentNullException(
                 nameof(serverAuthenticationOptions),
-                "The Ssl transport requires the Ssl server authentication options to be set.");
+                "The Ssl server transport requires the Ssl server authentication options to be set.");
         }
 
         return new TcpListener(serverAddress, options, serverAuthenticationOptions, _options);


### PR DESCRIPTION
This PR improves the error messages raised from `ArgumentException` or `ArgumentNullException`. The Quic transport also now check if Quic is supported when creating a connection or the listener. For client connections, this prevents the process to assert if Quic is not supported.