### PR TITLE
Make ssl ice-only

### DIFF
--- a/src/IceRpc/Transports/TcpServerTransport.cs
+++ b/src/IceRpc/Transports/TcpServerTransport.cs
@@ -29,11 +29,16 @@ public class TcpServerTransport : IDuplexServerTransport
         DuplexConnectionOptions options,
         SslServerAuthenticationOptions? serverAuthenticationOptions)
     {
-        if ((serverAddress.Transport is string transport && !IsValidTransportName(transport, serverAddress.Protocol)) ||
-            serverAddress.Params.Count > 0)
+        if (serverAddress.Transport is string transport && !IsValidTransportName(transport, serverAddress.Protocol))
+        {
+            throw new NotSupportedException(
+                $"The Tcp server transport does not support server addresses with transport '{transport}'.");
+        }
+
+        if (serverAddress.Params.Count > 0)
         {
             throw new ArgumentException(
-                $"The server address '{serverAddress}' contains query parameters that are not valid for the Tcp server transport.",
+                $"The server address '{serverAddress}' contains parameters that are not valid for the Tcp server transport.",
                 nameof(serverAddress));
         }
 


### PR DESCRIPTION
This PR makes the ssl transport name ice only.

Fixes #2930.