### PR TITLE
Slice tools cleanup

### DIFF
--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
@@ -3,8 +3,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <EnableDefaultSliceFileItems Condition="'$(EnableDefaultSliceFileItems)' == ''">true</EnableDefaultSliceFileItems>
-        <!-- Workaround for Omnisharp not setting $(Configuration) property when loading C# projects -->
-        <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
         <!-- Internal properties used to compute the slicec-cs compiler location for the current platform. -->
         <IceRPC_OSName Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</IceRPC_OSName>
         <IceRPC_OSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</IceRPC_OSName>

--- a/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
+++ b/tools/IceRpc.Slice.Tools/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
@@ -4,10 +4,10 @@
     <PropertyGroup>
         <EnableDefaultSliceFileItems Condition="'$(EnableDefaultSliceFileItems)' == ''">true</EnableDefaultSliceFileItems>
         <!-- Internal properties used to compute the slicec-cs compiler location for the current platform. -->
-        <IceRPC_OSName Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</IceRPC_OSName>
-        <IceRPC_OSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</IceRPC_OSName>
-        <IceRPC_OSName Condition="$([MSBuild]::IsOSPlatform('OSX'))">macos</IceRPC_OSName>
-        <IceRPC_OSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower())</IceRPC_OSArch>
+        <IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</IceRpcOSName>
+        <IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</IceRpcOSName>
+        <IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('OSX'))">macos</IceRpcOSName>
+        <IceRpcOSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower())</IceRpcOSArch>
     </PropertyGroup>
     <Choose>
         <When Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\slicec-cs')">
@@ -20,7 +20,7 @@
         <Otherwise>
             <!-- Use the Slice compiler from this NuGet package -->
             <PropertyGroup>
-                <SliceCompilerPath>$(MSBuildThisFileDirectory)..\tools\$(IceRPC_OSName)-$(IceRPC_OSArch)</SliceCompilerPath>
+                <SliceCompilerPath>$(MSBuildThisFileDirectory)..\tools\$(IceRpcOSName)-$(IceRpcOSArch)</SliceCompilerPath>
             </PropertyGroup>
         </Otherwise>
     </Choose>


### PR DESCRIPTION
Minor cleanup to IceRpc.Slice.Tools:

- Removed Omnisharp workaround
- Rename some internal properties for consistency with IceRpc.Protobuf.Tools