### PR TITLE
Minor fixes to the bit sequence reader/writer documentation

### DIFF
--- a/src/ZeroC.Slice/BitSequence.cs
+++ b/src/ZeroC.Slice/BitSequence.cs
@@ -28,7 +28,7 @@ public ref struct BitSequenceReader
         }
     }
 
-    /// <summary>Reads the next bit and advance the reader.</summary>
+    /// <summary>Reads the next bit.</summary>
     /// <returns><see langword="true" /> when the next bit is set; otherwise, <see langword="false" />.</returns>
     public bool Read()
     {


### PR DESCRIPTION
This PR fixes the links to the Slice documentation pages. It also fixes few things in the documentation of the reader/writer structs. For the `BitSequenceReader` doc, I changed it to match the `SequenceReader` documentation.