### PR TITLE
Display notes when logging errors

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/SliceCCSharpTask.cs
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/SliceCCSharpTask.cs
@@ -10,6 +10,8 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+#nullable enable
+
 namespace IceRpc.Slice.Tools;
 
 /// <summary>A MSbuild task to compile Slice files to C# using the IceRPC slicec-cs compiler.</summary>


### PR DESCRIPTION
We have to use LogError and LogWarning respectively for showing the error and warning notes as errors or warnings.

<img width="635" alt="slicec-error" src="https://user-images.githubusercontent.com/254604/231281406-8786fe04-af7c-4f7a-836c-48c1e9906aa7.png">

vs

<img width="678" alt="slicec-error-1" src="https://user-images.githubusercontent.com/254604/231282598-60866f0d-dc31-4019-a27d-1a1c0433f864.png">

Fix #2842

