### PR TITLE
Fix Links to Enumerators

### DIFF
--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -195,7 +195,7 @@ mod formatted_link_tests {
         let interface_link = interface_def.get_formatted_link("");
 
         // Assert
-        let expected = r#"<see cref="global::Test.IMyInterface" />"#;
+        let expected = r#"<see cref="Test.IMyInterface" />"#;
         assert_eq!(interface_link, expected);
     }
 
@@ -233,7 +233,7 @@ mod formatted_link_tests {
         let operation_link = operation.get_formatted_link("");
 
         // Assert
-        let expected = r#"<see cref="global::Test.IMyInterface.MyOperationAsync" />"#;
+        let expected = r#"<see cref="Test.IMyInterface.MyOperationAsync" />"#;
         assert_eq!(operation_link, expected);
     }
 
@@ -294,7 +294,7 @@ mod formatted_link_tests {
         let enumerator_link = enumerator.get_formatted_link("");
 
         // Assert
-        let expected = r#"<see cref="global::Test.MyEnum.Foo" />"#;
+        let expected = r#"<see cref="Test.MyEnum.Foo" />"#;
         assert_eq!(enumerator_link, expected);
     }
 
@@ -333,7 +333,7 @@ mod formatted_link_tests {
         let struct_link = struct_def.get_formatted_link("");
 
         // Assert
-        let expected = r#"<see cref="global::Test.MyStruct" />"#;
+        let expected = r#"<see cref="Test.MyStruct" />"#;
         assert_eq!(struct_link, expected);
     }
 

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -23,9 +23,10 @@ pub use slice_encoding_ext::EncodingExt;
 pub use type_ref_ext::TypeRefExt;
 
 fn scoped_identifier(identifier: String, identifier_namespace: String, current_namespace: &str) -> String {
+
     if current_namespace == identifier_namespace {
         identifier
     } else {
-        format!("global::{identifier_namespace}.{identifier}")
+        identifier_namespace + "." + &identifier
     }
 }


### PR DESCRIPTION
This PR fixes #3325 by ensuring links to enumerators are always scoped by their enums.