### PR TITLE
Update logo URL

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -52,6 +52,7 @@
       "_appName": "API",
       "_appFaviconPath": "images/favicon.ico",
       "_appLogoPath": "images/logo.svg",
+      "_appLogoUrl": "https://docs.testing.zeroc.com/api/csharp/api/IceRpc.html",
       "_appFooter": "© 2023 ZeroC",
       "_enableSearch": true,
       "_gitContribute": {


### PR DESCRIPTION
This PR updates the app logo URL to point to the API index.

For https://docs.testing.zeroc.com/api/csharp/index.html , I think we should either redirect it to the API index or give 404.