### PR TITLE
Mark deprecated enumerators as obsolete

### DIFF
--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -38,6 +38,10 @@ fn enum_values(enum_def: &Enum) -> CodeBlock {
             declaration.writeln(&comment_tag);
         }
 
+        if let Some(attribute) = enumerator.obsolete_attribute(false) {
+            writeln!(declaration, "[{attribute}]");
+        }
+
         writeln!(
             declaration,
             "{} = {},",


### PR DESCRIPTION
Fix to add obsolete attribute to deprecated enumerators, see #3234