### PR TITLE
Workaround failures when running with high number of workers

### DIFF
--- a/build/Coverlet.runsettings
+++ b/build/Coverlet.runsettings
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
     <NUnit>
-      <DisplayName>FullNameSep</DisplayName>
+        <DisplayName>FullNameSep</DisplayName>
+        <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
+        <NumberOfTestWorkers>10</NumberOfTestWorkers>
     </NUnit>
     <DataCollectionRunSettings>
         <DataCollectors>

--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
     <NUnit>
-      <DisplayName>FullNameSep</DisplayName>
+        <DisplayName>FullNameSep</DisplayName>
+        <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
+        <NumberOfTestWorkers>10</NumberOfTestWorkers>
     </NUnit>
 </RunSettings>


### PR DESCRIPTION
This is a workaround for #3346 