### PR TITLE
Disable CA2252 warning

### DIFF
--- a/src/IceRpc.Transports.Quic/IceRpc.Transports.Quic.csproj
+++ b/src/IceRpc.Transports.Quic/IceRpc.Transports.Quic.csproj
@@ -6,6 +6,8 @@
         <PackageTags>IceRPC;RPC</PackageTags>
         <!-- Properties for .NET QUIC -->
         <EnablePreviewFeatures>True</EnablePreviewFeatures>
+        <!-- CA2252: Opt in to preview features before using them. -->
+        <NoWarn>CA2252</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\IceRpc\IceRpc.csproj" ExactVersion="true" />

--- a/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
+++ b/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <!-- Missing XML comment for publicly visible type or member. -->
-    <NoWarn>CS1591</NoWarn>
+    <!-- CS1591: Missing XML comment for publicly visible type or member.
+         CA2252: Opt in to preview features before using them. -->
+    <NoWarn>CS1591;CA2252</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On Windows with .NET 8 preview build fails because of this warning:

```
C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\Internal\QuicMultiplexedListener.cs(90,15): error CA2252: Using 'QuicException' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for mo
re information. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252) [C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\IceRpc.Transports.Quic.csproj]
C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\Internal\QuicPipeReader.cs(36,13): error CA2252: Using 'Abort' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for more information. (
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252) [C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\IceRpc.Transports.Quic.csproj]
C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\Internal\QuicPipeReader.cs(36,27): error CA2252: Using 'Read' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for more information. (h
ttps://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252) [C:\Users\jose\source\repos\issue3218\src\IceRpc.Transports.Quic\IceRpc.Transports.Quic.csproj]
```