### PR TITLE
Slic test to ensure that `ReadAsync` fails if the connection is closed while the stream data is read

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -410,8 +410,7 @@ public abstract class MultiplexedConnectionConformanceTests
     }
 
     [Test]
-    public async Task Connection_dispose_or_close_aborts_pending_operations_with_operation_aborted_error(
-        [Values] bool close)
+    public async Task Connection_dispose_aborts_pending_operations_with_operation_aborted_error()
     {
         // Arrange
         IServiceCollection serviceCollection = CreateServiceCollection();
@@ -427,14 +426,7 @@ public abstract class MultiplexedConnectionConformanceTests
         ValueTask<ReadResult> readTask = streams.Local.Input.ReadAsync();
 
         // Act
-        if (close)
-        {
-            await sut.Client.CloseAsync(MultiplexedConnectionCloseError.NoError, default);
-        }
-        else
-        {
-            await sut.Client.DisposeAsync();
-        }
+        await sut.Client.DisposeAsync();
 
         // Assert
 


### PR DESCRIPTION
This test ensures that a pending `stream.Input.ReadAsync` call correctly fails if the connection is closed while data for this stream is being read on the duplex connection.

It also checks that closing or disposing the connection while stream operations are in progress behave the same way (operations are aborted).