### PR TITLE
Fix for #3354

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -298,7 +298,7 @@ internal class SlicConnection : IMultiplexedConnection
         void KeepAlive()
         {
             // _pendingPongCount can be < 0 if an unexpected pong is received. If it's the case, the connection is being
-            // teardown and there's no point in sending a ping frame.
+            // torn down and there's no point in sending a ping frame.
             if (Interlocked.Increment(ref _pendingPongCount) > 0)
             {
                 try


### PR DESCRIPTION
This PR fixes #3354 by adding a pending pong couter to keep track of the number of pongs to receive.