### PR TITLE
Minor `cs_validator` Cleanup.

### DIFF
--- a/tools/slicec-cs/src/cs_attributes.rs
+++ b/tools/slicec-cs/src/cs_attributes.rs
@@ -56,10 +56,12 @@ impl LanguageKind for CsAttributeKind {
     }
 }
 
-fn as_cs_attribute(attribute: &Attribute) -> Option<&CsAttributeKind> {
-    match &attribute.kind {
-        AttributeKind::LanguageKind { kind } => kind.as_any().downcast_ref::<CsAttributeKind>(),
-        _ => None,
+pub fn as_cs_attribute(attribute: &Attribute) -> Option<&CsAttributeKind> {
+    // `LanguageKind`s are created by slicec-cs (not slicec), so any `LanguageKind`s MUST be `CsLanguageKind`s.
+    if let AttributeKind::LanguageKind { kind } = &attribute.kind {
+        Some(kind.as_any().downcast_ref::<CsAttributeKind>().unwrap())
+    } else {
+        None
     }
 }
 

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -25,16 +25,11 @@ struct CsValidator<'a> {
     pub diagnostic_reporter: &'a mut DiagnosticReporter,
 }
 
-fn cs_attributes(attributes: Vec<&Attribute>) -> impl Iterator<Item = (&CsAttributeKind, Span)> {
-    attributes
-        .into_iter()
-        .filter_map(|attribute| match &attribute.kind {
-            AttributeKind::LanguageKind { kind } => Some((
-                kind.as_any().downcast_ref::<CsAttributeKind>().unwrap(),
-                attribute.span.clone(),
-            )),
-            _ => None,
-        })
+/// Returns an iterator of C# specific attributes with any non-C# attributes filtered out.
+fn get_cs_attributes(attributable: &impl Attributable) -> impl Iterator<Item = (&CsAttributeKind, &Span)> {
+    attributable.attributes(false).into_iter().filter_map(|attribute| {
+        cs_attributes::as_cs_attribute(attribute).map(|cs_attribute| (cs_attribute, &attribute.span))
+    })
 }
 
 fn report_unexpected_attribute(attribute: &CsAttributeKind, span: &Span, diagnostic_reporter: &mut DiagnosticReporter) {
@@ -70,10 +65,10 @@ fn validate_cs_encoded_result(operation: &Operation, span: &Span, diagnostic_rep
 }
 
 fn validate_collection_attributes<T: Attributable>(attributable: &T, diagnostic_reporter: &mut DiagnosticReporter) {
-    for (attribute, span) in cs_attributes(attributable.attributes(false)) {
+    for (attribute, span) in get_cs_attributes(attributable) {
         match attribute {
             CsAttributeKind::Generic { .. } => {}
-            _ => report_unexpected_attribute(attribute, &span, diagnostic_reporter),
+            _ => report_unexpected_attribute(attribute, span, diagnostic_reporter),
         }
     }
 }
@@ -89,8 +84,8 @@ fn validate_data_type_attributes(data_type: &TypeRef, diagnostic_reporter: &mut 
     match data_type.concrete_type() {
         Types::Sequence(_) | Types::Dictionary(_) => validate_collection_attributes(data_type, diagnostic_reporter),
         _ => {
-            for (attribute, span) in cs_attributes(data_type.attributes(false)) {
-                report_unexpected_attribute(attribute, &span, diagnostic_reporter);
+            for (attribute, span) in get_cs_attributes(data_type) {
+                report_unexpected_attribute(attribute, span, diagnostic_reporter);
             }
         }
     }
@@ -98,32 +93,32 @@ fn validate_data_type_attributes(data_type: &TypeRef, diagnostic_reporter: &mut 
 
 // Validates C# language specific attribute duplicates.
 fn validate_repeated_attributes(entity: &dyn Entity, diagnostic_reporter: &mut DiagnosticReporter) {
-    let attributes = entity
+    let cs_attributes = entity
         .attributes(false)
         .into_iter()
-        // TODO: this will be totally broken when we add support for another language mapping.
+        // `LanguageKind`s are created by slicec-cs (not slicec), so any `LanguageKind`s MUST be `CsLanguageKind`s.
         .filter(|attribute| matches!(attribute.kind, AttributeKind::LanguageKind { .. }))
         .collect::<Vec<_>>();
 
-    slice::validators::validate_repeated_attributes(&attributes, diagnostic_reporter);
+    slice::validators::validate_repeated_attributes(&cs_attributes, diagnostic_reporter);
 }
 
 impl Visitor for CsValidator<'_> {
     fn visit_file_start(&mut self, slice_file: &SliceFile) {
-        for (attribute, span) in cs_attributes(slice_file.attributes(false)) {
-            report_unexpected_attribute(attribute, &span, self.diagnostic_reporter);
+        for (attribute, span) in get_cs_attributes(slice_file) {
+            report_unexpected_attribute(attribute, span, self.diagnostic_reporter);
         }
     }
 
     fn visit_module_start(&mut self, module_def: &Module) {
         validate_repeated_attributes(module_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(module_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(module_def) {
             match attribute {
                 CsAttributeKind::Namespace { .. } => {}
                 CsAttributeKind::Identifier { .. } => {
                     let attribute = cs_attributes::IDENTIFIER.to_owned();
                     Diagnostic::new(Error::UnexpectedAttribute { attribute })
-                        .set_span(&span)
+                        .set_span(span)
                         .add_note(
                             format!("To rename a module use {} instead", cs_attributes::NAMESPACE),
                             None,
@@ -131,69 +126,69 @@ impl Visitor for CsValidator<'_> {
                         .report(self.diagnostic_reporter)
                 }
                 CsAttributeKind::Internal => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_struct_start(&mut self, struct_def: &Struct) {
         validate_repeated_attributes(struct_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(struct_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(struct_def) {
             match attribute {
                 CsAttributeKind::Readonly | CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_class_start(&mut self, class_def: &Class) {
         validate_repeated_attributes(class_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(class_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(class_def) {
             match attribute {
                 CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_exception_start(&mut self, exception_def: &Exception) {
         validate_repeated_attributes(exception_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(exception_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(exception_def) {
             match attribute {
                 CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         validate_repeated_attributes(interface_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(interface_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(interface_def) {
             match attribute {
                 CsAttributeKind::Internal => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_enum_start(&mut self, enum_def: &Enum) {
         validate_repeated_attributes(enum_def, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(enum_def.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(enum_def) {
             match attribute {
                 CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_operation_start(&mut self, operation: &Operation) {
         validate_repeated_attributes(operation, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(operation.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(operation) {
             match attribute {
                 CsAttributeKind::EncodedResult {} => {
-                    validate_cs_encoded_result(operation, &span, self.diagnostic_reporter)
+                    validate_cs_encoded_result(operation, span, self.diagnostic_reporter)
                 }
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
@@ -210,22 +205,22 @@ impl Visitor for CsValidator<'_> {
             .report(self.diagnostic_reporter);
         }
 
-        for (attribute, span) in cs_attributes(custom_type.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(custom_type) {
             match attribute {
                 CsAttributeKind::Custom { .. } => {}
-                _ => validate_common_attributes(attribute, &span, self.diagnostic_reporter),
+                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
 
     fn visit_type_alias(&mut self, type_alias: &TypeAlias) {
         validate_repeated_attributes(type_alias, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(type_alias.attributes(false)) {
+        for (attribute, span) in get_cs_attributes(type_alias) {
             match attribute {
                 CsAttributeKind::Identifier { .. } => Diagnostic::new(Error::UnexpectedAttribute {
                     attribute: cs_attributes::IDENTIFIER.to_owned(),
                 })
-                .set_span(&span)
+                .set_span(span)
                 .set_scope(type_alias.parser_scope())
                 .report(self.diagnostic_reporter),
                 _ => validate_data_type_attributes(&type_alias.underlying, self.diagnostic_reporter),
@@ -235,7 +230,7 @@ impl Visitor for CsValidator<'_> {
 
     fn visit_field(&mut self, field: &Field) {
         validate_repeated_attributes(field, self.diagnostic_reporter);
-        for (attribute, ..) in cs_attributes(field.attributes(false)) {
+        for (attribute, _) in get_cs_attributes(field) {
             match attribute {
                 CsAttributeKind::Identifier { .. } | CsAttributeKind::Attribute { .. } => {}
                 _ => validate_data_type_attributes(&field.data_type, self.diagnostic_reporter),
@@ -245,7 +240,7 @@ impl Visitor for CsValidator<'_> {
 
     fn visit_parameter(&mut self, parameter: &Parameter) {
         validate_repeated_attributes(parameter, self.diagnostic_reporter);
-        for (attribute, ..) in cs_attributes(parameter.attributes(false)) {
+        for (attribute, _) in get_cs_attributes(parameter) {
             match attribute {
                 CsAttributeKind::Identifier { .. } => {}
                 _ => validate_data_type_attributes(&parameter.data_type, self.diagnostic_reporter),
@@ -255,8 +250,8 @@ impl Visitor for CsValidator<'_> {
 
     fn visit_enumerator(&mut self, enumerator: &Enumerator) {
         validate_repeated_attributes(enumerator, self.diagnostic_reporter);
-        for (attribute, span) in cs_attributes(enumerator.attributes(false)) {
-            validate_common_attributes(attribute, &span, self.diagnostic_reporter)
+        for (attribute, span) in get_cs_attributes(enumerator) {
+            validate_common_attributes(attribute, span, self.diagnostic_reporter)
         }
     }
 }


### PR DESCRIPTION
Replaced my mistaken TODO with a comment explaining why it's safe to do it, along with some minor cleanup I'd already done on my branch.

`as_cs_attribute` is now public since `cs_validator` had duplicate logic (now it just calls this function).
Also, now it unwraps the cast from `LanguageKind` to `CsLanguageKind` since it can't fail (with a comment explaining why)

`cs_attributes` took a `Vec` of attributes to filter, now it takes a `dyn Attributable` and gets the attributes out of it. This what we were doing anyways, but instead of doing it 12 times (each when we call it), we do it once inside the function.