### PR TITLE
Remove FromPath helper method

### DIFF
--- a/tests/IceRpc.Slice.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Tests/OperationTests.cs
@@ -623,7 +623,7 @@ public class OperationTests
         var proxy = new MyOperationsAProxy(invoker);
 
         // Act
-        await proxy.OpWithProxyParameterAsync(PingableProxy.FromPath("/hello"));
+        await proxy.OpWithProxyParameterAsync(new PingableProxy { ServiceAddress = new() { Path = "/hello" }});
 
         // Assert
         Assert.That(service.ReceivedProxy, Is.Not.Null);
@@ -794,7 +794,8 @@ public class OperationTests
 
         public ValueTask<PingableProxy> OpWithProxyReturnValueAsync(
             IFeatureCollection features,
-            CancellationToken cancellationToken) => new(PingableProxy.FromPath("/hello"));
+            CancellationToken cancellationToken) => new(
+                new PingableProxy { ServiceAddress = new() { Path = "/hello" }});
         public ValueTask OpWithTrailingOptionalValuesAsync(int p1, int? p2, int p3, int? p4, int? p5, IFeatureCollection features, CancellationToken cancellationToken) => default;
         public ValueTask OpWithTrailingOptionalValuesAndStreamAsync(int p1, int? p2, int p3, int? p4, int? p5, IAsyncEnumerable<byte?> p6, IFeatureCollection features, CancellationToken cancellationToken) => default;
     }

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -123,12 +123,7 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
 
 fn proxy_impl_static_methods(interface_def: &Interface) -> CodeBlock {
     format!(
-        r#"/// <summary>Creates a relative proxy from a path.</summary>
-/// <param name="path">The path.</param>
-/// <returns>The new relative proxy.</returns>
-public static {proxy_impl} FromPath(string path) => new() {{ ServiceAddress = new() {{ Path = path }} }};
-
-/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>
+        r#"/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>
 /// <param name="invoker">The invocation pipeline of the proxy.</param>
 /// <param name="serviceAddress">The service address. <see langword="null" /> is equivalent to <see cref="DefaultServiceAddress" />.</param>
 /// <param name="encodeOptions">The encode options, used to customize the encoding of request payloads.</param>


### PR DESCRIPTION
Users can easily create a service address with a path, IMO this method doesn't add much value.

Fix #3568