### PR TITLE
No longer test Connect_cancellation with Quic, fixes #3170

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -316,28 +316,6 @@ public abstract class MultiplexedConnectionConformanceTests
         Assert.That(() => serverCloseTask, Throws.Nothing);
     }
 
-    /// <summary>Verifies that ConnectAsync can be canceled.</summary>
-    [Test]
-    public async Task Connect_cancellation()
-    {
-        await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
-
-        using var cts = new CancellationTokenSource();
-        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
-        var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
-        var clientConnection = clientTransport.CreateConnection(
-            listener.ServerAddress,
-            provider.GetRequiredService<IOptions<MultiplexedConnectionOptions>>().Value,
-            provider.GetService<SslClientAuthenticationOptions>());
-        var connectTask = clientConnection.ConnectAsync(cts.Token);
-
-        // Act
-        cts.Cancel();
-
-        // Assert
-        Assert.That(async () => await connectTask, Throws.InstanceOf<OperationCanceledException>());
-    }
-
     [Test]
     public async Task Create_client_connection_with_unknown_server_address_parameter_fails_with_format_exception()
     {


### PR DESCRIPTION
This PR removes the testing of `ConnectAsync` cancellation from the conformance tests. This is now just tested with Slic.

It worked pretty much all the time with Quic "by chance".

The Quic client connection establishment succeeds even if the listener is not accepting the connection. The Quic listener accepts it in the background... 

Reducing the listener backlog size doesn't work because once the backlog is full the client connection is rejected, it doesn't hang. 

The only ways this could work are hacky:
- loop until `ConnectAsync` throws OCE
- setup an ssl client authentication option with a verify that sleep to delay the connection establishment (but this breaks the Slic conformance test because coloc doesn't support SSL...).