### PR TITLE
Fixed QuicExceptionExtensions TODO

### DIFF
--- a/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
+++ b/src/IceRpc.Quic/Transports/Internal/QuicExceptionExtensions.cs
@@ -26,7 +26,7 @@ internal static class QuicExceptionExtensions
                                 IceRpcError.ConnectionAborted,
                                 $"The connection was aborted by the peer."),
                         _ => new IceRpcException(
-                                IceRpcError.IceRpcError,
+                                IceRpcError.ConnectionAborted,
                                 $"The connection was aborted by the peer with an unknown application error code: '{applicationErrorCode}'"),
                     } :
                     // An application error code should always be set with QuicError.ConnectionAborted.
@@ -41,7 +41,7 @@ internal static class QuicExceptionExtensions
                     applicationErrorCode == 0 ?
                         new IceRpcException(IceRpcError.TruncatedData, exception) :
                         new IceRpcException(
-                            IceRpcError.IceRpcError,
+                            IceRpcError.TruncatedData,
                             $"The stream was aborted by the peer with an unknown application error code: '{applicationErrorCode}'") :
                     // An application error code should always be set with QuicError.StreamAborted.
                     new IceRpcException(IceRpcError.IceRpcError, exception),

--- a/src/IceRpc/Transports/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Internal/SlicStream.cs
@@ -290,7 +290,7 @@ internal class SlicStream : IMultiplexedStream
         {
             // The peer aborted writes with unknown application error code.
             _inputPipeReader?.CompleteReads(new IceRpcException(
-                IceRpcError.IceRpcError,
+                IceRpcError.TruncatedData,
                 $"The peer aborted stream writes with an unknown application error code: '{errorCode}'"));
         }
     }
@@ -309,7 +309,7 @@ internal class SlicStream : IMultiplexedStream
         {
             // The peer aborted reads with unknown application error code.
             _outputPipeWriter?.CompleteWrites(new IceRpcException(
-                IceRpcError.IceRpcError,
+                IceRpcError.TruncatedData,
                 $"The peer aborted stream reads with an unknown application error code: '{errorCode}'"));
         }
     }


### PR DESCRIPTION
This PR fixes a TODO and map exceptions with bogus application error codes or no application error code to `IceRpcError.IceRpcError`). 