### PR TITLE
Document the MSRV in our Cargo file.

### DIFF
--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -8,6 +8,7 @@ The slicec-cs compiler, for compiling Slice files into C# code.
 keywords = ["slice", "ice", "icerpc"]
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.70"
 
 [dependencies]
 clap = { version = "4.3.15", features = ["derive"] }


### PR DESCRIPTION
We now specify the **m**inimum **s**upported **r**ust **v**ersion (MSRV) in our Cargo file.
Note that the MSRV didn't change, it has been `1.70` since before we released.

But now, if someone has an old compiler, instead of failing part-way through compilation,
Cargo will immediately fail, and emit a much more helpful error message.