### PR TITLE
Update slicec-cs to generate code for Result<Success, Failure>

### DIFF
--- a/src/ZeroC.Slice/Result.cs
+++ b/src/ZeroC.Slice/Result.cs
@@ -6,7 +6,7 @@ namespace ZeroC.Slice;
 /// type of Slice operations.</summary>
 /// <typeparam name="TSuccess">The success type.</typeparam>
 /// <typeparam name="TFailure">The failure type.</typeparam>
-/// <remarks>The Slice built-in generic type Result maps to this class in C#.</remarks>
+/// <remarks>The Slice Result type (a built-in generic type) maps to this generic class in C#.</remarks>
 [Dunet.Union]
 public abstract partial record class Result<TSuccess, TFailure>
 {

--- a/src/ZeroC.Slice/Result.cs
+++ b/src/ZeroC.Slice/Result.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace ZeroC.Slice;
+
+/// <summary>A discriminated union that represents either a success or a failure. It is typically used as the return
+/// type of Slice operations.</summary>
+/// <typeparam name="TSuccess">The success type.</typeparam>
+/// <typeparam name="TFailure">The failure type.</typeparam>
+/// <remarks>The Slice built-in generic type Result maps to this class in C#.</remarks>
+[Dunet.Union]
+public abstract partial record class Result<TSuccess, TFailure>
+{
+    /// <summary>Represents a successful <see cref="Result{TSuccess, TFailure}" />.</summary>
+    public partial record class Success(TSuccess Value);
+
+    /// <summary>Represents a failed <see cref="Result{TSuccess, TFailure}" />.</summary>
+    public partial record class Failure(TFailure Value);
+}

--- a/src/ZeroC.Slice/SliceDecoderExtensions.cs
+++ b/src/ZeroC.Slice/SliceDecoderExtensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -86,6 +87,24 @@ public static class SliceDecoderExtensions
             return dictionary;
         }
     }
+
+    /// <summary>Decodes a result.</summary>
+    /// <typeparam name="TSuccess">The type of the success value.</typeparam>
+    /// <typeparam name="TFailure">The type of the failure value.</typeparam>
+    /// <param name="decoder">The Slice decoder.</param>
+    /// <param name="successDecodeFunc">The decode function for the success type.</param>
+    /// <param name="failureDecodeFunc">The decode function for the failure type.</param>
+    /// <returns>The decoded result.</returns>
+    public static Result<TSuccess, TFailure> DecodeResult<TSuccess, TFailure>(
+        this ref SliceDecoder decoder,
+        DecodeFunc<TSuccess> successDecodeFunc,
+        DecodeFunc<TFailure> failureDecodeFunc) =>
+        decoder.DecodeVarInt32() switch
+        {
+            0 => new Result<TSuccess, TFailure>.Success(successDecodeFunc(ref decoder)),
+            1 => new Result<TSuccess, TFailure>.Failure(failureDecodeFunc(ref decoder)),
+            int value => throw new InvalidDataException($"Received invalid discriminant value '{value}' for Result.")
+        };
 
     /// <summary>Decodes a sequence of fixed-size numeric values.</summary>
     /// <typeparam name="T">The sequence element type.</typeparam>

--- a/src/ZeroC.Slice/SliceDecoderExtensions.cs
+++ b/src/ZeroC.Slice/SliceDecoderExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/ZeroC.Slice/ZeroC.Slice.csproj
+++ b/src/ZeroC.Slice/ZeroC.Slice.csproj
@@ -16,6 +16,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="dunet" Version="1.11.0" />
     </ItemGroup>
     <!-- NuGet package contents-->
     <!-- There is no need to compile the well known types with the Slice compiler since they are all custom. -->

--- a/tests/IceRpc.Slice.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Tests/OperationTests.cs
@@ -6,6 +6,7 @@ using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;
+using ZeroC.Slice;
 
 namespace IceRpc.Slice.Tests;
 
@@ -80,6 +81,36 @@ public partial class OperationTests
 
         Assert.That(r1, Is.EqualTo(10));
         Assert.That(r2, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task Operation_with_result_success()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+        var arg = new Result<string, int>.Success("hello");
+
+        // Act
+        Result<string, int> r = await proxy.OpWithResultAsync(arg);
+
+        // Assert
+        Assert.That(r, Is.EqualTo(arg));
+    }
+
+    [Test]
+    public async Task Operation_with_result_failure()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+        var arg = new Result<string, int>.Failure(123);
+
+        // Act
+        Result<string, int> r = await proxy.OpWithResultAsync(arg);
+
+        // Assert
+        Assert.That(r, Is.EqualTo(arg));
     }
 
     [Test]
@@ -696,6 +727,11 @@ public partial class OperationTests
             int p2,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new((p1, p2));
+
+        public ValueTask<Result<string, int>> OpWithResultAsync(
+            Result<string, int> p,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p);
 
         public ValueTask<int> OpWithCompressArgsAndReturnAttributeAsync(
             int p,

--- a/tests/IceRpc.Slice.Tests/OperationTests.slice
+++ b/tests/IceRpc.Slice.Tests/OperationTests.slice
@@ -13,6 +13,9 @@ interface MyOperationsA {
     // Multiple parameter and return
     opWithMultipleParametersAndReturnValues(p1: int32, p2: int32) -> (r1: int32, r2: int32)
 
+    // operation that accepts and returns a Result
+    opWithResult(p: Result<string, int32>) -> Result<string, int32>
+
     // Compress attribute
     [compress(Args, Return)] opWithCompressArgsAndReturnAttribute(p: int32) -> int32
 
@@ -33,7 +36,7 @@ interface MyOperationsA {
     // cancel and features as regular parameter names
     opWithSpecialParameterNames(cancel: int32, features: int32)
 
-    // Encoded result
+    // Encoded return
     [cs::encodedReturn] opWithSingleReturnValueAndEncodedReturnAttribute() -> Sequence<int32>
     [cs::encodedReturn] opWithMultipleReturnValuesAndEncodedReturnAttribute() -> (r1: Sequence<int32>, r2: Sequence<int32>)
     [cs::encodedReturn] opWithStreamReturnAndEncodedReturnAttribute() -> (r1: Sequence<int32>, r2: stream int32)

--- a/tests/ZeroC.Slice.Tests/ResultTests.cs
+++ b/tests/ZeroC.Slice.Tests/ResultTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ZeroC, Inc.
+
+using NUnit.Framework;
+
+namespace ZeroC.Slice.Tests;
+
+public class ResultTests
+{
+    [Test]
+    public void String_int32_result_encoded_like_compact_enum_with_fields([Values]bool success)
+    {
+        // Arrange
+        const string successValue = "hello";
+        const int failureValue = 123;
+
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        StringInt32Result result =
+            success ? new StringInt32Result.Success(successValue) : new StringInt32Result.Failure(failureValue);
+
+        encoder.EncodeStringInt32Result(result);
+
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
+
+        // Act
+        var holder = new StringInt32ResultHolder(ref decoder);
+
+        // Assert
+        if (success)
+        {
+            holder.Value.MatchSuccess(
+                success => Assert.That(success.Value, Is.EqualTo(successValue)),
+                () => Assert.Fail("Expected success"));
+        }
+        else
+        {
+            holder.Value.MatchFailure(
+                failure => Assert.That(failure.Value, Is.EqualTo(failureValue)),
+                () => Assert.Fail("Expected failure"));
+        }
+        Assert.That(decoder.Consumed, Is.EqualTo(encoder.EncodedByteCount));
+    }
+
+    [TestCase(null)]
+    [TestCase(123)]
+    public void String_opt_int32_result_encoded_like_compact_enum_with_fields(int? failureValue)
+    {
+        // Arrange
+
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        var result = new StringOptInt32Result.Failure(failureValue);
+
+        encoder.EncodeStringOptInt32Result(result);
+
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
+
+        // Act
+        var holder = new StringOptInt32ResultHolder(ref decoder);
+
+        // Assert
+        holder.Value.MatchFailure(
+            failure => Assert.That(failure.Value, Is.EqualTo(failureValue)),
+            () => Assert.Fail("Expected failure"));
+
+        Assert.That(decoder.Consumed, Is.EqualTo(encoder.EncodedByteCount));
+    }
+}

--- a/tests/ZeroC.Slice.Tests/ResultTests.slice
+++ b/tests/ZeroC.Slice.Tests/ResultTests.slice
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+module ZeroC::Slice::Tests
+
+// Equivalent to a Result<string, int32>
+compact enum StringInt32Result {
+    Success(value: string)
+    Failure(value: int32)
+}
+
+compact struct StringInt32ResultHolder {
+    value: Result<string, int32>
+}
+
+// Equivalent to a Result<string, int32?>
+compact enum StringOptInt32Result {
+    Success(value: string)
+    Failure(value: int32?)
+}
+
+compact struct StringOptInt32ResultHolder {
+    value: Result<string, int32?>
+}

--- a/tests/ZeroC.Slice.Tests/ZeroC.Slice.Tests.csproj
+++ b/tests/ZeroC.Slice.Tests/ZeroC.Slice.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -13,10 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="dunet" Version="1.10.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -605,7 +605,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "slicec"
 version = "0.2.1"
-source = "git+https://github.com/icerpc/slicec?rev=299638df7656c8c0370d5fad9e7756978e2a88eb#299638df7656c8c0370d5fad9e7756978e2a88eb"
+source = "git+https://github.com/icerpc/slicec?rev=7dcf09006f7684e14d5bfd865578fa9cca112f7e#7dcf09006f7684e14d5bfd865578fa9cca112f7e"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -605,7 +605,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "slicec"
 version = "0.2.1"
-source = "git+https://github.com/icerpc/slicec?rev=afba8cf1cde99fdbf475aa2839c08866076d8e77#afba8cf1cde99fdbf475aa2839c08866076d8e77"
+source = "git+https://github.com/icerpc/slicec?rev=299638df7656c8c0370d5fad9e7756978e2a88eb#299638df7656c8c0370d5fad9e7756978e2a88eb"
 dependencies = [
  "clap",
  "console",

--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 clap = { version = "4.3.15", features = ["derive"] }
 convert_case = "0.6.0"
 in_definite = "1.0.0"
-slicec = { git = "https://github.com/icerpc/slicec", rev = "299638df7656c8c0370d5fad9e7756978e2a88eb" }
+slicec = { git = "https://github.com/icerpc/slicec", rev = "7dcf09006f7684e14d5bfd865578fa9cca112f7e" }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 clap = { version = "4.3.15", features = ["derive"] }
 convert_case = "0.6.0"
 in_definite = "1.0.0"
-slicec = { git = "https://github.com/icerpc/slicec", rev = "afba8cf1cde99fdbf475aa2839c08866076d8e77" }
+slicec = { git = "https://github.com/icerpc/slicec", rev = "299638df7656c8c0370d5fad9e7756978e2a88eb" }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -238,9 +238,9 @@ pub fn decode_result(result_type_ref: &TypeRef<ResultType>, namespace: &str, enc
 
     format!(
         "\
-    decoder.DecodeResult(
-        {decode_success},
-        {decode_failure})"
+decoder.DecodeResult(
+    {decode_success},
+    {decode_failure})"
     )
     .into()
 }
@@ -428,12 +428,15 @@ fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) 
             );
         }
 
-        decode_func_body.indent();
+        let mut decode_func = CodeBlock::from(format!(
+            "\
+(ref SliceDecoder decoder) => decoder.DecodeBool() ?
+    {decode_func_body}
+    : null",
+        ));
 
-        // TODO: this won't result is a nice looking line when decode_func_body is multi-line
-        CodeBlock::from(format!(
-            "(ref SliceDecoder decoder) => decoder.DecodeBool() ? {decode_func_body} : null"
-        ))
+        decode_func.indent();
+        decode_func
     } else {
         let mut decode_func = decode_func(type_ref, namespace, encoding);
 
@@ -446,7 +449,7 @@ fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) 
             );
         }
 
-        decode_func.indent(); // TODO: this doesn't work
+        decode_func.indent();
         decode_func
     }
 }

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -230,8 +230,8 @@ decoder.DecodeDictionary(
 
 pub fn decode_result(result_type_ref: &TypeRef<ResultType>, namespace: &str, encoding: Encoding) -> CodeBlock {
     assert!(encoding != Encoding::Slice1);
-    let success_type = &result_type_ref.ok_type;
-    let failure_type = &result_type_ref.err_type;
+    let success_type = &result_type_ref.success_type;
+    let failure_type = &result_type_ref.failure_type;
 
     let decode_success = decode_result_field(success_type, namespace, encoding);
     let decode_failure = decode_result_field(failure_type, namespace, encoding);

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -442,8 +442,8 @@ fn encode_result(
     encoder_param: &str,
     encoding: Encoding,
 ) -> CodeBlock {
-    let success_type = &result_type_def.ok_type;
-    let failure_type = &result_type_def.err_type;
+    let success_type = &result_type_def.success_type;
+    let failure_type = &result_type_def.failure_type;
     format!(
         "\
 {encoder_param}.EncodeResult(

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -112,10 +112,10 @@ fn dictionary_type_to_string(dictionary_ref: &TypeRef<Dictionary>, namespace: &s
 // Helper method to convert a result type into a string
 fn result_type_to_string(result_type_ref: &TypeRef<ResultType>, namespace: &str) -> String {
     let success_type = result_type_ref
-        .ok_type
+        .success_type
         .cs_type_string(namespace, TypeContext::Nested, false);
     let failure_type = result_type_ref
-        .err_type
+        .failure_type
         .cs_type_string(namespace, TypeContext::Nested, false);
 
     format!("Result<{success_type}, {failure_type}>")

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -28,6 +28,7 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
             TypeRefs::Struct(struct_ref) => struct_ref.escape_scoped_identifier(namespace),
             TypeRefs::Class(class_ref) => class_ref.escape_scoped_identifier(namespace),
             TypeRefs::Enum(enum_ref) => enum_ref.escape_scoped_identifier(namespace),
+            TypeRefs::ResultType(result_type_ref) => result_type_to_string(result_type_ref, namespace),
             TypeRefs::CustomType(custom_type_ref) => {
                 let attribute = custom_type_ref.definition().find_attribute::<CsType>();
                 attribute.unwrap().type_string.clone()
@@ -106,4 +107,16 @@ fn dictionary_type_to_string(dictionary_ref: &TypeRef<Dictionary>, namespace: &s
                 "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<{key_type}, {value_type}>>"
             )
     }
+}
+
+// Helper method to convert a result type into a string
+fn result_type_to_string(result_type_ref: &TypeRef<ResultType>, namespace: &str) -> String {
+    let success_type = result_type_ref
+        .ok_type
+        .cs_type_string(namespace, TypeContext::Nested, false);
+    let failure_type = result_type_ref
+        .err_type
+        .cs_type_string(namespace, TypeContext::Nested, false);
+
+    format!("Result<{success_type}, {failure_type}>")
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -109,7 +109,7 @@ fn dictionary_type_to_string(dictionary_ref: &TypeRef<Dictionary>, namespace: &s
     }
 }
 
-// Helper method to convert a result type into a string
+/// Helper method to convert a result type into a string
 fn result_type_to_string(result_type_ref: &TypeRef<ResultType>, namespace: &str) -> String {
     let success_type = result_type_ref
         .success_type


### PR DESCRIPTION
This PR maps the new Slice built-in generic type Result<Success, Failure> to C#.

It also updates Dunet from version 1.10 to 1.11. Note that Dunet is now a runtime dependency (for the Dunet.Union attribute).

Fixes #3875.