### PR TITLE
Support 'cs::identifier' on custom types.

### DIFF
--- a/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
+++ b/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
@@ -28,7 +28,6 @@ impl CsIdentifier {
             }
 
             Attributables::SliceFile(_)
-            | Attributables::CustomType(_)
             | Attributables::TypeAlias(_)
             | Attributables::TypeRef(_) => report_unexpected_attribute(self, span, None, diagnostics),
 


### PR DESCRIPTION
This small PR implements #3805.