### PR TITLE
Support for report generator license

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -154,6 +154,10 @@ run_test()
 
     if [ "$coverage" == "yes" ]; then
         arguments=("-reports:tests/*/TestResults/*/coverage.cobertura.xml" "-targetdir:tests/CodeCoverageReport")
+        if [ -n "${REPORTGENERATOR_LICENSE}" ]; then
+            arguments+=("-license:${REPORTGENERATOR_LICENSE}")
+        fi
+
         run_command reportgenerator "${arguments[@]}"
         # Remove code coverage results after the report has been generated.
         find "tests" -type d -name "TestResults" -prune -exec rm -rf {} \;

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -156,6 +156,9 @@ function Test($config, $coverage) {
     RunCommand "dotnet" $arguments
     if ($coverage) {
         $arguments = @('-reports:tests/*/TestResults/*/coverage.cobertura.xml', '-targetdir:tests/CodeCoverageReport')
+        if ($env:REPORTGENERATOR_LICENSE) {
+            $arguments += @("-version:$env:REPORTGENERATOR_LICENSE")
+        }
         RunCommand "reportgenerator" $arguments
         # Remove code coverage results after the report has been generated.
         Get-ChildItem -Path .\tests\ -Filter TestResults -Recurse | Remove-Item -Recurse -Force


### PR DESCRIPTION
If the env variable `REPORTGENERATOR_LICENSE` is found, we use pass it as the report generator license key in the build script.