### PR TITLE
Split up Entity and Commentable.

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -583,7 +583,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/icerpc/slicec#5330d6b32f8c9e2c92be655d368931dd59619170"
+source = "git+ssh://git@github.com/icerpc/slicec#2609ab8d39d8a5aca0e2ccdb444afe18c0f6a0c2"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -8,7 +8,7 @@ use crate::cs_util::FieldType;
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::member_util::*;
-use crate::slicec_ext::{EntityExt, MemberExt, TypeRefExt};
+use crate::slicec_ext::{CommentExt, EntityExt, MemberExt, TypeRefExt};
 use slice::code_block::CodeBlock;
 
 use slice::grammar::*;

--- a/tools/slicec-cs/src/slicec_ext/comment_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/comment_ext.rs
@@ -1,0 +1,54 @@
+// Copyright (c) ZeroC, Inc.
+
+use super::EntityExt;
+use crate::comments::CommentTag;
+use slice::grammar::*;
+use slice::utils::code_gen_util::format_message;
+
+pub trait CommentExt: Commentable {
+    /// If this entity has a doc comment with an overview on it, this returns the overview formatted as a C# summary,
+    /// with any links resolved to the appropriate C# tag. Otherwise this returns `None`.
+    fn formatted_doc_comment_summary(&self) -> Option<String> {
+        self.comment().and_then(|comment| {
+            comment
+                .overview
+                .as_ref()
+                .map(|overview| format_message(&overview.message, |link| link.get_formatted_link(&self.namespace())))
+        })
+    }
+
+    /// Returns this entity's doc comment, formatted as a list of C# doc comment tag. The overview is converted to
+    /// a `summary` tag, and any `@see` sections are converted to `seealso` tags. Any links present in these are
+    /// resolved to the appropriate C# tag. If no doc comment is on this entity, this returns an empty vector.
+    fn formatted_doc_comment(&self) -> Vec<CommentTag> {
+        let mut comments = Vec::new();
+        if let Some(comment) = self.comment() {
+            // Add a summary comment tag if the comment contains an overview section.
+            if let Some(overview) = comment.overview.as_ref() {
+                let message = format_message(&overview.message, |link| link.get_formatted_link(&self.namespace()));
+                comments.push(CommentTag::new("summary", message));
+            }
+            // Add a see-also comment tag for each '@see' tag in the comment.
+            for see_tag in &comment.see {
+                match see_tag.linked_entity() {
+                    Ok(entity) => {
+                        // We re-use `get_formatted_link` to correctly generate the link, then rip out the link.
+                        let formatted_link = entity.get_formatted_link(&self.namespace());
+                        // The formatted link is always of the form `<tag attribute="link" />`. We get the link from
+                        // from this by splitting the string on '"' characters, and taking the 2nd element.
+                        let link = formatted_link.split('"').nth(1).unwrap();
+                        comments.push(CommentTag::with_tag_attribute("seealso", "cref", link, String::new()));
+                    }
+                    Err(identifier) => {
+                        // If there was an error resolving the link, print the identifier without any formatting.
+                        let name = &identifier.value;
+                        comments.push(CommentTag::with_tag_attribute("seealso", "cref", name, String::new()));
+                    }
+                }
+            }
+        }
+        comments
+    }
+}
+
+impl<T: Commentable + ?Sized> CommentExt for T {}

--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -1,12 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{scoped_identifier, InterfaceExt, MemberExt};
-use crate::comments::CommentTag;
 use crate::cs_attributes::{match_cs_identifier, match_cs_internal, match_cs_namespace, match_cs_readonly};
 use crate::cs_util::escape_keyword;
 use convert_case::{Case, Casing};
 use slice::grammar::*;
-use slice::utils::code_gen_util::format_message;
 
 pub trait EntityExt: Entity {
     // Returns the C# identifier for the entity, which is either the the identifier specified by the cs::identifier
@@ -168,50 +166,6 @@ pub trait EntityExt: Entity {
         } else {
             self.access_modifier()
         }
-    }
-
-    /// If this entity has a doc comment with an overview on it, this returns the overview formatted as a C# summary,
-    /// with any links resolved to the appropriate C# tag. Otherwise this returns `None`.
-    fn formatted_doc_comment_summary(&self) -> Option<String> {
-        self.comment().and_then(|comment| {
-            comment
-                .overview
-                .as_ref()
-                .map(|overview| format_message(&overview.message, |link| link.get_formatted_link(&self.namespace())))
-        })
-    }
-
-    /// Returns this entity's doc comment, formatted as a list of C# doc comment tag. The overview is converted to
-    /// a `summary` tag, and any `@see` sections are converted to `seealso` tags. Any links present in these are
-    /// resolved to the appropriate C# tag. If no doc comment is on this entity, this returns an empty vector.
-    fn formatted_doc_comment(&self) -> Vec<CommentTag> {
-        let mut comments = Vec::new();
-        if let Some(comment) = self.comment() {
-            // Add a summary comment tag if the comment contains an overview section.
-            if let Some(overview) = comment.overview.as_ref() {
-                let message = format_message(&overview.message, |link| link.get_formatted_link(&self.namespace()));
-                comments.push(CommentTag::new("summary", message));
-            }
-            // Add a see-also comment tag for each '@see' tag in the comment.
-            for see_tag in &comment.see {
-                match see_tag.linked_entity() {
-                    Ok(entity) => {
-                        // We re-use `get_formatted_link` to correctly generate the link, then rip out the link.
-                        let formatted_link = entity.get_formatted_link(&self.namespace());
-                        // The formatted link is always of the form `<tag attribute="link" />`. We get the link from
-                        // from this by splitting the string on '"' characters, and taking the 2nd element.
-                        let link = formatted_link.split('"').nth(1).unwrap();
-                        comments.push(CommentTag::with_tag_attribute("seealso", "cref", link, String::new()));
-                    }
-                    Err(identifier) => {
-                        // If there was an error resolving the link, print the identifier without any formatting.
-                        let name = &identifier.value;
-                        comments.push(CommentTag::with_tag_attribute("seealso", "cref", name, String::new()));
-                    }
-                }
-            }
-        }
-        comments
     }
 
     /// Returns a C# link tag that points to this entity from the provided namespace

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+mod comment_ext;
 mod entity_ext;
 mod enum_ext;
 mod interface_ext;
@@ -9,6 +10,7 @@ mod primitive_ext;
 mod slice_encoding_ext;
 mod type_ref_ext;
 
+pub use comment_ext::CommentExt;
 pub use entity_ext::EntityExt;
 pub use enum_ext::EnumExt;
 pub use interface_ext::InterfaceExt;


### PR DESCRIPTION
This PR pulls in the latest slicec that splits apart the `Entity` and `Commentable` trait.
It adds a new `comment_ext` file, just wanted to make sure I followed how we do these usually in `slicec-cs`.