### PR TITLE
Add nampespace overwrite files

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -47,7 +47,8 @@
         "overwrite": [
             {
                 "files": [
-                    "overwrite/**.md"
+                    "overwrite/**.md",
+                    "namespaces/**.md"
                 ],
                 "exclude": [
                     "obj/**",

--- a/docfx/namespaces/IceRpc.Builder.md
+++ b/docfx/namespaces/IceRpc.Builder.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Builder
+summary: *content
+---
+
+The IceRpc.Builder namespace.

--- a/docfx/namespaces/IceRpc.Compressor.md
+++ b/docfx/namespaces/IceRpc.Compressor.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Compressor
+summary: *content
+---
+
+The IceRpc.Compressor namespace.

--- a/docfx/namespaces/IceRpc.Deadline.md
+++ b/docfx/namespaces/IceRpc.Deadline.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Deadline
+summary: *content
+---
+
+The IceRpc.Deadline namespace.

--- a/docfx/namespaces/IceRpc.Features.md
+++ b/docfx/namespaces/IceRpc.Features.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Features
+summary: *content
+---
+
+The IceRpc.Features namespace.

--- a/docfx/namespaces/IceRpc.Ice.md
+++ b/docfx/namespaces/IceRpc.Ice.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Ice
+summary: *content
+---
+
+The IceRpc.Ice namespace.

--- a/docfx/namespaces/IceRpc.Locator.md
+++ b/docfx/namespaces/IceRpc.Locator.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Locator
+summary: *content
+---
+
+The IceRpc.Locator namespace.

--- a/docfx/namespaces/IceRpc.Logger.md
+++ b/docfx/namespaces/IceRpc.Logger.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Logger
+summary: *content
+---
+
+The IceRpc.Logger namespace.

--- a/docfx/namespaces/IceRpc.Metrics.md
+++ b/docfx/namespaces/IceRpc.Metrics.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Metrics
+summary: *content
+---
+
+The IceRpc.Metrics namespace.

--- a/docfx/namespaces/IceRpc.RequestContext.md
+++ b/docfx/namespaces/IceRpc.RequestContext.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.RequestContext
+summary: *content
+---
+
+The IceRpc.RequestContext namespace.

--- a/docfx/namespaces/IceRpc.Retry.md
+++ b/docfx/namespaces/IceRpc.Retry.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Retry
+summary: *content
+---
+
+The IceRpc.Retry namespace.

--- a/docfx/namespaces/IceRpc.Slice.md
+++ b/docfx/namespaces/IceRpc.Slice.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Slice
+summary: *content
+---
+
+The IceRpc.Slice namespace.

--- a/docfx/namespaces/IceRpc.Telemetry.md
+++ b/docfx/namespaces/IceRpc.Telemetry.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Telemetry
+summary: *content
+---
+
+The IceRpc.Telemetry namespace.

--- a/docfx/namespaces/IceRpc.Transports.Coloc.md
+++ b/docfx/namespaces/IceRpc.Transports.Coloc.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Transports.Coloc
+summary: *content
+---
+
+The IceRpc.Transports.Coloc namespace.

--- a/docfx/namespaces/IceRpc.Transports.Quic.md
+++ b/docfx/namespaces/IceRpc.Transports.Quic.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Transports.Quic
+summary: *content
+---
+
+The IceRpc.Transports.Quic namespace.

--- a/docfx/namespaces/IceRpc.Transports.Slic.md
+++ b/docfx/namespaces/IceRpc.Transports.Slic.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Transports.Slic
+summary: *content
+---
+
+The IceRpc.Transports.Slic namespace.

--- a/docfx/namespaces/IceRpc.Transports.Tcp.md
+++ b/docfx/namespaces/IceRpc.Transports.Tcp.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Transports.Tcp
+summary: *content
+---
+
+The IceRpc.Transports.Tcp namespace.

--- a/docfx/namespaces/IceRpc.Transports.md
+++ b/docfx/namespaces/IceRpc.Transports.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc.Transports
+summary: *content
+---
+
+The IceRpc.Transports namespace.

--- a/docfx/namespaces/IceRpc.md
+++ b/docfx/namespaces/IceRpc.md
@@ -1,0 +1,6 @@
+---
+uid: IceRpc
+summary: *content
+---
+
+The IceRpc namespace.

--- a/docfx/namespaces/Microsoft.Extensions.DependencyInjection.md
+++ b/docfx/namespaces/Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,6 @@
+---
+uid: Microsoft.Extensions.DependencyInjection
+summary: *content
+---
+
+The Microsoft.Extensions.DependencyInjection namespace.


### PR DESCRIPTION
This PR adds per namespace overwrite file, which can be used for adding a summary for the namespace. Fix #3114.

The summary has still to be written, I just added some placeholder text, but this can be done in separate PRs.