### PR TITLE
Fixed Links to type-aliases.

### DIFF
--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -1,8 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{scoped_identifier, InterfaceExt, MemberExt, ModuleExt};
-use crate::cs_attributes::CsType;
-use crate::cs_attributes::{CsAttribute, CsIdentifier, CsInternal};
+use crate::cs_attributes::{CsAttribute, CsIdentifier, CsInternal, CsType};
 use crate::cs_util::{escape_keyword, CsCase};
 use convert_case::Case;
 use slicec::grammar::attributes::Deprecated;


### PR DESCRIPTION
This PR 'fixes' links to type-aliases by not emitting them.
See https://github.com/icerpc/icerpc-csharp/issues/3419#issuecomment-1607655665

If a user tries to link to one, instead of generating a `see` tag, we just output the type-alias' identifier, just like we do for broken links. Note that this is C# specific behavior; in other languages where we _do_ generate code for type-aliases, we will also correctly generate links to them.