### PR TITLE
Fix bug in Slice stream test

### DIFF
--- a/tests/IceRpc.Tests/Slice/StreamTests.cs
+++ b/tests/IceRpc.Tests/Slice/StreamTests.cs
@@ -333,7 +333,7 @@ public class StreamTests
         }
     }
 
-    /// <summary>Test that canceling the iteration completes the pipe reader from which the stream elements are being
+    /// <summary>Test that abandoning the iteration completes the pipe reader from which the stream elements are being
     /// decoded.</summary>
     [Test]
     public async Task Decoding_completes_when_iteration_is_canceled()


### PR DESCRIPTION
This PR removes a bogus CTS and cancellation token in a stream test.

When you abandon an iteration, there is no need to use a cancellation token.
See also: https://docs.testing.zeroc.com/docs/slice/language-guide/parameters-and-fields#stream-parameters-in-c#
