### PR TITLE
More server address/service address tests

### DIFF
--- a/tests/IceRpc.Tests/ServerAddressTests.cs
+++ b/tests/IceRpc.Tests/ServerAddressTests.cs
@@ -285,4 +285,13 @@ public class ServerAddressTests
 
         Assert.That(serverAddress.Params, Has.Count.EqualTo(0));
     }
+
+    [TestCase("icerpc://127.0.0.1?transport=foo&p=v&p1=v1", "icerpc://127.0.0.1:4062?p1=v1&transport=foo&p=v")]
+    [TestCase("icerpc://127.0.0.1?transport=foo&p=v1&p=v2&p=v3", "icerpc://127.0.0.1:4062?p=v1,v2,v3&transport=foo")]
+    public void Server_address_equal(ServerAddress lhs, ServerAddress rhs) => Assert.That(lhs, Is.EqualTo(rhs));
+
+    [TestCase("icerpc://127.0.0.1", "icerpc://localhost")]
+    [TestCase("icerpc://127.0.0.1?transport=foo&p=v", "icerpc://127.0.0.1?transport=foo&p=v1")]
+    [TestCase("icerpc://127.0.0.1?p=v1&p=v2", "icerpc://127.0.0.1?p=v2&p=v1")]
+    public void Server_address_not_equal(ServerAddress lhs, ServerAddress rhs) => Assert.That(lhs, Is.Not.EqualTo(rhs));
 }

--- a/tests/IceRpc.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Tests/ServiceAddressTests.cs
@@ -559,4 +559,15 @@ public class ServiceAddressTests
         Assert.That(serviceAddress.Path, Is.EqualTo("/foo"));
         Assert.That(serviceAddress.Protocol, Is.Null);
     }
+
+    [TestCase("icerpc://127.0.0.1/path?transport=foo&p=v&p1=v1", "icerpc://127.0.0.1:4062/path?p1=v1&transport=foo&p=v")]
+    [TestCase("icerpc:/path?p=v&p1=v1", "icerpc:/path?p1=v1&p=v")]
+    [TestCase("icerpc:/path?p=v1,v2,v3&foo=bar", "icerpc:/path?foo=bar&p=v1&p=v2&p=v3")]
+    public void Service_address_equal(ServiceAddress lhs, ServiceAddress rhs) => Assert.That(lhs, Is.EqualTo(rhs));
+
+    [TestCase("icerpc://127.0.0.1/path", "icerpc://localhost/path")]
+    [TestCase("ice://127.0.0.1/path#foo", "ice://127.0.0.1/path#bar")]
+    [TestCase("icerpc://127.0.0.1/path?transport=foo&p=v", "icerpc://127.0.0.1/path?transport=foo&p=v1")]
+    public void Service_address_not_equal(ServiceAddress lhs, ServiceAddress rhs) =>
+        Assert.That(lhs, Is.Not.EqualTo(rhs));
 }


### PR DESCRIPTION
This PR adds tests for server addresses and service addresses. In particular, it exercises https://coverage.testing.zeroc.com/csharp/IceRpc_DictionaryExtensions.html
