### PR TITLE
Fix for #2978

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
@@ -84,6 +84,8 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
                             {
                                 _segments.Add(segment);
                             }
+
+                            // TODO: change the IDuplexConnection.WriteAsync API to use ReadOnlySequence<byte> instead.
                             await _connection.WriteAsync(_segments, _disposeCts.Token).ConfigureAwait(false);
                             _pipe.Reader.AdvanceTo(readResult.Buffer.End);
                         }


### PR DESCRIPTION
This PR fixes #2978.

It also simplifies `ReceiveControlFrameHeaderAsync` which wasn't fixed when we changed the encoding of the control frames (I kept `DecodeFrameType`... to decode the frame type, let me know if you prefer to remove it).

It also adds tests to ensure the protocol connection behaves correctly on bogus settings/goaway frames. I left a TODO in the test. I wonder if we should be consistent for the IceRpcError reported by ConnectAsync/ShutdownAsync on invalid data.