### PR TITLE
build.sh directory fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,7 @@ run_test()
 {
     arguments=("test" "-c" "$dotnet_config")
     if [ "$coverage" == "yes" ]; then
-        runsettings=${PWD}/'build/Coverlet.runsettings'
+        runsettings=${PWD}/build/Coverlet.runsettings
         arguments+=("/p:RunSettingsFilePath=$runsettings" "--collect:\"XPlat Code Coverage\"")
     fi
     run_command dotnet "${arguments[@]}"


### PR DESCRIPTION
This PR does two things:

1 . replace `realpath '/path'` by  `$PWD/path`

2. Change into the scripts directory when it first starts. I opted for a simple `cd "$(dirname "${BASH_SOURCE[0]}")"`. It has a few downsides.  It will fail if the script is sourced or if the script is executed from a symlink.  I don't think we need to care about these situations. 