### PR TITLE
Remove ConnectionCache TODO

### DIFF
--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -105,8 +105,9 @@ public class RetryInterceptor : IInvoker
                         else
                         {
                             Debug.Assert(exception is not null);
-                            // It's always safe to retry InvocationCanceled. For idempotent requests we also retry on
-                            // ConnectionAborted and TruncatedData.
+                            // It's always safe to retry InvocationCanceled because it's only raised before the request
+                            // is sent to the peer. For idempotent requests we can also retry on ConnectionAborted and
+                            // TruncatedData.
                             tryAgain = exception.IceRpcError switch
                             {
                                 IceRpcError.InvocationCanceled => true,
@@ -151,6 +152,5 @@ public class RetryInterceptor : IInvoker
     }
 
     private IDisposable? CreateRetryLogScope(int attempt) =>
-        _logger != NullLogger.Instance && attempt > 1 ?
-            _logger.RetryScope(attempt, _options.MaxAttempts) : null;
+        _logger != NullLogger.Instance && attempt > 1 ? _logger.RetryScope(attempt, _options.MaxAttempts) : null;
 }

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -484,7 +484,11 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
             {
                 connectionException = exception;
             }
-            catch (IceRpcException exception)
+            catch (IceRpcException exception) when (exception.IceRpcError is
+                IceRpcError.ConnectionAborted or
+                IceRpcError.ConnectionRefused or
+                IceRpcError.ServerBusy or
+                IceRpcError.ServerUnreachable)
             {
                 // keep going unless the connection cache was disposed or shut down
                 connectionException = exception;


### PR DESCRIPTION
This PR removes a connection cache TODO. Given that we were retrying `InvalidDataException` (which can't be raised anymore from `IProtocolConnection.ConnectAsync`), I assumed we should also retry on `IceRpcError.IceRpcError`.

The other option would be to be more restrictive and only retry on `ConnectionAborted`, `ServerBusy` and  `ConnectionRefused` (and `ServerUnreachable`?). The drawback is that some unexpected network failures will prevent to retry on other server addresses.

Also another strategy for the connection cache (that we could implement later) could be to establish connections in parallel (or kick a new connection establishment after a small delay if the current connection establishment doesn't return promptly). In this case, would we stop the parallel connection establishments as soon as we get an unexpected failure?

I have a slight preference for the lenient approach from this PR. What do you think? If we go for the selective solution, what error codes do we retry on?