### PR TITLE
Use langword instead of cref for ulong etc.

### DIFF
--- a/tools/slicec-cs/src/visitors/enum_visitor.rs
+++ b/tools/slicec-cs/src/visitors/enum_visitor.rs
@@ -76,7 +76,7 @@ fn enum_underlying_extensions(enum_def: &Enum) -> CodeBlock {
     builder.add_comment(
         "summary",
         format!(
-            r#"Provides an extension method for creating {} <see cref="{escaped_identifier}" /> from {} <see cref="{cs_type}" />."#,
+            r#"Provides an extension method for creating {} <see cref="{escaped_identifier}" /> from {} <see langword="{cs_type}" />."#,
             in_definite::get_a_or_an(&escaped_identifier),
             in_definite::get_a_or_an(&cs_type),
         ),


### PR DESCRIPTION
The goal is to fix generated docfx such as:
https://api.testing.zeroc.com/csharp/api/IceRpc.StatusCodeUlongExtensions.html#IceRpc_StatusCodeUlongExtensions_AsStatusCode_System_UInt64_