### PR TITLE
Remove references to Proxy from ZeroC.Slice

### DIFF
--- a/src/IceRpc.Slice/ProxySliceDecoderExtensions.cs
+++ b/src/IceRpc.Slice/ProxySliceDecoderExtensions.cs
@@ -13,7 +13,7 @@ public static class ProxySliceDecoderExtensions
     /// <returns>The decoded proxy, or <see langword="null" />.</returns>
     public static TProxy? DecodeNullableProxy<TProxy>(this ref SliceDecoder decoder) where TProxy : struct, IProxy =>
         decoder.DecodeNullableServiceAddress() is ServiceAddress serviceAddress ?
-            CreateProxy<TProxy>(serviceAddress, decoder.ProxyDecodingContext) : null;
+            CreateProxy<TProxy>(serviceAddress, decoder.DecodingContext) : null;
 
     /// <summary>Decodes a proxy struct.</summary>
     /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
@@ -23,7 +23,7 @@ public static class ProxySliceDecoderExtensions
         decoder.Encoding == SliceEncoding.Slice1 ?
             decoder.DecodeNullableProxy<TProxy>() ??
                 throw new InvalidDataException("Decoded null for a non-nullable proxy.") :
-           CreateProxy<TProxy>(decoder.DecodeServiceAddress(), decoder.ProxyDecodingContext);
+           CreateProxy<TProxy>(decoder.DecodeServiceAddress(), decoder.DecodingContext);
 
     private static TProxy CreateProxy<TProxy>(ServiceAddress serviceAddress, object? proxyDecodingContext)
         where TProxy : struct, IProxy

--- a/src/ZeroC.Slice/SliceDecoder.cs
+++ b/src/ZeroC.Slice/SliceDecoder.cs
@@ -16,6 +16,11 @@ public ref partial struct SliceDecoder
     /// <summary>Gets the number of bytes decoded in the underlying buffer.</summary>
     public readonly long Consumed => _reader.Consumed;
 
+    /// <summary>Gets the decoding context.</summary>
+    /// <remarks>The decoding context is a kind of cookie: the code that creates the decoder can store this context in
+    /// the decoder for later retrieval.</remarks>
+    public object? DecodingContext { get; }
+
     /// <summary>Gets the Slice encoding decoded by this decoder.</summary>
     public SliceEncoding Encoding { get; }
 
@@ -23,11 +28,6 @@ public ref partial struct SliceDecoder
     /// <value><see langword="true" /> when this decoder has reached the end of its underlying buffer; otherwise
     /// <see langword="false" />.</value>
     public readonly bool End => _reader.End;
-
-    /// <summary>Gets the proxy decoding context.</summary>
-    /// <remarks>The proxy decoding context is a kind of cookie: the code that creates the decoder can store this
-    /// context in the decoder for later retrieval.</remarks>
-    public object? ProxyDecodingContext { get; }
 
     /// <summary>Gets the number of bytes remaining in the underlying buffer.</summary>
     /// <value>The number of bytes remaining in the underlying buffer.</value>
@@ -63,7 +63,7 @@ public ref partial struct SliceDecoder
     /// <summary>Constructs a new Slice decoder over a byte buffer.</summary>
     /// <param name="buffer">The byte buffer.</param>
     /// <param name="encoding">The Slice encoding version.</param>
-    /// <param name="proxyDecodingContext">The proxy decoding context.</param>
+    /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>
@@ -72,13 +72,13 @@ public ref partial struct SliceDecoder
     public SliceDecoder(
         ReadOnlySequence<byte> buffer,
         SliceEncoding encoding,
-        object? proxyDecodingContext = null,
+        object? decodingContext = null,
         int maxCollectionAllocation = -1,
         IActivator? activator = null,
         int maxDepth = 3)
     {
         Encoding = encoding;
-        ProxyDecodingContext = proxyDecodingContext;
+        DecodingContext = decodingContext;
 
         _currentCollectionAllocation = 0;
 
@@ -100,7 +100,7 @@ public ref partial struct SliceDecoder
     /// <summary>Constructs a new Slice decoder over a byte buffer.</summary>
     /// <param name="buffer">The byte buffer.</param>
     /// <param name="encoding">The Slice encoding version.</param>
-    /// <param name="proxyDecodingContext">The proxy decoding context.</param>
+    /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
     /// length.</param>
@@ -109,14 +109,14 @@ public ref partial struct SliceDecoder
     public SliceDecoder(
         ReadOnlyMemory<byte> buffer,
         SliceEncoding encoding,
-        object? proxyDecodingContext = null,
+        object? decodingContext = null,
         int maxCollectionAllocation = -1,
         IActivator? activator = null,
         int maxDepth = 3)
         : this(
             new ReadOnlySequence<byte>(buffer),
             encoding,
-            proxyDecodingContext,
+            decodingContext,
             maxCollectionAllocation,
             activator,
             maxDepth)

--- a/src/ZeroC.Slice/SliceEncoderExtensions.cs
+++ b/src/ZeroC.Slice/SliceEncoderExtensions.cs
@@ -102,15 +102,12 @@ public static class SliceEncoderExtensions
     }
 
     /// <summary>Encodes a sequence.</summary>
-    /// <typeparam name="T">The type of the sequence elements. It is non-nullable except for nullable class and
-    /// proxy types.</typeparam>
+    /// <typeparam name="T">The type of the sequence elements. It is non-nullable except for nullable class and nullable
+    /// custom types with Slice1.</typeparam>
     /// <param name="encoder">The Slice encoder.</param>
     /// <param name="v">The sequence to encode.</param>
     /// <param name="encodeAction">The encode action for an element.</param>
-    public static void EncodeSequence<T>(
-        this ref SliceEncoder encoder,
-        IEnumerable<T> v,
-        EncodeAction<T> encodeAction)
+    public static void EncodeSequence<T>(this ref SliceEncoder encoder, IEnumerable<T> v, EncodeAction<T> encodeAction)
     {
         encoder.EncodeSize(v.Count()); // potentially slow Linq Count()
         foreach (T item in v)


### PR DESCRIPTION
The goal is to make ZeroC.Slice even more proxy-independent. See also https://github.com/icerpc/slicec/issues/673.