### PR TITLE
Connect_fails_if_listener_is_disposed test simplifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu22.04-8x
     timeout-minutes: 10
 
     steps:

--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -2,5 +2,7 @@
 <RunSettings>
     <NUnit>
         <DisplayName>FullNameSep</DisplayName>
+        <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
+        <NumberOfTestWorkers>4</NumberOfTestWorkers>
     </NUnit>
 </RunSettings>

--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -3,6 +3,6 @@
     <NUnit>
         <DisplayName>FullNameSep</DisplayName>
         <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
-        <NumberOfTestWorkers>4</NumberOfTestWorkers>
+        <NumberOfTestWorkers>8</NumberOfTestWorkers>
     </NUnit>
 </RunSettings>

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Tests.Common;
 using IceRpc.Transports;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -115,10 +116,8 @@ public abstract class MultiplexedListenerConformanceTests
             provider.GetService<SslClientAuthenticationOptions>());
 
         // Ensure the listener is accepting connections
-        var connectTask = connection1.ConnectAsync(default);
-        await using var serverConnection = (await listener.AcceptAsync(default)).Connection;
-        await serverConnection.ConnectAsync(default);
-        await connectTask;
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
 
         await using IMultiplexedConnection connection2 = clientTransport.CreateConnection(
             listener.ServerAddress,

--- a/tests/IceRpc.Tests/AssemblyInfo.cs
+++ b/tests/IceRpc.Tests/AssemblyInfo.cs
@@ -1,6 +1,3 @@
 // Copyright (c) ZeroC, Inc.
 
 [assembly: NUnit.Framework.Timeout(8000)]
-
-// Limit the maximum number of NUnit workers to workaround failures when running with high number of workers
-[assembly: NUnit.Framework.LevelOfParallelism(10)]


### PR DESCRIPTION
- For the QUIC Connect_fails_if_listener_is_disposed conformance test, successful connections must be disposed to ensure timely failures for new connections.
- Updated the CI job to use a larger 8-core runner.
- Limit test runners to 8 globally: some SSL tests were running slow with higher concurrency.
