### PR TITLE
Improve doc comments for generated exceptions

### DIFF
--- a/tools/slicec-cs/src/visitors/exception_visitor.rs
+++ b/tools/slicec-cs/src/visitors/exception_visitor.rs
@@ -76,7 +76,7 @@ impl Visitor for ExceptionVisitor<'_> {
                     .add_base_parameter("message")
                     .set_body(initialize_non_nullable_fields(&fields, FieldType::Exception))
                     // This is Slice1 only, there is no exception inheritance with Slice2. We hide this method because
-                    // this must be only called by the Activator
+                    // this must be only called by the Activator.
                     .add_never_editor_browsable_attribute()
                     .build(),
             );


### PR DESCRIPTION
This PR adds doc comments for the generated exception's decoding constructor, fix #2937 