### PR TITLE
Run QUIC tests serially

### DIFF
--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -3,6 +3,6 @@
     <NUnit>
         <DisplayName>FullNameSep</DisplayName>
         <!-- Limit the max number for NUnit workers to workaround failures when running with high number of workers -->
-        <NumberOfTestWorkers>8</NumberOfTestWorkers>
+        <NumberOfTestWorkers>4</NumberOfTestWorkers>
     </NUnit>
 </RunSettings>

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportConformanceTests.cs
@@ -7,7 +7,7 @@ using System.Net.Quic;
 
 namespace IceRpc.Tests.Transports;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 public class QuicConnectionConformanceTests : MultiplexedConnectionConformanceTests
 {
     [OneTimeSetUp]
@@ -23,7 +23,7 @@ public class QuicConnectionConformanceTests : MultiplexedConnectionConformanceTe
     protected override IServiceCollection CreateServiceCollection() => new ServiceCollection().AddQuicTest();
 }
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 public class QuicStreamConformanceTests : MultiplexedStreamConformanceTests
 {
     [OneTimeSetUp]
@@ -39,7 +39,7 @@ public class QuicStreamConformanceTests : MultiplexedStreamConformanceTests
     protected override IServiceCollection CreateServiceCollection() => new ServiceCollection().AddQuicTest();
 }
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 public class QuicListenerConformanceTests : MultiplexedListenerConformanceTests
 {
     [OneTimeSetUp]

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
@@ -12,7 +12,7 @@ using System.Security.Cryptography.X509Certificates;
 namespace IceRpc.Tests.Transports;
 
 /// <summary>Test Ssl authentication with Quic transport.</summary>
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 public class QuicTransportSslAuthenticationTests
 {
     [OneTimeSetUp]

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportTests.cs
@@ -12,7 +12,7 @@ using System.Security.Authentication;
 
 namespace IceRpc.Tests.Transports;
 
-[Parallelizable(ParallelScope.All)]
+[NonParallelizable]
 public class QuicTransportTests
 {
     [OneTimeSetUp]


### PR DESCRIPTION
There are a number of QUIC tests that are frequently failing, which seems can be related to https://github.com/dotnet/runtime/issues/55979

This PR adds NonParallelizable attribute to all QUIC test fixtures and also reduces the number of test workers to 4, with these changes I have been running the test suite in a loop for several hours without failures, let's see if it results in more stable CI builds too.

Fixes #3696
Fixes #3701