### PR TITLE
Rework AsCancellationToken

### DIFF
--- a/src/IceRpc/Internal/TaskExtensions.cs
+++ b/src/IceRpc/Internal/TaskExtensions.cs
@@ -5,27 +5,29 @@ namespace IceRpc.Internal;
 internal static class TaskExtensions
 {
     /// <summary>Converts this task into a linked cancellation token.</summary>
-    /// <param name="task">The task that upon successful completion cancels the linked token.</param>
+    /// <param name="task">The task that upon completion cancels the linked token.</param>
     /// <param name="token">The source token.</param>
-    /// <returns>A cancellation token that is canceled when <paramref name="task" /> completes successfully or
-    /// <paramref name="token" /> is canceled. If the task is canceled or fails, the returned token is not canceled.
-    /// </returns>
+    /// <returns>A cancellation token that is canceled when <paramref name="task" /> completes or
+    /// <paramref name="token" /> is canceled.</returns>
     internal static CancellationToken AsCancellationToken(this Task task, CancellationToken token)
     {
-#pragma warning disable CA2000
         var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-#pragma warning restore CA2000
 
         CancellationToken linkedToken = linkedCts.Token;
-
-        // CancellationToken.None because we need to run CancelOnSuccessAsync to dispose linkedCts.
-        _ = Task.Run(CancelOnSuccessAsync, CancellationToken.None);
+        _ = CancelOnCompleteAsync();
         return linkedToken;
 
-        async Task CancelOnSuccessAsync()
+        async Task CancelOnCompleteAsync()
         {
             using CancellationTokenSource cts = linkedCts; // takes ownership of linkedCts
-            await task.ConfigureAwait(false);
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch
+            {
+                // It's ok for task to complete with an exception.
+            }
             cts.Cancel();
         }
     }


### PR DESCRIPTION
This PR reworks the AsCancellationToken extension method:

1) the source token can now cancel the returned token even _after_ the task fails, which I find more logical (we don't use this path at all with writesClosed)

2) we execute the task monitoring with Task.Run. This way, in the common situation where writesClosed is not completed, AsCancellationToken() does _not_ trigger a context switch.

I suspect the performance impact of (2) is positive but small; I didn't measure it.

