### PR TITLE
Rename UnknownSlicedClass -> UnknownSliceClass

### DIFF
--- a/src/IceRpc/Slice/SliceDecoder.Class.cs
+++ b/src/IceRpc/Slice/SliceDecoder.Class.cs
@@ -281,7 +281,7 @@ public ref partial struct SliceDecoder
             if (instance is null && SkipSlice(typeId))
             {
                 // Slice off what we don't understand.
-                instance = new UnknownSlicedClass();
+                instance = new UnknownSliceClass();
                 // Don't decode the indirection table as it's the last entry in DeferredIndirectionTableList.
                 decodeIndirectionTable = false;
             }

--- a/src/IceRpc/Slice/SliceEncoder.Class.cs
+++ b/src/IceRpc/Slice/SliceEncoder.Class.cs
@@ -174,7 +174,7 @@ public ref partial struct SliceEncoder
 
             if (v.UnknownSlices.Count > 0 && _classContext.ClassFormat == ClassFormat.Sliced)
             {
-                EncodeUnknownSlices(v.UnknownSlices, fullySliced: v is UnknownSlicedClass);
+                EncodeUnknownSlices(v.UnknownSlices, fullySliced: v is UnknownSliceClass);
                 _classContext.Current.FirstSlice = false;
             }
             v.Encode(ref this);

--- a/src/IceRpc/Slice/UnknownSliceClass.cs
+++ b/src/IceRpc/Slice/UnknownSliceClass.cs
@@ -6,7 +6,7 @@ namespace IceRpc.Slice;
 
 /// <summary>Represents a fully sliced class instance. The <see cref="IActivator"/> used during decoding does not know
 /// this type or any of its base classes.</summary>
-public sealed class UnknownSlicedClass : SliceClass
+public sealed class UnknownSliceClass : SliceClass
 {
     /// <inheritdoc/>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -20,7 +20,7 @@ public sealed class UnknownSlicedClass : SliceClass
     {
     }
 
-    internal UnknownSlicedClass()
+    internal UnknownSliceClass()
     {
     }
 }

--- a/tests/IceRpc.Tests/Slice/SlicingTests.cs
+++ b/tests/IceRpc.Tests/Slice/SlicingTests.cs
@@ -51,7 +51,7 @@ public class SlicingTests
         decoder.CheckEndOfBuffer(skipTaggedParams: false);
 
         // Assert
-        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClass>() : Is.TypeOf<UnknownSlicedClass>());
+        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClass>() : Is.TypeOf<UnknownSliceClass>());
         Assert.That(r1.UnknownSlices, Is.Not.Empty);
         if (partialSlicing)
         {
@@ -112,7 +112,7 @@ public class SlicingTests
         decoder.CheckEndOfBuffer(skipTaggedParams: false);
 
         // Assert
-        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClassWithCompactId>() : Is.TypeOf<UnknownSlicedClass>());
+        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClassWithCompactId>() : Is.TypeOf<UnknownSliceClass>());
         Assert.That(r1.UnknownSlices, Is.Not.Empty);
 
         Assert.That(r2.UnknownSlices, Is.Empty);
@@ -167,7 +167,7 @@ public class SlicingTests
         decoder.CheckEndOfBuffer(skipTaggedParams: false);
 
         // Assert
-        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClass>() : Is.TypeOf<UnknownSlicedClass>());
+        Assert.That(r1, partialSlicing ? Is.TypeOf<SlicingDerivedClass>() : Is.TypeOf<UnknownSliceClass>());
         Assert.That(r1.UnknownSlices, Is.Not.Empty);
 
         Assert.That(r2.UnknownSlices, Is.Empty);


### PR DESCRIPTION
Now that the base class for Slice classes is SliceClass, UnknownSlicedClass is unexpected. Renamed to UnknownSliceClass.