### PR TITLE
Disallow 'cs::identifier' on 'Custom' and Allow 'cs::attribute' on 'Enumerators'

### DIFF
--- a/tests/IceRpc.Tests/Slice/EnumTests.cs
+++ b/tests/IceRpc.Tests/Slice/EnumTests.cs
@@ -135,4 +135,16 @@ public class EnumTests
             return decoder.DecodeSequence<MyUncheckedEnum>();
         }
     }
+
+    [Test]
+    public void Cs_attribute_on_enumerator()
+    {
+        // Arrange / Act
+        var memberInfos = typeof(MyUncheckedEnum).GetMember("E4");
+        var attributes = memberInfos[0].GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
+        var description = ((System.ComponentModel.DescriptionAttribute)attributes[0]).Description;
+
+        // Assert
+        Assert.That(description, Is.EqualTo("Sixteen"));
+    }
 }

--- a/tests/IceRpc.Tests/Slice/EnumTests.slice
+++ b/tests/IceRpc.Tests/Slice/EnumTests.slice
@@ -26,6 +26,8 @@ unchecked enum MyUncheckedEnum : uint32 {
     E1 = 2
     E2 = 4
     E3 = 8
+
+    [cs::attribute("System.ComponentModel.Description(\"Sixteen\")")]
     E4 = 16
 }
 

--- a/tests/IceRpc.Tests/Slice/StructTests.cs
+++ b/tests/IceRpc.Tests/Slice/StructTests.cs
@@ -435,4 +435,16 @@ public sealed class StructTests
                 (ref SliceDecoder decoder) => decoder.DecodeProxy<PingableProxy>() as PingableProxy?),
             Is.EqualTo(expected.I));
     }
+
+    [Test]
+    public void Cs_attribute_on_field()
+    {
+        // Arrange / Act
+        var memberInfos = typeof(MyStructWithFieldAttributes).GetMember("I");
+        var attributes = memberInfos[0].GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
+        var description = ((System.ComponentModel.DescriptionAttribute)attributes[0]).Description;
+
+        // Assert
+        Assert.That(description, Is.EqualTo("An integer"));
+    }
 }

--- a/tests/IceRpc.Tests/Slice/StructTests.slice
+++ b/tests/IceRpc.Tests/Slice/StructTests.slice
@@ -18,3 +18,8 @@ compact struct MyCompactStruct {
     i: int32
     j: int32
 }
+
+struct MyStructWithFieldAttributes {
+    [cs::attribute("System.ComponentModel.Description(\"An integer\")")]
+    i: int32,
+}

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -613,7 +613,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 [[package]]
 name = "slicec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/icerpc/slicec#4527922429c760c2595e01efab30bb0949ff64cd"
+source = "git+ssh://git@github.com/icerpc/slicec#6b86bf0e40683afe6ae02c65269c859d37cc363f"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/src/cs_attributes/cs_attribute.rs
+++ b/tools/slicec-cs/src/cs_attributes/cs_attribute.rs
@@ -18,7 +18,10 @@ impl CsAttribute {
     }
 
     pub fn validate_on(&self, applied_on: Attributables, span: &Span, reporter: &mut DiagnosticReporter) {
-        if !matches!(applied_on, Attributables::Enum(_) | Attributables::Field(_)) {
+        if !matches!(
+            applied_on,
+            Attributables::Enum(_) | Attributables::Enumerator(_) | Attributables::Field(_),
+        ) {
             // TODO Add a note explaining what this can be applied to, and how to put attributes on other things.
             report_unexpected_attribute(self, span, None, reporter);
         }

--- a/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
+++ b/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
@@ -26,9 +26,12 @@ impl CsIdentifier {
                 );
                 report_unexpected_attribute(self, span, Some(&note), reporter);
             }
-            Attributables::SliceFile(_) | Attributables::TypeAlias(_) | Attributables::TypeRef(_) => {
-                report_unexpected_attribute(self, span, None, reporter);
-            }
+
+            Attributables::SliceFile(_)
+            | Attributables::CustomType(_)
+            | Attributables::TypeAlias(_)
+            | Attributables::TypeRef(_) => report_unexpected_attribute(self, span, None, reporter),
+
             _ => {}
         }
     }

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -44,6 +44,10 @@ fn enum_values(enum_def: &Enum) -> CodeBlock {
             declaration.writeln(&comment_tag);
         }
 
+        for cs_attribute in enumerator.cs_attributes() {
+            writeln!(declaration, "[{cs_attribute}]")
+        }
+
         if let Some(attribute) = enumerator.obsolete_attribute() {
             writeln!(declaration, "[{attribute}]");
         }

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -20,14 +20,16 @@ pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
         .cs_type_string(&field.namespace(), TypeContext::Field, false);
     let mut prelude = CodeBlock::default();
 
-    let attributes = field.cs_attributes();
-
     for comment_tag in field.formatted_doc_comment() {
         prelude.writeln(&comment_tag)
     }
-    prelude.writeln(&attributes.into_iter().collect::<CodeBlock>());
+
+    for cs_attribute in field.cs_attributes() {
+        writeln!(prelude, "[{cs_attribute}]")
+    }
+
     if let Some(obsolete) = field.obsolete_attribute() {
-        prelude.writeln(&format!("[{obsolete}]"));
+        writeln!(prelude, "[{obsolete}]");
     }
 
     // All field modifiers are based on the parent's modifiers.


### PR DESCRIPTION
This PR:
- Disallows `cs::identifier` on custom types, #3322
- Allows `cs::attribute` on enumerators, #3323
- Fixed `cs::attribute` on struct fields: it didn't generate the `[]` around the attribute in C#. So, totally completely broken.

It also added tests for `cs::attribute`, since none existed.