### PR TITLE
Generate encode/decode extension methods for proxies

### DIFF
--- a/slice/Ice/Locator.slice
+++ b/slice/Ice/Locator.slice
@@ -33,7 +33,11 @@ interface Locator {
     /// should treat this exception like a null return value.
     idempotent findAdapterById(id: string) -> IceRpc::ServiceAddress? throws AdapterNotFoundException
 
-    /// Gets the locator registry.
-    /// @returns: The locator registry, or null if this locator has no associated registry.
-    idempotent getRegistry() -> LocatorRegistry?
+    /// Gets a proxy to the locator registry.
+    /// @returns: A proxy to the locator registry, or null if this locator has no associated registry.
+    idempotent getRegistry() -> LocatorRegistryProxy?
 }
+
+/// The LocatorProxy data type, encoded as a service address.
+[cs::type("IceRpc.Slice.Ice.LocatorProxy")]
+custom LocatorProxy

--- a/slice/Ice/LocatorRegistry.slice
+++ b/slice/Ice/LocatorRegistry.slice
@@ -55,5 +55,9 @@ interface LocatorRegistry {
     /// @param serverId: The server ID.
     /// @param proxy: A proxy for the Process service of the server application.
     /// @throws ServerNotFoundException: Thrown if the locator does not know a server application with this server ID.
-    idempotent setServerProcessProxy(serverId: string, proxy: Process) throws ServerNotFoundException
+    idempotent setServerProcessProxy(serverId: string, proxy: ProcessProxy) throws ServerNotFoundException
 }
+
+/// The LocatorRegistryProxy data type, encoded as a service address.
+[cs::type("IceRpc.Slice.Ice.LocatorRegistryProxy")]
+custom LocatorRegistryProxy

--- a/slice/Ice/Object.slice
+++ b/slice/Ice/Object.slice
@@ -21,3 +21,8 @@ interface Object {
     /// Pings the service.
     idempotent ice_ping()
 }
+
+/// The ObjectProxy data type, encoded as a service address.
+// TODO: add cs::identifier + test, see #3805
+[cs::type("IceRpc.Slice.Ice.IceObjectProxy")]
+custom ObjectProxy

--- a/slice/Ice/Process.slice
+++ b/slice/Ice/Process.slice
@@ -16,3 +16,7 @@ interface Process {
     /// @param fd: '1' for stdout, '2' for stderr.
     writeMessage(message: string, fd: int32)
 }
+
+/// The ProcessProxy data type, encoded as a service address.
+[cs::type("IceRpc.Slice.Ice.ProcessProxy")]
+custom ProcessProxy

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -8,7 +8,7 @@ using ZeroC.Slice;
 
 namespace IceRpc.Slice.Tests;
 
-/// <summary>Test encoding and decoding proxies.</summary>
+/// <summary>Test encoding and decoding service addresses and proxies.</summary>
 [Parallelizable(scope: ParallelScope.All)]
 public partial class ProxyTests
 {
@@ -25,7 +25,7 @@ public partial class ProxyTests
         var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
 
         // Act
-        PingableProxy? decoded = decoder.DecodeNullableProxy<PingableProxy>();
+        PingableProxy? decoded = decoder.DecodeNullablePingableProxy();
 
         // Assert
         Assert.That(decoded?.ServiceAddress, Is.EqualTo(expected));
@@ -83,14 +83,13 @@ public partial class ProxyTests
         var sut = new SliceDecoder(bufferWriter.WrittenMemory, encoding: encoding);
 
         // Act
-        var decoded = sut.DecodeProxy<IceObjectProxy>();
+        var decoded = sut.DecodePingableProxy();
 
         // Assert
         Assert.That(decoded.ServiceAddress, Is.EqualTo(expected));
     }
 
-    /// <summary>Verifies that a relative proxy decoded with the default service proxy factory gets a null invoker.
-    /// </summary>
+    /// <summary>Verifies that a relative proxy gets a null invoker by default.</summary>
     [Test]
     public void Decode_relative_proxy()
     {
@@ -101,7 +100,7 @@ public partial class ProxyTests
             var encoder = new SliceEncoder(bufferWriter, SliceEncoding.Slice2);
             encoder.EncodeServiceAddress(new ServiceAddress { Path = "/foo" });
             var decoder = new SliceDecoder(bufferWriter.WrittenMemory, encoding: SliceEncoding.Slice2);
-            return decoder.DecodeProxy<IceObjectProxy>().Invoker;
+            return decoder.DecodePingableProxy().Invoker;
         },
         Is.Null);
     }
@@ -176,7 +175,7 @@ public partial class ProxyTests
         Assert.That(service.ReceivedProxy!.Value.Invoker, Is.Null);
     }
 
-    /// <summary>Verifies that the invoker of a proxy decoded from an incoming request can be set using a Slice
+    /// <summary>Verifies that the invoker of a proxy decoded from an incoming request can be set using the Slice
     /// feature.</summary>
     [Test]
     public async Task Proxy_decoded_from_an_incoming_request_can_have_invoker_set_through_a_slice_feature()
@@ -199,7 +198,7 @@ public partial class ProxyTests
         Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(pipeline));
     }
 
-    /// <summary>Verifies that a proxy decoded from an incoming response inherits the callers invoker.</summary>
+    /// <summary>Verifies that a proxy decoded from an incoming response inherits the caller's invoker.</summary>
     [Test]
     public async Task Proxy_decoded_from_an_incoming_response_inherits_the_callers_invoker()
     {

--- a/tests/IceRpc.Slice.Tests/ProxyTests.slice
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.slice
@@ -7,9 +7,15 @@ interface MyBaseInterface {}
 interface MyDerivedInterface : MyBaseInterface {}
 
 interface ReceiveProxyTest {
-    receiveProxy() -> ReceiveProxyTest
+    receiveProxy() -> ReceiveProxyTestProxy
 }
 
+[cs::type("IceRpc.Slice.Tests.ReceiveProxyTestProxy")]
+custom ReceiveProxyTestProxy
+
 interface SendProxyTest {
-    sendProxy(proxy: SendProxyTest)
+    sendProxy(proxy: SendProxyTestProxy)
 }
+
+[cs::type("IceRpc.Slice.Tests.SendProxyTestProxy")]
+custom SendProxyTestProxy

--- a/tests/IntegrationTests/ProtocolBridgingTests.slice
+++ b/tests/IntegrationTests/ProtocolBridgingTests.slice
@@ -26,5 +26,8 @@ interface ProtocolBridgingTest {
     opContext()
 
     // Operation that returns a new proxy to the same target
-    opNewProxy() -> ProtocolBridgingTest
+    opNewProxy() -> ProtocolBridgingTestProxy
 }
+
+[cs::type("IceRpc.IntegrationTests.ProtocolBridgingTestProxy")]
+custom ProtocolBridgingTestProxy

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -128,12 +128,18 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
     if interface_def.supported_encodings().supports(Encoding::Slice1) {
         proxy_encoder_builder.add_comment(
             "summary",
-            "Provides extension methods for <see cref=\"SliceEncoder\" />.",
+            format!(
+                r#"
+Provides extension methods for <see cref="SliceEncoder" /> to encode a <see cref="{proxy_impl}" />."#
+            ),
         );
     } else {
         proxy_encoder_builder.add_comment(
             "summary",
-            "Provides an extension method for <see cref=\"SliceEncoder\" />.",
+            format!(
+                r#"
+Provides an extension method for <see cref="SliceEncoder" /> to encode a <see cref="{proxy_impl}" />."#
+            ),
         );
     }
 
@@ -174,12 +180,18 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
     if interface_def.supported_encodings().supports(Encoding::Slice1) {
         proxy_decoder_builder.add_comment(
             "summary",
-            "Provides extension methods for <see cref=\"SliceDecoder\" />.",
+            format!(
+                r#"
+Provides extension methods for <see cref="SliceDecoder" /> to decode a <see cref="{proxy_impl}" />."#
+            ),
         );
     } else {
         proxy_decoder_builder.add_comment(
             "summary",
-            "Provides an extension method for <see cref=\"SliceDecoder\" />.",
+            format!(
+                r#"
+Provides an extension method for <see cref="SliceDecoder" /> to decode a <see cref="{proxy_impl}" />."#
+            ),
         );
     }
 

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -120,6 +120,31 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
 
     code.add_block(&proxy_impl_builder.build());
 
+    let mut proxy_decoder_builder = ContainerBuilder::new(
+        &format!("{access} static class"),
+        &format!("{proxy_impl}DecoderExtensions"),
+    );
+
+    proxy_decoder_builder
+        .add_comment(
+            "summary",
+            format!(
+                r#"
+Provides extension method(s) for <see cref="SliceDecoder" />."#
+            ),
+        )
+        .add_block(
+            format!(
+                r#"
+/// <summary>Decodes an <see cref="IceRpc.ServiceAddress" /> into a <see cref="{proxy_impl}" />.</summary>
+{access} static {proxy_impl} Decode{proxy_impl}(this ref SliceDecoder decoder) =>
+    decoder.DecodeProxy<{proxy_impl}>();"#
+            )
+            .into(),
+        );
+
+    code.add_block(&proxy_decoder_builder.build());
+
     code
 }
 

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -120,28 +120,95 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
 
     code.add_block(&proxy_impl_builder.build());
 
-    let mut proxy_decoder_builder = ContainerBuilder::new(
+    let mut proxy_encoder_builder = ContainerBuilder::new(
         &format!("{access} static class"),
-        &format!("{proxy_impl}DecoderExtensions"),
+        &format!("{proxy_impl}SliceEncoderExtensions"),
     );
 
-    proxy_decoder_builder
-        .add_comment(
+    if interface_def.supported_encodings().supports(Encoding::Slice1) {
+        proxy_encoder_builder.add_comment(
             "summary",
-            format!(
-                r#"
-Provides extension method(s) for <see cref="SliceDecoder" />."#
-            ),
+            "Provides extension methods for <see cref=\"SliceEncoder\" />.",
+        );
+    } else {
+        proxy_encoder_builder.add_comment(
+            "summary",
+            "Provides an extension method for <see cref=\"SliceEncoder\" />.",
+        );
+    }
+
+    proxy_encoder_builder.add_block(
+        format!(
+            r#"
+/// <summary>Encodes a <see cref="{proxy_impl}" /> as an <see cref="IceRpc.ServiceAddress" />.</summary>
+/// <param name="encoder">The Slice encoder.</param>
+/// <param name="proxy">The proxy to encode as a service address.</param>
+{access} static void Encode{proxy_impl}(this ref SliceEncoder encoder, {proxy_impl} proxy) =>
+    encoder.EncodeServiceAddress(proxy.ServiceAddress);"#
         )
-        .add_block(
+        .into(),
+    );
+
+    if interface_def.supported_encodings().supports(Encoding::Slice1) {
+        proxy_encoder_builder.add_block(
             format!(
                 r#"
-/// <summary>Decodes an <see cref="IceRpc.ServiceAddress" /> into a <see cref="{proxy_impl}" />.</summary>
-{access} static {proxy_impl} Decode{proxy_impl}(this ref SliceDecoder decoder) =>
-    decoder.DecodeProxy<{proxy_impl}>();"#
+/// <summary>Encodes a nullable <see cref="{proxy_impl}" /> as a nullable
+/// <see cref="IceRpc.ServiceAddress" /> (Slice1 only).</summary>
+/// <param name="encoder">The Slice encoder.</param>
+/// <param name="proxy">The proxy to encode as a service address (can be null).</param>
+{access} static void EncodeNullable{proxy_impl}(this ref SliceEncoder encoder, {proxy_impl}? proxy) =>
+    encoder.EncodeNullableServiceAddress(proxy?.ServiceAddress);"#
             )
             .into(),
         );
+    }
+
+    code.add_block(&proxy_encoder_builder.build());
+
+    let mut proxy_decoder_builder = ContainerBuilder::new(
+        &format!("{access} static class"),
+        &format!("{proxy_impl}SliceDecoderExtensions"),
+    );
+
+    if interface_def.supported_encodings().supports(Encoding::Slice1) {
+        proxy_decoder_builder.add_comment(
+            "summary",
+            "Provides extension methods for <see cref=\"SliceDecoder\" />.",
+        );
+    } else {
+        proxy_decoder_builder.add_comment(
+            "summary",
+            "Provides an extension method for <see cref=\"SliceDecoder\" />.",
+        );
+    }
+
+    proxy_decoder_builder.add_block(
+        format!(
+            r#"
+/// <summary>Decodes an <see cref="IceRpc.ServiceAddress" /> into a <see cref="{proxy_impl}" />.</summary>
+/// <param name="decoder">The Slice decoder.</param>
+/// <returns>The proxy created from the decoded service address.</returns>
+{access} static {proxy_impl} Decode{proxy_impl}(this ref SliceDecoder decoder) =>
+    decoder.DecodeProxy<{proxy_impl}>();"#
+        )
+        .into(),
+    );
+
+    if interface_def.supported_encodings().supports(Encoding::Slice1) {
+        proxy_decoder_builder.add_block(
+            format!(
+                r#"
+/// <summary>Decodes a nullable <see cref="IceRpc.ServiceAddress" /> into a nullable
+/// <see cref="{proxy_impl}" /> (Slice1 only).</summary>
+/// <param name="decoder">The Slice decoder.</param>
+/// <returns>The proxy created from the decoded service address, or <langword name="null"/>.</returns>
+{access} static {proxy_impl}? DecodeNullable{proxy_impl}(this ref SliceDecoder decoder) =>
+    decoder.DecodeNullableProxy<{proxy_impl}>();"#
+            )
+            .into(),
+        );
+    }
 
     code.add_block(&proxy_decoder_builder.build());
 


### PR DESCRIPTION
This PR generates encode/decode methods for proxies, and adds a number of custom *Name*Proxy types.

Fixes #3803.