### PR TITLE
Configure slice extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
-  "cSpell.showStatus": true,
+  "dotnet.defaultSolution": "IceRpc.sln",
   "rust-analyzer.linkedProjects": ["tools/slicec-cs/Cargo.toml"],
-  "rust-analyzer.rustfmt.extraArgs": [
-    "+nightly"
-  ],
-  "dotnet.defaultSolution": "IceRpc.sln"
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "slice.referenceDirectories": ["slice"]
 }


### PR DESCRIPTION
This PR adds slice extension configuration settings to only look at the `slice` folder. Without this setting, the extension tries to compile all slice in the workspace, resulting in lots of redefinition errors.

**Edit**: Also the `"cSpell.showStatus": true`, was not doing anything so I removed it.