### PR TITLE
Cleanup templates project settings

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Client/IceRpc-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Client/IceRpc-Client.csproj
@@ -4,10 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
-    <ImplicitUsings>true</ImplicitUsings>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
     <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-DI-Client/IceRpc-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-DI-Client/IceRpc-DI-Client.csproj
@@ -4,10 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
-    <ImplicitUsings>true</ImplicitUsings>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
     <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-DI-Server/IceRpc-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-DI-Server/IceRpc-DI-Server.csproj
@@ -4,10 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>10.0</LangVersion>
-        <ImplicitUsings>true</ImplicitUsings>
-        <WarningLevel>4</WarningLevel>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <ImplicitUsings>enable</ImplicitUsings>
         <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
         <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
     </PropertyGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-Server/IceRpc-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Server/IceRpc-Server.csproj
@@ -4,10 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
-    <ImplicitUsings>true</ImplicitUsings>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
     <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>


### PR DESCRIPTION
This PR simplifies the template project settings to be consistent with the console template from .NET

With the console project there is only a few settings

```
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>
```