### PR TITLE
Upgrade PackageProjectUrl

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -31,7 +31,7 @@
         <Copyright>Copyright (c) ZeroC, Inc.</Copyright>
         <PackageIcon>icerpc-icon.png</PackageIcon>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/icerpc/icerpc-csharp</PackageProjectUrl>
+        <PackageProjectUrl>https://zeroc.com/icerpc</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageVersion>$(Version)</PackageVersion>

--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -15,7 +15,7 @@
       <Authors>ZeroC, Inc.</Authors>
       <PackageId>$(AssemblyName)</PackageId>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-      <PackageProjectUrl>https://github.com/icerpc/icerpc-csharp</PackageProjectUrl>
+      <PackageProjectUrl>https://zeroc.com/icerpc</PackageProjectUrl>
       <RepositoryUrl>https://github.com/icerpc/icerpc-csharp</RepositoryUrl>
       <RepositoryType>git</RepositoryType>
       <PackageIcon>icerpc-icon.png</PackageIcon>


### PR DESCRIPTION
Updates the project URL used by NuGet packages, to not be the same as RepositoryUrl which already points to the GitHub repository.