### PR TITLE
Include Common.props in IceRpc.Templates project

### DIFF
--- a/src/IceRpc.Templates/Directory.Build.props
+++ b/src/IceRpc.Templates/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)../../build/IceRpc.Version.props" />
+    <Import Project="$(MSBuildThisFileDirectory)../../build/Common.props" />
     <ItemGroup>
         <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../../build/CodeAnalysis.Base.globalconfig" />
     </ItemGroup>


### PR DESCRIPTION
Fix #3645 

The icon and other NuGet settings are defined in `build/Common.props`, but the file was not included in this project.