### PR TITLE
Remove extra semicolon in generated code

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -150,7 +150,7 @@ pub fn decode_tagged(
         .add_argument(format!("useTagEndMarker: {use_tag_end_marker}"))
         .build();
 
-    format!("{param} = {decode};").into()
+    format!("{param} = {decode}").into()
 }
 
 pub fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, encoding: Encoding) -> CodeBlock {


### PR DESCRIPTION
This PR fixes #3045.

I also verified there is no other ";;" in the generated code generated by the tests.