### PR TITLE
Update RetryInterceptor summary to use bullet list

### DIFF
--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -18,13 +18,13 @@ namespace IceRpc.Retry;
 /// with <see cref="ResettablePipeReaderDecorator" />. The decorator can be reset as long as the buffered data doesn't
 /// exceed <see cref="RetryOptions.MaxPayloadSize" />.<br/>The request can be retried under the following failure
 /// conditions:
-/// <list>
+/// <list type="bullet">
 /// <item><description>The status code carried by the response is <see cref="StatusCode.Unavailable"
 /// />.</description></item>
 /// <item><description>The status code carried by the response is <see cref="StatusCode.ServiceNotFound" /> and the
 /// protocol is ice.</description></item>
 /// <item><description>The request failed with an <see cref="IceRpcException" /> with one of the following error:
-/// <list>
+/// <list type="bullet">
 /// <item><description>The error code is <see cref="IceRpcError.InvocationCanceled" />.</description></item>
 /// <item><description>The error code is <see cref="IceRpcError.ConnectionAborted" /> or <see
 /// cref="IceRpcError.TruncatedData" /> and the request has the <see cref="RequestFieldKey.Idempotent" />


### PR DESCRIPTION
Fixes #2945 

Adding `type="bullet"` causes the list to be rendered properly in the API reference.

<img width="661" alt="Screenshot 2023-04-13 at 11 26 55 AM" src="https://user-images.githubusercontent.com/14209515/231809124-fda8e4d0-dd4c-415a-bf47-5035f5d22210.png">
