### PR TITLE
Docfx build fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -172,7 +172,8 @@ run_test()
 doc()
 {
     pushd docfx
-    run_command docfx "--property" "Configuration=$dotnet_config"
+    run_command docfx "metadata" "--property" "Configuration=$dotnet_config"
+    run_command docfx "build"
     popd
 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -168,7 +168,8 @@ function Test($config, $coverage) {
 function Doc() {
     $dotnetConfiguration = DotnetConfiguration($config)
     Push-Location "docfx"
-    RunCommand "docfx" @('--property', "Configuration=$dotnetConfiguration")
+    RunCommand "docfx" @('metadata', '--property', "Configuration=$dotnetConfiguration")
+    RunCommand "docfx" @('build')
     Pop-Location
 }
 

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -21,9 +21,6 @@
         }
     ],
     "build": {
-        "xrefService":[
-            "https://xref.docs.microsoft.com/query?uid={uid}"
-        ],
         "content": [
             {
                 "files": [


### PR DESCRIPTION
These fixes build failures with the latest docfx, the `--property` option is only valid for the metadata action.

We should upgrade the JOB that builds the doc to use [v2.66.2](https://github.com/dotnet/docfx/releases/tag/v2.66.2)

