### PR TITLE
Only run workflows for PRs on open, reopen, and ready for review

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,27 +4,27 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    types: [opened, reopened, ready_for_review]
     branches: ["main"]
 
 jobs:
   build_and_test:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Build
-      uses: ./.github/actions/build
-      env:
-        ICERPC_DEPLOY_KEY: ${{ secrets.ICERPC_DEPLOY_KEY }}
-        NUGET_API_TOKEN: ${{ secrets.NUGET_API_TOKEN }}
-    - name: Push
-      uses: ./.github/actions/push
-    - name: Build Examples
-      uses: ./.github/actions/build-examples
-    - name: Run Tests
-      uses: ./.github/actions/test
-    - name: Test Templates
-      uses: ./.github/actions/test-templates
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/actions/build
+        env:
+          ICERPC_DEPLOY_KEY: ${{ secrets.ICERPC_DEPLOY_KEY }}
+          NUGET_API_TOKEN: ${{ secrets.NUGET_API_TOKEN }}
+      - name: Push
+        uses: ./.github/actions/push
+      - name: Build Examples
+        uses: ./.github/actions/build-examples
+      - name: Run Tests
+        uses: ./.github/actions/test
+      - name: Test Templates
+        uses: ./.github/actions/test-templates

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,7 +1,8 @@
-name: 'Check spelling'
+name: "Check spelling"
 
 on:
   pull_request:
+    types: [opened, reopened, ready_for_review]
   push:
 
 jobs:


### PR DESCRIPTION
To prevent the workflows from running each time a commit is pushed to a PR, this now will make the runners only run the workflow on `open`, `reopen`, and `ready_for_review`.

The complete list of options is [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) if we want to add more. 

_**Note**: To run the workflow on extra commits in a PR you would now need to manually trigger the actions._