### PR TITLE
Add libmsquic

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -36,6 +36,13 @@ runs:
     uses: actions/setup-dotnet@v3
     with:
       dotnet-version: "7.0.x"
+  - name: Install libmsquic
+    run: |
+      wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+      sudo dpkg -i packages-microsoft-prod.deb
+      rm packages-microsoft-prod.deb
+      sudo apt install libmsquic
+    shell: bash
   - name: 🔗 Start SSH Agent
     uses: webfactory/ssh-agent@v0.5.4
     with:

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class QuicTransportServiceCollectionExtensions
                         new X509Certificate2("../../../certs/client.p12", "password")
                     },
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
-                certificate?.Issuer.Contains("Ice Tests CA", StringComparison.Ordinal) ?? false
+                certificate?.Issuer.Contains("IceRPC Tests CA", StringComparison.Ordinal) ?? false
         })
             .AddSingleton(provider => new SslServerAuthenticationOptions
             {


### PR DESCRIPTION
This PR updates the `.github` workflow to install `libmsquic`, which is a requisite for running Quic tests. The CI job was not running the Quic tests because of this missing dependency. There is also a fix for the Quic tests certificate validation callback, it was checking for "Ice Tests CA" but the updated tests contain "IceRPC Tests CA".