### PR TITLE
Add well-known types

### DIFF
--- a/slice/WellKnownTypes/Duration.slice
+++ b/slice/WellKnownTypes/Duration.slice
@@ -1,0 +1,9 @@
+// Copyright (c) ZeroC, Inc.
+
+[cs::namespace("IceRpc.Slice")]
+module WellKnownTypes
+
+/// Represents a length of time, encoded as a varint62.
+/// Precision: 100 nanoseconds.
+[cs::custom("System.TimeSpan")]
+custom Duration

--- a/slice/WellKnownTypes/TimeStamp.slice
+++ b/slice/WellKnownTypes/TimeStamp.slice
@@ -1,0 +1,10 @@
+// Copyright (c) ZeroC, Inc.
+
+[cs::namespace("IceRpc.Slice")]
+module WellKnownTypes
+
+/// Represents a specific point in time, encoded as an int64.
+/// Precision: 100 nanoseconds.
+/// Range: January 1, 0001 00:00:00 UTC to December 31, 9999 23:59:59.9999999 UTC in the Gregorian calendar.
+[cs::custom("System.DateTime")]
+custom TimeStamp

--- a/slice/WellKnownTypes/Uri.slice
+++ b/slice/WellKnownTypes/Uri.slice
@@ -1,0 +1,8 @@
+// Copyright (c) ZeroC, Inc.
+
+[cs::namespace("IceRpc.Slice")]
+module WellKnownTypes
+
+/// Represents a Uniform Resource Identifier (URI), encoded as a string.
+[cs::custom("System.Uri")]
+custom Uri

--- a/src/IceRpc/Slice/DurationSliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/DurationSliceDecoderExtensions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for decoding a WellKnownTypes::Duration.</summary>
+public static class DurationSliceDecoderExtensions
+{
+    /// <summary>Decodes a duration.</summary>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <returns>The duration decoded as a <see cref="TimeSpan"/>.</returns>
+    public static TimeSpan DecodeDuration(this ref SliceDecoder decoder) => new(decoder.DecodeVarInt62());
+}

--- a/src/IceRpc/Slice/DurationSliceEncoderExtensions.cs
+++ b/src/IceRpc/Slice/DurationSliceEncoderExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for encoding a TimeSpan as a WellKnownTypes::Duration.</summary>
+public static class DurationSliceEncoderExtensions
+{
+    /// <summary>Encodes a time span as a duration.</summary>
+    /// <param name="encoder">The Slice encoder.</param>
+    /// <param name="value">The value to encode.</param>
+    public static void EncodeDuration(this ref SliceEncoder encoder, TimeSpan value) =>
+        encoder.EncodeVarInt62(value.Ticks);
+}

--- a/src/IceRpc/Slice/TimeStampSliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/TimeStampSliceDecoderExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for decoding a WellKnownTypes::TimeStamp.</summary>
+public static class TimeStampSliceDecoderExtensions
+{
+    /// <summary>Decodes a time stamp.</summary>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <returns>The time stamp decoded as a <see cref="DateTime"/>.</returns>
+    public static DateTime DecodeTimeStamp(this ref SliceDecoder decoder)
+    {
+        long value = decoder.DecodeInt64();
+        try
+        {
+            return new DateTime(value, DateTimeKind.Utc);
+        }
+        catch (ArgumentOutOfRangeException exception)
+        {
+            throw new InvalidDataException(message: null, exception);
+        }
+    }
+}

--- a/src/IceRpc/Slice/TimeStampSliceEncoderExtensions.cs
+++ b/src/IceRpc/Slice/TimeStampSliceEncoderExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for encoding a DateTime as a WellKnownTypes::TimeStamp.</summary>
+public static class TimeStampSliceEncoderExtensions
+{
+    /// <summary>Encodes a DateTime as a time stamp.</summary>
+    /// <param name="encoder">The Slice encoder.</param>
+    /// <param name="value">The value to encode.</param>
+    public static void EncodeTimeStamp(this ref SliceEncoder encoder, DateTime value) =>
+        encoder.EncodeInt64(value.ToUniversalTime().Ticks);
+}

--- a/src/IceRpc/Slice/UriSliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/UriSliceDecoderExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for decoding a WellKnownTypes::Uri.</summary>
+public static class UriSliceDecoderExtensions
+{
+    /// <summary>Decodes a URI.</summary>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <returns>The URI decoded as a <see cref="Uri"/>.</returns>
+    public static Uri DecodeUri(this ref SliceDecoder decoder)
+    {
+        string value = decoder.DecodeString();
+        try
+        {
+            return new Uri(value, UriKind.RelativeOrAbsolute);
+        }
+        catch (UriFormatException exception)
+        {
+            throw new InvalidDataException(message: null, exception);
+        }
+    }
+}

--- a/src/IceRpc/Slice/UriSliceEncoderExtensions.cs
+++ b/src/IceRpc/Slice/UriSliceEncoderExtensions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice;
+
+/// <summary>Provides an extension method for encoding a URI as a WellKnownTypes::Uri.</summary>
+public static class UriSliceEncoderExtensions
+{
+    /// <summary>Encodes a URI.</summary>
+    /// <param name="encoder">The Slice encoder.</param>
+    /// <param name="value">The value to encode.</param>
+    public static void EncodeUri(this ref SliceEncoder encoder, Uri value) => encoder.EncodeString(value.ToString());
+}

--- a/tests/IceRpc.Tests/Slice/WellKnownTypes.slice
+++ b/tests/IceRpc.Tests/Slice/WellKnownTypes.slice
@@ -1,0 +1,9 @@
+// Copyright (c) ZeroC, Inc.
+
+module IceRpc::Tests::Slice
+
+struct WellKnown {
+    timeStamp: WellKnownTypes::TimeStamp
+    duration: WellKnownTypes::Duration
+    uri: WellKnownTypes::Uri
+}


### PR DESCRIPTION
This PR adds 3 well-known Slice types--custom types in module WellKnownTypes.

Their implementation is trivial so it's not immediately obvious which tests we need for these new types.

Fixes #2674.