### PR TITLE
Do not include Slice files with IceRpc.Slice.Tools package

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -77,11 +77,6 @@
          <Pack>true</Pack>
          <PackagePath>\</PackagePath>
       </None>
-      <Content Include="../../../../slice/**/*.slice"
-               Exclude="../../../../slice/**/Internal/*.slice">
-         <Pack>true</Pack>
-         <PackagePath>slice/</PackagePath>
-      </Content>
       <None Include="$(IntermediateOutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="tasks/" Visible="false" />
    </ItemGroup>
    <Choose>


### PR DESCRIPTION
This is leftover for when we use to include all Slice files in the tools package, now the Slice files are packaged with the corresponding C# project that builds them.