### PR TITLE
Use cs::identifier for ObjectProxy, add test

### DIFF
--- a/slice/Ice/Object.slice
+++ b/slice/Ice/Object.slice
@@ -23,6 +23,6 @@ interface Object {
 }
 
 /// The ObjectProxy data type, encoded as a service address.
-// TODO: add cs::identifier + test, see #3805
+[cs::identifier("IceObjectProxy")]
 [cs::type("IceRpc.Slice.Ice.IceObjectProxy")]
 custom ObjectProxy

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -226,6 +226,11 @@ public partial class ProxyTests
     [SliceService]
     private sealed partial class ReceiveProxyTestService : IReceiveProxyTestService
     {
+        public ValueTask<IceObjectProxy> ReceiveObjectProxyAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) =>
+            new(new IceObjectProxy { ServiceAddress = new(new Uri("icerpc:/hello")) });
+
         public ValueTask<ReceiveProxyTestProxy> ReceiveProxyAsync(
             IFeatureCollection features,
             CancellationToken cancellationToken) =>
@@ -235,7 +240,18 @@ public partial class ProxyTests
     [SliceService]
     private sealed partial class SendProxyTestService : ISendProxyTestService
     {
+        public IceObjectProxy? ReceivedObjectProxy { get; private set; }
+
         public SendProxyTestProxy? ReceivedProxy { get; private set; }
+
+        public ValueTask SendObjectProxyAsync(
+            IceObjectProxy proxy,
+            IFeatureCollection features,
+            CancellationToken cancellationToken)
+        {
+            ReceivedObjectProxy = proxy;
+            return default;
+        }
 
         public ValueTask SendProxyAsync(
             SendProxyTestProxy proxy,

--- a/tests/IceRpc.Slice.Tests/ProxyTests.slice
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.slice
@@ -8,6 +8,7 @@ interface MyDerivedInterface : MyBaseInterface {}
 
 interface ReceiveProxyTest {
     receiveProxy() -> ReceiveProxyTestProxy
+    receiveObjectProxy() -> Ice::ObjectProxy
 }
 
 [cs::type("IceRpc.Slice.Tests.ReceiveProxyTestProxy")]
@@ -15,6 +16,7 @@ custom ReceiveProxyTestProxy
 
 interface SendProxyTest {
     sendProxy(proxy: SendProxyTestProxy)
+    sendObjectProxy(proxy: Ice::ObjectProxy)
 }
 
 [cs::type("IceRpc.Slice.Tests.SendProxyTestProxy")]


### PR DESCRIPTION
This PR adds `cs::identifier` to ObjectProxy and adds a test to make sure it works.