### PR TITLE
Fix docfx warnings

### DIFF
--- a/src/IceRpc.Compressor/CompressorInterceptor.cs
+++ b/src/IceRpc.Compressor/CompressorInterceptor.cs
@@ -20,8 +20,8 @@ namespace IceRpc.Compressor;
 /// <see cref="StatusCode.Success" /> and the response carries a <see cref="ResponseFieldKey.CompressionFormat" /> field
 /// with a supported compression format (currently <see cref="CompressionFormat.Brotli" /> or
 /// <see cref="CompressionFormat.Deflate" />).</remarks>
-/// <seealso cref="CompressorPipelineExtensions.UseCompressor(Pipeline, CompressionFormat, CompressionLevel)"/>
-/// <seealso cref="CompressorDispatcherBuilderExtensions.UseCompressor(IDispatcherBuilder, CompressionFormat, CompressionLevel)"/>
+/// <seealso cref="CompressorPipelineExtensions"/>
+/// <seealso cref="CompressorDispatcherBuilderExtensions"/>
 public class CompressorInterceptor : IInvoker
 {
     private readonly CompressionFormat _compressionFormat;

--- a/src/IceRpc.Compressor/CompressorMiddleware.cs
+++ b/src/IceRpc.Compressor/CompressorMiddleware.cs
@@ -19,8 +19,8 @@ namespace IceRpc.Compressor;
 /// This middleware compresses the payload of a response and sets the <see cref="ResponseFieldKey.CompressionFormat" />
 /// field when the request has the <see cref="ICompressFeature" /> feature set and the response's CompressionFormat
 /// field is unset.</remarks>
-/// <seealso cref="CompressorRouterExtensions.UseCompressor(Router, CompressionFormat, CompressionLevel)"/>
-/// <seealso cref="CompressorDispatcherBuilderExtensions.UseCompressor(IDispatcherBuilder, CompressionFormat, CompressionLevel)"/>
+/// <seealso cref="CompressorRouterExtensions"/>
+/// <seealso cref="CompressorDispatcherBuilderExtensions"/>
 public class CompressorMiddleware : IDispatcher
 {
     private readonly CompressionFormat _compressionFormat;

--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -21,8 +21,8 @@ namespace IceRpc.Deadline;
 /// <see cref="StatusCode.DeadlineExpired"/>.<br/>
 /// The deadline interceptor must be installed before any interceptor than can run multiple times per request. In
 /// particular, it must be installed before the retry interceptor.</remarks>
-/// <seealso cref="DeadlineRouterExtensions.UseDeadline(Router)"/>
-/// <seealso cref="DeadlineDispatcherBuilderExtensions.UseDeadline(IDispatcherBuilder)"/>
+/// <seealso cref="DeadlinePipelineExtensions"/>
+/// <seealso cref="DeadlineInvokerBuilderExtensions"/>
 public class DeadlineInterceptor : IInvoker
 {
     private readonly bool _alwaysEnforceDeadline;

--- a/src/IceRpc.Deadline/DeadlineMiddleware.cs
+++ b/src/IceRpc.Deadline/DeadlineMiddleware.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
 using IceRpc.Slice;
 
@@ -8,6 +9,8 @@ namespace IceRpc.Deadline;
 /// <summary>Represents a middleware that decodes deadline fields into deadline features. When the decoded deadline
 /// expires, this middleware cancels the dispatch and throws a <see cref="DispatchException" /> with status code
 /// <see cref="StatusCode.DeadlineExpired" />.</summary>
+/// <seealso cref="DeadlineRouterExtensions"/>
+/// <seealso cref="DeadlineDispatcherBuilderExtensions"/>
 public class DeadlineMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;

--- a/src/IceRpc.Logger/LoggerInterceptor.cs
+++ b/src/IceRpc.Logger/LoggerInterceptor.cs
@@ -7,8 +7,8 @@ using System.Net;
 namespace IceRpc.Logger;
 
 /// <summary>An interceptor that writes a log entry to an <see cref="ILogger" /> for each invocation.</summary>
-/// <seealso cref="LoggerPipelineExtensions.UseLogger(Pipeline, ILoggerFactory)"/>
-/// <seealso cref="LoggerInvokerBuilderExtensions.UseLogger(IInvokerBuilder)"/>
+/// <seealso cref="LoggerPipelineExtensions"/>
+/// <seealso cref="LoggerInvokerBuilderExtensions"/>
 public class LoggerInterceptor : IInvoker
 {
     private readonly ILogger _logger;

--- a/src/IceRpc.Logger/LoggerMiddleware.cs
+++ b/src/IceRpc.Logger/LoggerMiddleware.cs
@@ -7,8 +7,8 @@ using System.Net;
 namespace IceRpc.Logger;
 
 /// <summary>A middleware that writes a log entry to an <see cref="ILogger" /> for each dispatch.</summary>
-/// <seealso cref="LoggerRouterExtensions.UseLogger(Router, ILoggerFactory)"/>
-/// <seealso cref="LoggerDispatcherBuilderExtensions.UseLogger(IDispatcherBuilder)"/>
+/// <seealso cref="LoggerRouterExtensions"/>
+/// <seealso cref="LoggerDispatcherBuilderExtensions"/>
 public class LoggerMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;

--- a/src/IceRpc.Metrics/MetricsInterceptor.cs
+++ b/src/IceRpc.Metrics/MetricsInterceptor.cs
@@ -9,8 +9,8 @@ namespace IceRpc.Metrics;
 /// <summary>An interceptor that publishes invocation metrics using a singleton meter named "IceRpc.Invocation".
 /// </summary>
 /// <seealso cref="Meter"/>
-/// <seealso cref="MetricsPipelineExtensions.UseMetrics(Pipeline)"/>
-/// <seealso cref="MetricsInvokerBuilderExtensions.UseMetrics(IInvokerBuilder)"/>
+/// <seealso cref="MetricsPipelineExtensions"/>
+/// <seealso cref="MetricsInvokerBuilderExtensions"/>
 public class MetricsInterceptor : IInvoker
 {
     private readonly IInvoker _next;

--- a/src/IceRpc.Metrics/MetricsMiddleware.cs
+++ b/src/IceRpc.Metrics/MetricsMiddleware.cs
@@ -9,8 +9,8 @@ namespace IceRpc.Metrics;
 /// <summary>A middleware that publishes dispatch metrics using a singleton meter named "IceRpc.Dispatch".
 /// </summary>
 /// <seealso cref="Meter"/>
-/// <seealso cref="MetricsRouterExtensions.UseMetrics(Router)"/>
-/// <seealso cref="MetricsDispatcherBuilderExtensions.UseMetrics(IDispatcherBuilder)"/>
+/// <seealso cref="MetricsRouterExtensions"/>
+/// <seealso cref="MetricsDispatcherBuilderExtensions"/>
 public class MetricsMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;

--- a/src/IceRpc.Retry/RetryInterceptor.cs
+++ b/src/IceRpc.Retry/RetryInterceptor.cs
@@ -38,8 +38,8 @@ namespace IceRpc.Retry;
 /// <para>If the status code carried by the response is <see cref="StatusCode.Unavailable" /> or <see
 /// cref="StatusCode.ServiceNotFound" /> (with the ice protocol), the address of the server is removed from the set of
 /// server addresses to retry on. This ensures the request won't be retried on the unavailable server.</para></remarks>
-/// <seealso cref="RetryPipelineExtensions.UseRetry(Pipeline)"/>
-/// <seealso cref="RetryInvokerBuilderExtensions.UseRetry(IInvokerBuilder)"/>
+/// <seealso cref="RetryPipelineExtensions"/>
+/// <seealso cref="RetryInvokerBuilderExtensions"/>
 public class RetryInterceptor : IInvoker
 {
     private readonly ILogger _logger;

--- a/src/IceRpc.Telemetry/TelemetryInterceptor.cs
+++ b/src/IceRpc.Telemetry/TelemetryInterceptor.cs
@@ -11,8 +11,8 @@ namespace IceRpc.Telemetry;
 /// activity context is written in the request <see cref="RequestFieldKey.TraceContext" /> field and can be restored on
 /// the server-side by installing the <see cref="TelemetryMiddleware" />.</summary>
 /// <remarks>The activities are only created for requests using the icerpc protocol.</remarks>
-/// <seealso cref="TelemetryPipelineExtensions.UseTelemetry(Pipeline, ActivitySource)"/>
-/// <seealso cref="TelemetryDispatcherBuilderExtensions.UseTelemetry(IDispatcherBuilder)"/>
+/// <seealso cref="TelemetryPipelineExtensions"/>
+/// <seealso cref="TelemetryDispatcherBuilderExtensions"/>
 public class TelemetryInterceptor : IInvoker
 {
     private readonly IInvoker _next;

--- a/src/IceRpc.Telemetry/TelemetryMiddleware.cs
+++ b/src/IceRpc.Telemetry/TelemetryMiddleware.cs
@@ -11,8 +11,8 @@ namespace IceRpc.Telemetry;
 /// middleware restores the parent invocation activity from the request <see cref="RequestFieldKey.TraceContext" />
 /// field before starting the dispatch activity.</summary>
 /// <remarks>The activities are only created for requests using the icerpc protocol.</remarks>
-/// <seealso cref="TelemetryRouterExtensions.UseTelemetry(Router, ActivitySource)" />
-/// <seealso cref="TelemetryDispatcherBuilderExtensions.UseTelemetry(IDispatcherBuilder)"/>
+/// <seealso cref="TelemetryRouterExtensions" />
+/// <seealso cref="TelemetryDispatcherBuilderExtensions"/>
 public class TelemetryMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;

--- a/src/IceRpc/RouterExtensions.cs
+++ b/src/IceRpc/RouterExtensions.cs
@@ -16,7 +16,6 @@ public static class RouterExtensions
     /// <returns>The router being configured.</returns>
     /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <seealso cref="Router.Mount(string, IDispatcher)" />
     public static Router Map<TService>(this Router router, IDispatcher service)
         where TService : class =>
         router.Map(typeof(TService).GetDefaultServicePath(), service);

--- a/src/IceRpc/Slice/AsyncEnumerableExtensions.cs
+++ b/src/IceRpc/Slice/AsyncEnumerableExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.IO.Pipelines;
 

--- a/src/IceRpc/Slice/IActivator.cs
+++ b/src/IceRpc/Slice/IActivator.cs
@@ -8,9 +8,7 @@ namespace IceRpc.Slice;
 /// <summary>Provides methods that create class and exception instances from Slice type IDs.</summary>
 /// <remarks>When decoding a Slice1-encoded buffer, a Slice decoder uses its activator to create a class or exception
 /// instance before decoding the instance's fields.</remarks>
-/// <seealso cref="SliceDecoder.DecodeClass{T}" />
-/// <seealso cref="SliceDecoder.DecodeNullableClass{T}" />
-/// <seealso cref="SliceDecoder.DecodeUserException(string?)" />
+/// <seealso cref="SliceDecoder" />
 public interface IActivator
 {
     /// <summary>Gets or creates an activator for the Slice types in the specified assembly and its referenced

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedConnectionConformanceTests.cs
@@ -3,7 +3,6 @@
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;

--- a/tests/IceRpc.Tests/Slice/ServiceTests.cs
+++ b/tests/IceRpc.Tests/Slice/ServiceTests.cs
@@ -2,9 +2,7 @@
 
 using IceRpc.Features;
 using IceRpc.Slice;
-using IceRpc.Tests.Common;
 using NUnit.Framework;
-using System.IO.Pipelines;
 
 namespace IceRpc.Tests.Slice;
 


### PR DESCRIPTION
This PR fixes docfx warnings, by updating `seealso` tag usage to not point to class methods. See #3130

I moved the issue to 0.2, to improve crefs once docfx linked issue gets fixed.