### PR TITLE
Map Slice fields to C# properties

### DIFF
--- a/tests/ZeroC.Slice.Tests/StructTests.cs
+++ b/tests/ZeroC.Slice.Tests/StructTests.cs
@@ -187,9 +187,21 @@ public sealed class StructTests
     public void Cs_readonly_on_field()
     {
         // Arrange / Act
-        var fieldInfo = typeof(MyStructWithFieldAttributes).GetField("J")!;
+        var propertyInfo = typeof(MyStructWithFieldAttributes).GetProperty("J")!;
+        var setMethodReturnParameterModifiers = propertyInfo.SetMethod!.ReturnParameter.GetRequiredCustomModifiers();
 
         // Assert
-        Assert.That(fieldInfo.IsInitOnly);
+        Assert.That(setMethodReturnParameterModifiers.Contains(typeof(System.Runtime.CompilerServices.IsExternalInit)));
+    }
+
+    [Test]
+    public void Clone_cs_readonly_struct()
+    {
+        var keyValuePair = new KeyValuePair(5, "foo");
+        keyValuePair = keyValuePair with { Value = "bar" };
+
+        // Assert
+        Assert.That(keyValuePair.Key, Is.EqualTo(5));
+        Assert.That(keyValuePair.Value, Is.EqualTo("bar"));
     }
 }

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -33,15 +33,13 @@ pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
         writeln!(prelude, "[{obsolete}]");
     }
 
-    let setter = if field.is_cs_readonly() { "init" } else { "set" };
-
     format!(
         "\
 {prelude}
 {access} {type_string} {name} {{ get; {setter}; }}",
         access = field.parent().access_modifier(),
         name = field.field_name(field_type),
-        field = if field.is_cs_readonly() { "init" } else { "set" },
+        setter = if field.is_cs_readonly() { "init" } else { "set" },
     )
 }
 

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -41,6 +41,7 @@ pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
 {access} {type_string} {name} {{ get; {setter}; }}",
         access = field.parent().access_modifier(),
         name = field.field_name(field_type),
+        field = if field.is_cs_readonly() { "init" } else { "set" },
     )
 }
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -29,6 +29,7 @@ impl<T: Member> MemberExt for T {
 }
 
 pub trait FieldExt {
+    /// Check if this field, or its parent struct, are marked with `cs::readonly`.
     fn is_cs_readonly(&self) -> bool;
 }
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{EntityExt, TypeRefExt};
+use crate::cs_attributes::CsReadonly;
 use crate::cs_util::{escape_keyword, format_comment_message, mangle_name, FieldType};
 use convert_case::Case;
 use slicec::grammar::*;
@@ -24,6 +25,19 @@ impl<T: Member> MemberExt for T {
 
     fn field_name(&self, field_type: FieldType) -> String {
         mangle_name(&self.escape_identifier(), field_type)
+    }
+}
+
+pub trait FieldExt {
+    fn is_cs_readonly(&self) -> bool;
+}
+
+impl FieldExt for Field {
+    fn is_cs_readonly(&self) -> bool {
+        self.all_attributes()
+            .concat()
+            .into_iter()
+            .any(|a| a.downcast::<CsReadonly>().is_some())
     }
 }
 

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -15,7 +15,7 @@ pub use comment_ext::CommentExt;
 pub use entity_ext::EntityExt;
 pub use enum_ext::EnumExt;
 pub use interface_ext::InterfaceExt;
-pub use member_ext::{MemberExt, ParameterExt, ParameterSliceExt};
+pub use member_ext::{FieldExt, MemberExt, ParameterExt, ParameterSliceExt};
 pub use module_ext::ModuleExt;
 pub use operation_ext::OperationExt;
 pub use primitive_ext::PrimitiveExt;


### PR DESCRIPTION
This PR changes the mapping for Slice fields. Prior to this PR, they were mapped to C# fields. This PR maps them to C# properties.

Rationale:
 - C# prefers auto-implemented public properties over public fields
 - for `cs::readonly` struct, you can now clone a readonly struct with `with` - this didn't work with readonly fields
 - it's consistent with the mapping for enum fields

Fixes #3858 

Note: this PR changes the mapping for all fields (struct, class, exception), not just struct fields.