### PR TITLE
Update slicec dependency

### DIFF
--- a/tests/IceRpc.Tests/Slice/ClassTests.slice
+++ b/tests/IceRpc.Tests/Slice/ClassTests.slice
@@ -41,8 +41,8 @@ interface ClassOperations {
     opMyClassCompact(p1: MyClassA) -> MyClassA
 
     // Sliced format
-    [format(Sliced)] opAnyClassSliced(p1: AnyClass) -> AnyClass
-    [format(Sliced)] opMyClassSliced(p1: MyClassA) -> MyClassA
+    [slicedFormat(Args, Return)] opAnyClassSliced(p1: AnyClass) -> AnyClass
+    [slicedFormat(Args, Return)] opMyClassSliced(p1: MyClassA) -> MyClassA
 }
 
 [cs::internal]

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -583,7 +583,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/icerpc/slicec#a96948993cce5bca0dc535fcdeca0bca282f5610"
+source = "git+ssh://git@github.com/icerpc/slicec#704a6ad644d2d96c9e631fbc98a6d2f73c941a87"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -529,7 +529,10 @@ int startPos_ = encoder_.EncodedByteCount;",
             _ => "SliceEncoder.EncodeVarUInt62((ulong)(encoder_.EncodedByteCount - startPos_), sizePlaceholder_);",
         },
         encoding = operation.encoding.to_cs_encoding(),
-        class_format = operation.format_type(),
+        class_format = match operation.slice_classes(return_type) {
+            true => "ClassFormat.Sliced",
+            false => "default", // compact is the default value
+        },
         encode_returns = encode_operation_parameters(operation, return_type, "encoder_"),
     )
     .into()

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -3,7 +3,7 @@
 use super::{EntityExt, InterfaceExt, MemberExt, ParameterExt, ParameterSliceExt};
 use crate::cs_attributes::match_cs_encoded_result;
 use crate::cs_util::FieldType;
-use slice::grammar::{Attributable, ClassFormat, Contained, Operation};
+use slice::grammar::{Attributable, Contained, Operation};
 use slice::utils::code_gen_util::TypeContext;
 
 pub trait OperationExt {
@@ -14,7 +14,7 @@ pub trait OperationExt {
     fn encoded_result_struct(&self) -> String;
 
     /// The Slice format type of the operation
-    fn format_type(&self) -> &str;
+    fn slice_classes(&self, is_dispatch: bool) -> bool;
 
     /// The operation return task.
     fn return_task(&self, is_dispatch: bool) -> String;
@@ -33,10 +33,10 @@ impl OperationExt for Operation {
         )
     }
 
-    fn format_type(&self) -> &str {
-        match self.class_format() {
-            ClassFormat::Sliced => "ClassFormat.Sliced",
-            ClassFormat::Compact => "default", // compact is the default value
+    fn slice_classes(&self, is_dispatch: bool) -> bool {
+        match is_dispatch {
+            true => self.slice_classes_in_return(),
+            false => self.slice_classes_in_arguments(),
         }
     }
 

--- a/tools/slicec-cs/src/validators/cs_validator.rs
+++ b/tools/slicec-cs/src/validators/cs_validator.rs
@@ -115,13 +115,13 @@ fn validate_repeated_attributes(entity: &dyn Entity, diagnostic_reporter: &mut D
 }
 
 impl Visitor for CsValidator<'_> {
-    fn visit_file_start(&mut self, slice_file: &SliceFile) {
+    fn visit_file(&mut self, slice_file: &SliceFile) {
         for (attribute, span) in get_cs_attributes(slice_file) {
             report_unexpected_attribute(attribute, span, self.diagnostic_reporter);
         }
     }
 
-    fn visit_module_start(&mut self, module_def: &Module) {
+    fn visit_module(&mut self, module_def: &Module) {
         validate_repeated_attributes(module_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(module_def) {
             match attribute {
@@ -141,7 +141,7 @@ impl Visitor for CsValidator<'_> {
         }
     }
 
-    fn visit_struct_start(&mut self, struct_def: &Struct) {
+    fn visit_struct(&mut self, struct_def: &Struct) {
         validate_repeated_attributes(struct_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(struct_def) {
             match attribute {
@@ -151,28 +151,28 @@ impl Visitor for CsValidator<'_> {
         }
     }
 
-    fn visit_class_start(&mut self, class_def: &Class) {
+    fn visit_class(&mut self, class_def: &Class) {
         validate_repeated_attributes(class_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(class_def) {
             validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter)
         }
     }
 
-    fn visit_exception_start(&mut self, exception_def: &Exception) {
+    fn visit_exception(&mut self, exception_def: &Exception) {
         validate_repeated_attributes(exception_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(exception_def) {
             validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter)
         }
     }
 
-    fn visit_interface_start(&mut self, interface_def: &Interface) {
+    fn visit_interface(&mut self, interface_def: &Interface) {
         validate_repeated_attributes(interface_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(interface_def) {
             validate_non_custom_type_attributes(attribute, span, self.diagnostic_reporter)
         }
     }
 
-    fn visit_enum_start(&mut self, enum_def: &Enum) {
+    fn visit_enum(&mut self, enum_def: &Enum) {
         validate_repeated_attributes(enum_def, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(enum_def) {
             match attribute {
@@ -182,7 +182,7 @@ impl Visitor for CsValidator<'_> {
         }
     }
 
-    fn visit_operation_start(&mut self, operation: &Operation) {
+    fn visit_operation(&mut self, operation: &Operation) {
         validate_repeated_attributes(operation, self.diagnostic_reporter);
         for (attribute, span) in get_cs_attributes(operation) {
             match attribute {

--- a/tools/slicec-cs/src/visitors/class_visitor.rs
+++ b/tools/slicec-cs/src/visitors/class_visitor.rs
@@ -19,7 +19,7 @@ pub struct ClassVisitor<'a> {
 }
 
 impl Visitor for ClassVisitor<'_> {
-    fn visit_class_start(&mut self, class_def: &Class) {
+    fn visit_class(&mut self, class_def: &Class) {
         let class_name = class_def.escape_identifier();
         let namespace = class_def.namespace();
         let has_base_class = class_def.base_class().is_some();

--- a/tools/slicec-cs/src/visitors/dispatch_visitor.rs
+++ b/tools/slicec-cs/src/visitors/dispatch_visitor.rs
@@ -18,7 +18,7 @@ pub struct DispatchVisitor<'a> {
 }
 
 impl Visitor for DispatchVisitor<'_> {
-    fn visit_interface_start(&mut self, interface_def: &Interface) {
+    fn visit_interface(&mut self, interface_def: &Interface) {
         let namespace = interface_def.namespace();
         let bases = interface_def.base_interfaces();
         let service_name = interface_def.service_name();

--- a/tools/slicec-cs/src/visitors/enum_visitor.rs
+++ b/tools/slicec-cs/src/visitors/enum_visitor.rs
@@ -14,7 +14,7 @@ pub struct EnumVisitor<'a> {
 }
 
 impl<'a> Visitor for EnumVisitor<'a> {
-    fn visit_enum_start(&mut self, enum_def: &Enum) {
+    fn visit_enum(&mut self, enum_def: &Enum) {
         let mut code = CodeBlock::default();
         code.add_block(&enum_declaration(enum_def));
         code.add_block(&enum_underlying_extensions(enum_def));

--- a/tools/slicec-cs/src/visitors/exception_visitor.rs
+++ b/tools/slicec-cs/src/visitors/exception_visitor.rs
@@ -19,7 +19,7 @@ pub struct ExceptionVisitor<'a> {
 }
 
 impl Visitor for ExceptionVisitor<'_> {
-    fn visit_exception_start(&mut self, exception_def: &Exception) {
+    fn visit_exception(&mut self, exception_def: &Exception) {
         let exception_name = exception_def.escape_identifier();
         let has_base = exception_def.base.is_some();
 

--- a/tools/slicec-cs/src/visitors/module_visitor.rs
+++ b/tools/slicec-cs/src/visitors/module_visitor.rs
@@ -14,7 +14,7 @@ pub struct ModuleVisitor<'a> {
 }
 
 impl Visitor for ModuleVisitor<'_> {
-    fn visit_file_end(&mut self, slice_file: &SliceFile) {
+    fn visit_file(&mut self, slice_file: &SliceFile) {
         let top_level_modules = slice_file
             .contents
             .iter()

--- a/tools/slicec-cs/src/visitors/proxy_visitor.rs
+++ b/tools/slicec-cs/src/visitors/proxy_visitor.rs
@@ -19,7 +19,7 @@ pub struct ProxyVisitor<'a> {
 }
 
 impl Visitor for ProxyVisitor<'_> {
-    fn visit_interface_start(&mut self, interface_def: &Interface) {
+    fn visit_interface(&mut self, interface_def: &Interface) {
         let namespace = interface_def.namespace();
         let interface = interface_def.interface_name(); // IFoo
         let slice_interface = interface_def.module_scoped_identifier();

--- a/tools/slicec-cs/src/visitors/struct_visitor.rs
+++ b/tools/slicec-cs/src/visitors/struct_visitor.rs
@@ -21,7 +21,7 @@ pub struct StructVisitor<'a> {
 }
 
 impl<'a> Visitor for StructVisitor<'a> {
-    fn visit_struct_start(&mut self, struct_def: &Struct) {
+    fn visit_struct(&mut self, struct_def: &Struct) {
         let escaped_identifier = struct_def.escape_identifier();
         let fields = struct_def.fields();
         let namespace = struct_def.namespace();


### PR DESCRIPTION
This PR updates the `slicec` dependency. A followup PR may want to add more testing for the various combinations of slicedFormat args.