### PR TITLE
Remove field name escaping

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -143,10 +143,8 @@ impl ContainerBuilder {
                 .data_type()
                 .cs_type_string(&field.namespace(), TypeContext::Field, false);
 
-            self.fields.push(format!(
-                "{type_string} {name}",
-                name = field.field_name(FieldType::Class),
-            ));
+            self.fields
+                .push(format!("{type_string} {name}", name = field.field_name(),));
         }
 
         self

--- a/tools/slicec-cs/src/cs_util.rs
+++ b/tools/slicec-cs/src/cs_util.rs
@@ -92,56 +92,6 @@ pub fn escape_keyword(identifier: &str) -> String {
     (if CS_KEYWORDS.contains(&identifier) { "@" } else { "" }.to_owned()) + identifier
 }
 
-/// The field container type, Class, Exception or NonMangled (currently used for structs),
-/// `mangle_name` operation use this enum to decide what names needs mangling.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FieldType {
-    NonMangled,
-    Class,
-    Exception,
-}
-
-/// Checks if the provided identifier would shadow a base method in an object or exception, and
-/// escapes it if necessary by appending a "Slice" prefix to the identifier.
-pub fn mangle_name(identifier: &str, field_type: FieldType) -> String {
-    // The names of all the methods defined on the Object base class.
-    const OBJECT_BASE_NAMES: [&str; 7] = [
-        "Equals",
-        "Finalize",
-        "GetHashCode",
-        "GetType",
-        "MemberwiseClone",
-        "ReferenceEquals",
-        "ToString",
-    ];
-    // The names of all the methods and properties defined on the Exception base class.
-    const EXCEPTION_BASE_NAMES: [&str; 10] = [
-        "Data",
-        "GetBaseException",
-        "GetObjectData",
-        "HelpLink",
-        "HResult",
-        "InnerException",
-        "Message",
-        "Source",
-        "StackTrace",
-        "TargetSite",
-    ];
-
-    let needs_mangling = match field_type {
-        FieldType::Exception => OBJECT_BASE_NAMES.contains(&identifier) | EXCEPTION_BASE_NAMES.contains(&identifier),
-        FieldType::Class => OBJECT_BASE_NAMES.contains(&identifier),
-        FieldType::NonMangled => false,
-    };
-
-    // If the name conflicts with a base method, add a Slice prefix to it.
-    if needs_mangling {
-        format!("Slice{identifier}")
-    } else {
-        identifier.to_owned()
-    }
-}
-
 pub trait CsCase {
     fn to_cs_case(&self, case: Case) -> String;
 }

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -9,7 +9,7 @@ use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
 use slicec::utils::code_gen_util::*;
 
-pub fn decode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, encoding: Encoding) -> CodeBlock {
+pub fn decode_fields(fields: &[&Field], namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
 
     let (required_fields, tagged_fields) = get_sorted_members(fields);
@@ -28,7 +28,7 @@ pub fn decode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, 
         writeln!(
             code,
             "this.{param} = {decode};",
-            param = field.field_name(field_type),
+            param = field.field_name(),
             decode = decode_member(field, namespace, encoding),
         );
     }
@@ -38,7 +38,7 @@ pub fn decode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, 
         writeln!(
             code,
             "this.{param} = {decode};",
-            param = field.field_name(field_type),
+            param = field.field_name(),
             decode = decode_tagged(field, namespace, true, encoding),
         );
     }
@@ -46,13 +46,7 @@ pub fn decode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, 
     code
 }
 
-pub fn decode_enum_fields(
-    fields: &[&Field],
-    enum_class: &str,
-    namespace: &str,
-    field_type: FieldType,
-    encoding: Encoding,
-) -> CodeBlock {
+pub fn decode_enum_fields(fields: &[&Field], enum_class: &str, namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
 
     let (required_fields, tagged_fields) = get_sorted_members(fields);
@@ -74,7 +68,7 @@ pub fn decode_enum_fields(
     for field in required_fields {
         new_instance_builder.add_argument(&format!(
             "{field_name}: {field_value}",
-            field_name = field.field_name(field_type),
+            field_name = field.field_name(),
             field_value = decode_member(field, namespace, encoding),
         ));
     }
@@ -83,7 +77,7 @@ pub fn decode_enum_fields(
     for field in tagged_fields {
         new_instance_builder.add_argument(&format!(
             "{field_name}: {field_value}",
-            field_name = field.field_name(field_type),
+            field_name = field.field_name(),
             field_value = decode_tagged(field, namespace, true, encoding),
         ));
     }

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -2,14 +2,13 @@
 
 use crate::builders::{Builder, FunctionCallBuilder};
 use crate::cs_attributes::CsType;
-use crate::cs_util::*;
 use crate::slicec_ext::*;
 use convert_case::Case;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
 use slicec::utils::code_gen_util::*;
 
-pub fn encode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, encoding: Encoding) -> CodeBlock {
+pub fn encode_fields(fields: &[&Field], namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
 
     let (required_fields, tagged_fields) = get_sorted_members(fields);
@@ -24,7 +23,7 @@ pub fn encode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, 
     }
 
     for field in required_fields {
-        let param = format!("this.{}", field.field_name(field_type));
+        let param = format!("this.{}", field.field_name());
         code.writeln(&encode_type(
             field.data_type(),
             TypeContext::Field,
@@ -37,7 +36,7 @@ pub fn encode_fields(fields: &[&Field], namespace: &str, field_type: FieldType, 
 
     // Encode tagged
     for field in tagged_fields {
-        let param = format!("this.{}", field.field_name(field_type));
+        let param = format!("this.{}", field.field_name());
         code.writeln(&encode_tagged_type(
             field,
             namespace,

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -3,7 +3,6 @@
 use crate::builders::{
     AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, FunctionBuilder, FunctionCallBuilder, FunctionType,
 };
-use crate::cs_util::*;
 use crate::decoding::decode_fields;
 use crate::encoding::encode_fields;
 use crate::member_util::*;
@@ -51,7 +50,7 @@ pub fn generate_class(class_def: &Class) -> CodeBlock {
     class_builder.add_block(
         fields
             .iter()
-            .map(|m| field_declaration(m, FieldType::Class))
+            .map(|m| field_declaration(m))
             .collect::<Vec<_>>()
             .join("\n\n")
             .into(),
@@ -115,7 +114,7 @@ pub fn generate_class(class_def: &Class) -> CodeBlock {
         decode_constructor.add_base_parameter("ref decoder");
     }
     decode_constructor
-        .set_body(initialize_required_fields(&fields, FieldType::Class))
+        .set_body(initialize_required_fields(&fields))
         .add_never_editor_browsable_attribute();
 
     class_builder.add_block(decode_constructor.build());
@@ -153,12 +152,7 @@ fn constructor(
     builder.set_body({
         let mut code = CodeBlock::default();
         for field in fields {
-            writeln!(
-                code,
-                "this.{} = {};",
-                field.field_name(FieldType::Class),
-                field.parameter_name(),
-            );
+            writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name(),);
         }
         code
     });
@@ -190,7 +184,6 @@ fn encode_and_decode(class_def: &Class) -> CodeBlock {
             code.writeln(&encode_fields(
                 &fields,
                 namespace,
-                FieldType::Class,
                 Encoding::Slice1, // classes are Slice1 only
             ));
 
@@ -214,7 +207,6 @@ fn encode_and_decode(class_def: &Class) -> CodeBlock {
             code.writeln(&decode_fields(
                 &fields,
                 namespace,
-                FieldType::Class,
                 Encoding::Slice1, // classes are Slice1 only
             ));
             code.writeln("decoder.EndSlice();");

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -2,7 +2,6 @@
 
 use crate::builders::{AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, FunctionBuilder, FunctionType};
 use crate::cs_attributes::CsEncodedReturn;
-use crate::cs_util::*;
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::slicec_ext::*;
@@ -429,7 +428,7 @@ await request.DecodeEmptyArgsAsync({encoding}, cancellationToken).ConfigureAwait
         [parameter] => vec![parameter.parameter_name_with_prefix("sliceP_")],
         _ => parameters
             .into_iter()
-            .map(|parameter| "args.".to_owned() + &parameter.field_name(FieldType::NonMangled))
+            .map(|parameter| "args.".to_owned() + &parameter.field_name())
             .collect(),
     };
     args.push("request.Features".to_owned());
@@ -528,7 +527,7 @@ fn dispatch_return_payload(operation: &Operation, encoding: &str) -> CodeBlock {
         1 => "returnValue".to_owned(),
         _ => non_streamed_return_values
             .iter()
-            .map(|r| format!("returnValue.{}", &r.field_name(FieldType::NonMangled)))
+            .map(|r| format!("returnValue.{}", &r.field_name()))
             .collect::<Vec<_>>()
             .join(", "),
     });
@@ -555,7 +554,7 @@ fn payload_continuation(operation: &Operation, encoding: &str) -> CodeBlock {
             let stream_arg = if return_values.len() == 1 {
                 "returnValue".to_owned()
             } else {
-                format!("returnValue.{}", &stream_return.field_name(FieldType::NonMangled))
+                format!("returnValue.{}", &stream_return.field_name())
             };
 
             match stream_type.concrete_type() {

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -2,7 +2,7 @@
 
 use crate::builders::{AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, FunctionBuilder, FunctionType};
 use crate::comments::CommentTag;
-use crate::cs_util::{CsCase, FieldType};
+use crate::cs_util::CsCase;
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::slicec_ext::*;
@@ -172,7 +172,6 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                     code.writeln(&encode_fields(
                         &enumerator.fields(),
                         &namespace,
-                        FieldType::NonMangled,
                         Encoding::Slice2,
                     ));
 
@@ -522,7 +521,6 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
                             &enumerator.fields(),
                             &decoded_type,
                             &namespace,
-                            FieldType::NonMangled,
                             Encoding::Slice2,
                         ));
 

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -4,7 +4,6 @@ use crate::builders::{
     AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, EncodingBlockBuilder, FunctionBuilder, FunctionType,
 };
 use crate::cs_attributes::CsReadonly;
-use crate::cs_util::FieldType;
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::member_util::*;
@@ -36,7 +35,7 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     builder.add_block(
         fields
             .iter()
-            .map(|m| field_declaration(m, FieldType::NonMangled))
+            .map(|m| field_declaration(m))
             .collect::<Vec<_>>()
             .join("\n\n")
             .into(),
@@ -64,12 +63,7 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     main_constructor.set_body({
         let mut code = CodeBlock::default();
         for field in &fields {
-            writeln!(
-                code,
-                "this.{} = {};",
-                field.field_name(FieldType::NonMangled),
-                field.parameter_name(),
-            );
+            writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name(),);
         }
         code
     });
@@ -78,10 +72,10 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     // Decode constructor
     let mut decode_body = EncodingBlockBuilder::new("decoder.Encoding", struct_def.supported_encodings())
         .add_encoding_block(Encoding::Slice1, || {
-            decode_fields(&fields, &namespace, FieldType::NonMangled, Encoding::Slice1)
+            decode_fields(&fields, &namespace, Encoding::Slice1)
         })
         .add_encoding_block(Encoding::Slice2, || {
-            decode_fields(&fields, &namespace, FieldType::NonMangled, Encoding::Slice2)
+            decode_fields(&fields, &namespace, Encoding::Slice2)
         })
         .build();
 
@@ -112,10 +106,10 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     // Encode method
     let mut encode_body = EncodingBlockBuilder::new("encoder.Encoding", struct_def.supported_encodings())
         .add_encoding_block(Encoding::Slice1, || {
-            encode_fields(&fields, &namespace, FieldType::NonMangled, Encoding::Slice1)
+            encode_fields(&fields, &namespace, Encoding::Slice1)
         })
         .add_encoding_block(Encoding::Slice2, || {
-            encode_fields(&fields, &namespace, FieldType::NonMangled, Encoding::Slice2)
+            encode_fields(&fields, &namespace, Encoding::Slice2)
         })
         .build();
 

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::comments::CommentTag;
-use crate::cs_util::*;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::{Contained, Field, Member};
@@ -15,7 +14,7 @@ pub fn escape_parameter_name(parameters: &[&impl Member], name: &str) -> String 
     }
 }
 
-pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
+pub fn field_declaration(field: &Field) -> String {
     let type_string = field
         .data_type()
         .cs_type_string(&field.namespace(), TypeContext::Field, false);
@@ -38,14 +37,13 @@ pub fn field_declaration(field: &Field, field_type: FieldType) -> String {
 {prelude}
 {access} {type_string} {name} {{ get; {setter}; }}",
         access = field.parent().access_modifier(),
-        name = field.field_name(field_type),
+        name = field.field_name(),
         setter = if field.is_cs_readonly() { "init" } else { "set" },
     )
 }
 
-pub fn initialize_required_fields(fields: &[&Field], field_type: FieldType) -> CodeBlock {
+pub fn initialize_required_fields(fields: &[&Field]) -> CodeBlock {
     // This helper should only be used for classes and exceptions
-    debug_assert!(matches!(field_type, FieldType::Class | FieldType::Exception));
 
     let mut code = CodeBlock::default();
 
@@ -54,7 +52,7 @@ pub fn initialize_required_fields(fields: &[&Field], field_type: FieldType) -> C
         if !data_type.is_optional && !data_type.is_value_type() {
             // This is to suppress compiler warnings for non-nullable fields.
             // We don't need it for value fields since they are initialized to default.
-            writeln!(code, "this.{} = default!;", field.field_name(field_type));
+            writeln!(code, "this.{} = default!;", field.field_name());
         }
     }
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -2,7 +2,7 @@
 
 use super::{EntityExt, TypeRefExt};
 use crate::cs_attributes::CsReadonly;
-use crate::cs_util::{escape_keyword, format_comment_message, mangle_name, FieldType};
+use crate::cs_util::{escape_keyword, format_comment_message};
 use convert_case::Case;
 use slicec::grammar::*;
 use slicec::utils::code_gen_util::TypeContext;
@@ -10,7 +10,7 @@ use slicec::utils::code_gen_util::TypeContext;
 pub trait MemberExt {
     fn parameter_name(&self) -> String;
     fn parameter_name_with_prefix(&self, prefix: &str) -> String;
-    fn field_name(&self, field_type: FieldType) -> String;
+    fn field_name(&self) -> String;
 }
 
 impl<T: Member> MemberExt for T {
@@ -23,8 +23,8 @@ impl<T: Member> MemberExt for T {
         escape_keyword(&name)
     }
 
-    fn field_name(&self, field_type: FieldType) -> String {
-        mangle_name(&self.escape_identifier(), field_type)
+    fn field_name(&self) -> String {
+        self.escape_identifier()
     }
 }
 
@@ -104,9 +104,7 @@ impl ParameterSliceExt for [&Parameter] {
             _ => format!(
                 "({})",
                 self.iter()
-                    .map(|m| m.cs_type_string(namespace, context, ignore_optional)
-                        + " "
-                        + &m.field_name(FieldType::NonMangled))
+                    .map(|m| m.cs_type_string(namespace, context, ignore_optional) + " " + &m.field_name())
                     .collect::<Vec<String>>()
                     .join(", "),
             ),

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -2,7 +2,6 @@
 
 use super::{EntityExt, MemberExt, ParameterExt, ParameterSliceExt};
 use crate::cs_attributes::CsEncodedReturn;
-use crate::cs_util::FieldType;
 use slicec::grammar::{AttributeFunctions, Contained, Operation};
 use slicec::utils::code_gen_util::TypeContext;
 
@@ -60,7 +59,7 @@ fn operation_return_type(operation: &Operation, is_dispatch: bool, context: Type
             format!(
                 "(global::System.IO.Pipelines.PipeReader Payload, {} {})",
                 stream_member.cs_type_string(&namespace, context, false),
-                stream_member.field_name(FieldType::NonMangled),
+                stream_member.field_name(),
             )
         } else {
             "global::System.IO.Pipelines.PipeReader".to_owned()


### PR DESCRIPTION
This PR removes the field name escaping (or mangling), where we would add a Slice prefix to a mapped field name if it matched `Equals` or other various common methods. 

It was not really correct since we didn't apply this logic to struct fields.

After this PR, a user with a field named `Equals` needs to remap it with `cs::identifier`. Otherwise, he'll get a C# compilation error.

Fixes #3859  