### PR TITLE
Ensure decoded dispatch exception has ConvertToUnhandled set to true

### DIFF
--- a/tests/IceRpc.Tests/Slice/IncommingResponseTests.cs
+++ b/tests/IceRpc.Tests/Slice/IncommingResponseTests.cs
@@ -22,6 +22,7 @@ public class IncomingResponseTests
             StatusCode.DeadlineExpired,
             "deadline expired");
 
+        // Act/Assert
         DispatchException? decodedException = Assert.ThrowsAsync<DispatchException>(
             async () => await response.DecodeVoidReturnValueAsync(
                 request,
@@ -42,6 +43,7 @@ public class IncomingResponseTests
             StatusCode.DeadlineExpired,
             "deadline expired");
 
+        // Act/Assert
         DispatchException? decodedException = Assert.ThrowsAsync<DispatchException>(
             async () => await response.DecodeReturnValueAsync(
                 request,


### PR DESCRIPTION
Fix #3487

Added an assert to ensure that the decoded dispatch exception has ConvertToUnhandled set to true, the downside is that it adds a dependency to Slice in the protocol connection test.