### PR TITLE
Workaround for slow Quic tests when running on Linux/OpenSSL 3.0

### DIFF
--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -2,7 +2,5 @@
 <RunSettings>
     <NUnit>
         <DisplayName>FullNameSep</DisplayName>
-        <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
-        <NumberOfTestWorkers>10</NumberOfTestWorkers>
     </NUnit>
 </RunSettings>

--- a/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Quic.Tests/AssemblyInfo.cs
@@ -11,6 +11,9 @@ using System.Runtime.Versioning;
 [assembly: NUnit.Framework.Timeout(16000)]
 #endif
 
+// TODO: Remove once OpenSSL performance issues are resolved (https://github.com/openssl/openssl/issues/17627).
+[assembly: NUnit.Framework.LevelOfParallelism(2)]
+
 // We need these attributes because the .NET QUIC APIs have the same.
 [assembly: SupportedOSPlatform("linux")]
 [assembly: SupportedOSPlatform("macOS")]

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
@@ -24,9 +24,6 @@ public class QuicConnectionConformanceTests : MultiplexedConnectionConformanceTe
 }
 
 [Parallelizable(ParallelScope.All)]
-[System.Runtime.Versioning.SupportedOSPlatform("macOS")]
-[System.Runtime.Versioning.SupportedOSPlatform("linux")]
-[System.Runtime.Versioning.SupportedOSPlatform("windows")]
 public class QuicStreamConformanceTests : MultiplexedStreamConformanceTests
 {
     [OneTimeSetUp]

--- a/tests/IceRpc.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Tests/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 [assembly: NUnit.Framework.Timeout(8000)]
+
+// Limit the maximum number of NUnit workers to workaround failures when running with high number of workers
+[assembly: NUnit.Framework.LevelOfParallelism(10)]


### PR DESCRIPTION
This PR improves a bit the run time of Quic tests. See #3411.

@externl It might be worth checking if reducing parallelism of TLS tests from `IceRpc.Tests` also solves https://github.com/icerpc/icerpc-csharp/issues/3346 on our CI host.
- replace `[Parallelizable(scope: ParallelScope.All)]` with `[Parallelizable(scope: ParallelScope.Fixtures)] ` in `TcpTransportTests` and `SslTransportXxxTests`
- remove `[assembly: NUnit.Framework.LevelOfParallelism(10)]` from `IceRpc.Tests/AssemblyInfo.cs`.
