### PR TITLE
Remove Ice prefix from Process and IdentityPath

### DIFF
--- a/slice/Ice/IdentityPath.slice
+++ b/slice/Ice/IdentityPath.slice
@@ -8,5 +8,4 @@ module Ice
 /// The path of a service, encoded as an Ice identity. Use this type when converting an Ice::Identity parameter or field
 /// in an .ice file into the equivalent parameter or field in .slice syntax.
 [cs::custom("string")]
-[cs::identifier("IceIdentityPath")]
 custom IdentityPath

--- a/slice/Ice/Process.slice
+++ b/slice/Ice/Process.slice
@@ -7,7 +7,6 @@ module Ice
 
 /// A server application managed by a locator implementation such as IceGrid hosts a Process service and registers a
 /// proxy to this service with the locator registry. See {@link LocatorRegistry::setServerProcessProxy}.
-[cs::identifier("IceProcess")]
 interface Process {
     /// Initiates a graceful shutdown of the server application.
     shutdown()

--- a/src/IceRpc/Ice/IdentityPathSliceDecoderExtensions.cs
+++ b/src/IceRpc/Ice/IdentityPathSliceDecoderExtensions.cs
@@ -6,10 +6,10 @@ using IceRpc.Slice.Internal;
 namespace IceRpc.Ice;
 
 /// <summary>Provides an extension method for decoding a path encoded as an Ice identity.</summary>
-public static class IceIdentityPathSliceDecoderExtensions
+public static class IdentityPathSliceDecoderExtensions
 {
     /// <summary>Decodes a path encoded as an Ice identity.</summary>
     /// <param name="decoder">The Slice decoder.</param>
-    /// <returns>The decoded Ice identity path.</returns>
-    public static string DecodeIceIdentityPath(this ref SliceDecoder decoder) => new Identity(ref decoder).ToPath();
+    /// <returns>The decoded identity path.</returns>
+    public static string DecodeIdentityPath(this ref SliceDecoder decoder) => new Identity(ref decoder).ToPath();
 }

--- a/src/IceRpc/Ice/IdentityPathSliceEncoderExtensions.cs
+++ b/src/IceRpc/Ice/IdentityPathSliceEncoderExtensions.cs
@@ -6,11 +6,11 @@ using IceRpc.Slice.Internal;
 namespace IceRpc.Ice;
 
 /// <summary>Provides an extension method for encoding a path as an Ice identity.</summary>
-public static class IceIdentityPathSliceEncoderExtensions
+public static class IdentityPathSliceEncoderExtensions
 {
     /// <summary>Encodes a path as an Ice identity.</summary>
     /// <param name="encoder">The Slice encoder.</param>
     /// <param name="value">The path to encode as an Ice identity.</param>
-    public static void EncodeIceIdentityPath(this ref SliceEncoder encoder, string value) =>
+    public static void EncodeIdentityPath(this ref SliceEncoder encoder, string value) =>
         Identity.Parse(value).Encode(ref encoder);
 }

--- a/src/IceRpc/Slice/ServiceAddressDecoderExtensions.cs
+++ b/src/IceRpc/Slice/ServiceAddressDecoderExtensions.cs
@@ -52,7 +52,7 @@ public static class ServiceAddressSliceDecoderExtensions
             throw new InvalidOperationException(
                 $"Decoding a nullable Proxy with {decoder.Encoding} requires a bit sequence.");
         }
-        string path = decoder.DecodeIceIdentityPath();
+        string path = decoder.DecodeIdentityPath();
         return path != "/" ? decoder.DecodeServiceAddressCore(path) : null;
     }
 

--- a/src/IceRpc/Slice/ServiceAddressEncoderExtensions.cs
+++ b/src/IceRpc/Slice/ServiceAddressEncoderExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceAddressSliceEncoderExtensions
             //     - a sequence of server addresses (can be empty)
             //     - an adapter ID string present only when the sequence of server addresses is empty
 
-            encoder.EncodeIceIdentityPath(value.Path);
+            encoder.EncodeIdentityPath(value.Path);
 
             if (value.Protocol is not Protocol protocol)
             {


### PR DESCRIPTION
This PR removes the Ice prefix from the mapped `Ice::Process` and `Ice::IdentityPath`.

It doesn't remove it from the mapped `Ice::Object`. We could (there is no clash); however, I find references to ObjectProxy, IObject and IObjectService much weirder than references to IceObjectProxy, IIceObject and IIceObjectService.

Fixes #2892.