### PR TITLE
Remove extra blank lines in Protobuf generated code

### DIFF
--- a/tools/IceRpc.ProtocGen/Program.cs
+++ b/tools/IceRpc.ProtocGen/Program.cs
@@ -62,7 +62,7 @@ namespace {descriptor.GetCsharpNamespace()};".Trim();
         new CodeGeneratorResponse.Types.File
         {
             Name = $"{Path.GetFileNameWithoutExtension(descriptor.Name).ToPascalCase()}.IceRpc.cs",
-            Content = builder.ToString().RemoveSuperfluousEmptyLines().ReplaceLineEndings()
+            Content = builder.ToString().ReplaceLineEndings().RemoveSuperfluousEmptyLines()
         });
 }
 

--- a/tools/IceRpc.ProtocGen/Program.cs
+++ b/tools/IceRpc.ProtocGen/Program.cs
@@ -62,7 +62,7 @@ namespace {descriptor.GetCsharpNamespace()};".Trim();
         new CodeGeneratorResponse.Types.File
         {
             Name = $"{Path.GetFileNameWithoutExtension(descriptor.Name).ToPascalCase()}.IceRpc.cs",
-            Content = builder.ToString().RemoveSuperflousEmptyLines().ReplaceLineEndings()
+            Content = builder.ToString().RemoveSuperfluousEmptyLines().ReplaceLineEndings()
         });
 }
 

--- a/tools/IceRpc.ProtocGen/Program.cs
+++ b/tools/IceRpc.ProtocGen/Program.cs
@@ -62,7 +62,7 @@ namespace {descriptor.GetCsharpNamespace()};".Trim();
         new CodeGeneratorResponse.Types.File
         {
             Name = $"{Path.GetFileNameWithoutExtension(descriptor.Name).ToPascalCase()}.IceRpc.cs",
-            Content = builder.ToString().ReplaceLineEndings()
+            Content = builder.ToString().RemoveSuperflousEmptyLines().ReplaceLineEndings()
         });
 }
 

--- a/tools/IceRpc.ProtocGen/StringExtensions.cs
+++ b/tools/IceRpc.ProtocGen/StringExtensions.cs
@@ -9,7 +9,7 @@ internal static class StringExtensions
     /// <param name="value">The string to be processed.</param>
     /// <returns>The processed string without consecutive empty lines, and without empty lines that are between an open
     /// and a close brace '{', '}' or between consecutive close '}'.</returns>
-    internal static string RemoveSuperflousEmptyLines(this string value)
+    internal static string RemoveSuperfluousEmptyLines(this string value)
     {
         string[] lines = value.Split('\n');
         var processedLines = new List<string>();

--- a/tools/IceRpc.ProtocGen/StringExtensions.cs
+++ b/tools/IceRpc.ProtocGen/StringExtensions.cs
@@ -1,48 +1,33 @@
 // Copyright (c) ZeroC, Inc.
 
+using System.Text;
+
 namespace IceRpc.ProtocGen;
 
 internal static class StringExtensions
 {
-    /// <summary>Removes consecutive empty lines, and empty lines that are between an open and a close brace '{', '}'
-    /// or between consecutive close '}'.</summary>
+    /// <summary>Removes consecutive empty lines, and empty lines that are before a close brace '}'.</summary>
     /// <param name="value">The string to be processed.</param>
-    /// <returns>The processed string without consecutive empty lines, and without empty lines that are between an open
-    /// and a close brace '{', '}' or between consecutive close '}'.</returns>
+    /// <returns>The processed string without consecutive empty lines, and empty lines that are before a close
+    /// brace '}'.</returns>
     internal static string RemoveSuperfluousEmptyLines(this string value)
     {
-        string[] lines = value.Split('\n');
-        var processedLines = new List<string>();
-        string? previous = null;
+        string[] lines = value.Split(Environment.NewLine, StringSplitOptions.None);
+        var builder = new StringBuilder();
 
         for (int i = 0; i < lines.Length; i++)
         {
             string current = lines[i];
             string? next = (i + 1 < lines.Length) ? lines[i + 1].Trim() : null;
 
-            if (ShouldKeepLine(previous, current, next))
+            if (ShouldKeepLine(current, next))
             {
-                processedLines.Add(current);
-                previous = current.Trim();
+                builder.AppendLine(current);
             }
         }
-        return string.Join("\n", processedLines);
+        return builder.ToString();
 
-        static bool ShouldKeepLine(string? previous, string current, string? next)
-        {
-            if (!string.IsNullOrWhiteSpace(current.Trim()))
-            {
-                return true;
-            }
-            else if (string.IsNullOrWhiteSpace(next))
-            {
-                return false;
-            }
-            else if (next == "}" && (previous == "{" || previous == "}"))
-            {
-                return false;
-            }
-            return true;
-        }
+        static bool ShouldKeepLine(string current, string? next) =>
+            !(string.IsNullOrWhiteSpace(current) && (string.IsNullOrWhiteSpace(next) || next == "}"));
     }
 }

--- a/tools/IceRpc.ProtocGen/StringExtensions.cs
+++ b/tools/IceRpc.ProtocGen/StringExtensions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.ProtocGen;
+
+internal static class StringExtensions
+{
+    /// <summary>Removes consecutive empty lines, and empty lines that are between an open and a close brace '{', '}'
+    /// or between consecutive close '}'.</summary>
+    /// <param name="value">The string to be processed.</param>
+    /// <returns>The processed string without consecutive empty lines, and without empty lines that are between an open
+    /// and a close brace '{', '}' or between consecutive close '}'.</returns>
+    internal static string RemoveSuperflousEmptyLines(this string value)
+    {
+        string[] lines = value.Split('\n');
+        var processedLines = new List<string>();
+        string? previous = null;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string current = lines[i];
+            string? next = (i + 1 < lines.Length) ? lines[i + 1].Trim() : null;
+
+            if (ShouldKeepLine(previous, current, next))
+            {
+                processedLines.Add(current);
+                previous = current.Trim();
+            }
+        }
+        return string.Join("\n", processedLines);
+
+        static bool ShouldKeepLine(string? previous, string current, string? next)
+        {
+            if (!string.IsNullOrWhiteSpace(current.Trim()))
+            {
+                return true;
+            }
+            else if (string.IsNullOrWhiteSpace(next))
+            {
+                return false;
+            }
+            else if (next == "}" && (previous == "{" || previous == "}"))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fix #3759

I added a helper method to remove that allows removing extra empty lines, because I think is nice to be able to use the string templates in the generators. I think the string templates make it easy to see what the generator produces.