### PR TITLE
Moved resettable pipe reader decorator tests

### DIFF
--- a/tests/IceRpc.Tests/ResettablePipeReaderDecoratorTests.cs
+++ b/tests/IceRpc.Tests/ResettablePipeReaderDecoratorTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;
 
-namespace IceRpc.Retry.Tests;
+namespace IceRpc.Tests;
 
 public sealed class ResettablePipeReaderDecoratorTests
 {


### PR DESCRIPTION
This PR just moves the resettable pipe reader decorator tests to IceRpc.Tests given that this class is in the IceRpc-core