### PR TITLE
Remove setup-dotnet action, .NET comes pre-installed with the CI image

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -32,10 +32,6 @@ runs:
       key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       restore-keys: |
         ${{ runner.os }}-cargo-
-  - name: 🔗 Setup .NET
-    uses: actions/setup-dotnet@v3
-    with:
-      dotnet-version: "7.0.x"
   - name: Install libmsquic
     run: |
       wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb


### PR DESCRIPTION
We don't need to run setup-dotnet as the CI image comes with .NET 7.x pre installed

For the included packages see https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md