### PR TITLE
DevelopmentDependency for IceRpc.Slice.Tools

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -21,6 +21,7 @@
       <PackageIcon>logo.png</PackageIcon>
       <Copyright>Copyright (c) ZeroC, Inc.</Copyright>
       <Description>Provides tools to generate C# code from Slice definitions; includes support for MSBuild projects.</Description>
+      <DevelopmentDependency>true</DevelopmentDependency>
       <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
       <PackageTags>IceRPC;RPC;MSbuild;Slice</PackageTags>
       <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This PR updates the packaging of IceRpc.Slice.Tools.

See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets

The goal is to get PrivateAssets=all when adding IceRpc.Slice.Tools to a project with `dotnet add package IceRpc.Slice.Tools`. 

I am now getting:
```xml
    <PackageReference Include="IceRpc.Slice.Tools" Version="0.1.0">
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
      <PrivateAssets>all</PrivateAssets>
    </PackageReference>
```

and I think that's fine.

