### PR TITLE
Remove ProtobufD methods

### DIFF
--- a/src/IceRpc.Protobuf.Generators/Internal/DiagnosticDescriptors.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/DiagnosticDescriptors.cs
@@ -6,10 +6,10 @@ namespace IceRpc.Protobuf.Generators.Internal;
 
 internal static class DiagnosticDescriptors
 {
-    internal static DiagnosticDescriptor DuplicateOperationNames { get; } = new DiagnosticDescriptor(
+    internal static DiagnosticDescriptor DuplicateRpcName { get; } = new DiagnosticDescriptor(
         id: "PROTO0001",
-        title: "Multiple Protobuf operations cannot have the same name within a service class",
-        messageFormat: "Multiple Protobuf operations named {0} in class {1}",
+        title: "Multiple Protobuf rpc methods cannot have the same name within a service class",
+        messageFormat: "Multiple Protobuf rpc methods named {0} in class {1}",
         category: "ProtobufServiceGenerator",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/IceRpc.Protobuf.Generators/Internal/DiagnosticDescriptors.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/DiagnosticDescriptors.cs
@@ -8,7 +8,7 @@ internal static class DiagnosticDescriptors
 {
     internal static DiagnosticDescriptor DuplicateRpcName { get; } = new DiagnosticDescriptor(
         id: "PROTO0001",
-        title: "Multiple Protobuf rpc methods cannot have the same name within a service class",
+        title: "An IceRPC service class cannot implement multiple Protobuf rpc methods with the same name",
         messageFormat: "Multiple Protobuf rpc methods named {0} in class {1}",
         category: "ProtobufServiceGenerator",
         DiagnosticSeverity.Error,

--- a/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
@@ -29,7 +29,7 @@ case ""{serviceMethod.OperationName}"":
 {{
     var inputParam = new {serviceMethod.InputTypeName}();
     await inputParam.MergeFromAsync(request.Payload).ConfigureAwait(false);
-    var outputParam = await (this as {serviceMethod.InterfaceName}).{serviceMethod.MethodName}(
+    var outputParam = await (({serviceMethod.InterfaceName})this).{serviceMethod.MethodName}(
         inputParam,
         request.Features,
         cancellationToken).ConfigureAwait(false);
@@ -43,7 +43,7 @@ case ""{serviceMethod.OperationName}"":
                 {
                     dispatchImplementation += @$"
 default:
-    return base.DispatchAsync(request, cancellationToken);";
+    return await base.DispatchAsync(request, cancellationToken).ConfigureAwait(false);";
                 }
                 else
                 {

--- a/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Protobuf.Generators.Internal;
 
 internal sealed class Parser
 {
-    internal const string OperationAttribute = "IceRpc.Protobuf.ProtobufOperationAttribute";
+    internal const string RpcAttribute = "IceRpc.Protobuf.ProtobufOperationAttribute";
     internal const string ServiceAttribute = "IceRpc.Protobuf.ProtobufServiceAttribute";
 
     private readonly CancellationToken _cancellationToken;
@@ -28,7 +28,7 @@ internal sealed class Parser
         _reportDiagnostic = reportDiagnostic;
         _cancellationToken = cancellationToken;
 
-        _operationAttribute = _compilation.GetTypeByMetadataName(OperationAttribute);
+        _operationAttribute = _compilation.GetTypeByMetadataName(RpcAttribute);
         _serviceAttribute = _compilation.GetTypeByMetadataName(ServiceAttribute);
     }
 
@@ -77,7 +77,7 @@ internal sealed class Parser
                     {
                         _reportDiagnostic(
                             Diagnostic.Create(
-                                DiagnosticDescriptors.DuplicateOperationNames,
+                                DiagnosticDescriptors.DuplicateRpcName,
                                 classDeclaration.GetLocation(),
                                 method.OperationName,
                                 classDeclaration.Identifier.Text));
@@ -190,7 +190,12 @@ internal sealed class Parser
                 items.Length == 1,
                 "Unexpected number of arguments in attribute constructor.");
             string operationName = (string)items[0].Value!;
-            serviceMethods.Add(new ServiceMethod(dispatchMethodName: GetFullName(method), operationName));
+            serviceMethods.Add(
+                new ServiceMethod(
+                    operationName,
+                    interfaceName: $"global::{GetFullName(interfaceSymbol)}",
+                    methodName: method.Name,
+                    inputTypeName: $"global::{GetFullName(method.Parameters[0].Type)}"));
         }
         return serviceMethods;
     }

--- a/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
@@ -10,7 +10,7 @@ namespace IceRpc.Protobuf.Generators.Internal;
 
 internal sealed class Parser
 {
-    internal const string RpcAttribute = "IceRpc.Protobuf.ProtobufOperationAttribute";
+    internal const string OperationAttribute = "IceRpc.Protobuf.ProtobufOperationAttribute";
     internal const string ServiceAttribute = "IceRpc.Protobuf.ProtobufServiceAttribute";
 
     private readonly CancellationToken _cancellationToken;
@@ -28,7 +28,7 @@ internal sealed class Parser
         _reportDiagnostic = reportDiagnostic;
         _cancellationToken = cancellationToken;
 
-        _operationAttribute = _compilation.GetTypeByMetadataName(RpcAttribute);
+        _operationAttribute = _compilation.GetTypeByMetadataName(OperationAttribute);
         _serviceAttribute = _compilation.GetTypeByMetadataName(ServiceAttribute);
     }
 

--- a/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
@@ -2,7 +2,7 @@
 
 namespace IceRpc.Protobuf.Generators.Internal;
 
-/// <summary>Represents a RPC method on a Protobuf Service.</summary>
+/// <summary>Represents an RPC method on a Protobuf service.</summary>
 internal readonly record struct ServiceMethod
 {
     // The name of the Protobuf rpc method as specified in the Protobuf file. It's also used as the IceRPC operation
@@ -16,7 +16,7 @@ internal readonly record struct ServiceMethod
     // The name of the mapped C# method on the Service interface. For example: "GreetAsync".
     internal string MethodName { get; }
 
-    // The fully qualified input type name (in C#). For example: "global::Google.Protobuf.WellKnownTypes.Empty".
+    // The fully qualified input type name (in C#). For example: "global::VisitorCenter.GreetRequest".
     internal string InputTypeName { get; }
 
     internal ServiceMethod(string operationName, string interfaceName, string methodName, string inputTypeName)

--- a/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
@@ -2,21 +2,28 @@
 
 namespace IceRpc.Protobuf.Generators.Internal;
 
-/// <summary>Represents an RPC operation annotated with the <c>IceRpc.Protobuf.ProtobufOperationAttribute</c>
-/// attribute.</summary>
+/// <summary>Represents a RPC method on a Protobuf Service.</summary>
 internal readonly record struct ServiceMethod
 {
-    // The fully qualified name of the generated dispatch helper method, for example:
-    // "VisitorCenter.GreetAsync"
-    internal string DispatchMethodName { get; }
-
-    // The name of the service operation as defined in the Protobuf service, for example:
-    // "Greet"
+    // The name of the Protobuf rpc method as specified in the Protobuf file. It's also used as the IceRPC operation
+    // name. For example: "Greet".
     internal string OperationName { get; }
 
-    internal ServiceMethod(string dispatchMethodName, string operationName)
+    // The fully qualified name of the mapped C# Service interface. For example:
+    // "global::VisitorCenter.IGreeterService".
+    internal string InterfaceName { get; }
+
+    // The name of the mapped C# method on the Service interface. For example: "GreetAsync".
+    internal string MethodName { get; }
+
+    // The fully qualified input type name (in C#). For example: "global::Google.Protobuf.WellKnownTypes.Empty".
+    internal string InputTypeName { get; }
+
+    internal ServiceMethod(string operationName, string interfaceName, string methodName, string inputTypeName)
     {
-        DispatchMethodName = dispatchMethodName;
         OperationName = operationName;
+        InterfaceName = interfaceName;
+        MethodName = methodName;
+        InputTypeName = inputTypeName;
     }
 }

--- a/src/IceRpc.Protobuf/ProtobufOperationAttribute.cs
+++ b/src/IceRpc.Protobuf/ProtobufOperationAttribute.cs
@@ -4,13 +4,14 @@ using System.ComponentModel;
 
 namespace IceRpc.Protobuf;
 
-/// <summary>Represents an attribute that protoc-gen-icerpc-csharp uses to mark helper methods it generates in Service
-/// interfaces.</summary>
+/// <summary>Represents an attribute that protoc-gen-icerpc-csharp applies to abstract methods in Service interfaces.
+/// </summary>
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class ProtobufOperationAttribute : Attribute
 {
-    /// <summary>Gets the operation name.</summary>
+    /// <summary>Gets the operation name. It corresponds to the name of the rpc method in the Protobuf file, with the
+    /// same spelling and the same case.</summary>
     /// <value>The operation name.</value>
     public string Value { get; }
 

--- a/src/IceRpc.Protobuf/ProtobufServiceAttribute.cs
+++ b/src/IceRpc.Protobuf/ProtobufServiceAttribute.cs
@@ -2,11 +2,9 @@
 
 namespace IceRpc.Protobuf;
 
-/// <summary>Represents an attribute used to mark classes implementing Protobuf services.</summary>
-/// <remarks>The Protobuf source generator implements <see cref="IDispatcher"/> for classes marked with this attribute.
-/// The <see cref="AttributeUsageAttribute.Inherited"/> is set to <see langword="false"/> because we only need to
-/// generate the <see cref="IDispatcher"/> implementation for classes including the attribute, and not for derived
-/// classes.</remarks>
+/// <summary>Represents an attribute applied on classes implementing Protobuf services with IceRPC.</summary>
+/// <remarks>The Protobuf Service source generator implements <see cref="IDispatcher"/> for classes with this
+/// attribute - and not in derived classes unless they also carry this attribute.</remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
 public sealed class ProtobufServiceAttribute : Attribute
 {

--- a/tools/IceRpc.ProtocGen/ServiceGenerator.cs
+++ b/tools/IceRpc.ProtocGen/ServiceGenerator.cs
@@ -25,8 +25,8 @@ internal class ServiceGenerator
     /// <param name=""cancellationToken"">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A value task holding the output message.</returns>
     [ProtobufOperation(""{method.Name}"")]
-    global::System.Threading.Tasks.ValueTask<global::{returnType}> {methodName}(
-        global::{inputType} message,
+    global::System.Threading.Tasks.ValueTask<{returnType}> {methodName}(
+        {inputType} message,
         IceRpc.Features.IFeatureCollection features,
         global::System.Threading.CancellationToken cancellationToken);";
         }

--- a/tools/IceRpc.ProtocGen/ServiceGenerator.cs
+++ b/tools/IceRpc.ProtocGen/ServiceGenerator.cs
@@ -19,34 +19,23 @@ internal class ServiceGenerator
 
             // Add an abstract method to the interface for each service method.
             methods += $@"
-    global::System.Threading.Tasks.ValueTask<{returnType}> {methodName}(
-        {inputType} message,
+    /// <summary>Implements rpc method <c>{method.Name}</c>.</summary>
+    /// <param name=""message"">The input message.</param>
+    /// <param name=""features"">The dispatch features.</param>
+    /// <param name=""cancellationToken"">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>A value task holding the output message.</returns>
+    [ProtobufOperation(""{method.Name}"")]
+    global::System.Threading.Tasks.ValueTask<global::{returnType}> {methodName}(
+        global::{inputType} message,
         IceRpc.Features.IFeatureCollection features,
         global::System.Threading.CancellationToken cancellationToken);";
-
-            // Add a static method for each service method, the implementation calls the abstract method and creates
-            // the outgoing response.
-            methods += $@"
-    [ProtobufOperation(""{method.Name}"")]
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected static async global::System.Threading.Tasks.ValueTask<IceRpc.OutgoingResponse> ProtobufD{methodName}(
-        I{service.Name.ToPascalCase()}Service target,
-        IceRpc.IncomingRequest request,
-        global::System.Threading.CancellationToken cancellationToken)
-    {{
-        var inputParam = new {inputType}();
-        await inputParam.MergeFromAsync(request.Payload).ConfigureAwait(false);
-        var returnParam = await target.{methodName}(inputParam, request.Features, cancellationToken).ConfigureAwait(false);
-        return new IceRpc.OutgoingResponse(request)
-        {{
-            Payload = returnParam.ToPipeReader()
-        }};
-    }}";
         }
 
         return @$"
-/// <remarks>protoc-gen-icerpc-csharp generated this server-side interface from Protobuf service <c>{service.FullName}</c>.
-/// </remarks>
+/// <summary>Represents a template that you use to implement Protobuf service <c>{service.FullName}</c>
+/// with IceRPC.</summary>
+/// <remarks>protoc-gen-icerpc-csharp generated this server-side interface.</remarks>
+/// <seealso cref=""IceRpc.Protobuf.ProtobufServiceAttribute"" />
 [IceRpc.DefaultServicePath(""/{service.FullName}"")]
 public partial interface I{service.Name.ToPascalCase()}Service
 {{


### PR DESCRIPTION
This PR removes the ProtobufD methods generated by IceRpc.ProtocGen.

They are replaced by better code generated by the Protobuf Service source generator.