### PR TITLE
Remove proxy dependency from SliceDecoder

### DIFF
--- a/src/IceRpc/Slice/GenericProxy.cs
+++ b/src/IceRpc/Slice/GenericProxy.cs
@@ -4,7 +4,6 @@ namespace IceRpc.Slice;
 
 /// <summary>Provides an implementation of <see cref="IProxy" /> that does not implement any Slice interface. It's used
 /// to create concrete untyped proxies.</summary>
-/// <seealso cref="ISliceFeature.ProxyFactory" />
 public readonly record struct GenericProxy : IProxy
 {
     /// <inheritdoc/>
@@ -16,12 +15,24 @@ public readonly record struct GenericProxy : IProxy
     /// <inheritdoc/>
     public ServiceAddress ServiceAddress { get; init; }
 
-    /// <summary>Creates a generic proxy from a proxy struct of type <typeparamref name="TProxy" />.
-    /// </summary>
+    /// <summary>Creates a clone of this proxy with the provided service address.</summary>
+    /// <param name="serviceAddress">The service address to use for the clone.</param>
+    /// <returns>The clone.</returns>
+    /// <remarks>When <paramref name="serviceAddress" /> is a relative service address, the service address of the clone
+    /// is a clone of the original service address with the path from <paramref name="serviceAddress" />.</remarks>
+    /// <seealso cref="ISliceFeature.ProxyFactory" />
+    public GenericProxy With(ServiceAddress serviceAddress) =>
+        this with
+        {
+            ServiceAddress = serviceAddress.Protocol is null ?
+                ServiceAddress with { Path = serviceAddress.Path } : serviceAddress
+        };
+
+    /// <summary>Creates a generic proxy from a proxy struct of type <typeparamref name="TProxy" />.</summary>
     /// <typeparam name="TProxy">The type of the source proxy.</typeparam>
     /// <param name="proxy">The source proxy.</param>
     /// <returns>A new generic proxy.</returns>
-    public static GenericProxy FromProxy<TProxy>(TProxy proxy) where TProxy : struct, IProxy =>
+    internal static GenericProxy FromProxy<TProxy>(TProxy proxy) where TProxy : struct, IProxy =>
         new()
         {
             EncodeOptions = proxy.EncodeOptions,

--- a/src/IceRpc/Slice/ISliceFeature.cs
+++ b/src/IceRpc/Slice/ISliceFeature.cs
@@ -30,7 +30,7 @@ public interface ISliceFeature
     /// <value>The maximum size of a Slice payload segment, in bytes.</value>
     int MaxSegmentSize { get; }
 
-    /// <summary>Gets the proxy factory to use when decoding proxies in request or response payloads.</summary>
+    /// <summary>Gets the proxy factory to customize the decoding of proxies in request or response payloads.</summary>
     /// <value>The proxy factory used when decoding proxies.</value>
-    Func<ServiceAddress, GenericProxy?, GenericProxy>? ProxyFactory { get; }
+    Func<ServiceAddress, GenericProxy>? ProxyFactory { get; }
 }

--- a/src/IceRpc/Slice/IncomingRequestExtensions.cs
+++ b/src/IceRpc/Slice/IncomingRequestExtensions.cs
@@ -96,7 +96,7 @@ public static class IncomingRequestExtensions
         return request.DecodeValueAsync(
             encoding,
             feature,
-            templateProxy: null,
+            feature.ProxyFactory,
             decodeFunc,
             feature.Activator ?? defaultActivator,
             cancellationToken);

--- a/src/IceRpc/Slice/IncomingResponseExtensions.cs
+++ b/src/IceRpc/Slice/IncomingResponseExtensions.cs
@@ -47,7 +47,7 @@ public static class IncomingResponseExtensions
             StatusCode.Success => response.DecodeValueAsync(
                 encoding,
                 feature,
-                sender,
+                feature.ProxyFactory ?? sender.With,
                 decodeReturnValue,
                 activator,
                 cancellationToken),
@@ -175,8 +175,7 @@ public static class IncomingResponseExtensions
                 var decoder = new SliceDecoder(
                     buffer,
                     encoding,
-                    feature.ProxyFactory,
-                    sender,
+                    feature.ProxyFactory ?? sender.With,
                     maxCollectionAllocation: feature.MaxCollectionAllocation,
                     activator,
                     maxDepth: feature.MaxDepth);
@@ -193,8 +192,7 @@ public static class IncomingResponseExtensions
                 var decoder = new SliceDecoder(
                     buffer,
                     encoding,
-                    feature.ProxyFactory,
-                    sender,
+                    feature.ProxyFactory ?? sender.With,
                     maxCollectionAllocation: feature.MaxCollectionAllocation);
 
                 try

--- a/src/IceRpc/Slice/Internal/IncomingFrameExtensions.cs
+++ b/src/IceRpc/Slice/Internal/IncomingFrameExtensions.cs
@@ -12,7 +12,7 @@ internal static class IncomingFrameExtensions
     /// <param name="frame">The incoming frame.</param>
     /// <param name="encoding">The Slice encoding version.</param>
     /// <param name="feature">The Slice feature.</param>
-    /// <param name="templateProxy">The template proxy.</param>
+    /// <param name="proxyFactory">The proxy factory.</param>
     /// <param name="decodeFunc">The decode function for the payload arguments or return value.</param>
     /// <param name="activator">The activator.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
@@ -21,7 +21,7 @@ internal static class IncomingFrameExtensions
         this IncomingFrame frame,
         SliceEncoding encoding,
         ISliceFeature feature,
-        GenericProxy? templateProxy,
+        Func<ServiceAddress, GenericProxy>? proxyFactory,
         DecodeFunc<T> decodeFunc,
         IActivator? activator,
         CancellationToken cancellationToken)
@@ -42,8 +42,7 @@ internal static class IncomingFrameExtensions
             var decoder = new SliceDecoder(
                 readResult.Buffer,
                 encoding,
-                feature.ProxyFactory,
-                templateProxy,
+                proxyFactory,
                 feature.MaxCollectionAllocation,
                 activator,
                 feature.MaxDepth);

--- a/src/IceRpc/Slice/PipeReaderExtensions.cs
+++ b/src/IceRpc/Slice/PipeReaderExtensions.cs
@@ -86,7 +86,7 @@ public static class PipeReaderExtensions
     /// <param name="reader">The pipe reader.</param>
     /// <param name="encoding">The Slice encoding version.</param>
     /// <param name="decodeFunc">The function used to decode the streamed member.</param>
-    /// <param name="templateProxy">The template proxy.</param>
+    /// <param name="sender">The proxy that sent the request, if applicable.</param>
     /// <param name="sliceFeature">The slice feature to customize the decoding.</param>
     /// <returns>The async enumerable to decode and return the streamed members.</returns>
     /// <remarks>The reader ownership is transferred to the returned async enumerable. The caller should no longer use
@@ -95,21 +95,22 @@ public static class PipeReaderExtensions
         this PipeReader reader,
         SliceEncoding encoding,
         DecodeFunc<T> decodeFunc,
-        GenericProxy? templateProxy = null,
+        GenericProxy? sender = null,
         ISliceFeature? sliceFeature = null)
     {
         sliceFeature ??= SliceFeature.Default;
+
+        Func<ServiceAddress, GenericProxy>? proxyFactory = sliceFeature.ProxyFactory;
+        if (proxyFactory is null && sender is GenericProxy proxy)
+        {
+            proxyFactory = proxy.With;
+        }
         return reader.ToAsyncEnumerable(ReadAsync, DecodeBuffer);
 
         IEnumerable<T> DecodeBuffer(ReadOnlySequence<byte> buffer)
         {
             // No activator or max depth since streams are Slice2+.
-            var decoder = new SliceDecoder(
-                buffer,
-                encoding,
-                sliceFeature.ProxyFactory,
-                templateProxy,
-                sliceFeature.MaxCollectionAllocation);
+            var decoder = new SliceDecoder(buffer, encoding, proxyFactory, sliceFeature.MaxCollectionAllocation);
 
             var items = new List<T>();
             do

--- a/src/IceRpc/Slice/SliceDecoder.cs
+++ b/src/IceRpc/Slice/SliceDecoder.cs
@@ -15,11 +15,17 @@ namespace IceRpc.Slice;
 /// <summary>Provides methods to decode data encoded with Slice1 or Slice2.</summary>
 public ref partial struct SliceDecoder
 {
-    /// <summary>Gets the Slice encoding decoded by this decoder.</summary>
-    public SliceEncoding Encoding { get; }
-
     /// <summary>Gets the number of bytes decoded in the underlying buffer.</summary>
     public readonly long Consumed => _reader.Consumed;
+
+    /// <summary>Gets the decoding context.</summary>
+    /// <remarks>The decoding context is a kind of cookie the code that creates the decoder can store in the decoder for
+    /// later retrieval.
+    /// </remarks>
+    public object? DecodingContext { get; }
+
+    /// <summary>Gets the Slice encoding decoded by this decoder.</summary>
+    public SliceEncoding Encoding { get; }
 
     private const string EndOfBufferMessage = "Attempting to decode past the end of the Slice decoder buffer.";
 
@@ -45,18 +51,13 @@ public ref partial struct SliceDecoder
     // The maximum depth when decoding a class recursively.
     private readonly int _maxDepth;
 
-    private readonly Func<ServiceAddress, GenericProxy?, GenericProxy>? _proxyFactory;
-
     // The sequence reader.
     private SequenceReader<byte> _reader;
-
-    private readonly GenericProxy? _templateProxy;
 
     /// <summary>Constructs a new Slice decoder over a byte buffer.</summary>
     /// <param name="buffer">The byte buffer.</param>
     /// <param name="encoding">The Slice encoding version.</param>
-    /// <param name="proxyFactory">The proxy factory.</param>
-    /// <param name="templateProxy">The template proxy to give to <paramref name="proxyFactory" />.</param>
+    /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>
@@ -65,17 +66,15 @@ public ref partial struct SliceDecoder
     public SliceDecoder(
         ReadOnlySequence<byte> buffer,
         SliceEncoding encoding,
-        Func<ServiceAddress, GenericProxy?, GenericProxy>? proxyFactory = null,
-        GenericProxy? templateProxy = null,
+        object? decodingContext = null,
         int maxCollectionAllocation = -1,
         IActivator? activator = null,
         int maxDepth = 3)
     {
         Encoding = encoding;
+        DecodingContext = decodingContext;
 
         _currentCollectionAllocation = 0;
-        _proxyFactory = proxyFactory;
-        _templateProxy = templateProxy;
 
         _maxCollectionAllocation = maxCollectionAllocation == -1 ? 8 * (int)buffer.Length :
             (maxCollectionAllocation >= 0 ? maxCollectionAllocation :
@@ -95,8 +94,7 @@ public ref partial struct SliceDecoder
     /// <summary>Constructs a new Slice decoder over a byte buffer.</summary>
     /// <param name="buffer">The byte buffer.</param>
     /// <param name="encoding">The Slice encoding version.</param>
-    /// <param name="proxyFactory">The proxy factory.</param>
-    /// <param name="templateProxy">The template proxy to give to <paramref name="proxyFactory" />.</param>
+    /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>
@@ -105,16 +103,14 @@ public ref partial struct SliceDecoder
     public SliceDecoder(
         ReadOnlyMemory<byte> buffer,
         SliceEncoding encoding,
-        Func<ServiceAddress, GenericProxy?, GenericProxy>? proxyFactory = null,
-        GenericProxy? templateProxy = null,
+        object? decodingContext = null,
         int maxCollectionAllocation = -1,
         IActivator? activator = null,
         int maxDepth = 3)
         : this(
             new ReadOnlySequence<byte>(buffer),
             encoding,
-            proxyFactory,
-            templateProxy,
+            decodingContext,
             maxCollectionAllocation,
             activator,
             maxDepth)
@@ -292,24 +288,6 @@ public ref partial struct SliceDecoder
     /// <returns>The ulong decoded by this decoder.</returns>
     public ulong DecodeVarUInt62() =>
         TryDecodeVarUInt62(out ulong value) ? value : throw new InvalidDataException(EndOfBufferMessage);
-
-    // Decode methods for constructed types
-
-    /// <summary>Decodes a nullable proxy struct (Slice1 only).</summary>
-    /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
-    /// <returns>The decoded proxy, or <see langword="null" />.</returns>
-    public TProxy? DecodeNullableProxy<TProxy>() where TProxy : struct, IProxy =>
-        this.DecodeNullableServiceAddress() is ServiceAddress serviceAddress ?
-            CreateProxy<TProxy>(serviceAddress) : null;
-
-    /// <summary>Decodes a proxy struct.</summary>
-    /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
-    /// <returns>The decoded proxy struct.</returns>
-    public TProxy DecodeProxy<TProxy>() where TProxy : struct, IProxy =>
-        Encoding == SliceEncoding.Slice1 ?
-            DecodeNullableProxy<TProxy>() ??
-                throw new InvalidDataException("Decoded null for a non-nullable proxy.") :
-           CreateProxy<TProxy>(this.DecodeServiceAddress());
 
     // Other methods
 
@@ -753,34 +731,6 @@ public ref partial struct SliceDecoder
         }
         value = 0;
         return false;
-    }
-
-    private TProxy CreateProxy<TProxy>(ServiceAddress serviceAddress) where TProxy : struct, IProxy
-    {
-        if (_proxyFactory is null)
-        {
-            return _templateProxy is GenericProxy templateProxy ?
-                new TProxy
-                {
-                    EncodeOptions = templateProxy.EncodeOptions,
-                    Invoker = templateProxy.Invoker,
-                    ServiceAddress = serviceAddress.Protocol is null ?
-                        templateProxy.ServiceAddress with { Path = serviceAddress.Path } : serviceAddress
-                }
-                :
-                new TProxy { ServiceAddress = serviceAddress };
-        }
-        else
-        {
-            GenericProxy proxy = _proxyFactory(serviceAddress, _templateProxy);
-
-            return new TProxy
-            {
-                EncodeOptions = proxy.EncodeOptions,
-                Invoker = proxy.Invoker,
-                ServiceAddress = proxy.ServiceAddress
-            };
-        }
     }
 
     private bool DecodeTagHeader(int tag, TagFormat expectedFormat, bool useTagEndMarker)

--- a/src/IceRpc/Slice/SliceDecoderExtensions.cs
+++ b/src/IceRpc/Slice/SliceDecoderExtensions.cs
@@ -228,4 +228,43 @@ public static class SliceDecoderExtensions
             return sequence;
         }
     }
+
+    // TODO: the location of the following methods is temporary
+
+    /// <summary>Decodes a nullable proxy struct (Slice1 only).</summary>
+    /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <returns>The decoded proxy, or <see langword="null" />.</returns>
+    public static TProxy? DecodeNullableProxy<TProxy>(this ref SliceDecoder decoder) where TProxy : struct, IProxy =>
+        decoder.DecodeNullableServiceAddress() is ServiceAddress serviceAddress ?
+            CreateProxy<TProxy>(serviceAddress, decoder.DecodingContext) : null;
+
+    /// <summary>Decodes a proxy struct.</summary>
+    /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <returns>The decoded proxy struct.</returns>
+    public static TProxy DecodeProxy<TProxy>(this ref SliceDecoder decoder) where TProxy : struct, IProxy =>
+        decoder.Encoding == SliceEncoding.Slice1 ?
+            decoder.DecodeNullableProxy<TProxy>() ??
+                throw new InvalidDataException("Decoded null for a non-nullable proxy.") :
+           CreateProxy<TProxy>(decoder.DecodeServiceAddress(), decoder.DecodingContext);
+
+    private static TProxy CreateProxy<TProxy>(ServiceAddress serviceAddress, object? decodingContext)
+        where TProxy : struct, IProxy
+    {
+        if (decodingContext is Func<ServiceAddress, GenericProxy> proxyFactory)
+        {
+            GenericProxy proxy = proxyFactory(serviceAddress);
+            return new TProxy
+            {
+                EncodeOptions = proxy.EncodeOptions,
+                Invoker = proxy.Invoker,
+                ServiceAddress = proxy.ServiceAddress
+            };
+        }
+        else
+        {
+            return new TProxy { ServiceAddress = serviceAddress };
+        }
+    }
 }

--- a/src/IceRpc/Slice/SliceFeature.cs
+++ b/src/IceRpc/Slice/SliceFeature.cs
@@ -28,7 +28,7 @@ public sealed class SliceFeature : ISliceFeature
     public int MaxSegmentSize { get; }
 
     /// <inheritdoc/>
-    public Func<ServiceAddress, GenericProxy?, GenericProxy>? ProxyFactory { get; }
+    public Func<ServiceAddress, GenericProxy>? ProxyFactory { get; }
 
     /// <summary>Constructs a Slice feature.</summary>
     /// <param name="activator">The activator.</param>
@@ -47,7 +47,7 @@ public sealed class SliceFeature : ISliceFeature
         int maxCollectionAllocation = -1,
         int maxDepth = -1,
         int maxSegmentSize = -1,
-        Func<ServiceAddress, GenericProxy?, GenericProxy>? proxyFactory = null,
+        Func<ServiceAddress, GenericProxy>? proxyFactory = null,
         ISliceFeature? defaultFeature = null)
     {
         defaultFeature ??= Default;
@@ -77,6 +77,6 @@ public sealed class SliceFeature : ISliceFeature
 
         public int MaxSegmentSize => 1024 * 1024;
 
-        public Func<ServiceAddress, GenericProxy?, GenericProxy>? ProxyFactory => null;
+        public Func<ServiceAddress, GenericProxy>? ProxyFactory => null;
     }
 }

--- a/tests/IceRpc.Tests/Slice/ProxyTests.cs
+++ b/tests/IceRpc.Tests/Slice/ProxyTests.cs
@@ -31,7 +31,8 @@ public class ProxyTests
         Assert.That(decoded?.ServiceAddress, Is.EqualTo(expected));
     }
 
-    /// <summary>Verifies that calling <see cref="SliceDecoder.DecodeProxy" /> correctly decodes a proxy.</summary>
+    /// <summary>Verifies that calling <see cref="SliceDecoderExtensions.DecodeProxy" /> correctly decodes a proxy.
+    /// </summary>
     /// <param name="value">The service address of the proxy to encode.</param>
     /// <param name="expected">The expected URI string of the service address.</param>
     /// <param name="encoding">The encoding used to decode the service address.</param>
@@ -189,7 +190,7 @@ public class ProxyTests
         var router = new Router();
         router.Map<ISendProxyTestService>(service);
         router.UseFeature<ISliceFeature>(
-            new SliceFeature(proxyFactory: (serviceAddress, _) =>
+            new SliceFeature(proxyFactory: serviceAddress =>
                 new GenericProxy
                 {
                     Invoker = pipeline,


### PR DESCRIPTION
This PR makes the SliceDecoder proxy-independent.

This is achieved by giving SliceDecoder a cookie-like DecoderContext (an `object?`) that IceRPC can inject into SliceDecoder when decoding the payload of an incoming frame.

This object is then an IceRpc-specifc proxy factory (`Func<ServiceAddress, GenericProxy>`).

Compared to the previous code:
(i) the decoding of proxies may be slightly slower since we cast the `object?` into this proxy factory (very minor)
(ii) we're allocating a delegate per invocation (see `sender.With`) just in case the invocation returns a proxy

It's possible we can optimize out (ii) in the common case where an operation doesn't return any proxy. This does not seem critical though.