### PR TITLE
Add tests to ensure that IceRpc+Protobuf completes the payloads

### DIFF
--- a/tests/IceRpc.Tests.Common/ColocInvoker.cs
+++ b/tests/IceRpc.Tests.Common/ColocInvoker.cs
@@ -70,7 +70,9 @@ public sealed class ColocInvoker : IInvoker
                 // using the ColocInvoker when attempting to send more data than allowed by the threshold.
                 var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
                 await outgoingFrame.Payload.CopyToAsync(pipe.Writer, cancellationToken);
+                outgoingFrame.Payload.Complete();
                 await outgoingFrame.PayloadContinuation.CopyToAsync(pipe.Writer, cancellationToken);
+                outgoingFrame.PayloadContinuation.Complete();
                 pipe.Writer.Complete();
                 payload = pipe.Reader;
             }


### PR DESCRIPTION
This PR adds tests to ensure that IceRpc+Protobuf integration completes the request and response payloads, there is also a minor fix for the ColocInvoker used by some tests, which didn't complete the outgoing frame payloads.