### PR TITLE
SliceC MSBuild task cleanup

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/SliceCCSharpTask.cs
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/SliceCCSharpTask.cs
@@ -3,6 +3,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
This PR simplifies the logging of diagnostic messages in SliceC MSBuild task.