### PR TITLE
Prevent updates to slice/ subtree

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Subtree Rules
+        uses: icerpc/subtree-rules@main
+        with:
+          subtreePath: 'slice/'
     - name: Build
       uses: ./.github/actions/build
       env:


### PR DESCRIPTION
This PR adds an action that will fail if a PR updates both files in the "slice/" subtree and files outside it.

I created an action for this in https://github.com/icerpc/subtree-rules

I also set up a repository for testing this action and created a few PRs that demonstrate how it works, see https://github.com/icerpc/subtree-test/pulls

See #3143