### PR TITLE
Add test for Protobuf max message length

### DIFF
--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ZeroC, Inc.
+
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using IceRpc.Features;
+using IceRpc.Tests.Common;
+using NUnit.Framework;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace IceRpc.Protobuf.Tests;
+
+[Parallelizable(scope: ParallelScope.All)]
+public partial class PipeReaderExtensionsTests
+{
+    [Test]
+    public void Read_message_throws_invalid_data_exception_when_max_message_lenght_is_exceeded()
+    {
+        // Arrange
+        var stringValue = new StringValue();
+        stringValue.Value = new string('s', 1024);
+        var pipeReader = stringValue.EncodeAsLengthPrefixedMessage(new PipeOptions(pauseWriterThreshold: 0));
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipeReader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipeReader.Complete();
+    }
+}

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -1,11 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using IceRpc.Features;
-using IceRpc.Tests.Common;
 using NUnit.Framework;
-using System.Buffers;
 using System.IO.Pipelines;
 
 namespace IceRpc.Protobuf.Tests;
@@ -14,7 +10,7 @@ namespace IceRpc.Protobuf.Tests;
 public partial class PipeReaderExtensionsTests
 {
     [Test]
-    public void Read_message_throws_invalid_data_exception_when_max_message_lenght_is_exceeded()
+    public void Read_message_throws_invalid_data_exception_when_max_message_length_is_exceeded()
     {
         // Arrange
         var stringValue = new StringValue();


### PR DESCRIPTION
This PR adds a test to ensure that `DecodeProtobufMessageAsync` throws `InvalidDataException` when the max message length is exceeded.