### PR TITLE
Add test for enumerator attribute

### DIFF
--- a/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
+++ b/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.ComponentModel;
 
 namespace ZeroC.Slice.Tests;
 
@@ -111,4 +112,8 @@ public class EnumWithFieldsTests
         Assert.That(decoded, Is.EqualTo(shape));
         Assert.That(decoder.Consumed, Is.EqualTo(encoder.EncodedByteCount));
     }
+
+    [Test]
+    public void Enumerator_with_fields_gets_attribute() =>
+        Assert.That(typeof(ShapeWithAttribute.Rectangle).GetSliceTypeId(), Is.EqualTo("MyRectangle"));
 }

--- a/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
+++ b/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
-using System.ComponentModel;
 
 namespace ZeroC.Slice.Tests;
 

--- a/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.slice
+++ b/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.slice
@@ -25,3 +25,14 @@ unchecked enum RevisedShape {
     Square(side: uint32, tag(1) color: Color?)
     Oval(name: string?, major: uint32, minor: uint32)
 }
+
+enum ShapeWithAttribute {
+    [cs::attribute("SliceTypeId(\"MyCircle\")")]
+    Circle(radius: uint32)
+
+    [cs::attribute("SliceTypeId(\"MyRectangle\")")]
+    Rectangle(width: uint32, height: uint32)
+
+    [cs::attribute("SliceTypeId(\"MyTriangle\")")]
+    Triangle(side1: uint32, side2: uint32, side3: uint32)
+}


### PR DESCRIPTION
This new test verifies that `[cs::attribute]` works for enumerators in enum with fields.