### PR TITLE
Remove cs::internal from modules

### DIFF
--- a/slice/IceRpc/Internal/IceDefinitions.slice
+++ b/slice/IceRpc/Internal/IceDefinitions.slice
@@ -2,12 +2,12 @@
 
 encoding = Slice1
 
-[cs::internal]
 module IceRpc::Internal
 
 // These definitions help with the encoding of ice frames.
 
 /// Each ice frame has a type identified by this enumeration.
+[cs::internal]
 enum IceFrameType {
     Request = 0
     RequestBatch = 1
@@ -17,6 +17,7 @@ enum IceFrameType {
 }
 
 /// The ice frame prologue.
+[cs::internal]
 [cs::readonly]
 compact struct IcePrologue {
     magic1: uint8
@@ -34,6 +35,7 @@ compact struct IcePrologue {
 
 /// Determines the retry behavior an invocation in case of a (potentially) recoverable error. OperationMode is
 /// sent with each ice request to allow the server to verify the assumptions made by the caller.
+[cs::internal]
 enum OperationMode {
     /// Ordinary operations have <c>Normal</c> mode. These operations can modify object state; invoking such
     /// an operation twice in a row may have different semantics than invoking it once. The Ice run time guarantees
@@ -52,6 +54,7 @@ enum OperationMode {
 
 /// The payload of most request and response frames starts with an encapsulation header that specifies the size of
 /// the encapsulation and its encoding.
+[cs::internal]
 [cs::readonly]
 compact struct EncapsulationHeader {
     encapsulationSize: int32
@@ -64,6 +67,7 @@ compact struct EncapsulationHeader {
 /// - a request ID
 /// - a request header (below)
 /// - a request payload, with encapsulationSize - 6 bytes
+[cs::internal]
 [cs::readonly]
 compact struct IceRequestHeader {
     path: Ice::IdentityPath
@@ -82,6 +86,7 @@ compact struct IceRequestHeader {
 /// - a reply status
 /// - when reply status is OK or UserException, an encapsulation header followed by a response payload, with
 /// encapsulationSize - 6 bytes
+[cs::internal]
 enum ReplyStatus {
     /// A successful reply message.
     Ok = 0
@@ -110,6 +115,7 @@ enum ReplyStatus {
 
 /// The data carried by a RequestFailedException (ObjectNotExistException, FacetNotExistException or
 /// OperationNotExistException).
+[cs::internal]
 [cs::readonly]
 compact struct RequestFailedExceptionData {
     path: Ice::IdentityPath

--- a/slice/IceRpc/Internal/IceRpcDefinitions.slice
+++ b/slice/IceRpc/Internal/IceRpcDefinitions.slice
@@ -1,11 +1,11 @@
 // Copyright (c) ZeroC, Inc.
 
-[cs::internal]
 module IceRpc::Internal
 
 // These definitions help with the encoding of icerpc frames.
 
 /// Each icerpc control frame has a type identified by this enumeration.
+[cs::internal]
 enum IceRpcControlFrameType : uint8 {
     /// The Settings frame is sent by each peer on connection establishment to exchange settings.
     Settings = 0
@@ -19,6 +19,7 @@ enum IceRpcControlFrameType : uint8 {
 /// - a request header size (varuint62)
 /// - a request header (below)
 /// - a request payload
+[cs::internal]
 [cs::readonly]
 compact struct IceRpcRequestHeader {
     path: string
@@ -30,6 +31,7 @@ compact struct IceRpcRequestHeader {
 /// - a response header size (varuint62)
 /// - a response header (below)
 /// - a response payload
+[cs::internal]
 [cs::readonly]
 compact struct IceRpcResponseHeader {
     statusCode: StatusCode
@@ -38,12 +40,14 @@ compact struct IceRpcResponseHeader {
 }
 
 /// The settings frame is sent by each peer on connection establishment to exchange settings.
+[cs::internal]
 [cs::readonly]
 compact struct IceRpcSettings {
     value: dictionary<IceRpcSettingKey, varuint62>
 }
 
 /// The keys for Settings entries.
+[cs::internal]
 unchecked enum IceRpcSettingKey : varuint62 {
     MaxHeaderSize = 0
 }
@@ -51,6 +55,7 @@ unchecked enum IceRpcSettingKey : varuint62 {
 /// The GoAway frame is sent on connection shutdown to notify the peer that it shouldn't send additional requests and to
 /// provide two stream IDs. Requests carried by streams with IDs greater or equal to these stream IDs were not accepted
 /// or otherwise processed, and as a result can be safely retried.
+[cs::internal]
 [cs::readonly]
 compact struct IceRpcGoAway {
     bidirectionalStreamId: varuint62

--- a/slice/IceRpc/Slice/Internal/Fragment.slice
+++ b/slice/IceRpc/Slice/Internal/Fragment.slice
@@ -2,7 +2,6 @@
 
 encoding = Slice1
 
-[cs::internal]
 module IceRpc::Slice::Internal
 
 /// The fragment of a service, encoded as a sequence of 0 or 1 elements. The empty string is encoded as an empty

--- a/slice/IceRpc/Slice/Internal/Identity.slice
+++ b/slice/IceRpc/Slice/Internal/Identity.slice
@@ -2,10 +2,10 @@
 
 encoding = Slice1
 
-[cs::internal]
 module IceRpc::Slice::Internal
 
 /// The identity of a service. Used only with Slice1.
+[cs::internal]
 [cs::readonly]
 compact struct Identity {
     /// The name of the identity.

--- a/slice/IceRpc/Slice/Internal/InvocationMode.slice
+++ b/slice/IceRpc/Slice/Internal/InvocationMode.slice
@@ -2,11 +2,11 @@
 
 encoding = Slice1
 
-[cs::internal]
 module IceRpc::Slice::Internal
 
 /// A service address encoded with Slice1 includes an InvocationMode which specifies the behavior when sending requests to that service.
 /// When encoding a service address, IceRPC always uses Twoway.
+[cs::internal]
 enum InvocationMode {
     /// This is the default invocation mode; a request using this mode always expects a response.
     Twoway

--- a/slice/IceRpc/Transports/Internal/SlicDefinitions.slice
+++ b/slice/IceRpc/Transports/Internal/SlicDefinitions.slice
@@ -1,10 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 // These definitions help with the encoding of Slic frames.
-[cs::internal]
 module IceRpc::Transports::Internal
 
 /// The Slic frame types.
+[cs::internal]
 enum FrameType : uint8 {
     /// The initialization frame is sent by the client-side Slic connection on connection establishment.
     Initialize = 1
@@ -46,6 +46,7 @@ enum FrameType : uint8 {
 
 /// The keys for supported Slic connection parameters exchanged with the Initialize and
 /// InitializeAck frames.
+[cs::internal]
 unchecked enum ParameterKey : varuint62 {
     /// The maximum number of bidirectional streams. The peer shouldn't open more streams than the maximum defined
     /// by this parameter.
@@ -68,6 +69,7 @@ unchecked enum ParameterKey : varuint62 {
 typealias ParameterFields = dictionary<ParameterKey, sequence<uint8>>
 
 /// The Slic initialize frame body.
+[cs::internal]
 [cs::readonly]
 compact struct InitializeBody {
     /// The application protocol name.
@@ -78,6 +80,7 @@ compact struct InitializeBody {
 }
 
 /// The Slic initialize acknowledgment frame body.
+[cs::internal]
 [cs::readonly]
 compact struct InitializeAckBody {
     /// The parameters.
@@ -88,6 +91,7 @@ compact struct InitializeAckBody {
 /// from the initialize frame is not supported by the receiver. Upon receiving the Version frame the receiver
 /// should send back a new Initialize frame with a version matching one of the versions provided by the Version
 /// frame body.
+[cs::internal]
 [cs::readonly]
 compact struct VersionBody {
     /// The supported Slic versions.
@@ -95,6 +99,7 @@ compact struct VersionBody {
 }
 
 /// The body of a Slic close frame. This frame is sent when the connection is explicitly closed.
+[cs::internal]
 [cs::readonly]
 compact struct CloseBody {
     /// The application error code indicating the reason of the closure.
@@ -103,6 +108,7 @@ compact struct CloseBody {
 
 /// The body of the Stream reset frame. This frame is sent to notify the peer that sender is no longer interested in
 /// the stream.
+[cs::internal]
 [cs::readonly]
 compact struct StreamResetBody {
     /// The application error code indicating the reason of the reset.
@@ -110,6 +116,7 @@ compact struct StreamResetBody {
 }
 
 /// The body of the Stream consumed frame. This frame is sent to increase the peer's send credit.
+[cs::internal]
 [cs::readonly]
 compact struct StreamConsumedBody {
     /// The size of the consumed data.
@@ -118,6 +125,7 @@ compact struct StreamConsumedBody {
 
 /// The body of the Stream stop sending frame. This frame is sent to notify the peer that the receiver is no longer
 /// interested in receiving data.
+[cs::internal]
 [cs::readonly]
 compact struct StreamStopSendingBody {
     /// The application error code indicating the reason why the peer no longer needs to receive data.

--- a/slice/IceRpc/Transports/Internal/TcpServerAddressBody.slice
+++ b/slice/IceRpc/Transports/Internal/TcpServerAddressBody.slice
@@ -2,10 +2,10 @@
 
 encoding = Slice1
 
-[cs::internal]
 module IceRpc::Transports::Internal
 
 /// Represents the body of a tcp or ssl server address in an ice service address. Used only with Slice1.
+[cs::internal]
 [cs::readonly]
 compact struct TcpServerAddressBody{
     host: string

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -80,6 +80,18 @@ fn validate_common_attributes(attribute: &CsAttributeKind, span: &Span, diagnost
     }
 }
 
+/// Validates attributes on constructed types other than custom.
+fn validate_non_custom_type_attributes(
+    attribute: &CsAttributeKind,
+    span: &Span,
+    diagnostic_reporter: &mut DiagnosticReporter,
+) {
+    match attribute {
+        CsAttributeKind::Internal { .. } => {}
+        _ => validate_common_attributes(attribute, span, diagnostic_reporter),
+    }
+}
+
 fn validate_data_type_attributes(data_type: &TypeRef, diagnostic_reporter: &mut DiagnosticReporter) {
     match data_type.concrete_type() {
         Types::Sequence(_) | Types::Dictionary(_) => validate_collection_attributes(data_type, diagnostic_reporter),
@@ -125,7 +137,6 @@ impl Visitor for CsValidator<'_> {
                         )
                         .report(self.diagnostic_reporter)
                 }
-                CsAttributeKind::Internal => {}
                 _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
@@ -135,8 +146,8 @@ impl Visitor for CsValidator<'_> {
         validate_repeated_attributes(struct_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(struct_def) {
             match attribute {
-                CsAttributeKind::Readonly | CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
+                CsAttributeKind::Readonly | CsAttributeKind::Attribute { .. } => {}
+                _ => validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
@@ -145,8 +156,8 @@ impl Visitor for CsValidator<'_> {
         validate_repeated_attributes(class_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(class_def) {
             match attribute {
-                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
+                CsAttributeKind::Attribute { .. } => {}
+                _ => validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
@@ -155,8 +166,8 @@ impl Visitor for CsValidator<'_> {
         validate_repeated_attributes(exception_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(exception_def) {
             match attribute {
-                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
+                CsAttributeKind::Attribute { .. } => {}
+                _ => validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }
@@ -164,10 +175,8 @@ impl Visitor for CsValidator<'_> {
     fn visit_interface_start(&mut self, interface_def: &Interface) {
         validate_repeated_attributes(interface_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(interface_def) {
-            match attribute {
-                CsAttributeKind::Internal => {}
-                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
-            }
+            // TODO: explain why we don't support cs::attribute on interfaces
+            validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter)
         }
     }
 
@@ -175,8 +184,8 @@ impl Visitor for CsValidator<'_> {
         validate_repeated_attributes(enum_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(enum_def) {
             match attribute {
-                CsAttributeKind::Internal | CsAttributeKind::Attribute { .. } => {}
-                _ => validate_common_attributes(attribute, span, self.diagnostic_reporter),
+                CsAttributeKind::Attribute { .. } => {}
+                _ => validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter),
             }
         }
     }


### PR DESCRIPTION
This PR removes `cs::internal` from modules: you now have to specify it on each type that you want to map to internal class/structs/interfaces.

I initially wanted to add support for a file-level `[[cs::internal]]` however:
(a) it does not appear we have support for file-level attributes in slicec-cs, 
and more importantly,
(b) it's a bad idea

In C#, C++, Java etc, you can't change the _default_ access control for all constructs in a file.

For example, in C#, the default access control is internal, and if you don't like this default, you must explicitly specify public, protected etc. for each interface, struct (etc.) where this default is not appropriate. This explicit access control is actually required in the IceRPC source code.

It should be the same for Slice, which a slightly coarser granularity (only type level; operation/field level is possible but overkill).

Fixes #2829.