### PR TITLE
Simplify Activator API

### DIFF
--- a/build/CodeAnalysis.Base.globalconfig
+++ b/build/CodeAnalysis.Base.globalconfig
@@ -160,6 +160,9 @@ dotnet_diagnostic.SA1000.severity = warning
 # SA1001: Commas should not be preceded by whitespace
 dotnet_diagnostic.SA1001.severity = warning
 
+# SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none
+
 # SA1013: Closing brace should not be preceded by a space
 dotnet_diagnostic.SA1013.severity = warning
 

--- a/src/ZeroC.Slice/IActivator.cs
+++ b/src/ZeroC.Slice/IActivator.cs
@@ -31,14 +31,12 @@ public interface IActivator
 
     /// <summary>Creates an instance of a Slice class based on a type ID.</summary>
     /// <param name="typeId">The Slice type ID.</param>
-    /// <param name="decoder">The decoder.</param>
     /// <returns>A new instance of the class identified by <paramref name="typeId" />.</returns>
-    object? CreateClassInstance(string typeId, ref SliceDecoder decoder);
+    object? CreateClassInstance(string typeId);
 
     /// <summary>Creates an instance of a Slice exception based on a type ID.</summary>
     /// <param name="typeId">The Slice type ID.</param>
-    /// <param name="decoder">The decoder.</param>
     /// <param name="message">The exception message.</param>
     /// <returns>A new instance of the class identified by <paramref name="typeId" />.</returns>
-    object? CreateExceptionInstance(string typeId, ref SliceDecoder decoder, string? message);
+    object? CreateExceptionInstance(string typeId, string? message);
 }

--- a/src/ZeroC.Slice/SliceDecoder.Class.cs
+++ b/src/ZeroC.Slice/SliceDecoder.Class.cs
@@ -50,7 +50,7 @@ public ref partial struct SliceDecoder
 
             DecodeIndirectionTableIntoCurrent(); // we decode the indirection table immediately.
 
-            sliceException = activator.CreateExceptionInstance(typeId, ref this, message) as SliceException;
+            sliceException = activator.CreateExceptionInstance(typeId, message) as SliceException;
             if (sliceException is null && SkipSlice(typeId))
             {
                 // Cannot decode this exception.
@@ -261,7 +261,7 @@ public ref partial struct SliceDecoder
             // not created yet.
             if (typeId is not null)
             {
-                instance = activator.CreateClassInstance(typeId, ref this) as SliceClass;
+                instance = activator.CreateClassInstance(typeId) as SliceClass;
             }
 
             if (instance is null && SkipSlice(typeId))

--- a/tests/ZeroC.Slice.Tests/ActivatorTests.cs
+++ b/tests/ZeroC.Slice.Tests/ActivatorTests.cs
@@ -66,10 +66,8 @@ public class ActivatorTests
     [Test, TestCaseSource(nameof(ReferencedAssembliesClassTypeIds))]
     public void Activator_cannot_create_instances_of_classes_defined_in_unknown_assemblies(string typeId)
     {
-        var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(typeof(SliceDecoder).Assembly);
-
-        object? instance = sut.CreateClassInstance(typeId, ref decoder);
+        object? instance = sut.CreateClassInstance(typeId);
 
         Assert.That(instance, Is.Null);
     }
@@ -77,10 +75,9 @@ public class ActivatorTests
     [Test, TestCaseSource(nameof(ReferencedAssembliesClassTypeIds))]
     public void Activator_cannot_create_instances_of_exceptions_defined_in_unknown_assemblies(string typeId)
     {
-        var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(typeof(SliceDecoder).Assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId, ref decoder, message: null);
+        object? instance = sut.CreateExceptionInstance(typeId, message: null);
 
         Assert.That(instance, Is.Null);
     }
@@ -91,10 +88,9 @@ public class ActivatorTests
         string typeId,
         Type expectedType)
     {
-        var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(assembly);
 
-        object? instance = sut.CreateClassInstance(typeId, ref decoder);
+        object? instance = sut.CreateClassInstance(typeId);
 
         Assert.That(instance, Is.Not.Null);
         Assert.That(instance!.GetType(), Is.EqualTo(expectedType));
@@ -109,7 +105,7 @@ public class ActivatorTests
         var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId, ref decoder, message: null);
+        object? instance = sut.CreateExceptionInstance(typeId, message: null);
 
         Assert.That(instance, Is.Not.Null);
         Assert.That(instance!.GetType(), Is.EqualTo(expectedType));

--- a/tests/ZeroC.Slice.Tests/SlicingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SlicingTests.cs
@@ -268,10 +268,10 @@ public class SlicingTests
             _excludeTypeId = excludeTypeId;
         }
 
-        public object? CreateClassInstance(string typeId, ref SliceDecoder decoder) =>
-            _excludeTypeId == typeId ? null : _decoratee.CreateClassInstance(typeId, ref decoder);
+        public object? CreateClassInstance(string typeId) =>
+            _excludeTypeId == typeId ? null : _decoratee.CreateClassInstance(typeId);
 
-        public object? CreateExceptionInstance(string typeId, ref SliceDecoder decoder, string? message) =>
-            _excludeTypeId == typeId ? null : _decoratee.CreateExceptionInstance(typeId, ref decoder, message);
+        public object? CreateExceptionInstance(string typeId, string? message) =>
+            _excludeTypeId == typeId ? null : _decoratee.CreateExceptionInstance(typeId, message);
     }
 }

--- a/tests/ZeroC.Slice.Tests/TaggedTests.cs
+++ b/tests/ZeroC.Slice.Tests/TaggedTests.cs
@@ -538,11 +538,11 @@ public class TaggedTests
         private readonly string _replacementTypeId;
         private readonly string _typeId;
 
-        public object? CreateClassInstance(string typeId, ref SliceDecoder decoder) =>
-            _decoratee.CreateClassInstance(typeId == _typeId ? _replacementTypeId : typeId, ref decoder);
+        public object? CreateClassInstance(string typeId) =>
+            _decoratee.CreateClassInstance(typeId == _typeId ? _replacementTypeId : typeId);
 
-        public object? CreateExceptionInstance(string typeId, ref SliceDecoder decoder, string? message) =>
-            _decoratee.CreateExceptionInstance(typeId, ref decoder, message);
+        public object? CreateExceptionInstance(string typeId, string? message) =>
+            _decoratee.CreateExceptionInstance(typeId, message);
 
         internal TypeReplacementActivator(IActivator decoratee, string typeId, string replacementTypeId)
         {

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -63,9 +63,9 @@ pub fn generate_exception(exception_def: &Exception) -> CodeBlock {
                         &exception_name
                     ),
                 )
-                .add_parameter("string?", "message", Some("null"), None)
+                .add_parameter("string?", "message", None, None)
                 .add_base_parameter("message")
-                .add_parameter("global::System.Exception?", "innerException", Some("null"), None)
+                .add_parameter("global::System.Exception?", "innerException", None, None)
                 .add_base_parameter("innerException")
                 .set_body(initialize_required_fields(fields))
                 .build(),


### PR DESCRIPTION
This PR simplifies the Activator API by removing the unused `ref SliceDecoder` parameter.

Fixes #3876.