### PR TITLE
Make IProxy.Invoker not nullable

### DIFF
--- a/src/IceRpc.Slice/IProxy.cs
+++ b/src/IceRpc.Slice/IProxy.cs
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-using System.ComponentModel.DataAnnotations;
-
 namespace IceRpc.Slice;
 
 /// <summary>Represents a local ambassador for a remote service.</summary>

--- a/src/IceRpc.Slice/IProxy.cs
+++ b/src/IceRpc.Slice/IProxy.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+using System.ComponentModel.DataAnnotations;
+
 namespace IceRpc.Slice;
 
 /// <summary>Represents a local ambassador for a remote service.</summary>
@@ -10,7 +12,7 @@ public interface IProxy
     SliceEncodeOptions? EncodeOptions { get; init; }
 
     /// <summary>Gets or initializes the invocation pipeline of this proxy.</summary>
-    IInvoker? Invoker { get; init; }
+    IInvoker Invoker { get; init; }
 
     /// <summary>Gets or initializes the address of the remote service.</summary>
     ServiceAddress ServiceAddress { get; init; }

--- a/src/IceRpc.Slice/ProxySliceDecoderExtensions.cs
+++ b/src/IceRpc.Slice/ProxySliceDecoderExtensions.cs
@@ -30,7 +30,7 @@ public static class ProxySliceDecoderExtensions
     {
         if (decodingContext is null)
         {
-            return new TProxy { ServiceAddress = serviceAddress };
+            return new TProxy { Invoker = InvalidInvoker.Instance, ServiceAddress = serviceAddress };
         }
         else
         {

--- a/src/IceRpc.Slice/SliceServiceProviderExtensions.cs
+++ b/src/IceRpc.Slice/SliceServiceProviderExtensions.cs
@@ -15,20 +15,28 @@ public static class SliceServiceProviderExtensions
     /// invocation pipeline, and the <see cref="SliceEncodeOptions" /> retrieved from <paramref name="provider" /> as
     /// its encode options.</remarks>
     public static TProxy CreateSliceProxy<TProxy>(this IServiceProvider provider, ServiceAddress? serviceAddress = null)
-        where TProxy : struct, IProxy =>
-        serviceAddress is null ?
-        new TProxy
+        where TProxy : struct, IProxy
+    {
+        var invoker = (IInvoker?)provider.GetService(typeof(IInvoker));
+        if (invoker is null)
         {
-            EncodeOptions = (SliceEncodeOptions?)provider.GetService(typeof(SliceEncodeOptions)),
-            Invoker = (IInvoker?)provider.GetService(typeof(IInvoker))
+            throw new InvalidOperationException("Could not find service of type 'IInvoker' in the service container.");
         }
-        :
-        new TProxy
-        {
-            EncodeOptions = (SliceEncodeOptions?)provider.GetService(typeof(SliceEncodeOptions)),
-            Invoker = (IInvoker?)provider.GetService(typeof(IInvoker)),
-            ServiceAddress = serviceAddress
-        };
+
+        return serviceAddress is null ?
+            new TProxy
+            {
+                EncodeOptions = (SliceEncodeOptions?)provider.GetService(typeof(SliceEncodeOptions)),
+                Invoker = invoker
+            }
+            :
+            new TProxy
+            {
+                EncodeOptions = (SliceEncodeOptions?)provider.GetService(typeof(SliceEncodeOptions)),
+                Invoker = invoker,
+                ServiceAddress = serviceAddress
+            };
+    }
 
     /// <summary>Creates a Slice proxy with this service provider.</summary>
     /// <typeparam name="TProxy">The Slice proxy struct.</typeparam>

--- a/src/IceRpc/InvalidInvoker.cs
+++ b/src/IceRpc/InvalidInvoker.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc;
+
+/// <summary>Implements the <see cref="IInvoker" /> interface by always throwing
+/// <see cref="InvalidOperationException" />.</summary>
+public class InvalidInvoker : IInvoker
+{
+    /// <summary>Gets the singleton instance of <see cref="InvalidInvoker" />.</summary>
+    public static IInvoker Instance { get; } = new InvalidInvoker();
+
+    /// <inheritdoc/>
+    public Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException("Invalid invoker.");
+
+    private InvalidInvoker()
+    {
+    }
+}

--- a/tests/IceRpc.Slice.Tests/InvalidProxy.cs
+++ b/tests/IceRpc.Slice.Tests/InvalidProxy.cs
@@ -12,7 +12,7 @@ internal class InvalidProxy : IProxy
         init { }
     }
 
-    public IInvoker? Invoker
+    public IInvoker Invoker
     {
         get => throw new NotImplementedException();
         init { }

--- a/tests/IceRpc.Slice.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Tests/OperationTests.cs
@@ -615,7 +615,7 @@ public partial class OperationTests
     }
 
     [Test]
-    public async Task Proxy_decoded_from_incoming_request_has_a_null_invoker()
+    public async Task Proxy_decoded_from_incoming_request_has_invalid_invoker()
     {
         // Arrange
         var service = new MyOperationsAService();
@@ -627,7 +627,7 @@ public partial class OperationTests
 
         // Assert
         Assert.That(service.ReceivedProxy, Is.Not.Null);
-        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(InvalidInvoker.Instance));
     }
 
     [Test]

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -89,7 +89,7 @@ public partial class ProxyTests
         Assert.That(decoded.ServiceAddress, Is.EqualTo(expected));
     }
 
-    /// <summary>Verifies that a relative proxy gets a null invoker by default.</summary>
+    /// <summary>Verifies that a relative proxy gets the invalid invoker by default.</summary>
     [Test]
     public void Decode_relative_proxy()
     {
@@ -102,7 +102,7 @@ public partial class ProxyTests
             var decoder = new SliceDecoder(bufferWriter.WrittenMemory, encoding: SliceEncoding.Slice2);
             return decoder.DecodePingableProxy().Invoker;
         },
-        Is.Null);
+        Is.EqualTo(InvalidInvoker.Instance));
     }
 
     [Test]
@@ -159,9 +159,9 @@ public partial class ProxyTests
         },
         Throws.TypeOf<ArgumentException>());
 
-    /// <summary>Verifies that a proxy decoded from an incoming request has a null invoker by default.</summary>
+    /// <summary>Verifies that a proxy decoded from an incoming request has the invalid invoker by default.</summary>
     [Test]
-    public async Task Proxy_decoded_from_an_incoming_request_has_null_invoker()
+    public async Task Proxy_decoded_from_an_incoming_request_has_invalid_invoker()
     {
         // Arrange
         var service = new SendProxyTestService();
@@ -172,7 +172,7 @@ public partial class ProxyTests
 
         // Assert
         Assert.That(service.ReceivedProxy, Is.Not.Null);
-        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(InvalidInvoker.Instance));
     }
 
     /// <summary>Verifies that the invoker of a proxy decoded from an incoming request can be set using the Slice
@@ -229,12 +229,12 @@ public partial class ProxyTests
         public ValueTask<IceObjectProxy> ReceiveObjectProxyAsync(
             IFeatureCollection features,
             CancellationToken cancellationToken) =>
-            new(new IceObjectProxy { ServiceAddress = new(new Uri("icerpc:/hello")) });
+            new(new IceObjectProxy(InvalidInvoker.Instance, new Uri("icerpc:/hello")));
 
         public ValueTask<ReceiveProxyTestProxy> ReceiveProxyAsync(
             IFeatureCollection features,
             CancellationToken cancellationToken) =>
-            new(new ReceiveProxyTestProxy { ServiceAddress = new(new Uri("icerpc:/hello")) });
+            new(new ReceiveProxyTestProxy(InvalidInvoker.Instance, new Uri("icerpc:/hello")));
     }
 
     [SliceService]

--- a/tests/IceRpc.Slice.Tests/StructTests.cs
+++ b/tests/IceRpc.Slice.Tests/StructTests.cs
@@ -15,7 +15,7 @@ public sealed class StructTests
     {
         var expected = new MyCompactStructWithNullableProxy(
             10,
-            serviceAddress is null ? null : new PingableProxy { ServiceAddress = new(new Uri(serviceAddress)) });
+            serviceAddress is null ? null : new PingableProxy(InvalidInvoker.Instance, new Uri(serviceAddress)));
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
         encoder.EncodeInt32(expected.A);
@@ -34,7 +34,7 @@ public sealed class StructTests
         var expected = new MyCompactStructWithNullableProxy(
             10,
             serviceAddress is null ? null :
-                new PingableProxy { ServiceAddress = new(new Uri(serviceAddress)) });
+                new PingableProxy(InvalidInvoker.Instance, new Uri(serviceAddress)));
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
         var bitSequenceWriter = encoder.GetBitSequenceWriter(1);
@@ -62,9 +62,9 @@ public sealed class StructTests
         {
             I = new PingableProxy?[]
             {
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 null,
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -86,9 +86,9 @@ public sealed class StructTests
         {
             I = new PingableProxy?[]
             {
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 null,
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -111,9 +111,9 @@ public sealed class StructTests
         {
             I = new Dictionary<int, PingableProxy?>
             {
-                [1] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                [1] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 [2] = null,
-                [3] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                [3] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -136,9 +136,9 @@ public sealed class StructTests
         {
             I = new Dictionary<int, PingableProxy?>
             {
-                [1] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                [1] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 [2] = null,
-                [3] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                [3] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -160,7 +160,7 @@ public sealed class StructTests
     {
         var expected = new MyCompactStructWithNullableProxy(
             10,
-            serviceAddress is null ? null : new PingableProxy { ServiceAddress = new(new Uri(serviceAddress)) });
+            serviceAddress is null ? null : new PingableProxy(InvalidInvoker.Instance, new Uri(serviceAddress)));
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
 
@@ -178,7 +178,7 @@ public sealed class StructTests
     {
         var expected = new MyCompactStructWithNullableProxy(
             10,
-            serviceAddress is null ? null : new PingableProxy { ServiceAddress = new(new Uri(serviceAddress)) });
+            serviceAddress is null ? null : new PingableProxy(InvalidInvoker.Instance, new Uri(serviceAddress)));
 
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
@@ -200,9 +200,9 @@ public sealed class StructTests
         {
             I = new PingableProxy?[]
             {
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 null,
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -223,9 +223,9 @@ public sealed class StructTests
         {
             I = new PingableProxy?[]
             {
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 null,
-                new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -247,9 +247,9 @@ public sealed class StructTests
         {
             I = new Dictionary<int, PingableProxy?>
             {
-                [1] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                [1] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 [2] = null,
-                [3] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                [3] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -273,9 +273,9 @@ public sealed class StructTests
         {
             I = new Dictionary<int, PingableProxy?>
             {
-                [1] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service1")) },
+                [1] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service1")),
                 [2] = null,
-                [3] = new PingableProxy { ServiceAddress = new(new Uri("icerpc://localhost/service2")) },
+                [3] = new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc://localhost/service2")),
             }
         };
         var buffer = new MemoryBufferWriter(new byte[256]);

--- a/tests/IntegrationTests/ProtocolBridgingTests.cs
+++ b/tests/IntegrationTests/ProtocolBridgingTests.cs
@@ -22,15 +22,13 @@ public sealed partial class ProtocolBridgingTests
         var forwarderServerAddress = new ServerAddress(new Uri($"{forwarderProtocol}://colochost1"));
         var targetServerAddress = new ServerAddress(new Uri($"{targetProtocol}://colochost2"));
 
-        var forwarderProxy = new ProtocolBridgingTestProxy
-        {
-            ServiceAddress = new(new Uri($"{forwarderServerAddress}forward"))
-        };
+        var forwarderProxy = new ProtocolBridgingTestProxy(
+            InvalidInvoker.Instance,
+            new Uri($"{forwarderServerAddress}forward"));
 
-        var targetProxy = new ProtocolBridgingTestProxy
-        {
-            ServiceAddress = new(new Uri($"{targetServerAddress}target"))
-        };
+        var targetProxy = new ProtocolBridgingTestProxy(
+            InvalidInvoker.Instance,
+            new Uri($"{targetServerAddress}target"));
 
         var targetService = new ProtocolBridgingTestService(targetServerAddress);
 
@@ -141,7 +139,7 @@ public sealed partial class ProtocolBridgingTests
                 ServerAddress = _publishedServerAddress
             };
 
-            return new(new ProtocolBridgingTestProxy { ServiceAddress = serviceAddress });
+            return new(new ProtocolBridgingTestProxy(InvalidInvoker.Instance, serviceAddress));
         }
 
         public ValueTask OpOnewayAsync(int x, IFeatureCollection features, CancellationToken cancellationToken) => default;

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -71,10 +71,10 @@ This remote service must implement Slice interface {slice_interface}."#
 public const string DefaultServicePath = "{default_service_path}";
 
 /// <inheritdoc/>
-public SliceEncodeOptions? EncodeOptions {{ get; init; }} = null;
+public SliceEncodeOptions? EncodeOptions {{ get; init; }}
 
 /// <inheritdoc/>
-public IceRpc.IInvoker? Invoker {{ get; init; }} = null;
+public required IceRpc.IInvoker Invoker {{ get; init; }}
 
 /// <inheritdoc/>
 public IceRpc.ServiceAddress ServiceAddress {{ get; init; }} = _defaultServiceAddress;
@@ -232,13 +232,15 @@ fn proxy_impl_static_methods(interface_def: &Interface) -> CodeBlock {
         r#"/// <summary>Creates a relative proxy from a path.</summary>
 /// <param name="path">The path.</param>
 /// <returns>The new relative proxy.</returns>
-public static {proxy_impl} FromPath(string path) => new() {{ ServiceAddress = new() {{ Path = path }} }};
+public static {proxy_impl} FromPath(string path) =>
+    new(IceRpc.InvalidInvoker.Instance, new IceRpc.ServiceAddress {{ Path = path }});
 
 /// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>
 /// <param name="invoker">The invocation pipeline of the proxy.</param>
 /// <param name="serviceAddress">The service address. <see langword="null" /> is equivalent to an icerpc service address
 /// with path <see cref="DefaultServicePath" />.</param>
 /// <param name="encodeOptions">The encode options, used to customize the encoding of request payloads.</param>
+[System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute]
 public {proxy_impl}(
     IceRpc.IInvoker invoker,
     IceRpc.ServiceAddress? serviceAddress = null,
@@ -253,12 +255,13 @@ public {proxy_impl}(
 /// <param name="invoker">The invocation pipeline of the proxy.</param>
 /// <param name="serviceAddressUri">A URI that represents a service address.</param>
 /// <param name="encodeOptions">The encode options, used to customize the encoding of request payloads.</param>
+[System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute]
 public {proxy_impl}(IceRpc.IInvoker invoker, System.Uri serviceAddressUri, SliceEncodeOptions? encodeOptions = null)
     : this(invoker, new IceRpc.ServiceAddress(serviceAddressUri), encodeOptions)
 {{
 }}
 
-/// <summary>Constructs a proxy with the default service address and a <see langword="null" /> invoker.</summary>
+/// <summary>Constructs a proxy with an icerpc service address with path <see cref="DefaultServicePath" />.</summary>
 public {proxy_impl}()
 {{
 }}"#,


### PR DESCRIPTION
This PR makes IProxy.Invoker not nullable, just like IProtobufClient.Incoker.

Rather than null, the code now uses  InvalidInvoker.Instance when it needs an invalid invoker - typically when the proxy is used for encoding and not for invoking.
