### PR TITLE
Remove IListener base interface

### DIFF
--- a/src/IceRpc/Transports/IListener.cs
+++ b/src/IceRpc/Transports/IListener.cs
@@ -4,27 +4,23 @@ using System.Net;
 
 namespace IceRpc.Transports;
 
-/// <summary>The base interface for listeners.</summary>
-public interface IListener : IAsyncDisposable
+/// <summary>A listener listens for connection requests from clients.</summary>
+/// <typeparam name="T">The connection type.</typeparam>
+/// <remarks>The IceRPC core and the Slic transport implementation call this interface. They provide the following
+/// guarantees:
+/// <list type="bullet">
+/// <item><description>The <see cref="AcceptAsync" /> method is never called concurrently.</description></item>
+/// <item><description>The <see cref="IAsyncDisposable.DisposeAsync" /> method can be called while an
+/// <see cref="AcceptAsync" /> call is in progress. It can be called multiple times but not concurrently.</description>
+/// </item>
+/// </list>
+/// </remarks>
+public interface IListener<T> : IAsyncDisposable
 {
     /// <summary>Gets the server address of this listener. That's the address a client would connect to.</summary>
     /// <value>The server address.</value>
     ServerAddress ServerAddress { get; }
-}
 
-/// <summary>A listener listens for connection requests from clients.</summary>
-/// <typeparam name="T">The connection type.</typeparam>
-/// <remarks>The IceRPC core and Slice transport implementation uses this interface. It provides the following
-/// guarantees:
-/// <list type="bullet">
-/// <item><description>The <see cref="AcceptAsync" /> method is never called concurrently.</description></item>
-/// <item><description>The <see cref="IAsyncDisposable.DisposeAsync" /> method can be called while an <see
-/// cref="AcceptAsync" /> call is in progress. It can be called multiple times but not
-/// concurrently.</description></item>
-/// </list>
-/// </remarks>
-public interface IListener<T> : IListener
-{
     /// <summary>Accepts a new connection.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with the accepted connection and network address of the client. This


### PR DESCRIPTION
This PR merges IListener into `IListener<T>`. We never used this base interface anywhere.