### PR TITLE
Move DecodeExceptionFunc delegate to IceRpc.Slice

### DIFF
--- a/src/IceRpc.Slice/IncomingResponseExtensions.cs
+++ b/src/IceRpc.Slice/IncomingResponseExtensions.cs
@@ -9,6 +9,12 @@ using ZeroC.Slice;
 
 namespace IceRpc.Slice;
 
+/// <summary>Represents a delegate that decodes a Slice exception from a Slice decoder.</summary>
+/// <param name="decoder">The Slice decoder.</param>
+/// <param name="message">The exception message.</param>
+/// <returns>The decoded Slice exception.</returns>
+public delegate SliceException DecodeExceptionFunc(ref SliceDecoder decoder, string? message);
+
 /// <summary>Provides extension methods for <see cref="IncomingResponse" /> to decode its Slice-encoded payload.
 /// </summary>
 public static class IncomingResponseExtensions

--- a/src/ZeroC.Slice/DecodeFunc.cs
+++ b/src/ZeroC.Slice/DecodeFunc.cs
@@ -7,9 +7,3 @@ namespace ZeroC.Slice;
 /// <param name="decoder">The Slice decoder.</param>
 /// <returns>The value.</returns>
 public delegate T DecodeFunc<T>(ref SliceDecoder decoder);
-
-/// <summary>Represents a delegate that decodes a Slice exception from a Slice decoder.</summary>
-/// <param name="decoder">The Slice decoder.</param>
-/// <param name="message">The exception message.</param>
-/// <returns>The decoded Slice exception.</returns>
-public delegate SliceException DecodeExceptionFunc(ref SliceDecoder decoder, string? message);


### PR DESCRIPTION
This PR moves this delegate to the only file that needs it.