### PR TITLE
Change secondary class constructor

### DIFF
--- a/tests/IceRpc.Tests/Slice/ClassTests.slice
+++ b/tests/IceRpc.Tests/Slice/ClassTests.slice
@@ -34,6 +34,15 @@ class MyDerivedClassWithTaggedFields : MyClassWithTaggedFields {
 
 class MyDerivedCompactClass(789) : MyCompactClass {}
 
+class MyClassWithValues {
+    a: int32
+    tag(5) b: int32?
+    c: AnyClass
+    d: AnyClass?
+    tag(3) e: int32?
+    f: int32
+}
+
 // Tests for operations that accept and return class instances
 interface ClassOperations {
     // Compact format

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -64,7 +64,7 @@ pub fn generate_exception(exception_def: &Exception, generated_code: &mut Genera
                     .add_parameter("string?", "message", Some("null"), None)
                     .add_base_parameter("ref decoder")
                     .add_base_parameter("message")
-                    .set_body(initialize_non_nullable_fields(&fields, FieldType::Exception))
+                    .set_body(initialize_required_fields(&fields, FieldType::Exception))
                     // This is Slice1 only, there is no exception inheritance with Slice2. We hide this method because
                     // this must be only called by the Activator.
                     .add_never_editor_browsable_attribute()
@@ -101,7 +101,7 @@ pub fn generate_exception(exception_def: &Exception, generated_code: &mut Genera
                         "\
 {}
 ConvertToUnhandled = true;",
-                        initialize_non_nullable_fields(&fields, FieldType::Exception),
+                        initialize_required_fields(&fields, FieldType::Exception),
                     )
                     .into()
                 })

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -39,7 +39,7 @@ pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
     )
 }
 
-pub fn initialize_non_nullable_fields(fields: &[&Field], field_type: FieldType) -> CodeBlock {
+pub fn initialize_required_fields(fields: &[&Field], field_type: FieldType) -> CodeBlock {
     // This helper should only be used for classes and exceptions
     debug_assert!(matches!(field_type, FieldType::Class | FieldType::Exception));
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -10,7 +10,6 @@ pub trait MemberExt {
     fn parameter_name(&self) -> String;
     fn parameter_name_with_prefix(&self, prefix: &str) -> String;
     fn field_name(&self, field_type: FieldType) -> String;
-    fn is_default_initialized(&self) -> bool;
 }
 
 impl<T: Member> MemberExt for T {
@@ -25,19 +24,6 @@ impl<T: Member> MemberExt for T {
 
     fn field_name(&self, field_type: FieldType) -> String {
         mangle_name(&self.escape_identifier(), field_type)
-    }
-
-    fn is_default_initialized(&self) -> bool {
-        let data_type = self.data_type();
-
-        if data_type.is_optional {
-            return true;
-        }
-
-        match data_type.concrete_type() {
-            Types::Struct(struct_def) => struct_def.fields().iter().all(|m| m.is_default_initialized()),
-            _ => data_type.is_value_type(),
-        }
     }
 }
 


### PR DESCRIPTION
This PR changes the secondary constructor to suppress only parameters for optional types.

Note: we don't generate such a secondary constructor for exceptions.

Fixes #3247.