### PR TITLE
Move IceRpc.Slice tests to IceRpc.Slice.Tests namespace

### DIFF
--- a/tests/IceRpc.Slice.Tests/ClassTests.cs
+++ b/tests/IceRpc.Slice.Tests/ClassTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using System.IO.Pipelines;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(ParallelScope.All)]
 public sealed class ClassTests

--- a/tests/IceRpc.Slice.Tests/ClassTests.slice
+++ b/tests/IceRpc.Slice.Tests/ClassTests.slice
@@ -2,7 +2,7 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 class MyClassA {
     theB: MyClassB?

--- a/tests/IceRpc.Slice.Tests/CustomDictionary.cs
+++ b/tests/IceRpc.Slice.Tests/CustomDictionary.cs
@@ -3,7 +3,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 // A custom dictionary type to test the dictionary mapping for fields. Mapping for a field of dictionary type requires
 // a type that implements IDictionary<TKey, TValue> and provides a constructor with a size parameter.

--- a/tests/IceRpc.Slice.Tests/CustomSequence.cs
+++ b/tests/IceRpc.Slice.Tests/CustomSequence.cs
@@ -2,7 +2,7 @@
 
 using System.Collections;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 public class CustomSequence<T> : IList<T>
 {

--- a/tests/IceRpc.Slice.Tests/DictionaryMappingTests.cs
+++ b/tests/IceRpc.Slice.Tests/DictionaryMappingTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using System.IO.Pipelines;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class DictionaryMappingTests

--- a/tests/IceRpc.Slice.Tests/DictionaryMappingTests.slice
+++ b/tests/IceRpc.Slice.Tests/DictionaryMappingTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 interface DictionaryMappingOperations {
     returnDictionaryTuple() -> (r1: Dictionary<int32, int32> r2: Dictionary<int32, int32>)

--- a/tests/IceRpc.Slice.Tests/DocumentationTests.Slice1.slice
+++ b/tests/IceRpc.Slice.Tests/DocumentationTests.Slice1.slice
@@ -2,7 +2,7 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 // This file contains Slice definitions for testing the mapping of doc comments
 

--- a/tests/IceRpc.Slice.Tests/DocumentationTests.slice
+++ b/tests/IceRpc.Slice.Tests/DocumentationTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 // This file contains Slice definitions for testing the mapping of doc comments
 

--- a/tests/IceRpc.Slice.Tests/EnumTests.cs
+++ b/tests/IceRpc.Slice.Tests/EnumTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using System.IO.Pipelines;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 public class EnumTests
 {

--- a/tests/IceRpc.Slice.Tests/EnumTests.slice
+++ b/tests/IceRpc.Slice.Tests/EnumTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 enum MyEnum : int32 {
     Enum1

--- a/tests/IceRpc.Slice.Tests/ExceptionTests.cs
+++ b/tests/IceRpc.Slice.Tests/ExceptionTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(ParallelScope.All)]
 public sealed class ExceptionTests

--- a/tests/IceRpc.Slice.Tests/ExceptionTests.slice
+++ b/tests/IceRpc.Slice.Tests/ExceptionTests.slice
@@ -2,7 +2,7 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 exception MyException {
     i: int32

--- a/tests/IceRpc.Slice.Tests/IdentifierAttributeTests.cs
+++ b/tests/IceRpc.Slice.Tests/IdentifierAttributeTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice.Identifiers;
+namespace IceRpc.Slice.Tests.Identifiers;
 
 /// <summary>These tests verify that the cs::identifier attribute will cause slicec-cs to generate C# with the
 /// specified identifiers. As such, most of these tests cover trivial things. The purpose is mainly to ensure that the

--- a/tests/IceRpc.Slice.Tests/IdentifierAttributeTests.slice
+++ b/tests/IceRpc.Slice.Tests/IdentifierAttributeTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 [cs::identifier("REnamedInterface")]
 interface OriginalInterface {

--- a/tests/IceRpc.Slice.Tests/IdentityTests.cs
+++ b/tests/IceRpc.Slice.Tests/IdentityTests.cs
@@ -3,7 +3,7 @@
 using IceRpc.Internal;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class IdentityTests

--- a/tests/IceRpc.Slice.Tests/IncommingResponseTests.cs
+++ b/tests/IceRpc.Slice.Tests/IncommingResponseTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class IncomingResponseTests

--- a/tests/IceRpc.Slice.Tests/InvalidProxy.cs
+++ b/tests/IceRpc.Slice.Tests/InvalidProxy.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 internal static class InvalidProxy
 {

--- a/tests/IceRpc.Slice.Tests/InvokeAsyncTests.cs
+++ b/tests/IceRpc.Slice.Tests/InvokeAsyncTests.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Internal;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class InvokeAsyncTests

--- a/tests/IceRpc.Slice.Tests/NamespaceAttributeTests.cs
+++ b/tests/IceRpc.Slice.Tests/NamespaceAttributeTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class NamespaceAttributeTests

--- a/tests/IceRpc.Slice.Tests/NamespaceAttributeTests1.slice
+++ b/tests/IceRpc.Slice.Tests/NamespaceAttributeTests1.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 interface NamespaceOperations {
     op1(p: WithNamespace::S1) -> WithNamespace::S1

--- a/tests/IceRpc.Slice.Tests/NamespaceAttributeTests2.slice
+++ b/tests/IceRpc.Slice.Tests/NamespaceAttributeTests2.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-[cs::namespace("IceRpc.Tests.Slice.NamespaceAttribute.MappedNamespace")]
+[cs::namespace("IceRpc.Slice.Tests.NamespaceAttribute.MappedNamespace")]
 module WithNamespace
 
 struct S1 {

--- a/tests/IceRpc.Slice.Tests/OperationEncodingTests.cs
+++ b/tests/IceRpc.Slice.Tests/OperationEncodingTests.cs
@@ -6,7 +6,7 @@ using System.Buffers;
 using System.IO.Pipelines;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class OperationEncodingTests

--- a/tests/IceRpc.Slice.Tests/OperationEncodingTests.slice
+++ b/tests/IceRpc.Slice.Tests/OperationEncodingTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 // Used for testing the generated Request and Response classes.
 interface MyOperationsB {

--- a/tests/IceRpc.Slice.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Tests/OperationTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class OperationTests

--- a/tests/IceRpc.Slice.Tests/OperationTests.slice
+++ b/tests/IceRpc.Slice.Tests/OperationTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 // Used for testing the generated code corresponding to proxy and dispatch visitors.
 interface MyOperationsA {

--- a/tests/IceRpc.Slice.Tests/Pingable.slice
+++ b/tests/IceRpc.Slice.Tests/Pingable.slice
@@ -2,7 +2,7 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 // A simple interface reused by several tests.
 interface Pingable {

--- a/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
+++ b/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
@@ -6,7 +6,7 @@ using System.Buffers;
 using System.IO.Pipelines;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class PipeReaderTests

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Slice.Ice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 /// <summary>Test encoding and decoding proxies.</summary>
 [Parallelizable(scope: ParallelScope.All)]

--- a/tests/IceRpc.Slice.Tests/ProxyTests.slice
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 interface MyBaseInterface {}
 

--- a/tests/IceRpc.Slice.Tests/SequenceMappingTests.cs
+++ b/tests/IceRpc.Slice.Tests/SequenceMappingTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.IO.Pipelines;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class SequenceMappingTests

--- a/tests/IceRpc.Slice.Tests/SequenceMappingTests.slice
+++ b/tests/IceRpc.Slice.Tests/SequenceMappingTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 interface SequenceMappingOperations {
 

--- a/tests/IceRpc.Slice.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Slice.Tests/ServiceAddressTests.cs
@@ -4,7 +4,7 @@ using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 /// <summary>Tests the encoding and decoding of service address.</summary>
 [Parallelizable(scope: ParallelScope.All)]

--- a/tests/IceRpc.Slice.Tests/ServiceTests.cs
+++ b/tests/IceRpc.Slice.Tests/ServiceTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class ServiceTests

--- a/tests/IceRpc.Slice.Tests/ServiceTests.slice
+++ b/tests/IceRpc.Slice.Tests/ServiceTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 interface Service1 {
     op1()

--- a/tests/IceRpc.Slice.Tests/Slice1NullableTests.cs
+++ b/tests/IceRpc.Slice.Tests/Slice1NullableTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class Slice1NullableTests

--- a/tests/IceRpc.Slice.Tests/StreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/StreamTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Internal; // For InvalidPipeReader
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Buffers;
@@ -9,7 +8,7 @@ using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 public class StreamTests
 {

--- a/tests/IceRpc.Slice.Tests/StructTests.Slice1.slice
+++ b/tests/IceRpc.Slice.Tests/StructTests.Slice1.slice
@@ -2,7 +2,7 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 compact struct MyCompactStructWithNullableProxy {
     a: int32

--- a/tests/IceRpc.Slice.Tests/StructTests.cs
+++ b/tests/IceRpc.Slice.Tests/StructTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(ParallelScope.All)]
 public sealed class StructTests

--- a/tests/IceRpc.Slice.Tests/StructTests.slice
+++ b/tests/IceRpc.Slice.Tests/StructTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 struct MyStruct {
     i: int32

--- a/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.Slice1.slice
+++ b/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.Slice1.slice
@@ -2,6 +2,6 @@
 
 mode = Slice1
 
-module IceRpc::Tests::Slice::TypeIdAttributeTestNamespace
+module IceRpc::Slice::Tests::TypeIdAttributeTestNamespace
 
 class MyClass {}

--- a/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.cs
+++ b/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.Slice;
 using IceRpc.Slice.Ice;
 using NUnit.Framework;
 using ZeroC.Slice;
 
-namespace IceRpc.Tests.Slice.TypeIdAttributeTestNamespace;
+namespace IceRpc.Slice.Tests.TypeIdAttributeTestNamespace;
 
 public sealed class TypeIdAttributeTests
 {
@@ -24,12 +23,12 @@ public sealed class TypeIdAttributeTests
     private static readonly Dictionary<Type, string[]> _allTypeIds = new()
     {
         [typeof(IceObjectProxy)] = new string[] { "::Ice::Object" },
-        [typeof(PingableProxy)] = new string[] { "::IceRpc::Tests::Slice::Pingable" },
+        [typeof(PingableProxy)] = new string[] { "::IceRpc::Slice::Tests::Pingable" },
         [typeof(IMyDerivedInterface)] = new string[]
         {
-            "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::MyDerivedInterface",
-            "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::MyInterface",
-            "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::myOtherInterface",
+            "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::MyDerivedInterface",
+            "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::MyInterface",
+            "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::myOtherInterface",
         },
         [typeof(ServerAddress)] = Array.Empty<string>(),
         [typeof(ServiceAddress)] = Array.Empty<string>(),
@@ -39,12 +38,12 @@ public sealed class TypeIdAttributeTests
     /// <param name="type">The <see cref="Type" /> of the generated type to test.</param>
     /// <param name="expected">The expected type ID.</param>
     [TestCase(typeof(IceObjectProxy), "::Ice::Object")]
-    [TestCase(typeof(PingableProxy), "::IceRpc::Tests::Slice::Pingable")]
-    [TestCase(typeof(IMyInterface), "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::MyInterface")]
-    [TestCase(typeof(MyInterfaceProxy), "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::MyInterface")]
-    [TestCase(typeof(IMyInterfaceService), "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::MyInterface")]
-    [TestCase(typeof(MyOtherInterfaceProxy), "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::myOtherInterface")]
-    [TestCase(typeof(IMyOtherInterfaceService), "::IceRpc::Tests::Slice::TypeIdAttributeTestNamespace::myOtherInterface")]
+    [TestCase(typeof(PingableProxy), "::IceRpc::Slice::Tests::Pingable")]
+    [TestCase(typeof(IMyInterface), "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::MyInterface")]
+    [TestCase(typeof(MyInterfaceProxy), "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::MyInterface")]
+    [TestCase(typeof(IMyInterfaceService), "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::MyInterface")]
+    [TestCase(typeof(MyOtherInterfaceProxy), "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::myOtherInterface")]
+    [TestCase(typeof(IMyOtherInterfaceService), "::IceRpc::Slice::Tests::TypeIdAttributeTestNamespace::myOtherInterface")]
     public void Get_slice_type_id(Type type, string? expected)
     {
         string? typeId = type.GetSliceTypeId();
@@ -62,11 +61,11 @@ public sealed class TypeIdAttributeTests
     /// <param name="type">The <see cref="Type" /> of the generated type to test.</param>
     /// <param name="expected">The expected type ID.</param>
     [TestCase(typeof(IceObjectProxy), "/Ice.Object")]
-    [TestCase(typeof(PingableProxy), "/IceRpc.Tests.Slice.Pingable")]
-    [TestCase(typeof(IMyInterface), "/IceRpc.Tests.Slice.TypeIdAttributeTestNamespace.MyInterface")]
-    [TestCase(typeof(MyInterfaceProxy), "/IceRpc.Tests.Slice.TypeIdAttributeTestNamespace.MyInterface")]
-    [TestCase(typeof(IMyInterfaceService), "/IceRpc.Tests.Slice.TypeIdAttributeTestNamespace.MyInterface")]
-    [TestCase(typeof(MyOtherInterfaceProxy), "/IceRpc.Tests.Slice.TypeIdAttributeTestNamespace.myOtherInterface")]
+    [TestCase(typeof(PingableProxy), "/IceRpc.Slice.Tests.Pingable")]
+    [TestCase(typeof(IMyInterface), "/IceRpc.Slice.Tests.TypeIdAttributeTestNamespace.MyInterface")]
+    [TestCase(typeof(MyInterfaceProxy), "/IceRpc.Slice.Tests.TypeIdAttributeTestNamespace.MyInterface")]
+    [TestCase(typeof(IMyInterfaceService), "/IceRpc.Slice.Tests.TypeIdAttributeTestNamespace.MyInterface")]
+    [TestCase(typeof(MyOtherInterfaceProxy), "/IceRpc.Slice.Tests.TypeIdAttributeTestNamespace.myOtherInterface")]
     public void Get_default_path(Type type, string expected)
     {
         string defaultPath = type.GetDefaultServicePath();

--- a/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.slice
+++ b/tests/IceRpc.Slice.Tests/TypeIdAttributeTests.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice::TypeIdAttributeTestNamespace
+module IceRpc::Slice::Tests::TypeIdAttributeTestNamespace
 
 interface MyInterface {}
 

--- a/tests/IceRpc.Slice.Tests/TypeNameQualificationTests.cs
+++ b/tests/IceRpc.Slice.Tests/TypeNameQualificationTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Features;
-using IceRpc.Slice;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 
-namespace IceRpc.Tests.Slice;
+namespace IceRpc.Slice.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class TypeNameQualificationTests

--- a/tests/IceRpc.Slice.Tests/TypeNameQualificationTests1.slice
+++ b/tests/IceRpc.Slice.Tests/TypeNameQualificationTests1.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice
+module IceRpc::Slice::Tests
 
 struct S {
     v: string

--- a/tests/IceRpc.Slice.Tests/TypeNameQualificationTests2.slice
+++ b/tests/IceRpc.Slice.Tests/TypeNameQualificationTests2.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-module IceRpc::Tests::Slice::Inner
+module IceRpc::Slice::Tests::Inner
 
 struct S {
     v: int32


### PR DESCRIPTION
This PR moves the IceRpc.Slice tests to the correct namespace.