### PR TITLE
Update tests to use new tag syntax and updated validation to use UnexpectedAttribute

### DIFF
--- a/tests/IceRpc.Tests/Slice/ClassTests.slice
+++ b/tests/IceRpc.Tests/Slice/ClassTests.slice
@@ -20,11 +20,11 @@ class MyClassC {
 class MyCompactClass(15) {}
 
 class MyClassWithTaggedMembers {
-    a: tag(10) int32?
+    tag(10) a: int32?
 }
 
 class MyDerivedClassWithTaggedMembers : MyClassWithTaggedMembers {
-    b: tag(20) string?
+    tag(20) b: string?
 }
 
 class MyDerivedCompactClass(789) : MyCompactClass {}

--- a/tests/IceRpc.Tests/Slice/ExceptionTests.Slice1.slice
+++ b/tests/IceRpc.Tests/Slice/ExceptionTests.Slice1.slice
@@ -12,8 +12,8 @@ exception MyException {
 exception MyExceptionWithTaggedMembers {
     i: int32
     j: int32
-    k: tag(1) int32?
-    l: tag(255) int32?
+    tag(1) k: int32?
+    tag(255) l: int32?
 }
 
 exception MyDerivedException : MyException {

--- a/tests/IceRpc.Tests/Slice/OperationEncodingTests.slice
+++ b/tests/IceRpc.Tests/Slice/OperationEncodingTests.slice
@@ -15,6 +15,6 @@ interface MyOperationsB {
         (r1: int32, r2: string, r3: int32?, r4: string?)
 
     // Tagged input parameters and return values
-    opTagged(p1: int32, p2: string, p3: tag(1) int32?, p4: tag(2) string?) ->
-        (r1: int32, r2: string, r3: tag(1) int32?, r4: tag(2) string?)
+    opTagged(p1: int32, p2: string, tag(1) p3: int32?, tag(2) p4: string?) ->
+        (r1: int32, r2: string, tag(1) r3: int32?, tag(2) r4: string?)
 }

--- a/tests/IceRpc.Tests/Slice/OperationTests.slice
+++ b/tests/IceRpc.Tests/Slice/OperationTests.slice
@@ -48,7 +48,7 @@ interface MyOperationsA {
     opReadOnlyMemoryOptional(p1: sequence<int32>?) -> sequence<int32>?
 
     // ReadOnlyMemory tagged input parameters and return values
-    opReadOnlyMemoryTagged(p1: tag(1) sequence<int32>?) -> tag(1) sequence<int32>?
+    opReadOnlyMemoryTagged(tag(1) p1: sequence<int32>?) -> tag(1) sequence<int32>?
 
     // Proxy parameter and return value
     opWithProxyParameter(service: Pingable)
@@ -64,9 +64,9 @@ interface MyDerivedOperationsA : MyOperationsA {
 }
 
 interface MyTaggedOperations {
-    op(x: int32, y: tag(1) int32?, z: tag(2) int32?)
+    op(x: int32, tag(1) y: int32?, tag(2) z: int32?)
 }
 
 interface MyTaggedOperationsReadOnlyMemoryParams {
-    op(x: sequence<int32>, y: tag(1) sequence<int32>?, z: tag(2) sequence<int32>?)
+    op(x: sequence<int32>, tag(1) y: sequence<int32>?, tag(2) z: sequence<int32>?)
 }

--- a/tests/IceRpc.Tests/Slice/TaggedTests.Slice1.slice
+++ b/tests/IceRpc.Tests/Slice/TaggedTests.Slice1.slice
@@ -16,14 +16,14 @@ compact struct VarLengthStruct {
 enum MyEnum { One, Two }
 
 class ClassWithTaggedMembers {
-    a: tag(1) uint8?               // Uses F1 tag format
-    b: tag(2) int16?               // Uses F2 tag format
-    c: tag(3) int32?               // Uses F4 tag format
-    d: tag(4) int64?               // Uses F8 tag format
-    e: tag(5) FixedLengthStruct?   // Uses VSize tag format
-    f: tag(6) VarLengthStruct?     // Use FSize tag format
-    g: tag(7) MyEnum?              // Uses Size tag format
-    h: tag(8) sequence<uint8>?     // Uses OptimizedVSize tag format
-    i: tag(9) sequence<int32>?     // Uses FSize tag format
-    j: tag(10) string?             // Uses OptimizedVSize tag format
+    tag(1) a: uint8?               // Uses F1 tag format
+    tag(2) b: int16?               // Uses F2 tag format
+    tag(3) c: int32?               // Uses F4 tag format
+    tag(4) d: int64?               // Uses F8 tag format
+    tag(5) e: FixedLengthStruct?   // Uses VSize tag format
+    tag(6) f: VarLengthStruct?     // Use FSize tag format
+    tag(7) g: MyEnum?              // Uses Size tag format
+    tag(8) h: sequence<uint8>?     // Uses OptimizedVSize tag format
+    tag(9) i: sequence<int32>?     // Uses FSize tag format
+    tag(10) j: string?             // Uses OptimizedVSize tag format
 }

--- a/tests/IceRpc.Tests/Slice/TaggedTests.slice
+++ b/tests/IceRpc.Tests/Slice/TaggedTests.slice
@@ -3,9 +3,9 @@
 module IceRpc::Tests::Slice
 
 struct MyStructWithTaggedMembers {
-    a: tag(1) uint8?
-    b: tag(2) MyStruct?
-    c: tag(3) MyEnum?
-    d: tag(4) sequence<uint8>?
-    e: tag(5) string?
+    tag(1) a: uint8?
+    tag(2) b: MyStruct?
+    tag(3) c: MyEnum?
+    tag(4) d: sequence<uint8>?
+    tag(5) e: string?
 }

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -3,6 +3,46 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,24 +92,33 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.13"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.12"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -79,11 +128,23 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
 dependencies = [
- "os_str_bytes",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -164,13 +225,13 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -247,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -314,9 +375,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -348,12 +409,6 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parking_lot"
@@ -458,9 +513,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
 dependencies = [
  "bitflags",
  "errno",
@@ -490,18 +545,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -528,7 +583,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/zeroc-ice/slicec#63a5b4a07fb33927a1c1932706c5ca9b8af8cd70"
+source = "git+ssh://git@github.com/zeroc-ice/slicec#b38c57eb3f986ae0e152b8d5a873f2d8ba0d88cd"
 dependencies = [
  "clap",
  "console",
@@ -574,9 +629,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.10"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,15 +647,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -657,6 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,15 +729,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -2,7 +2,7 @@
 
 use crate::cs_attributes::{self, match_cs_custom, CsAttributeKind};
 use slice::compilation_result::{CompilationData, CompilationResult};
-use slice::diagnostics::{Diagnostic, DiagnosticReporter, Error, Warning};
+use slice::diagnostics::{Diagnostic, DiagnosticReporter, Error};
 use slice::grammar::*;
 use slice::slice_file::Span;
 use slice::visitor::Visitor;
@@ -222,9 +222,8 @@ impl Visitor for CsValidator<'_> {
         validate_repeated_attributes(type_alias, self.diagnostic_reporter);
         for (attribute, ..) in &cs_attributes(&type_alias.attributes(false)) {
             match attribute {
-                CsAttributeKind::Identifier { .. } => Diagnostic::new(Warning::InconsequentialUseOfAttribute {
+                CsAttributeKind::Identifier { .. } => Diagnostic::new(Error::UnexpectedAttribute {
                     attribute: cs_attributes::IDENTIFIER.to_owned(),
-                    kind: "typealias".to_owned(),
                 })
                 .set_span(type_alias.span())
                 .set_scope(type_alias.parser_scope())

--- a/tools/slicec-cs/src/validators/tests.rs
+++ b/tools/slicec-cs/src/validators/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::super::*;
-use slice::diagnostics::{Diagnostic, Error, Warning};
+use slice::diagnostics::{Diagnostic, Error};
 
 fn parse_for_diagnostics(slice: &str) -> Vec<Diagnostic> {
     let data = match slice::compile_from_strings(&[slice], None)
@@ -126,9 +126,8 @@ fn identifier_attribute_on_type_alias_fails() {
     let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    let expected = [Diagnostic::new(Warning::InconsequentialUseOfAttribute {
+    let expected = [Diagnostic::new(Error::UnexpectedAttribute {
         attribute: cs_attributes::IDENTIFIER.to_owned(),
-        kind: "typealias".to_owned(),
     })];
     std::iter::zip(expected, diagnostics)
         .for_each(|(expected, actual)| assert_eq!(expected.message(), actual.message()));


### PR DESCRIPTION
This PR updates slicec-cs to use the latest version of slicec. This required updating some tests to use the new tag syntax and validation to use `UnexpectedAttribute`.

