### PR TITLE
Add slicec-cs test to compile all test Slice

### DIFF
--- a/tools/slicec-cs/src/code_gen.rs
+++ b/tools/slicec-cs/src/code_gen.rs
@@ -22,7 +22,7 @@ pub fn compiler_chain(compilation_data: CompilationData) -> CompilationResult {
 }
 
 // Generate the code for a single Slice file.
-pub fn generate(slice_file: &SliceFile) -> String {
+pub fn generate_code(slice_file: &SliceFile) -> String {
     let mut generated_code = GeneratedCode::new();
 
     generated_code.preamble.push(preamble(slice_file));
@@ -97,7 +97,7 @@ using IceRpc.Slice;
 
 #[cfg(test)]
 mod test {
-    use super::{compile, generate};
+    use super::{compile, generate_code};
     use slice::command_line::SliceOptions;
     use slice::diagnostics::DiagnosticReporter;
     use slice::utils::file_util::resolve_files_from;
@@ -129,7 +129,7 @@ mod test {
 
             let compilation_data = compile(&options).unwrap();
 
-            generate(compilation_data.files.values().next().unwrap());
+            generate_code(compilation_data.files.values().next().unwrap());
         }
     }
 }

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -16,7 +16,7 @@ mod slicec_ext;
 mod validators;
 mod visitors;
 
-use code_gen::{compile, generate};
+use code_gen::{compile, generate_code};
 use cs_options::CsOptions;
 use slice::clap::Parser;
 use slice::compilation_result::CompilationResult;
@@ -41,7 +41,7 @@ fn try_main() -> CompilationResult {
 
     if !slice_options.dry_run {
         for slice_file in compilation_data.files.values().filter(|file| file.is_source) {
-            let code_string = generate(slice_file);
+            let code_string = generate_code(slice_file);
 
             let path = match &slice_options.output_dir {
                 Some(output_dir) => Path::new(output_dir),

--- a/tools/slicec-cs/src/validators/tests.rs
+++ b/tools/slicec-cs/src/validators/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::code_gen::compiler_chain;
-use super::super::*;
+use crate::cs_attributes;
 use slice::diagnostics::{Diagnostic, Error};
 
 fn parse_for_diagnostics(slice: &str) -> Vec<Diagnostic> {


### PR DESCRIPTION
This PR adds a new `slicec-cs` test which finds all the test Slice files and runs the code generation on them. This is useful because it allows us to use the Rust code coverage tool to see how much coverage we're getting in `slicec-cs` from the test Slice. 

This required a little restructuring of the files to move the compiler chain, compilation, and generation out of `main.rs`. This way we can use the full compiler chain in the tests. 