### PR TITLE
Simplify generated code for Protobuf service dispatch

### DIFF
--- a/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
@@ -22,17 +22,9 @@ internal class Emitter
                 dispatchImplementation = "";
                 foreach (ServiceMethod serviceMethod in serviceClass.ServiceMethods)
                 {
-                    string methodType = (serviceMethod.IsClientStreaming, serviceMethod.IsServerStreaming) switch
-                    {
-                        (false, false) => "Unary",
-                        (true, false) => "ClientStreaming",
-                        (false, true) => "ServerStreaming",
-                        (true, true) => "BidiStreaming",
-                    };
-
                     dispatchImplementation += @$"
 ""{serviceMethod.OperationName}"" =>
-    request.Dispatch{methodType}Async(
+    request.Dispatch{serviceMethod.MethodKind}Async(
         {serviceMethod.InputTypeName}.Parser,
         (({serviceMethod.InterfaceName})this).{serviceMethod.MethodName},
         cancellationToken),".Trim();

--- a/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
@@ -12,10 +12,6 @@ internal class Emitter
             // stop if we're asked to.
             cancellationToken.ThrowIfCancellationRequested();
 
-            string methodModifier =
-                serviceClass.HasBaseServiceClass ? "public override" :
-                serviceClass.IsSealed ? "public" : "public virtual";
-
             string dispatchImplementation;
             if (serviceClass.ServiceMethods.Count > 0)
             {
@@ -55,6 +51,10 @@ request.Operation switch
                     "base.DispatchAsync(request, cancellationToken);" :
                     "new(new IceRpc.OutgoingResponse(request, IceRpc.StatusCode.NotImplemented));";
             }
+
+            string methodModifier =
+                serviceClass.HasBaseServiceClass ? "public override" :
+                serviceClass.IsSealed ? "public" : "public virtual";
 
             string dispatcherClass = $@"
 partial {serviceClass.Keyword} {serviceClass.Name} : IceRpc.IDispatcher

--- a/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Emitter.cs
@@ -39,6 +39,7 @@ internal class Emitter
 
                     dispatchImplementation += "\n\n";
                 }
+
                 if (serviceClass.HasBaseServiceClass)
                 {
                     dispatchImplementation += @$"
@@ -49,6 +50,7 @@ _ => base.DispatchAsync(request, cancellationToken)".Trim();
                     dispatchImplementation += @$"
 _ => new(new IceRpc.OutgoingResponse(request, IceRpc.StatusCode.NotImplemented))".Trim();
                 }
+
                 dispatchImplementation = @$"
 request.Operation switch
 {{

--- a/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/Parser.cs
@@ -215,14 +215,22 @@ internal sealed class Parser
             bool isServerStreaming = SymbolEqualityComparer.Default.Equals(
                 genericReturnType.TypeArguments[0].OriginalDefinition,
                 _asyncEnumerableSymbol);
+
+            string methodKind = (isClientStreaming, isServerStreaming) switch
+            {
+                (false, false) => "Unary",
+                (true, false) => "ClientStreaming",
+                (false, true) => "ServerStreaming",
+                (true, true) => "BidiStreaming",
+            };
+
             serviceMethods.Add(
                 new ServiceMethod(
                     operationName,
                     interfaceName: $"global::{GetFullName(interfaceSymbol)}",
                     methodName: method.Name,
-                    inputTypeName: $"global::{inputTypeName}",
-                    isClientStreaming,
-                    isServerStreaming));
+                    methodKind,
+                    inputTypeName: $"global::{inputTypeName}"));
         }
         return serviceMethods;
     }

--- a/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
+++ b/src/IceRpc.Protobuf.Generators/Internal/ServiceMethod.cs
@@ -12,11 +12,8 @@ internal readonly record struct ServiceMethod
     // "global::VisitorCenter.IGreeterService".
     internal string InterfaceName { get; }
 
-    // Indicates if the client streams multiple requests.
-    internal bool IsClientStreaming { get; }
-
-    // Indicates if the server streams multiple responses.
-    internal bool IsServerStreaming { get; }
+    // The kind of the RPC method: "Unary", "ClientStreaming", "ServerStreaming", or "BidiStreaming".
+    internal string MethodKind { get; }
 
     // The name of the mapped C# method on the Service interface. For example: "GreetAsync".
     internal string MethodName { get; }
@@ -29,15 +26,13 @@ internal readonly record struct ServiceMethod
         string operationName,
         string interfaceName,
         string methodName,
-        string inputTypeName,
-        bool isClientStreaming,
-        bool isServerStreaming)
+        string methodKind,
+        string inputTypeName)
     {
         OperationName = operationName;
         InterfaceName = interfaceName;
         MethodName = methodName;
+        MethodKind = methodKind;
         InputTypeName = inputTypeName;
-        IsClientStreaming = isClientStreaming;
-        IsServerStreaming = isServerStreaming;
     }
 }

--- a/src/IceRpc.Protobuf/AssemblyInfo.cs
+++ b/src/IceRpc.Protobuf/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Runtime.CompilerServices;
+
+// Make internals visible to the tests assembly, to allow writing unit tests for the internal classes
+[assembly: InternalsVisibleTo("IceRpc.Protobuf.Tests")]

--- a/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
+++ b/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
@@ -1,0 +1,134 @@
+// Copyright (c) ZeroC, Inc.
+
+using Google.Protobuf;
+using IceRpc.Features;
+
+namespace IceRpc.Protobuf;
+
+/// <summary>Provides extension methods for <see cref="IncomingRequest" />.</summary>
+public static class IncomingRequestExtensions
+{
+    /// <summary>Dispatches a unary RPC method.</summary>
+    /// <typeparam name="TInput">The type of the input message.</typeparam>
+    /// <typeparam name="TOutput">The type of the output message.</typeparam>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="inputParser">A message parser used to decode the request payload.</param>
+    /// <param name="method">The user-provided implementation of the RPC method.</param>
+    /// <param name="cancellationToken">The cancellation token that accepts cancellation requests.</param>
+    /// <returns>A value task that holds the outgoing response.</returns>
+    public static async ValueTask<OutgoingResponse> DispatchUnaryAsync<TInput, TOutput>(
+        this IncomingRequest request,
+        MessageParser<TInput> inputParser,
+        Func<TInput, IFeatureCollection, CancellationToken, ValueTask<TOutput>> method,
+        CancellationToken cancellationToken) where TInput : IMessage<TInput>
+                                             where TOutput : IMessage<TOutput>
+    {
+        IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
+
+        TInput input = await request.Payload.DecodeProtobufMessageAsync(
+            inputParser,
+            protobufFeature.MaxMessageLength,
+            cancellationToken).ConfigureAwait(false);
+
+        TOutput output = await method(input, request.Features, cancellationToken).ConfigureAwait(false);
+
+        return new OutgoingResponse(request)
+        {
+            Payload = output.EncodeAsLengthPrefixedMessage(
+                protobufFeature.EncodeOptions?.PipeOptions ?? ProtobufEncodeOptions.Default.PipeOptions)
+        };
+    }
+
+    /// <summary>Dispatches a client-streaming RPC method.</summary>
+    /// <typeparam name="TInput">The type of the input message.</typeparam>
+    /// <typeparam name="TOutput">The type of the output message.</typeparam>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="inputParser">A message parser used to decode the request payload.</param>
+    /// <param name="method">The user-provided implementation of the RPC method.</param>
+    /// <param name="cancellationToken">The cancellation token that accepts cancellation requests.</param>
+    /// <returns>A value task that holds the outgoing response.</returns>
+    public static async ValueTask<OutgoingResponse> DispatchClientStreamingAsync<TInput, TOutput>(
+        this IncomingRequest request,
+        MessageParser<TInput> inputParser,
+        Func<IAsyncEnumerable<TInput>, IFeatureCollection, CancellationToken, ValueTask<TOutput>> method,
+        CancellationToken cancellationToken) where TInput : IMessage<TInput>
+                                             where TOutput : IMessage<TOutput>
+    {
+        IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
+
+        IAsyncEnumerable<TInput> input = request.DetachPayload().ToAsyncEnumerable(
+            inputParser,
+            protobufFeature.MaxMessageLength,
+            cancellationToken);
+
+        TOutput output = await method(input, request.Features, cancellationToken).ConfigureAwait(false);
+
+        return new OutgoingResponse(request)
+        {
+            Payload = output.EncodeAsLengthPrefixedMessage(
+                protobufFeature.EncodeOptions?.PipeOptions ?? ProtobufEncodeOptions.Default.PipeOptions)
+        };
+    }
+
+    /// <summary>Dispatches a server-streaming RPC method.</summary>
+    /// <typeparam name="TInput">The type of the input message.</typeparam>
+    /// <typeparam name="TOutput">The type of the output message.</typeparam>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="inputParser">A message parser used to decode the request payload.</param>
+    /// <param name="method">The user-provided implementation of the RPC method.</param>
+    /// <param name="cancellationToken">The cancellation token that accepts cancellation requests.</param>
+    /// <returns>A value task that holds the outgoing response.</returns>
+    public static async ValueTask<OutgoingResponse> DispatchServerStreamingAsync<TInput, TOutput>(
+        this IncomingRequest request,
+        MessageParser<TInput> inputParser,
+        Func<TInput, IFeatureCollection, CancellationToken, ValueTask<IAsyncEnumerable<TOutput>>> method,
+        CancellationToken cancellationToken) where TInput : IMessage<TInput>
+                                             where TOutput : IMessage<TOutput>
+    {
+        IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
+
+        TInput input = await request.Payload.DecodeProtobufMessageAsync(
+            inputParser,
+            protobufFeature.MaxMessageLength,
+            cancellationToken).ConfigureAwait(false);
+
+        IAsyncEnumerable<TOutput> output = await method(input, request.Features, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OutgoingResponse(request)
+        {
+            PayloadContinuation = output.ToPipeReader(protobufFeature.EncodeOptions)
+        };
+    }
+
+    /// <summary>Dispatches a bidi-streaming RPC method.</summary>
+    /// <typeparam name="TInput">The type of the input message.</typeparam>
+    /// <typeparam name="TOutput">The type of the output message.</typeparam>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="inputParser">A message parser used to decode the request payload.</param>
+    /// <param name="method">The user-provided implementation of the RPC method.</param>
+    /// <param name="cancellationToken">The cancellation token that accepts cancellation requests.</param>
+    /// <returns>A value task that holds the outgoing response.</returns>
+    public static async ValueTask<OutgoingResponse> DispatchBidiStreamingAsync<TInput, TOutput>(
+        this IncomingRequest request,
+        MessageParser<TInput> inputParser,
+        Func<IAsyncEnumerable<TInput>, IFeatureCollection, CancellationToken, ValueTask<IAsyncEnumerable<TOutput>>> method,
+        CancellationToken cancellationToken) where TInput : IMessage<TInput>
+                                             where TOutput : IMessage<TOutput>
+    {
+        IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
+
+        IAsyncEnumerable<TInput> input = request.DetachPayload().ToAsyncEnumerable(
+            inputParser,
+            protobufFeature.MaxMessageLength,
+            cancellationToken);
+
+        IAsyncEnumerable<TOutput> output = await method(input, request.Features, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OutgoingResponse(request)
+        {
+            PayloadContinuation = output.ToPipeReader(protobufFeature.EncodeOptions)
+        };
+    }
+}

--- a/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
+++ b/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
@@ -2,6 +2,7 @@
 
 using Google.Protobuf;
 using IceRpc.Features;
+using IceRpc.Protobuf.Internal;
 
 namespace IceRpc.Protobuf;
 

--- a/src/IceRpc.Protobuf/Internal/AsyncEnumerableExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/AsyncEnumerableExtensions.cs
@@ -6,11 +6,11 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO.Pipelines;
 
-namespace IceRpc.Protobuf;
+namespace IceRpc.Protobuf.Internal;
 
 /// <summary>Provides an extension method for <see cref="IAsyncEnumerable{T}" /> to encode elements into a <see
 /// cref="PipeReader"/>.</summary>
-public static class AsyncEnumerableExtensions
+internal static class AsyncEnumerableExtensions
 {
     /// <summary>Encodes an async enumerable into a stream of bytes represented by a <see cref="PipeReader"/>.</summary>
     /// <typeparam name="T">The async enumerable element type.</typeparam>
@@ -18,7 +18,7 @@ public static class AsyncEnumerableExtensions
     /// <param name="encodeOptions">The Protobuf encode options.</param>
     /// <returns>A pipe reader that represents the encoded stream of bytes.</returns>
     /// <remarks>This extension method is used to encode streaming parameters and streaming return values.</remarks>
-    public static PipeReader ToPipeReader<T>(
+    internal static PipeReader ToPipeReader<T>(
         this IAsyncEnumerable<T> asyncEnumerable,
         ProtobufEncodeOptions? encodeOptions = null) where T : IMessage<T> =>
         new AsyncEnumerablePipeReader<T>(asyncEnumerable, encodeOptions);

--- a/src/IceRpc.Protobuf/Internal/MessageExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/MessageExtensions.cs
@@ -5,16 +5,16 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.IO.Pipelines;
 
-namespace IceRpc.Protobuf;
+namespace IceRpc.Protobuf.Internal;
 
 /// <summary>Provides an extension method for <see cref="IMessage" />.</summary>
-public static class MessageExtensions
+internal static class MessageExtensions
 {
     /// <summary>Encodes an <see cref="IMessage"/> as a length-prefixed message, using the Protobuf encoding.</summary>
     /// <param name="message">The <see cref="IMessage" /> to encode.</param>
     /// <param name="pipeOptions">The options used to create the pipe.</param>
     /// <returns>A <see cref="PipeReader" /> containing the length-prefixed message.</returns>
-    public static PipeReader EncodeAsLengthPrefixedMessage(this IMessage message, PipeOptions pipeOptions)
+    internal static PipeReader EncodeAsLengthPrefixedMessage(this IMessage message, PipeOptions pipeOptions)
     {
         var pipe = new Pipe(pipeOptions);
         pipe.Writer.Write(new Span<byte>([0])); // Not compressed

--- a/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
@@ -7,10 +7,10 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 
-namespace IceRpc.Protobuf;
+namespace IceRpc.Protobuf.Internal;
 
 /// <summary>Provides extension methods for <see cref="PipeReader" />.</summary>
-public static class PipeReaderExtensions
+internal static class PipeReaderExtensions
 {
     /// <summary>Decodes a Protobuf length prefixed message from a <see cref="PipeReader" />.</summary>
     /// <param name="reader">The <see cref="PipeReader" /> containing the Protobuf length prefixed message.</param>
@@ -18,7 +18,7 @@ public static class PipeReaderExtensions
     /// <param name="maxMessageLength">The maximum allowed length.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The decoded message object.</returns>
-    public static async ValueTask<T> DecodeProtobufMessageAsync<T>(
+    internal static async ValueTask<T> DecodeProtobufMessageAsync<T>(
         this PipeReader reader,
         MessageParser<T> parser,
         int maxMessageLength,
@@ -40,7 +40,7 @@ public static class PipeReaderExtensions
     /// <param name="maxMessageLength">The maximum allowed length.</param>
     /// <param name="cancellationToken">The cancellation token which is provided to <see
     /// cref="IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)" />.</param>
-    public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(
+    internal static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(
         this PipeReader reader,
         MessageParser<T> messageParser,
         int maxMessageLength,

--- a/src/IceRpc.Protobuf/InvokerExtensions.cs
+++ b/src/IceRpc.Protobuf/InvokerExtensions.cs
@@ -2,6 +2,7 @@
 
 using Google.Protobuf;
 using IceRpc.Features;
+using IceRpc.Protobuf.Internal;
 using System.Collections.Immutable;
 using System.IO.Pipelines;
 

--- a/tests/IceRpc.Protobuf.Tests/IceRpc.Protobuf.Tests.csproj
+++ b/tests/IceRpc.Protobuf.Tests/IceRpc.Protobuf.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using Google.Protobuf.WellKnownTypes;
+using IceRpc.Protobuf.Internal;
 using NUnit.Framework;
 using System.IO.Pipelines;
 

--- a/tests/IceRpc.Protobuf.Tests/ServiceTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/ServiceTests.cs
@@ -55,7 +55,6 @@ public partial class ServiceTests
         Assert.That(async () => await mySecondWidgetClient.OpSecondAsync(new Empty()), Throws.Nothing);
     }
 
-
     [ProtobufService]
     internal partial class MultipleServices : IMyFirstWidgetService, IMySecondWidgetService
     {
@@ -85,4 +84,14 @@ public partial class ServiceTests
 
     [ProtobufService]
     internal partial class MultipleServices2 : BaseImplementsMultipleServices { }
+
+    // Avoid un-instantiated internal classes
+    // TODO: we should actually test dispatching to these services
+    #pragma warning disable CA1812
+    [ProtobufService]
+    internal partial class TrivialService { }
+
+    [ProtobufService]
+    internal partial class DerivedMultipleServices : MultipleServices { }
+    #pragma warning restore CA1812
 }

--- a/tests/IceRpc.Protobuf.Tests/StreamTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/StreamTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Protobuf.Internal;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Buffers;


### PR DESCRIPTION
and reduce IceRpc.Protobuf public API.

Fixes #3770.

This PR also makes the generated code for IceRpc.Protobuf.Tests persistent. On my mac, the generated code is in:
```
cat ./tests/IceRpc.Protobuf.Tests/obj/Debug/net8.0/generated/IceRpc.Protobuf.Generators/IceRpc.Protobuf.Generators.ServiceGenerator/Service.g.cs
```