### PR TITLE
Don't encode a non-null service address with null identity

### DIFF
--- a/src/IceRpc/Slice/ServiceAddressSliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/ServiceAddressSliceDecoderExtensions.cs
@@ -54,7 +54,7 @@ public static class ServiceAddressSliceDecoderExtensions
         if (decoder.Encoding != SliceEncoding.Slice1)
         {
             throw new InvalidOperationException(
-                $"Decoding a nullable Proxy with {decoder.Encoding} requires a bit sequence.");
+                $"Decoding a nullable service address with {decoder.Encoding} requires a bit sequence.");
         }
         string path = decoder.DecodeIdentityPath();
         return path != "/" ? decoder.DecodeServiceAddressCore(path) : null;

--- a/src/IceRpc/Slice/ServiceAddressSliceEncoderExtensions.cs
+++ b/src/IceRpc/Slice/ServiceAddressSliceEncoderExtensions.cs
@@ -29,7 +29,15 @@ public static class ServiceAddressSliceEncoderExtensions
             // - a sequence of server addresses (can be empty)
             // - an adapter ID string present only when the sequence of server addresses is empty
 
-            encoder.EncodeIdentityPath(value.Path);
+            var identity = Identity.Parse(value.Path);
+            if (identity.Name.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Cannot encode a non-null service address with a null Ice identity.",
+                    nameof(value));
+            }
+            identity.Encode(ref encoder);
+
             encoder.EncodeFragment(value.Fragment);
             encoder.EncodeInvocationMode(InvocationMode.Twoway);
             encoder.EncodeBool(false);               // Secure

--- a/tests/IceRpc.Tests/Slice/ProxyTests.cs
+++ b/tests/IceRpc.Tests/Slice/ProxyTests.cs
@@ -15,7 +15,7 @@ namespace IceRpc.Tests.Slice;
 [Parallelizable(scope: ParallelScope.All)]
 public class ProxyTests
 {
-    /// <summary>Verifies that nullable proxies are correctly encoded withSlice1 encoding.</summary>
+    /// <summary>Verifies that nullable proxies are correctly encoded with Slice1 encoding.</summary>
     /// <param name="expected">The nullable proxy to test with.</param>
     [TestCase("icerpc://host.zeroc.com/hello")]
     [TestCase(null)]
@@ -152,6 +152,18 @@ public class ProxyTests
             encoder.EncodeServiceAddress(serviceAddress);
         },
         Throws.TypeOf<FormatException>());
+
+    // we have to use icerpc since for an ice service address these path are rejected
+    [TestCase("icerpc://host:10000")]
+    [TestCase("icerpc://host:10000/foo/")]
+    public void Encode_service_address_with_null_identity_fails(ServiceAddress serviceAddress) =>
+        Assert.That(() =>
+        {
+            var bufferWriter = new MemoryBufferWriter(new byte[256]);
+            var encoder = new SliceEncoder(bufferWriter, SliceEncoding.Slice1);
+            encoder.EncodeServiceAddress(serviceAddress);
+        },
+        Throws.TypeOf<ArgumentException>());
 
     /// <summary>Verifies that a proxy decoded from an incoming request has a null invoker by default.</summary>
     [Test]


### PR DESCRIPTION
This PR adds a check and test to make sure we don't encode a non-null service address with a null identity (with Slice1).