### PR TITLE
Fix NuGet warning NU5129

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.PlatformInfo.props
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.PlatformInfo.props
@@ -1,8 +1,0 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <OSName Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</OSName>
-        <OSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</OSName>
-        <OSName Condition="$([MSBuild]::IsOSPlatform('OSX'))">macos</OSName>
-        <OSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower())</OSArch>
-    </PropertyGroup>
-</Project>


### PR DESCRIPTION
Fixes #2883, the final backslash in `PackagePath` triggers this warning

```
         <PackagePath>build\</PackagePath>
```

Updated paths to use a slash instead of a backslash fixed the warning, tested on Linux and Windows

```
         <PackagePath>build/</PackagePath>
```

I updated other paths in the project for consistency.