### PR TITLE
Remove IMultiplexedStream.ReadsClosed

### DIFF
--- a/src/IceRpc.Transports.Quic/Internal/QuicMultiplexedStream.cs
+++ b/src/IceRpc.Transports.Quic/Internal/QuicMultiplexedStream.cs
@@ -23,8 +23,6 @@ internal class QuicMultiplexedStream : IMultiplexedStream
     public PipeWriter Output =>
         _outputPipeWriter ?? throw new InvalidOperationException("A remote unidirectional stream has no Output.");
 
-    public Task ReadsClosed => _inputPipeReader?.Closed ?? Task.CompletedTask;
-
     public Task WritesClosed => _outputPipeWriter?.Closed ?? Task.CompletedTask;
 
     private readonly QuicPipeReader? _inputPipeReader;

--- a/src/IceRpc.Transports.Quic/Internal/QuicPipeReader.cs
+++ b/src/IceRpc.Transports.Quic/Internal/QuicPipeReader.cs
@@ -9,10 +9,7 @@ namespace IceRpc.Transports.Quic.Internal;
 /// <summary>Implements a PipeReader over a QuicStream.</summary>
 internal class QuicPipeReader : PipeReader
 {
-    internal Task Closed { get; }
-
-    // Complete is not thread-safe; it's volatile because we check _isCompleted in the implementation of Closed.
-    private volatile bool _isCompleted;
+    private bool _isCompleted;
     private readonly Action _completeCallback;
     private readonly Action _throwIfConnectionClosedOrDisposed;
     private readonly PipeReader _pipeReader;
@@ -138,19 +135,5 @@ internal class QuicPipeReader : PipeReader
         // Work around bug from StreamPipeReader with the BugFixStreamPipeReaderDecorator
         _pipeReader = new BugFixStreamPipeReaderDecorator(_pipeReader);
 #endif
-
-        Closed = ClosedAsync();
-
-        async Task ClosedAsync()
-        {
-            try
-            {
-                await _stream.ReadsClosed.ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ignore
-            }
-        }
     }
 }

--- a/src/IceRpc/Internal/MultiplexedStreamDecorator.cs
+++ b/src/IceRpc/Internal/MultiplexedStreamDecorator.cs
@@ -18,8 +18,6 @@ internal sealed class MultiplexedStreamDecorator : IMultiplexedStream
 
     public bool IsStarted => _decoratee.IsStarted;
 
-    public Task ReadsClosed => _decoratee.ReadsClosed;
-
     public Task WritesClosed => _decoratee.WritesClosed;
 
     public PipeReader Input => _input ?? _decoratee.Input;

--- a/src/IceRpc/Transports/IMultiplexedStream.cs
+++ b/src/IceRpc/Transports/IMultiplexedStream.cs
@@ -30,19 +30,6 @@ public interface IMultiplexedStream : IDuplexPipe
     /// the first STREAM frame.</remarks>
     bool IsStarted { get; }
 
-    /// <summary>Gets a task that completes when all read network activity ceases for this stream. This occurs when:
-    /// <list type="bullet">
-    /// <item><description><see cref="PipeReader.Complete(Exception?)" /> is called on this stream's <see
-    /// cref="IDuplexPipe.Input" />.</description></item>
-    /// <item><description>the implementation detects that the peer wrote an "end stream" to mark a successful
-    /// write completion.</description></item>
-    /// <item><description>the peer aborts writes by calling <see cref="PipeWriter.Complete(Exception?)" /> with a
-    /// non-null exception on the stream's <see cref="IDuplexPipe.Output" />.</description></item>
-    /// <item><description>the implementation detects a network failure that prevents further reads on the underlying
-    /// network stream.</description></item></list>The task is never faulted or canceled.</summary>
-    /// <value>The reads closed task.</value>
-    Task ReadsClosed { get; }
-
     /// <summary>Gets a task that completes when all write network activity ceases for this stream. This occurs when:
     /// <list type="bullet">
     /// <item><description><see cref="PipeWriter.Complete(Exception?)" /> is called on this stream's <see

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -483,9 +483,7 @@ public abstract class MultiplexedConnectionConformanceTests
 
         // Assert
         Assert.That(async () => await streams.Remote.WritesClosed, Throws.Nothing);
-        Assert.That(async () => await streams.Remote.ReadsClosed, Throws.Nothing);
         Assert.That(async () => await streams.Local.WritesClosed, Throws.Nothing);
-        Assert.That(async () => await streams.Local.ReadsClosed, Throws.Nothing);
     }
 
     /// <summary>Write data until the transport flow control start blocking, at this point we start a read task and

--- a/tests/IceRpc.Tests.Common/TestMultiplexedTransportDecorator.cs
+++ b/tests/IceRpc.Tests.Common/TestMultiplexedTransportDecorator.cs
@@ -361,9 +361,6 @@ public sealed class TestMultiplexedStreamDecorator : IMultiplexedStream
     public PipeWriter Output => _output ?? throw new InvalidOperationException("No output for unidirectional stream.");
 
     /// <inheritdoc/>
-    public Task ReadsClosed => _decoratee.ReadsClosed;
-
-    /// <inheritdoc/>
     public Task WritesClosed => _decoratee.WritesClosed;
 
     private readonly IMultiplexedStream _decoratee;


### PR DESCRIPTION
This PR removes this property. It's a follow-up to #3287, and is layered over that PR.

Interestingly, it doesn't remove a "Completed Work Item" from Slic. It looks like a TCS that is completed but has no continuation doesn't count as a "completed work item".