### PR TITLE
Refactors how Slic keeps connections alive

### DIFF
--- a/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
@@ -23,7 +23,7 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
             .ConfigureAwait(false);
 
         // Schedules or reschedules a keep alive after a successful connection establishment.
-        ScheduleKeepAlive();
+        ScheduleKeepAliveAfterWrite();
         return connectionInformation;
     }
 
@@ -83,13 +83,13 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
             // After each successful write, we (re)schedule one ping (heartbeat) at _writeIdleTimeout / 2 in the future.
             // Since each ping is itself a write, if there is no application activity at all, we'll send successive
             // pings at _writeIdleTimeout / 2 intervals.
-            ScheduleKeepAlive();
+            ScheduleKeepAliveAfterWrite();
         }
     }
 
     /// <summary>Constructs a decorator that ensures a call to <see cref="ReadAsync" /> will fail after readIdleTimeout.
-    /// This decorator also schedules a keepAliveAction after each write (see <see cref="ScheduleKeepAlive" />).
-    /// </summary>
+    /// This decorator also schedules a keepAliveAction after each write (see
+    /// <see cref="ScheduleKeepAliveAfterWrite" />).</summary>
     internal IceDuplexConnectionDecorator(
         IDuplexConnection decoratee,
         TimeSpan readIdleTimeout,
@@ -106,5 +106,6 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
     }
 
     /// <summary>Schedules one keep alive in writeIdleTimeout / 2.</summary>
-    private void ScheduleKeepAlive() => _keepAliveTimer.Change(_writeIdleTimeout / 2, Timeout.InfiniteTimeSpan);
+    private void ScheduleKeepAliveAfterWrite() =>
+        _keepAliveTimer.Change(_writeIdleTimeout / 2, Timeout.InfiniteTimeSpan);
 }

--- a/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
@@ -1,0 +1,110 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Transports;
+using System.Buffers;
+using System.Diagnostics;
+
+namespace IceRpc.Internal;
+
+/// <summary>Decorates <see cref="ReadAsync" /> to fail if no byte is received for over readIdleTimeout. Also decorates
+/// <see cref="WriteAsync" /> to schedule a keep alive action (writeIdleTimeout / 2) after a successful write. Both
+/// sides of the connection are expected to use the same idle timeouts.</summary>
+internal class IceDuplexConnectionDecorator : IDuplexConnection
+{
+    private readonly IDuplexConnection _decoratee;
+    private readonly Timer _keepAliveTimer;
+    private readonly CancellationTokenSource _readCts = new();
+    private readonly TimeSpan _readIdleTimeout;
+    private readonly TimeSpan _writeIdleTimeout;
+
+    public async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken)
+    {
+        TransportConnectionInformation connectionInformation = await _decoratee.ConnectAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Schedules or reschedules a keep alive after a successful connection establishment.
+        ScheduleKeepAlive();
+        return connectionInformation;
+    }
+
+    public void Dispose()
+    {
+        _decoratee.Dispose();
+        _readCts.Dispose();
+
+        // Using Dispose is fine, there's no need to wait for the keep alive action to terminate if it's running.
+        _keepAliveTimer.Dispose();
+    }
+
+    public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        return _readIdleTimeout == Timeout.InfiniteTimeSpan ?
+            _decoratee.ReadAsync(buffer, cancellationToken) :
+            PerformReadAsync();
+
+        async ValueTask<int> PerformReadAsync()
+        {
+            try
+            {
+                using CancellationTokenRegistration _ = cancellationToken.UnsafeRegister(
+                    cts => ((CancellationTokenSource)cts!).Cancel(),
+                    _readCts);
+                _readCts.CancelAfter(_readIdleTimeout); // enable idle timeout before reading
+                return await _decoratee.ReadAsync(buffer, _readCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                throw new IceRpcException(
+                    IceRpcError.ConnectionIdle,
+                    $"The connection did not receive any bytes for over {_readIdleTimeout.TotalSeconds} s.");
+            }
+            finally
+            {
+                _readCts.CancelAfter(Timeout.InfiniteTimeSpan); // disable idle timeout if not canceled
+            }
+        }
+    }
+
+    public Task ShutdownWriteAsync(CancellationToken cancellationToken) =>
+        _decoratee.ShutdownWriteAsync(cancellationToken);
+
+    public ValueTask WriteAsync(ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
+    {
+        return _writeIdleTimeout == Timeout.InfiniteTimeSpan ?
+            _decoratee.WriteAsync(buffer, cancellationToken) :
+            PerformWriteAsync();
+
+        async ValueTask PerformWriteAsync()
+        {
+            await _decoratee.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+            // After each successful write, we (re)schedule one ping (heartbeat) at _writeIdleTimeout / 2 in the future.
+            // Since each ping is itself a write, if there is no application activity at all, we'll send successive
+            // pings at _writeIdleTimeout / 2 intervals.
+            ScheduleKeepAlive();
+        }
+    }
+
+    /// <summary>Constructs a decorator that ensures a call to <see cref="ReadAsync" /> will fail after readIdleTimeout.
+    /// This decorator also schedules a keepAliveAction after each write (see <see cref="ScheduleKeepAlive" />).
+    /// </summary>
+    internal IceDuplexConnectionDecorator(
+        IDuplexConnection decoratee,
+        TimeSpan readIdleTimeout,
+        TimeSpan writeIdleTimeout,
+        Action keepAliveAction)
+    {
+        Debug.Assert(writeIdleTimeout != Timeout.InfiniteTimeSpan);
+        _decoratee = decoratee;
+        _readIdleTimeout = readIdleTimeout; // can be infinite i.e. disabled
+        _writeIdleTimeout = writeIdleTimeout;
+        _keepAliveTimer = new Timer(_ => keepAliveAction());
+
+        // We can't schedule a keep alive right away because the connection is not connected yet.
+    }
+
+    /// <summary>Schedules one keep alive in writeIdleTimeout / 2.</summary>
+    private void ScheduleKeepAlive() => _keepAliveTimer.Change(_writeIdleTimeout / 2, Timeout.InfiniteTimeSpan);
+}

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -55,10 +55,9 @@ internal class SlicConnection : IMultiplexedConnection
     private Task<TransportConnectionInformation>? _connectTask;
     private readonly CancellationTokenSource _disposedCts = new();
     private Task? _disposeTask;
-    private readonly IDuplexConnection _duplexConnection;
+    private readonly SlicDuplexConnectionDecorator _duplexConnection;
     private readonly DuplexConnectionReader _duplexConnectionReader;
     private readonly SlicDuplexConnectionWriter _duplexConnectionWriter;
-    private readonly Action<TimeSpan, Action?> _enableIdleTimeoutAndKeepAlive;
     private bool _isClosed;
     private ulong? _lastRemoteBidirectionalStreamId;
     private ulong? _lastRemoteUnidirectionalStreamId;
@@ -265,9 +264,7 @@ internal class SlicConnection : IMultiplexedConnection
 
             if (idleTimeout != Timeout.InfiniteTimeSpan)
             {
-                // Only client connections send ping frames when idle to keep the server connection alive. The server
-                // sends back a Pong frame in turn to keep alive the client connection.
-                _enableIdleTimeoutAndKeepAlive(idleTimeout, IsServer ? null : KeepAlive);
+                _duplexConnection.Enable(idleTimeout);
             }
 
             _readFramesTask = ReadFramesAsync(_disposedCts.Token);
@@ -316,31 +313,6 @@ internal class SlicConnection : IMultiplexedConnection
                         (ref SliceDecoder decoder) => new VersionBody(ref decoder))),
                 _ => throw new InvalidDataException($"Received unexpected Slic frame: '{frameType}'."),
             };
-
-        void KeepAlive()
-        {
-            // _pendingPongCount can be < 0 if an unexpected pong is received. If it's the case, the connection is being
-            // torn down and there's no point in sending a ping frame.
-            if (Interlocked.Increment(ref _pendingPongCount) > 0)
-            {
-                try
-                {
-                    // For now, the Ping frame payload is just a long which is always set to 0. In the future, it could
-                    // be a ping frame type value if the ping frame is used for different purpose (e.g: a KeepAlive or
-                    // RTT ping frame type).
-                    WriteConnectionFrame(FrameType.Ping, new PingBody(0L).Encode);
-                }
-                catch (IceRpcException)
-                {
-                    // Expected if the connection is closed.
-                }
-                catch (Exception exception)
-                {
-                    Debug.Fail($"The Slic keep alive timer failed with an unexpected exception: {exception}");
-                    throw;
-                }
-            }
-        }
 
         async ValueTask<T> ReadFrameAsync<T>(
             Func<FrameType?, ReadOnlySequence<byte>, T> decodeFunc,
@@ -577,10 +549,11 @@ internal class SlicConnection : IMultiplexedConnection
 
         _closedCancellationToken = _closedCts.Token;
 
-        var duplexConnectionDecorator = new SlicDuplexConnectionDecorator(duplexConnection);
-        _enableIdleTimeoutAndKeepAlive = duplexConnectionDecorator.Enable;
+        // Only the client-side sends pings to keep the connection alive when idle timeout (set later) is not infinite.
+        _duplexConnection = IsServer ?
+            new SlicDuplexConnectionDecorator(duplexConnection) :
+            new SlicDuplexConnectionDecorator(duplexConnection, SendReadPing, SendWritePing);
 
-        _duplexConnection = duplexConnectionDecorator;
         _duplexConnectionReader = new DuplexConnectionReader(_duplexConnection, options.Pool, options.MinSegmentSize);
         _duplexConnectionWriter = new SlicDuplexConnectionWriter(
             _duplexConnection,
@@ -597,6 +570,48 @@ internal class SlicConnection : IMultiplexedConnection
         {
             _nextBidirectionalId = 0;
             _nextUnidirectionalId = 2;
+        }
+
+        void SendPing(long payload)
+        {
+            try
+            {
+                WriteConnectionFrame(FrameType.Ping, new PingBody(payload).Encode);
+            }
+            catch (IceRpcException)
+            {
+                // Expected if the connection is closed.
+            }
+            catch (Exception exception)
+            {
+                Debug.Fail($"The Slic keep alive timer failed with an unexpected exception: {exception}");
+                throw;
+            }
+        }
+
+        void SendReadPing()
+        {
+            // ReadKeepAlive is no-op unless _pendingPongCount == 0 before the Increment below: we send a Ping only if
+            // there is no outstanding Pong.
+
+            if (Interlocked.Increment(ref _pendingPongCount) == 1)
+            {
+                SendPing(1L);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _pendingPongCount);
+            }
+        }
+
+        void SendWritePing()
+        {
+            // _pendingPongCount can be <= 0 if an unexpected pong is received. If it's the case, the connection is
+            // being torn down and there's no point in sending a ping frame.
+            if (Interlocked.Increment(ref _pendingPongCount) > 0)
+            {
+                SendPing(0L);
+            }
         }
     }
 
@@ -1190,8 +1205,8 @@ internal class SlicConnection : IMultiplexedConnection
                     (ref SliceDecoder decoder) => new PongBody(ref decoder),
                     cancellationToken).ConfigureAwait(false);
 
-                // For now, we only send a 0 payload value.
-                if (pongBody.Payload != 0L)
+                // For now, we only send a 0 and 1 payload value.
+                if (pongBody.Payload != 0L && pongBody.Payload != 1L)
                 {
                     throw new InvalidDataException($"Received {nameof(FrameType.Pong)} with unexpected payload.");
                 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -593,7 +593,6 @@ internal class SlicConnection : IMultiplexedConnection
         {
             // ReadKeepAlive is no-op unless _pendingPongCount == 0 before the Increment below: we send a Ping only if
             // there is no outstanding Pong.
-
             if (Interlocked.Increment(ref _pendingPongCount) == 1)
             {
                 SendPing(1L);
@@ -1205,7 +1204,7 @@ internal class SlicConnection : IMultiplexedConnection
                     (ref SliceDecoder decoder) => new PongBody(ref decoder),
                     cancellationToken).ConfigureAwait(false);
 
-                // For now, we only send a 0 and 1 payload value.
+                // For now, we only send a 0 or 1 payload value (0 for "write ping" and 1 for "read ping").
                 if (pongBody.Payload != 0L && pongBody.Payload != 1L)
                 {
                     throw new InvalidDataException($"Received {nameof(FrameType.Pong)} with unexpected payload.");

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -591,8 +591,8 @@ internal class SlicConnection : IMultiplexedConnection
 
         void SendReadPing()
         {
-            // ReadKeepAlive is no-op unless _pendingPongCount == 0 before the Increment below: we send a Ping only if
-            // there is no outstanding Pong.
+            // SendReadPing is no-op unless _pendingPongCount == 0 before the Increment below: we send a Ping only if
+            // there is no pending Pong.
             if (Interlocked.Increment(ref _pendingPongCount) == 1)
             {
                 SendPing(1L);

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -584,7 +584,7 @@ internal class SlicConnection : IMultiplexedConnection
             }
             catch (Exception exception)
             {
-                Debug.Fail($"The Slic keep alive timer failed with an unexpected exception: {exception}");
+                Debug.Fail($"The sending of a Ping frame failed with an unexpected exception: {exception}");
                 throw;
             }
         }

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -591,15 +591,10 @@ internal class SlicConnection : IMultiplexedConnection
 
         void SendReadPing()
         {
-            // SendReadPing is no-op unless _pendingPongCount == 0 before the Increment below: we send a Ping only if
-            // there is no pending Pong.
-            if (Interlocked.Increment(ref _pendingPongCount) == 1)
+            // This local function is no-op if there is already a pending Pong.
+            if (Interlocked.CompareExchange(ref _pendingPongCount, 1, 0) == 0)
             {
                 SendPing(1L);
-            }
-            else
-            {
-                Interlocked.Decrement(ref _pendingPongCount);
             }
         }
 

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -577,7 +577,7 @@ internal class SlicConnection : IMultiplexedConnection
 
         _closedCancellationToken = _closedCts.Token;
 
-        var duplexConnectionDecorator = new IdleTimeoutDuplexConnectionDecorator(duplexConnection);
+        var duplexConnectionDecorator = new SlicDuplexConnectionDecorator(duplexConnection);
         _enableIdleTimeoutAndKeepAlive = duplexConnectionDecorator.Enable;
 
         _duplexConnection = duplexConnectionDecorator;

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
@@ -46,10 +46,15 @@ internal class SlicDuplexConnectionDecorator : IDuplexConnection
                 _readCts.CancelAfter(_idleTimeout); // enable idle timeout before reading
 
                 int bytesRead = await _decoratee.ReadAsync(buffer, _readCts.Token).ConfigureAwait(false);
-                // Debug.Assert(bytesRead > 0); // TODO: uncomment when #3671 is fixed
 
                 // After each successful read, we schedule one ping some time in the future.
-                ResetReadTimer();
+                if (bytesRead > 0)
+                {
+                    ResetReadTimer();
+                }
+                // When 0, the other side called ShutdownWriteAsync, so there is no point to send a ping since we can't
+                // get back a pong.
+
                 return bytesRead;
             }
             catch (OperationCanceledException)

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
@@ -5,8 +5,9 @@ using System.Diagnostics;
 
 namespace IceRpc.Transports.Slic.Internal;
 
-/// <summary>Decorates <see cref="ReadAsync" /> to fail if no byte is received for over readIdleTimeout. Also decorates
-/// <see cref="WriteAsync" /> to schedule a keep alive action (writeIdleTimeout / 2) after a successful write.</summary>
+/// <summary>Decorates <see cref="ReadAsync" /> to fail if no byte is received for over idle timeout. Also optionally
+/// decorates both <see cref="ReadAsync"/> and <see cref="WriteAsync" /> to schedule pings that prevent both the local
+/// and remote idle timers from expiring.</summary>
 internal class SlicDuplexConnectionDecorator : IDuplexConnection
 {
     private readonly IDuplexConnection _decoratee;

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionDecorator.cs
@@ -14,8 +14,8 @@ internal class SlicDuplexConnectionDecorator : IDuplexConnection
     private TimeSpan _idleTimeout = Timeout.InfiniteTimeSpan;
     private readonly CancellationTokenSource _readCts = new();
 
-    private Timer? _readTimer;
-    private Timer? _writeTimer;
+    private readonly Timer? _readTimer;
+    private readonly Timer? _writeTimer;
 
     public Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken) =>
         _decoratee.ConnectAsync(cancellationToken);

--- a/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Tests.Common;
+using IceRpc.Transports.Slic.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System.Buffers;
+
+namespace IceRpc.Internal;
+
+[Parallelizable(scope: ParallelScope.All)]
+public class IceIdleTimeoutTests
+{
+    [Test]
+    public async Task Ice_connection_idle_after_idle_timeout()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddDuplexTransportTest()
+            .AddColocTransport()
+            .BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerDuplexConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        using var clientConnection = new IceDuplexConnectionDecorator(
+            sut.Client,
+            readIdleTimeout: TimeSpan.FromMilliseconds(500),
+            writeIdleTimeout: TimeSpan.FromMilliseconds(500),
+            keepAliveAction: () => {});
+
+        // Write and read data to the connection
+        await sut.Server.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);
+        Memory<byte> buffer = new byte[1];
+        await clientConnection.ReadAsync(buffer, default);
+
+        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
+
+        // Act/Assert
+        Assert.That(
+            async () => await clientConnection.ReadAsync(buffer, default),
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionIdle));
+
+        Assert.That(
+            TimeSpan.FromMilliseconds(Environment.TickCount64) - startTime,
+            Is.GreaterThan(TimeSpan.FromMilliseconds(490)));
+    }
+
+    [Test]
+    public async Task Ice_keep_alive_action_is_called()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddDuplexTransportTest()
+            .AddColocTransport()
+            .BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerDuplexConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        using var semaphore = new SemaphoreSlim(0, 1);
+        using var clientConnection = new IceDuplexConnectionDecorator(
+            sut.Client,
+            readIdleTimeout: Timeout.InfiniteTimeSpan,
+            writeIdleTimeout: TimeSpan.FromMilliseconds(500),
+            keepAliveAction: () => semaphore.Release());
+
+        // Write and read data.
+        await clientConnection.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);
+        await sut.Server.ReadAsync(new byte[10], default);
+
+        var startTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
+
+        // Act/Assert
+        Assert.That(() => semaphore.WaitAsync(), Throws.Nothing);
+
+        Assert.That(
+            TimeSpan.FromMilliseconds(Environment.TickCount64) - startTime,
+            Is.LessThan(TimeSpan.FromMilliseconds(500)));
+    }
+}

--- a/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
@@ -24,7 +24,7 @@ public class SlicIdleTimeoutTests
         await sut.AcceptAndConnectAsync();
 
         using var clientConnection = new SlicDuplexConnectionDecorator(sut.Client);
-        clientConnection.Enable(TimeSpan.FromMilliseconds(500), keepAliveAction: null);
+        clientConnection.Enable(TimeSpan.FromMilliseconds(500));
 
         // Write and read data to the connection
         await sut.Server.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);
@@ -56,10 +56,11 @@ public class SlicIdleTimeoutTests
         await sut.AcceptAndConnectAsync();
 
         using var semaphore = new SemaphoreSlim(0, 1);
-        using var clientConnection = new SlicDuplexConnectionDecorator(sut.Client);
-        clientConnection.Enable(
-            TimeSpan.FromMilliseconds(500),
-            keepAliveAction: () => semaphore.Release());
+        using var clientConnection = new SlicDuplexConnectionDecorator(
+            sut.Client,
+            sendReadPing: () => {},
+            sendWritePing: () => semaphore.Release());
+        clientConnection.Enable(TimeSpan.FromMilliseconds(500));
 
         // Write and read data.
         await clientConnection.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);

--- a/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
@@ -1,18 +1,18 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Tests.Common;
-using IceRpc.Transports.Internal;
+using IceRpc.Transports.Slic.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System.Buffers;
 
-namespace IceRpc.Tests.Transports;
+namespace IceRpc.Tests.Transports.Slic;
 
 [Parallelizable(scope: ParallelScope.All)]
-public class IdleTimeoutTests
+public class SlicIdleTimeoutTests
 {
     [Test]
-    public async Task Connection_idle_after_idle_timeout()
+    public async Task Slic_connection_idle_after_idle_timeout()
     {
         // Arrange
         await using ServiceProvider provider = new ServiceCollection()
@@ -23,7 +23,7 @@ public class IdleTimeoutTests
         var sut = provider.GetRequiredService<ClientServerDuplexConnection>();
         await sut.AcceptAndConnectAsync();
 
-        using var clientConnection = new IdleTimeoutDuplexConnectionDecorator(sut.Client);
+        using var clientConnection = new SlicDuplexConnectionDecorator(sut.Client);
         clientConnection.Enable(TimeSpan.FromMilliseconds(500), keepAliveAction: null);
 
         // Write and read data to the connection
@@ -44,7 +44,7 @@ public class IdleTimeoutTests
     }
 
     [Test]
-    public async Task Keep_alive_action_is_called()
+    public async Task Slic_keep_alive_action_is_called()
     {
         // Arrange
         await using ServiceProvider provider = new ServiceCollection()
@@ -56,10 +56,9 @@ public class IdleTimeoutTests
         await sut.AcceptAndConnectAsync();
 
         using var semaphore = new SemaphoreSlim(0, 1);
-        using var clientConnection = new IdleTimeoutDuplexConnectionDecorator(
-            sut.Client,
-            readIdleTimeout: Timeout.InfiniteTimeSpan,
-            writeIdleTimeout: TimeSpan.FromMilliseconds(500),
+        using var clientConnection = new SlicDuplexConnectionDecorator(sut.Client);
+        clientConnection.Enable(
+            TimeSpan.FromMilliseconds(500),
             keepAliveAction: () => semaphore.Release());
 
         // Write and read data.


### PR DESCRIPTION
This PR refactors how Slic keeps connections alive.

Fixes #3665.

With this new implementation, Slic keeps connection alive by sending Ping frames from client connections (like before).

The algorithm is now:
 - send a Ping frame idle timeout * 0.6 after the last write even if there is an outstanding pong (= like before, except it's now 0.6 instead of 0.5)
 -  send a Ping frame idle timeout * 0.5 after the last read unless there is already an outstanding pong (new)

This PR also refactors the idle timeout decorator and associated tests. They are now 2 separate decorators, one for Ice and one for Slic. This PR didn't change the Ice logic.