### PR TITLE
Rename "Continuous Integration" workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: ci
 
 on:
   push:


### PR DESCRIPTION
Updated the workflow name, which is used for the badge. See https://github.com/icerpc/icerpc-csharp/pull/3635#issuecomment-1707175544