### PR TITLE
Fix bug in slicec-cs for empty unchecked enum

### DIFF
--- a/tests/ZeroC.Slice.Tests/EnumTests.slice
+++ b/tests/ZeroC.Slice.Tests/EnumTests.slice
@@ -30,3 +30,5 @@ unchecked enum MyUncheckedEnum : uint32 {
     [cs::attribute("System.ComponentModel.Description(\"Sixteen\")")]
     E4 = 16
 }
+
+unchecked enum MyVarInt62Alias : varint62 {}

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -105,8 +105,8 @@ fn enum_underlying_extensions(enum_def: &Enum) -> CodeBlock {
     let use_set = if let Some((min_value, max_value)) = min_max_values {
         !enum_def.is_unchecked && (enum_def.enumerators.len() as i128) < max_value - min_value + 1
     } else {
-        // This means there are no enumerators.*
-        true
+        // An unchecked enum with no enumerator.
+        false
     };
 
     if use_set {


### PR DESCRIPTION
This PR fixes #3856.