### PR TITLE
Fixed Langauge Specific Attribute Filtering

### DIFF
--- a/tools/slicec-cs/src/cs_attributes.rs
+++ b/tools/slicec-cs/src/cs_attributes.rs
@@ -70,7 +70,7 @@ impl From<CsAttributeKind> for AttributeKind {
     }
 }
 
-fn as_cs_attribute(attribute: &Attribute) -> Option<&CsAttributeKind> {
+pub fn as_cs_attribute(attribute: &Attribute) -> Option<&CsAttributeKind> {
     match &attribute.kind {
         AttributeKind::LanguageKind { kind } => kind.as_any().downcast_ref::<CsAttributeKind>(),
         _ => None,

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -27,16 +27,9 @@ struct CsValidator<'a> {
 
 /// Returns an iterator of C# specific attributes with any non-C# attributes filtered out.
 fn get_cs_attributes(attributable: &impl Attributable) -> impl Iterator<Item = (&CsAttributeKind, &Span)> {
-    attributable
-        .attributes(false)
-        .into_iter()
-        .filter_map(|attribute| match &attribute.kind {
-            AttributeKind::LanguageKind { kind } => {
-                let converted = kind.as_any().downcast_ref::<CsAttributeKind>();
-                converted.map(|cs_attribute| (cs_attribute, &attribute.span))
-            }
-            _ => None,
-        })
+    attributable.attributes(false).into_iter().filter_map(|attribute| {
+        cs_attributes::as_cs_attribute(attribute).map(|cs_attribute| (cs_attribute, &attribute.span))
+    })
 }
 
 fn report_unexpected_attribute(attribute: &CsAttributeKind, span: &Span, diagnostic_reporter: &mut DiagnosticReporter) {


### PR DESCRIPTION
Currently, the `CsValidator` assumes that whenever it sees an `LanguageKind` of an attribute that it must be a `CsLanguageKind`. This is true right now when we only have 1 language, but won't be in the future.

This PR fixes our filtering logic to check that an attribute is a `LanguageKind` and a `CsLanguageKind`,
and fixes the spot where we were unwrapping one into another (which would panic when we add a 2nd language).