### PR TITLE
Update deadline interceptor and middleware to use TimeStamp

### DIFF
--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -66,10 +66,9 @@ public class DeadlineInterceptor : IInvoker
 
         if (deadline != DateTime.MaxValue)
         {
-            long deadlineValue = (long)(deadline - DateTime.UnixEpoch).TotalMilliseconds;
             request.Fields = request.Fields.With(
                 RequestFieldKey.Deadline,
-                (ref SliceEncoder encoder) => encoder.EncodeVarInt62(deadlineValue));
+                (ref SliceEncoder encoder) => encoder.EncodeTimeStamp(deadline));
         }
 
         return timeout is null ? _next.InvokeAsync(request, cancellationToken) : PerformInvokeAsync(timeout.Value);

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -172,6 +172,6 @@ public sealed class DeadlineInterceptorTests
         pipe.Reader.TryRead(out var readResult);
         var decoder = new SliceDecoder(readResult.Buffer, SliceEncoding.Slice2);
         decoder.SkipSize();
-        return DateTime.UnixEpoch + TimeSpan.FromMilliseconds(decoder.DecodeVarInt62());
+        return decoder.DecodeTimeStamp();
     }
 }

--- a/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
@@ -96,8 +96,7 @@ public sealed class DeadlineMiddlewareTests
     {
         var pipe = new Pipe();
         var encoder = new SliceEncoder(pipe.Writer, SliceEncoding.Slice2);
-        long deadlineValue = (long)(deadline - DateTime.UnixEpoch).TotalMilliseconds;
-        encoder.EncodeVarInt62(deadlineValue);
+        encoder.EncodeTimeStamp(deadline);
         pipe.Writer.Complete();
 
         return pipe.Reader;


### PR DESCRIPTION
Fixes #2815.

Previously, the deadline was encoded as a number of millisecond since the Unix epoch, as a varint62. It's now an int64 with 100 nanoseconds (== 0.1 us) precision, starting in January 1, 0001 00:00:00 UTC. 

Note that even with milliseconds and the Unix epoch, using a varint62 does not (did not) make sense. The number of milliseconds since the Unix epoch is now 1,679,687,299 (and counting!) and a varint32/62 greater than 1,073,741,823 is always encoded on 8 bytes.