### PR TITLE
Update doc-comments to use "otherwise, false"

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -562,10 +562,10 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// <summary>Tries to get an existing connection matching one of the addresses of the server address feature.
     /// </summary>
     /// <param name="serverAddressFeature">The server address feature.</param>
-    /// <param name="connection">When this method returns <see langword="true" /> it contains an active connection,
-    /// otherwise, it is <see langword="null" />.</param>
-    /// <returns><see langword="true" /> when an active connection matching any of the addresses of the server
-    /// address feature is found, <see langword="false"/> otherwise.</returns>
+    /// <param name="connection">When this method returns <see langword="true" />, this argument contains an active
+    /// connection; otherwise, it is set to <see langword="null" />.</param>
+    /// <returns><see langword="true" /> when an active connection matching any of the addresses of the server address
+    /// feature is found; otherwise, <see langword="false"/>.</returns>
     private bool TryGetActiveConnection(
         IServerAddressFeature serverAddressFeature,
         [NotNullWhen(true)] out IProtocolConnection? connection)

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -18,7 +18,7 @@ public record class ConnectionOptions
     /// fails when this read waits for over <see cref="IceIdleTimeout" /> to receive any byte. When the Ice idle check
     /// is disabled, the <see cref="IceIdleTimeout" /> has no effect on reads: a read on the underlying transport
     /// connection can wait forever to receive a byte.</summary>
-    /// <value><see langword="true"/> if Ice idle check is enabled; <see langword="false"/> otherwise. Defaults to <see
+    /// <value><see langword="true"/> if Ice idle check is enabled; otherwise, <see langword="false"/>. Defaults to <see
     /// langword="false"/> for compatibility with the default ACM configuration of Ice 3.7. The recommended setting is
     /// <see langword="true"/> when the peer is an Ice application with the HeartbeatAlways ACM configuration or when
     /// the peer is an IceRPC application.</value>

--- a/src/IceRpc/Features/IDispatchInformationFeature.cs
+++ b/src/IceRpc/Features/IDispatchInformationFeature.cs
@@ -13,7 +13,7 @@ public interface IDispatchInformationFeature
     string Fragment { get; }
 
     /// <summary>Gets a value indicating whether this request is one-way or two-way.</summary>
-    /// <value><see langword="true" /> for one-way requests, <see langword="false" /> otherwise.</value>
+    /// <value><see langword="true" /> for one-way requests; otherwise, <see langword="false" />.</value>
     bool IsOneway { get; }
 
     /// <summary>Gets the name of the operation to call on the target service.</summary>

--- a/src/IceRpc/Features/IFeatureCollection.cs
+++ b/src/IceRpc/Features/IFeatureCollection.cs
@@ -7,8 +7,8 @@ namespace IceRpc.Features;
 public interface IFeatureCollection : IEnumerable<KeyValuePair<Type, object>>
 {
     /// <summary>Gets a value indicating whether this feature collection is read-only or read-write.</summary>
-    /// <value><see langword="true" /> if the feature collection is read-only; <see langword="false" />
-    /// otherwise.</value>
+    /// <value><see langword="true" /> if the feature collection is read-only; otherwise, <see langword="false" />.
+    /// </value>
     bool IsReadOnly { get; }
 
     /// <summary>Gets or sets a feature. Setting null removes the feature.</summary>

--- a/src/IceRpc/IncomingRequest.cs
+++ b/src/IceRpc/IncomingRequest.cs
@@ -30,7 +30,7 @@ public sealed class IncomingRequest : IncomingFrame, IDisposable
     }
 
     /// <summary>Gets a value indicating whether this request is one-way or two-way.</summary>
-    /// <value><see langword="true" /> for one-way requests, <see langword="false" /> otherwise. The default is
+    /// <value><see langword="true" /> for one-way requests; otherwise, <see langword="false" />. The default is
     /// <see langword="false" />.</value>
     public bool IsOneway { get; init; }
 

--- a/src/IceRpc/IncomingResponse.cs
+++ b/src/IceRpc/IncomingResponse.cs
@@ -11,7 +11,7 @@ public sealed class IncomingResponse : IncomingFrame
 {
     /// <summary>Gets the error message of this response.</summary>
     /// <value>The error message of this response if <see cref="StatusCode" /> is different from <see
-    /// cref="StatusCode.Success" />; <see langword="null"/> otherwise.</value>
+    /// cref="StatusCode.Success" />; otherwise, <see langword="null"/>.</value>
     public string? ErrorMessage { get; }
 
     /// <summary>Gets the fields of this incoming response.</summary>

--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -19,7 +19,7 @@ public sealed class OutgoingRequest : OutgoingFrame, IDisposable
         ImmutableDictionary<RequestFieldKey, OutgoingFieldValue>.Empty;
 
     /// <summary>Gets a value indicating whether this request is one-way or two-way.</summary>
-    /// <value><see langword="true" /> for one-way requests, <see langword="false" /> otherwise. The default is
+    /// <value><see langword="true" /> for one-way requests; otherwise, <see langword="false" />. The default is
     /// <see langword="false" />.</value>
     public bool IsOneway { get; init; }
 

--- a/src/IceRpc/OutgoingResponse.cs
+++ b/src/IceRpc/OutgoingResponse.cs
@@ -9,7 +9,7 @@ public sealed class OutgoingResponse : OutgoingFrame
 {
     /// <summary>Gets the error message of this response.</summary>
     /// <value>The error message of this response if <see cref="StatusCode" /> is different from <see
-    /// cref="StatusCode.Success" />; <see langword="null" /> otherwise.</value>
+    /// cref="StatusCode.Success" />; otherwise, <see langword="null" />.</value>
     public string? ErrorMessage { get; }
 
     /// <summary>Gets or sets the fields of this response.</summary>

--- a/src/IceRpc/Protocol.cs
+++ b/src/IceRpc/Protocol.cs
@@ -37,12 +37,12 @@ public class Protocol
     internal byte ByteValue { get; }
 
     /// <summary>Gets a value indicating whether or not this protocol supports fragments in service addresses.</summary>
-    /// <value><see langword="true" /> if the protocol supports fragments; <see langword="false" /> otherwise.</value>
+    /// <value><see langword="true" /> if the protocol supports fragments; otherwise, <see langword="false" />.</value>
     internal bool HasFragment { get; }
 
     /// <summary>Gets a value indicating whether or not this protocol supports payload continuations.</summary>
-    /// <value><see langword="true" /> if the protocol supports payload continuations; <see langword="false" />
-    /// otherwise.</value>
+    /// <value><see langword="true" /> if the protocol supports payload continuations; otherwise,
+    /// <see langword="false" />.</value>
     internal bool HasPayloadContinuation { get; }
 
     /// <summary>Gets a value indicating whether or not the implementation of the protocol connection supports payload
@@ -61,8 +61,8 @@ public class Protocol
     /// <summary>Tries to parse a string into a protocol.</summary>
     /// <param name="name">The name of the protocol.</param>
     /// <param name="protocol">The protocol parsed from the name.</param>
-    /// <returns><see langword="true" /> when <paramref name="name" /> was successfully parsed into a protocol; <see
-    /// langword="false" /> otherwise.</returns>
+    /// <returns><see langword="true" /> when <paramref name="name" /> was successfully parsed into a protocol;
+    /// otherwise, <see langword="false" />.</returns>
     public static bool TryParse(string name, [NotNullWhen(true)] out Protocol? protocol)
     {
         name = name.ToLowerInvariant();

--- a/src/IceRpc/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc/ResettablePipeReaderDecorator.cs
@@ -13,7 +13,7 @@ namespace IceRpc;
 public sealed class ResettablePipeReaderDecorator : PipeReader
 {
     /// <summary>Gets or sets a value indicating whether this decorator can be reset.</summary>
-    /// <value><see langword="true"/> if this decorator can be reset; <see langword="false"/> otherwise. Defaults to
+    /// <value><see langword="true"/> if this decorator can be reset; otherwise, <see langword="false"/>. Defaults to
     /// <see langword="true"/>.</value>
     public bool IsResettable
     {

--- a/src/IceRpc/ServerAddress.cs
+++ b/src/IceRpc/ServerAddress.cs
@@ -88,8 +88,8 @@ public readonly record struct ServerAddress
     }
 
     /// <summary>Gets the URI used to create this server address.</summary>
-    /// <value>The <see cref="Uri" /> of this server address if it was constructed from an URI; <see langword="null"/>
-    /// otherwise.</value>
+    /// <value>The <see cref="Uri" /> of this server address if it was constructed from an URI; otherwise,
+    /// <see langword="null"/>.</value>
     public Uri? OriginalUri { get; private init; }
 
     private readonly string _host = "::0";
@@ -173,7 +173,7 @@ public readonly record struct ServerAddress
     /// <summary>Checks if this server address is equal to another server address.</summary>
     /// <param name="other">The other server address.</param>
     /// <returns><see langword="true" /> when the two server addresses have the same properties, including the same
-    /// parameters; <see langword="false" /> otherwise.</returns>
+    /// parameters; otherwise, <see langword="false" />.</returns>
     public bool Equals(ServerAddress other) =>
         Protocol == other.Protocol &&
         Host == other.Host &&

--- a/src/IceRpc/Slice/SliceDecoder.cs
+++ b/src/IceRpc/Slice/SliceDecoder.cs
@@ -642,21 +642,21 @@ public ref partial struct SliceDecoder
     /// <param name="value">When this method returns <see langword="true" />, this value is set to the decoded byte.
     /// Otherwise, this value is set to its default value.</param>
     /// <returns><see langword="true" /> if the decoder is not at the end of the buffer and the decode operation
-    /// succeeded; <see langword="false" /> otherwise.</returns>
+    /// succeeded; otherwise, <see langword="false" />.</returns>
     internal bool TryDecodeUInt8(out byte value) => _reader.TryRead(out value);
 
     /// <summary>Tries to decode a Slice int32 into an int.</summary>
     /// <param name="value">When this method returns <see langword="true" />, this value is set to the decoded int.
     /// Otherwise, this value is set to its default value.</param>
     /// <returns><see langword="true" /> if the decoder is not at the end of the buffer and the decode operation
-    /// succeeded; <see langword="false" /> otherwise.</returns>
+    /// succeeded; otherwise, <see langword="false" />.</returns>
     internal bool TryDecodeInt32(out int value) => SequenceMarshal.TryRead(ref _reader, out value);
 
     /// <summary>Tries to decode a size encoded on a variable number of bytes.</summary>
     /// <param name="size">When this method returns <see langword="true" />, this value is set to the decoded size.
     /// Otherwise, this value is set to its default value.</param>
     /// <returns><see langword="true" /> if the decoder is not at the end of the buffer and the decode operation
-    /// succeeded; <see langword="false" /> otherwise.</returns>
+    /// succeeded; otherwise, <see langword="false" />.</returns>
     internal bool TryDecodeSize(out int size)
     {
         if (Encoding == SliceEncoding.Slice1)
@@ -706,7 +706,7 @@ public ref partial struct SliceDecoder
     /// <param name="value">When this method returns <see langword="true" />, this value is set to the decoded ulong.
     /// Otherwise, this value is set to its default value.</param>
     /// <returns><see langword="true" /> if the decoder is not at the end of the buffer and the decode operation
-    /// succeeded; <see langword="false" /> otherwise.</returns>
+    /// succeeded; otherwise, <see langword="false" />.</returns>
     internal bool TryDecodeVarUInt62(out ulong value)
     {
         if (_reader.TryPeek(out byte b))

--- a/src/IceRpc/Transports/IMultiplexedConnection.cs
+++ b/src/IceRpc/Transports/IMultiplexedConnection.cs
@@ -74,8 +74,8 @@ public interface IMultiplexedConnection : IAsyncDisposable
 
     /// <summary>Creates a local stream. The creation will block if the maximum number of unidirectional or
     /// bidirectional streams prevents creating the new stream.</summary>
-    /// <param name="bidirectional"><see langword="true"/> to create a bidirectional stream, <see langword="false"/>
-    /// otherwise.</param>
+    /// <param name="bidirectional"><see langword="true"/> to create a bidirectional stream, otherwise,
+    /// <see langword="false"/>.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task that completes on the local stream is created.</returns>
     /// <returns>A task that completes successfully with the local stream. This task can also complete with one of the

--- a/src/IceRpc/Transports/IMultiplexedStream.cs
+++ b/src/IceRpc/Transports/IMultiplexedStream.cs
@@ -14,19 +14,18 @@ public interface IMultiplexedStream : IDuplexPipe
     ulong Id { get; }
 
     /// <summary>Gets a value indicating whether the stream is bidirectional.</summary>
-    /// <value><see langword="true" /> if the stream is a bidirectional stream; <see langword="false" />
-    /// otherwise.</value>
+    /// <value><see langword="true" /> if the stream is a bidirectional stream; otherwise, <see langword="false" />.
+    /// </value>
     bool IsBidirectional { get; }
 
     /// <summary>Gets a value indicating whether the stream is remote. A remote stream is a stream initiated by the peer
     /// and it's returned by <see
     /// cref="IMultiplexedConnection.AcceptStreamAsync(CancellationToken)" />.</summary>
-    /// <value><see langword="true" /> if the stream is a remote stream; <see langword="false" />
-    /// otherwise.</value>
+    /// <value><see langword="true" /> if the stream is a remote stream; otherwise, <see langword="false" />.</value>
     bool IsRemote { get; }
 
     /// <summary>Gets a value indicating whether the stream is started.</summary>
-    /// <value><see langword="true" /> if the stream is started; <see langword="false" /> otherwise.</value>
+    /// <value><see langword="true" /> if the stream is started; otherwise, <see langword="false" />.</value>
     /// <remarks>Remote streams are always started after construction. A local stream is started after the sending of
     /// the first STREAM frame.</remarks>
     bool IsStarted { get; }

--- a/tests/IceRpc.Locator.Tests/LocatorInterceptorTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocatorInterceptorTests.cs
@@ -150,7 +150,7 @@ public class LocatorInterceptorTests
     // A mock location resolver that return cached and non cached server addresses depending on the refreshCache parameter
     private sealed class MockCachedLocationResolver : ILocationResolver
     {
-        /// <summary><see langword="true" /> if the last call asked to refresh the cache otherwise,
+        /// <summary><see langword="true" /> if the last call asked to refresh the cache; otherwise,
         /// <see langword="false" />.</summary>
         public bool RefreshCache { get; set; }
         private readonly ServiceAddress _serviceAddress = new(new Uri("ice://localhost:10000/foo"));
@@ -168,7 +168,7 @@ public class LocatorInterceptorTests
     // A mock location resolver that always return non cached server addresses
     private sealed class MockNonCachedLocationResolver : ILocationResolver
     {
-        /// <summary><see langword="true" /> if the last call asked to refresh the cache otherwise,
+        /// <summary><see langword="true" /> if the last call asked to refresh the cache; otherwise,
         /// <see langword="false" />.</summary>
         public bool RefreshCache { get; set; }
         private readonly ServiceAddress _serviceAddress = new(new Uri("ice://localhost:10000/foo"));

--- a/tests/IceRpc.Tests.Common/ClientServerMultiplexedConnection.cs
+++ b/tests/IceRpc.Tests.Common/ClientServerMultiplexedConnection.cs
@@ -38,8 +38,8 @@ public sealed class ClientServerMultiplexedConnection : IAsyncDisposable
         Task.WhenAll(AcceptAsync(cancellationToken), Client.ConnectAsync(cancellationToken));
 
     /// <summary>Creates and accepts a stream with the client and server connections.</summary>
-    /// <param name="bidirectional"><see langword="true"/> to create a bidirectional stream, <see langword="false"/>
-    /// otherwise.</param>
+    /// <param name="bidirectional"><see langword="true"/> to create a bidirectional stream; otherwise,
+    /// <see langword="false"/>.</param>
     /// <param name="createWithServerConnection">Creates the stream with the server connection instead of the client
     /// connection.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>


### PR DESCRIPTION
"; otherwise, false." is more common / standard formulation than "; false otherwise".