### PR TITLE
Protobuf tools version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
           Copy-Item "slicec-cs-x86_64-pc-windows-msvc\slicec-cs.exe" -Destination "$env:GITHUB_WORKSPACE\tools\slicec-cs\target\release"
       - name: Pack IceRPC Tools
         working-directory: tools
-        run: dotnet pack --configuration Release --output ../
+        run: |
+          dotnet build --configuration release
+          dotnet pack --configuration Release --output ../
         env:
           SLICEC_CS_STAGING_PATH: ${{ github.workspace }}\tools\slicec-cs\staging
       - name: Pack IceRPC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Pack IceRPC Tools
         working-directory: tools
         run: |
-          dotnet build --configuration release
+          dotnet build --configuration Release
           dotnet pack --configuration Release --output ../
         env:
           SLICEC_CS_STAGING_PATH: ${{ github.workspace }}\tools\slicec-cs\staging

--- a/build.sh
+++ b/build.sh
@@ -89,7 +89,7 @@ publish()
     global_packages=$(dotnet nuget locals -l global-packages)
     global_packages=${global_packages/global-packages: /""}
     run_command rm "-rf" "$global_packages/zeroc.slice/$version" "$global_packages/icerpc/$version" "$global_packages"/icerpc.*/"$version"
-    run_command dotnet "nuget" "push" "tools/**/$dotnet_config/*.$version.nupkg" "--source" "$global_packages"
+    run_command dotnet "nuget" "push" "tools/**/$dotnet_config/*.$version*.nupkg" "--source" "$global_packages"
     run_command dotnet "nuget" "push" "src/**/$dotnet_config/*.$version.nupkg" "--source" "$global_packages"
 }
 

--- a/build/IceRpc.Version.props
+++ b/build/IceRpc.Version.props
@@ -2,5 +2,6 @@
     <PropertyGroup>
         <!-- The version used by NuGet packages and assembly files -->
         <Version Condition="'$(Version)' == ''">0.2.0</Version>
+        <IceRpcProtobufToolsVersion>0.2.0.1</IceRpcProtobufToolsVersion>
     </PropertyGroup>
 </Project>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -115,7 +115,7 @@ function Publish($config) {
         $package_name = $package_name.Substring(0, $package_name.Length - ".$version".Length)
         Remove-Item $global_packages"\$package_name\$version" -Recurse -Force -ErrorAction Ignore
     }
-    RunCommand "dotnet" @('nuget', 'push', "tools\**\$dotnetConfiguration\*.$version.nupkg", '--source', $global_packages)
+    RunCommand "dotnet" @('nuget', 'push', "tools\**\$dotnetConfiguration\*.$version*.nupkg", '--source', $global_packages)
     RunCommand "dotnet" @('nuget', 'push', "src\**\$dotnetConfiguration\*.$version.nupkg", '--source', $global_packages)
 }
 

--- a/docfx/examples/IceRpc.Examples/IceRpc.Examples.csproj
+++ b/docfx/examples/IceRpc.Examples/IceRpc.Examples.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(Version)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" />
   </ItemGroup>
 </Project>

--- a/docfx/examples/IceRpc.RequestContext.Examples/IceRpc.RequestContext.Examples.csproj
+++ b/docfx/examples/IceRpc.RequestContext.Examples/IceRpc.RequestContext.Examples.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="IceRpc.RequestContext" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(Version)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="generated\" />

--- a/examples/protobuf/Deadline/Client/Client.csproj
+++ b/examples/protobuf/Deadline/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />
   </ItemGroup>

--- a/examples/protobuf/Deadline/Server/Server.csproj
+++ b/examples/protobuf/Deadline/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />

--- a/examples/protobuf/GenericHost/Client/Client.csproj
+++ b/examples/protobuf/GenericHost/Client/Client.csproj
@@ -25,7 +25,7 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />

--- a/examples/protobuf/GenericHost/Server/Server.csproj
+++ b/examples/protobuf/GenericHost/Server/Server.csproj
@@ -25,7 +25,7 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />

--- a/examples/protobuf/Greeter/Client/Client.csproj
+++ b/examples/protobuf/Greeter/Client/Client.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/Greeter/Server/Server.csproj
+++ b/examples/protobuf/Greeter/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/Logger/Client/Client.csproj
+++ b/examples/protobuf/Logger/Client/Client.csproj
@@ -12,7 +12,7 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
   </ItemGroup>

--- a/examples/protobuf/Logger/Server/Server.csproj
+++ b/examples/protobuf/Logger/Server/Server.csproj
@@ -12,7 +12,7 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />

--- a/examples/protobuf/Metrics/Client/Client.csproj
+++ b/examples/protobuf/Metrics/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Metrics" Version="$(Version)" />
   </ItemGroup>

--- a/examples/protobuf/Metrics/Server/Server.csproj
+++ b/examples/protobuf/Metrics/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Metrics" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />

--- a/examples/protobuf/MultipleServices/Client/Client.csproj
+++ b/examples/protobuf/MultipleServices/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
     <ProtoFile Include="../proto/request_counter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/MultipleServices/Server/Server.csproj
+++ b/examples/protobuf/MultipleServices/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
     <ProtoFile Include="../proto/request_counter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>

--- a/examples/protobuf/Quic/Client/Client.csproj
+++ b/examples/protobuf/Quic/Client/Client.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Transports.Quic" Version="$(Version)" />

--- a/examples/protobuf/Quic/Server/Server.csproj
+++ b/examples/protobuf/Quic/Server/Server.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Transports.Quic" Version="$(Version)" />

--- a/examples/protobuf/RequestContext/Client/Client.csproj
+++ b/examples/protobuf/RequestContext/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.RequestContext" Version="$(Version)" />
   </ItemGroup>

--- a/examples/protobuf/RequestContext/Server/Server.csproj
+++ b/examples/protobuf/RequestContext/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.RequestContext" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />

--- a/examples/protobuf/Retry/Client/Client.csproj
+++ b/examples/protobuf/Retry/Client/Client.csproj
@@ -12,7 +12,7 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
     <PackageReference Include="IceRpc.Retry" Version="$(Version)" />

--- a/examples/protobuf/Retry/Server/Server.csproj
+++ b/examples/protobuf/Retry/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>

--- a/examples/protobuf/Secure/Client/Client.csproj
+++ b/examples/protobuf/Secure/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/Secure/Server/Server.csproj
+++ b/examples/protobuf/Secure/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>

--- a/examples/protobuf/Stream/Client/Client.csproj
+++ b/examples/protobuf/Stream/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/generator.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/Stream/Server/Server.csproj
+++ b/examples/protobuf/Stream/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/generator.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>

--- a/examples/protobuf/Telemetry/Client/Client.csproj
+++ b/examples/protobuf/Telemetry/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(Version)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.6.0" />

--- a/examples/protobuf/Telemetry/Server/Server.csproj
+++ b/examples/protobuf/Telemetry/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProtoFile Include="../proto/greeter.proto" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(Version)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.6.0" />

--- a/examples/protobuf/Thermostat/Client/Client.csproj
+++ b/examples/protobuf/Thermostat/Client/Client.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
   </ItemGroup>

--- a/examples/protobuf/Thermostat/Device/Device.csproj
+++ b/examples/protobuf/Thermostat/Device/Device.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/examples/protobuf/Thermostat/Server/Server.csproj
+++ b/examples/protobuf/Thermostat/Server/Server.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(Version)" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcProtobufToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(Version)" />
     <Compile Include="../../../common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
   </ItemGroup>

--- a/src/IceRpc.Templates/IceRpc.Templates.csproj
+++ b/src/IceRpc.Templates/IceRpc.Templates.csproj
@@ -11,6 +11,7 @@
         <PackageType>Template</PackageType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Version>$(IceRpcProtobufToolsVersion)</Version>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Templates\**\*" Exclude="Templates\**\bin\**;Templates\**\obj\**">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -9,7 +9,7 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.2.0" />
     <PackageReference Include="IceRpc.Deadline" Version="0.2.0" />
     <PackageReference Include="IceRpc.Logger" Version="0.2.0" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0.1" PrivateAssets="All" />
       <PackageReference Include="IceRpc.Protobuf" Version="0.2.0" />
       <PackageReference Include="IceRpc.Deadline" Version="0.2.0" />
       <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.2.0" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0.1" PrivateAssets="All" />
         <PackageReference Include="IceRpc.Protobuf" Version="0.2.0" />
         <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.2.0" />
         <PackageReference Include="IceRpc.Logger" Version="0.2.0" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -9,7 +9,7 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.2.0.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.2.0" />
     <PackageReference Include="IceRpc.Deadline" Version="0.2.0" />
     <PackageReference Include="IceRpc.Logger" Version="0.2.0" />

--- a/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -29,6 +29,7 @@
       <IncludeBuildOutput>false</IncludeBuildOutput>
       <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
       <NoWarn>NU5100</NoWarn>
+      <Version>$(IceRpcProtobufToolsVersion)</Version>
    </PropertyGroup>
    <ItemGroup>
       <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" />


### PR DESCRIPTION
This PR updates the protobuf tools version to `0.2.0.1`, The 0.2.0 published package was broken because of a bug in the release CI workflow and didn't include the protoc compiler and the icerpc generator.

The PR also fixes the release workflow issue that caused the broken package.