### PR TITLE
Fix for #2622

### DIFF
--- a/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
@@ -5,7 +5,9 @@ using System.Runtime.Versioning;
 // TODO: we don't use a 8 s timeout to workaround connection establishment delays that occur with the
 // Connect_fails_if_listener_is_disposed test. The https://github.com/dotnet/runtime/issues/77310 issue is possibly the
 // cause of this delay. The issue is fixed with .NET 8.
-#if !NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
+[assembly: NUnit.Framework.Timeout(8000)]
+#else
 [assembly: NUnit.Framework.Timeout(16000)]
 #endif
 


### PR DESCRIPTION
#2622 is fixed with .NET 8. This PR disables the workaround for NET8_0_OR_GREATER.