### PR TITLE
Enable CI build for GitHub builds

### DIFF
--- a/build/IceRpc.Src.props
+++ b/build/IceRpc.Src.props
@@ -10,5 +10,8 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)Common.props" />
 </Project>


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild

Fix #3644