### PR TITLE
Fix throw in Invalid class

### DIFF
--- a/src/IceRpc/Internal/InvalidPipeReader.cs
+++ b/src/IceRpc/Internal/InvalidPipeReader.cs
@@ -10,20 +10,19 @@ internal sealed class InvalidPipeReader : PipeReader
     /// <summary>Gets the invalid pipe reader singleton instance.</summary>
     public static PipeReader Instance { get; } = new InvalidPipeReader();
 
-    private static readonly Exception _invalidOperationException =
-        new InvalidOperationException("Reading an invalid pipe reader is not allowed.");
+    private const string ExceptionMessage = "Reading an invalid pipe reader is not allowed.";
 
-    public override bool TryRead(out ReadResult result) => throw _invalidOperationException;
+    public override bool TryRead(out ReadResult result) => throw new InvalidOperationException(ExceptionMessage);
 
     public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default) =>
-        throw _invalidOperationException;
+        throw new InvalidOperationException(ExceptionMessage);
 
-    public override void AdvanceTo(SequencePosition consumed) => throw _invalidOperationException;
+    public override void AdvanceTo(SequencePosition consumed) => throw new InvalidOperationException(ExceptionMessage);
 
     public override void AdvanceTo(SequencePosition consumed, SequencePosition examined) =>
-        throw _invalidOperationException;
+        throw new InvalidOperationException(ExceptionMessage);
 
-    public override void CancelPendingRead() => throw _invalidOperationException;
+    public override void CancelPendingRead() => throw new InvalidOperationException(ExceptionMessage);
 
     public override void Complete(Exception? exception = null)
     {

--- a/src/IceRpc/Internal/InvalidPipeWriter.cs
+++ b/src/IceRpc/Internal/InvalidPipeWriter.cs
@@ -9,19 +9,18 @@ internal sealed class InvalidPipeWriter : PipeWriter
 {
     public override bool CanGetUnflushedBytes => false;
 
-    public override long UnflushedBytes => throw _invalidOperationException;
+    public override long UnflushedBytes => throw new InvalidOperationException(ExceptionMessage);
 
     /// <summary>Gets the InvalidPipeWriter singleton instance.</summary>
     internal static PipeWriter Instance { get; } = new InvalidPipeWriter();
 
-    private static readonly Exception _invalidOperationException =
-        new InvalidOperationException("Writing an invalid pipe writer is not allowed.");
+    private const string ExceptionMessage = "Writing an invalid pipe writer is not allowed.";
 
-    public override void Advance(int bytes) => throw _invalidOperationException;
+    public override void Advance(int bytes) => throw new InvalidOperationException(ExceptionMessage);
 
-    public override Stream AsStream(bool leaveOpen = false) => throw _invalidOperationException;
+    public override Stream AsStream(bool leaveOpen = false) => throw new InvalidOperationException(ExceptionMessage);
 
-    public override void CancelPendingFlush() => throw _invalidOperationException;
+    public override void CancelPendingFlush() => throw new InvalidOperationException(ExceptionMessage);
 
     public override void Complete(Exception? exception)
     {
@@ -29,18 +28,18 @@ internal sealed class InvalidPipeWriter : PipeWriter
     }
 
     public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken) =>
-       throw _invalidOperationException;
+       throw new InvalidOperationException(ExceptionMessage);
 
-    public override Memory<byte> GetMemory(int sizeHint) => throw _invalidOperationException;
+    public override Memory<byte> GetMemory(int sizeHint) => throw new InvalidOperationException(ExceptionMessage);
 
-    public override Span<byte> GetSpan(int sizeHint) => throw _invalidOperationException;
+    public override Span<byte> GetSpan(int sizeHint) => throw new InvalidOperationException(ExceptionMessage);
 
     public override ValueTask<FlushResult> WriteAsync(
         ReadOnlyMemory<byte> source,
-        CancellationToken cancellationToken) => throw _invalidOperationException;
+        CancellationToken cancellationToken) => throw new InvalidOperationException(ExceptionMessage);
 
     protected override Task CopyFromAsync(Stream source, CancellationToken cancellationToken) =>
-        throw _invalidOperationException;
+        throw new InvalidOperationException(ExceptionMessage);
 
     private InvalidPipeWriter()
     {


### PR DESCRIPTION
This PR fixes the throwing of exceptions in the Invalid classes.

It's a bad pattern to throw the same exception over and over since the stack trace gets rewritten in the exception each time.