### PR TITLE
Fix Broken Code Generation for Nested Optional Collections (Fixes #3881)

### DIFF
--- a/tests/IceRpc.Slice.Tests/DictionaryMappingTests.slice
+++ b/tests/IceRpc.Slice.Tests/DictionaryMappingTests.slice
@@ -71,3 +71,13 @@ interface DictionaryMappingOperations {
 compact struct StructWithCustomDictionary {
     value: [cs::type("CustomDictionary<int, int>")] Dictionary<int32, int32>
 }
+
+// Just to test that the generated code compiles.
+struct NestedOptionalDictionaries {
+    d1: Dictionary<string, Dictionary<string, Dictionary<string, bool?>>>
+    d2: Dictionary<string, Dictionary<string, Dictionary<string, bool>?>>
+    d3: Dictionary<string, Dictionary<string, Dictionary<string, bool>>?>
+    d4: Dictionary<string, Dictionary<string, Dictionary<string, bool>>>?
+
+    d5: Dictionary<string, Dictionary<string, Dictionary<string, bool?>?>?>?
+}

--- a/tests/IceRpc.Slice.Tests/SequenceMappingTests.slice
+++ b/tests/IceRpc.Slice.Tests/SequenceMappingTests.slice
@@ -81,3 +81,13 @@ interface SequenceMappingOperations {
         r2: [cs::type("CustomSequence<int>")] Sequence<int32>
     )
 }
+
+// Just to test that the generated code compiles.
+struct NestedOptionalSequences {
+    s1: Sequence<Sequence<Sequence<string?>>>
+    s2: Sequence<Sequence<Sequence<string>?>>
+    s3: Sequence<Sequence<Sequence<string>>?>
+    s4: Sequence<Sequence<Sequence<string>>>?
+
+    s5: Sequence<Sequence<Sequence<string?>?>?>?
+}

--- a/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
+++ b/tools/slicec-cs/src/cs_attributes/cs_identifier.rs
@@ -27,9 +27,9 @@ impl CsIdentifier {
                 report_unexpected_attribute(self, span, Some(&note), diagnostics);
             }
 
-            Attributables::SliceFile(_)
-            | Attributables::TypeAlias(_)
-            | Attributables::TypeRef(_) => report_unexpected_attribute(self, span, None, diagnostics),
+            Attributables::SliceFile(_) | Attributables::TypeAlias(_) | Attributables::TypeRef(_) => {
+                report_unexpected_attribute(self, span, None, diagnostics)
+            }
 
             _ => {}
         }

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -198,7 +198,7 @@ pub fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, 
         write!(
             decode_value,
             " as {}",
-            value_type.cs_type_string(namespace, TypeContext::Nested, false),
+            value_type.cs_type_string(namespace, TypeContext::Nested, true),
         );
     }
 
@@ -239,7 +239,7 @@ pub fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encodi
         write!(
             code,
             "({}[])",
-            element_type.cs_type_string(namespace, TypeContext::Nested, true),
+            element_type.cs_type_string(namespace, TypeContext::Nested, false),
         );
     };
 

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -386,7 +386,7 @@ fn encode_action_body(
             write!(
                 code,
                 "{}",
-                encode_dictionary(dictionary_ref, namespace, "value", "encoder", encoding)
+                encode_dictionary(dictionary_ref, namespace, value, "encoder", encoding)
             )
         }
         TypeRefs::Sequence(sequence_ref) => {
@@ -395,7 +395,7 @@ fn encode_action_body(
             write!(
                 code,
                 "{}",
-                encode_sequence(sequence_ref, namespace, "value", type_context, "encoder", encoding),
+                encode_sequence(sequence_ref, namespace, value, type_context, "encoder", encoding),
             )
         }
         TypeRefs::Struct(_) => write!(code, "{value}.Encode(ref encoder)"),


### PR DESCRIPTION
This small PR fixes the bug found in #3881, and fixes an identical bug that was causing dictionaries to break too.
In both cases we weren't correctly handled collections of optional collections. We perform a cast on the inner collection, and these casts weren't taking nullability into account when they needed to.

It also adds some 'tests', which just ensures that the generated code compiles.
Apart from the small test added in this PR, we have no tests for nested dictionaries in Slice.
We should probably add some.

@bernardnormier believes we can avoid these casts altogether by moving them into the factory.
But for now I'd like to get the bug fixed and some basic tests in place before we worry about cleaning things up.