### PR TITLE
Test for stream flow control when peer has buffered data

### DIFF
--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -552,7 +552,7 @@ public class SlicTransportTests
         // Arrange
         IServiceCollection serviceCollection = new ServiceCollection().AddSlicTest();
         serviceCollection.AddOptions<MultiplexedConnectionOptions>().Configure(
-                options => options.MaxBidirectionalStreams = 1);
+            options => options.MaxBidirectionalStreams = 1);
 
         await using ServiceProvider provider = serviceCollection.BuildServiceProvider(validateScopes: true);
         var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();


### PR DESCRIPTION
This PR fixes #3228.

When max stream count is reached, the test makes sure that a new stream can't be opened by the client until the server  consumed the buffered data of one of the remote stream.

This works with Slic but doesn't work Quic so I'm making this a draft pull request. I'll provide a test case for Quic on the issue.