### PR TITLE
Support for build script version argument

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,8 @@ usage()
     echo "                            The NuGet packages are pushed to the local global-packages source."
     echo "  --coverage                Collect code coverage from test runs."
     echo "                            Requires reportgenerator command from https://github.com/danielpalme/ReportGenerator."
-    echo " --version                  The version override for the NuGet packages."
+    echo "  --version                 The version override for the IceRPC NuGet packages. The default version is the version"
+    echo "                            specified in the build/IceRpc.Version.props file."
     echo "  --help   | -h             Print help and exit."
 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -213,7 +213,8 @@ function Get-Help() {
     Write-Host "                            The NuGet packages are pushed to the local global-packages source."
     Write-Host "  -coverage                 Collect code coverage from test runs."
     Write-Host "                            Requires reportgenerator command from https://github.com/danielpalme/ReportGenerator"
-    Write-Host "  -version                  The version override for the IceRPC NuGet packages. The default version is the one specified in the build/IceRpv.Version.props file."
+    Write-Host "  -version                  The version override for the IceRPC NuGet packages. The default version is the version"
+    Write-Host "                            specified in the build/IceRpc.Version.props file."
     Write-Host "  -help                     Print help and exit."
 }
 


### PR DESCRIPTION
This PR adds support for a `build.sh` `--version <version>` argument. The version specified on the command line overrides the version defined in `build/IceRpc.Version.props`.