### PR TITLE
Added PipeWriter extensions tests

### DIFF
--- a/src/IceRpc/Internal/PipeWriterExtensions.cs
+++ b/src/IceRpc/Internal/PipeWriterExtensions.cs
@@ -142,6 +142,10 @@ internal static class PipeWriterExtensions
             {
                 flushResult = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
+            else if (source.IsSingleSegment)
+            {
+                flushResult = await writer.WriteAsync(source.First, cancellationToken).ConfigureAwait(false);
+            }
             else
             {
                 foreach (ReadOnlyMemory<byte> buffer in source)

--- a/tests/IceRpc.Tests/PipeWriterExtentionsTests.cs
+++ b/tests/IceRpc.Tests/PipeWriterExtentionsTests.cs
@@ -132,7 +132,7 @@ public class PipeWriterExtensionsTests
     }
 
     [Test]
-    public async Task ReadOnlySequencePipeWriter_copy_from_with_end_stream_completes_the_writer()
+    public async Task ReadOnlySequencePipeWriter_copy_from_with_end_stream_read_as_completed_read_result()
     {
         // Arrange
         var destinationPipe = new Pipe();
@@ -175,7 +175,6 @@ public class PipeWriterExtensionsTests
         sourcePipe.Writer.Write(new byte[10]);
         sourcePipe.Writer.Write(new byte[10]);
         sourcePipe.Writer.Complete();
-        _ = await sourcePipe.Writer.FlushAsync();
 
         var writesClosedTcs = new TaskCompletionSource();
 


### PR DESCRIPTION
This PR adds tests for pipe writer extensions and in particular the `CopyFromAsync`. 

It also fixes #3190 to ensure the writer is completed. This ensures that the reader returns a completed read result regardless of the type of the writer.