### PR TITLE
Better error message with Windows build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -238,6 +238,7 @@ while [[ $# -gt 0 ]]; do
 
             if [ $found -eq 0 ]; then
                 echo "Unknown argument: " "$1"
+                echo ""
                 usage
                 exit 1
             fi
@@ -252,7 +253,8 @@ fi
 
 configs=("debug" "release")
 if [[ ! " ${configs[*]} " == *" ${config} "* ]]; then
-    echo "invalid config: " $config
+    echo "Invalid config: '" $config "', config must 'debug' or 'release'"
+    echo ""
     usage
     exit 1
 fi

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -229,8 +229,10 @@ function Get-Help() {
 
 $configs = "debug","release"
 if ( $configs -notcontains $config ) {
+    Write-Host "Invalid config: '$config', config must 'debug' or 'release'"
+    Write-Host ""
     Get-Help
-    throw new-object system.ArgumentException "config must debug or release"
+    exit 1
 }
 
 $actions = @("build", "clean", "doc", "test", "pack", "publish", "examples", "docfxExamples", "installTemplates")
@@ -289,11 +291,6 @@ foreach ($action in $passedInActions) {
         }
         "help" {
             Get-Help
-        }
-        default {
-            Write-Error "Invalid action value" $action
-            Get-Help
-            exit 1
         }
     }
 }


### PR DESCRIPTION
Updated the script to provide clear error messages

We were using positional binding, the first unknown argument was bound to the config parameter, resuing in the confusing error message.

The script was also throwing an argument exception for the unknown config, resulting in the red error message.

```
C:\Users\jose\source\repos\icerpc-csharp>build --help
Unknown argument: --help

Usage: build [actions] [arguments]

Actions (defaults to -build):
  -build                    Build the IceRPC assemblies and the slicec-cs compiler.
  -pack                     Create the IceRPC NuGet packages.
  -examples                 Build the example project (uses installed NuGet packages).
  -docfxExamples            Build the examples used in docfx generated documentation (uses installed NuGet packages).
  -publish                  Publish the IceRPC NuGet packages to the global-packages source.
  -installTemplates         Install the IceRPC dotnet new project templates.
  -clean                    Clean all build artifacts.
  -test                     Runs tests.
  -doc                      Generate the C# API documentation
                            Requires docfx from https://github.com/dotnet/docfx

Arguments:
  -config                   Build configuration: debug or release, the default is debug.
  -version                  The version override for the IceRPC NuGet packages. The default version is the version
                            specified in the build/IceRpc.Version.props file.
  -coverage                 Collect code coverage from test runs.
                            Requires reportgenerator command from https://github.com/danielpalme/ReportGenerator
  -help                     Print help and exit.
```

Fix #3221 