### PR TITLE
Use embedded debug type

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -18,7 +18,8 @@
         <NetRuntimeVersion>7.0.0</NetRuntimeVersion>
         <!-- TODO update to 1.2 stable release https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187#issuecomment-1043221630 -->
         <StyleCopAnalyzersVersion>1.2.0-beta.435</StyleCopAnalyzersVersion>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
+        <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,10 @@
     <Import Project="$(MSBuildThisFileDirectory)../build/IceRpc.Src.props" Condition="'$(IsSrcProject)' == 'true'" />
     <Import Project="$(MSBuildThisFileDirectory)../build/IceRpc.Version.props" Condition="'$(IsTemplateProject)' == 'true'" />
     <Import Project="$(MSBuildThisFileDirectory)../tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props" Condition="'$(IsSrcProject)' == 'true'"/>
+    <PropertyGroup>
+        <!-- Include PDB in the built .nupkg -->
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
     <ItemGroup>
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)../build/StyleCop.json" Link="stylecop.json" />
         <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.Base.globalconfig" />


### PR DESCRIPTION
I think it is more convenient to use the embedded debug type, otherwise, we will have to upload the symbols to our symbol server. 

IceRpc.dll optimized build with embedded symbols is 515 K vs  435K without