### PR TITLE
Initial split of the generated code into 2 files

### DIFF
--- a/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -66,7 +66,7 @@
                     Add GeneratePath metadata with the normalized path, this is required for excludes below to work
                     with different path separators.
                 -->
-                <GeneratedPath>$([MSBuild]::NormalizePath('%(OutputDir)/%(Filename).cs'))</GeneratedPath>
+                <GeneratedPath>$([MSBuild]::NormalizePath('%(OutputDir)/%(Filename)*.cs'))</GeneratedPath>
             </SliceFile>
             <!--
                 Create a Compile item for each SliceFile item, representing the generated C# file.

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -35,32 +35,20 @@ pub fn main() {
 
     if !compilation_state.diagnostics.has_errors() && !slice_options.dry_run {
         for slice_file in compilation_state.files.values().filter(|file| file.is_source) {
-            let code = generate_from_slice_file(slice_file, &cs_options);
-
-            let path = match &slice_options.output_dir {
-                Some(output_dir) => Path::new(output_dir),
-                _ => Path::new("."),
-            }
-            .join(format!("{}.cs", &slice_file.filename))
-            .to_owned();
-
-            // If the file already exists and its contents match the generated code, we don't re-write it.
-            if matches!(std::fs::read(&path), Ok(file_bytes) if file_bytes == code.as_bytes()) {
-                continue;
-            }
-
-            match write_file(&path, &code) {
-                Ok(_) => (),
-                Err(error) => {
-                    Diagnostic::new(Error::IO {
-                        action: "write",
-                        path: path.display().to_string(),
-                        error,
-                    })
-                    .push_into(&mut compilation_state.diagnostics);
-                    continue;
-                }
-            }
+            let code = generate_from_slice_file(slice_file, false, &cs_options);
+            write_code(
+                &slice_file.filename,
+                &slice_options.output_dir,
+                &code,
+                &mut compilation_state.diagnostics,
+            );
+            let interface_code = generate_from_slice_file(slice_file, true, &cs_options);
+            write_code(
+                &format!("{}.IceRpc", &slice_file.filename),
+                &slice_options.output_dir,
+                &interface_code,
+                &mut compilation_state.diagnostics,
+            );
         }
     }
 
@@ -70,4 +58,32 @@ pub fn main() {
 fn write_file(path: &Path, contents: &str) -> Result<(), io::Error> {
     let mut file = File::create(path)?;
     file.write_all(contents.as_bytes())
+}
+
+fn write_code(
+    filename: &str,
+    output_dir: &Option<String>,
+    code: &str,
+    diagnostics: &mut slicec::diagnostics::Diagnostics,
+) {
+    let path = match &output_dir {
+        Some(value) => Path::new(value),
+        _ => Path::new("."),
+    }
+    .join(format!("{}.cs", &filename));
+
+    // If the file already exists and its contents match the generated code, we don't re-write it.
+    if !matches!(std::fs::read(&path), Ok(file_bytes) if file_bytes == code.as_bytes()) {
+        match write_file(&path, code) {
+            Ok(_) => (),
+            Err(error) => {
+                Diagnostic::new(Error::IO {
+                    action: "write",
+                    path: path.display().to_string(),
+                    error,
+                })
+                .push_into(diagnostics);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is a first attempt to split the generated code between .cs and .IceRpc.cs. 

It doesn't work well because of IceRpc.Slice.Tools. I updated it but I am now getting lots of warnings:
```
CSC : warning CS2002: Source file 'C:\Users\bernard\source\repos\icerpc-csharp\tests\IceRpc.Slice.Tests\generated\ClassTests.cs' specified multiple times [C:\Users\bernard\source\repos\
icerpc-csharp\tests\IceRpc.Slice.Tests\IceRpc.Slice.Tests.csproj]
CSC : warning CS2002: Source file 'C:\Users\bernard\source\repos\icerpc-csharp\tests\IceRpc.Slice.Tests\generated\ClassTests.IceRpc.cs' specified multiple times [C:\Users\bernard\source
\repos\icerpc-csharp\tests\IceRpc.Slice.Tests\IceRpc.Slice.Tests.csproj]
CSC
```
