### PR TITLE
cs::attribute cleanup

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::comments::CommentTag;
-use crate::cs_attributes::{match_cs_attribute, match_cs_generic};
+use crate::cs_attributes::match_cs_generic;
 use crate::member_util::escape_parameter_name;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
@@ -30,20 +30,11 @@ pub trait AttributeBuilder {
         self
     }
 
-    /// Adds the C# Obsolete attribute if the container has the Slice deprecated attribute.
-    fn add_obsolete_attribute(&mut self, container: &dyn Entity) -> &mut Self {
-        if let Some(attribute) = container.obsolete_attribute() {
+    /// Adds the C# Obsolete attribute if the entity has the Slice deprecated attribute.
+    fn add_obsolete_attribute(&mut self, entity: &dyn Entity) -> &mut Self {
+        if let Some(attribute) = entity.obsolete_attribute() {
             self.add_attribute(attribute);
         }
-        self
-    }
-
-    /// Adds any `cs::attribute` attributes
-    fn add_container_attributes(&mut self, container: &dyn Entity) -> &mut Self {
-        for attribute in container.attributes(false).into_iter().filter_map(match_cs_attribute) {
-            self.add_attribute(attribute);
-        }
-
         self
     }
 }

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -36,8 +36,7 @@ pub fn generate_class(class_def: &Class, generated_code: &mut GeneratedCode) {
         .add_generated_remark("class", class_def)
         .add_type_id_attribute(class_def)
         .add_compact_type_id_attribute(class_def)
-        .add_obsolete_attribute(class_def)
-        .add_container_attributes(class_def);
+        .add_obsolete_attribute(class_def);
 
     if let Some(base) = class_def.base_class() {
         class_builder.add_base(base.escape_scoped_identifier(&namespace));

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -26,8 +26,7 @@ pub fn generate_dispatch(interface_def: &Interface, generated_code: &mut Generat
             r#"Your service implementation must implement this interface and derive from <see cref="Service" />."#,
             interface_def,
         )
-        .add_type_id_attribute(interface_def)
-        .add_container_attributes(interface_def);
+        .add_type_id_attribute(interface_def);
 
     interface_builder.add_bases(
         &bases
@@ -342,7 +341,6 @@ fn operation_declaration(operation: &Operation) -> CodeBlock {
     )
     .add_comments(operation.formatted_doc_comment())
     .add_operation_parameters(operation, TypeContext::Decode)
-    .add_container_attributes(operation)
     .build()
 }
 

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -28,8 +28,7 @@ pub fn generate_exception(exception_def: &Exception, generated_code: &mut Genera
     exception_class_builder
         .add_comments(exception_def.formatted_doc_comment())
         .add_generated_remark("class", exception_def)
-        .add_obsolete_attribute(exception_def)
-        .add_container_attributes(exception_def);
+        .add_obsolete_attribute(exception_def);
 
     if exception_def.supported_encodings().supports(&Encoding::Slice1) {
         exception_class_builder.add_type_id_attribute(exception_def);

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -38,7 +38,6 @@ pub fn generate_proxy(interface_def: &Interface, generated_code: &mut GeneratedC
                 interface_def,
             )
             .add_type_id_attribute(interface_def)
-            .add_container_attributes(interface_def)
             .add_bases(&interface_bases)
             .add_block(proxy_interface_operations(interface_def))
             .build(),
@@ -59,7 +58,6 @@ This remote service must implement Slice interface {slice_interface}."#
         )
         .add_generated_remark("record struct", interface_def)
         .add_type_id_attribute(interface_def)
-        .add_container_attributes(interface_def)
         .add_block(request_class(interface_def))
         .add_block(response_class(interface_def))
         .add_block(
@@ -332,7 +330,6 @@ fn proxy_interface_operations(interface_def: &Interface) -> CodeBlock {
                 FunctionType::Declaration,
             )
             .add_obsolete_attribute(operation)
-            .add_container_attributes(operation)
             .add_comments(operation.formatted_doc_comment())
             .add_operation_parameters(operation, TypeContext::Encode)
             .build(),

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -25,8 +25,7 @@ pub fn generate_struct(struct_def: &Struct, generated_code: &mut GeneratedCode) 
     builder
         .add_comments(struct_def.formatted_doc_comment())
         .add_generated_remark("record struct", struct_def)
-        .add_obsolete_attribute(struct_def)
-        .add_container_attributes(struct_def);
+        .add_obsolete_attribute(struct_def);
 
     builder.add_block(
         fields


### PR DESCRIPTION
Fix #2962, the previous fix in #2973 was incompleted, as @bernardnormier mentioned in the comments.

Removed `add_container_attributes` , which added `cs::atribute` attributes to a container, this is only valid for enums