### PR TITLE
Generate doc comment for @param on enumerator fields

### DIFF
--- a/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.slice
+++ b/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.slice
@@ -12,9 +12,21 @@ enum PaintColor {
     Yellow(shade: string, code: uint16?) // Extra enumerator, not compatible with Color
 }
 
+/// An extensive shape.
 unchecked enum Shape {
+    /// A circle.
+    /// @param radius: The radius of the circle.
     Circle(radius: uint32)
+
+    /// A rectangle.
+    /// @param width: The width of the rectangle.
+    /// @param height: The height of the rectangle.
     Rectangle(width: uint32, height: uint32)
+
+    /// A triangle.
+    /// @param side1: The length of the first side.
+    /// @param side2: The length of the second side.
+    /// @param side3: The length of the third side.
     Triangle(side1: uint32, side2: uint32, side3: uint32)
 }
 

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -132,8 +132,11 @@ impl ContainerBuilder {
         self
     }
 
-    pub fn add_field(&mut self, field: String) -> &mut Self {
-        self.fields.push(field);
+    pub fn add_field(&mut self, field_name: &str, field_type: &str, doc_comment: Option<&str>) -> &mut Self {
+        if let Some(comment) = doc_comment {
+            self.add_comment_with_attribute("param", "name", field_name, comment);
+        }
+        self.fields.push(format!("{field_type} {field_name}"));
         self
     }
 
@@ -143,8 +146,11 @@ impl ContainerBuilder {
                 .data_type()
                 .cs_type_string(&field.namespace(), TypeContext::Field, false);
 
-            self.fields
-                .push(format!("{type_string} {name}", name = field.field_name(),));
+            self.add_field(
+                &field.field_name(),
+                &type_string,
+                field.formatted_param_doc_comment().as_deref(),
+            );
         }
 
         self

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -374,7 +374,7 @@ impl FunctionBuilder {
                 &parameter_type,
                 &parameter_name,
                 default_value,
-                parameter.formatted_parameter_doc_comment(),
+                parameter.formatted_param_doc_comment(),
             );
         }
 

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -204,7 +204,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
                         &param.cs_type_string(namespace, TypeContext::Encode, false),
                         &param.parameter_name(),
                         None,
-                        param.formatted_parameter_doc_comment(),
+                        param.formatted_param_doc_comment(),
                     );
                 }
             }

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -197,9 +197,6 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
         let mut builder = ContainerBuilder::new("public partial record class", "Unknown");
 
         builder
-            .add_field("int Discriminant".to_owned())
-            .add_field("global::System.ReadOnlyMemory<byte> Fields".to_owned())
-            .add_base(enum_def.escape_identifier())
             .add_comment(
                 "summary",
                 format!(
@@ -207,18 +204,9 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                     enum_name = enum_def.identifier(),
                 ),
             )
-            .add_comment_with_attribute(
-                "param",
-                "name",
-                "Discriminant",
-                "The discriminant of this unknown enumerator.",
-            )
-            .add_comment_with_attribute(
-                "param",
-                "name",
-                "Fields",
-                "The encoded fields of this unknown enumerator.",
-            )
+            .add_field("Discriminant", "int", Some("The discriminant of this enumerator."))
+            .add_field("Fields", "global::System.ReadOnlyMemory<byte>", Some("The encoded fields of this unknown enumerator."))
+            .add_base(enum_def.escape_identifier())
             .add_block(
                 FunctionBuilder::new("internal override", "void", "Encode", FunctionType::BlockBody)
                     .add_parameter("ref SliceEncoder", "encoder", None, None)

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -204,7 +204,7 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                     enum_name = enum_def.identifier(),
                 ),
             )
-            .add_field("Discriminant", "int", Some("The discriminant of this enumerator."))
+            .add_field("Discriminant", "int", Some("The discriminant of this unknown enumerator."))
             .add_field("Fields", "global::System.ReadOnlyMemory<byte>", Some("The encoded fields of this unknown enumerator."))
             .add_base(enum_def.escape_identifier())
             .add_block(

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -492,7 +492,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
                 &param.cs_type_string(namespace, TypeContext::Encode, false),
                 &param.parameter_name(),
                 None,
-                param.formatted_parameter_doc_comment(),
+                param.formatted_param_doc_comment(),
             );
         }
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -55,7 +55,7 @@ impl FieldExt for Field {
                     .map(|param_tag| format_comment_message(&param_tag.message, &self.namespace()))
             })
         } else {
-            None
+            panic!("Called 'formatted_param_doc_comment' on field outside of enumerator!");
         }
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -32,6 +32,8 @@ pub trait FieldExt {
     /// Check if this field, or its parent struct, are marked with `cs::readonly`.
     fn is_cs_readonly(&self) -> bool;
 
+    /// Returns the value of the `@param` doc-comment tag for this enumerator field, if a tag with this field name is
+    /// present. Panics if this field is not an enumerator field.
     fn formatted_param_doc_comment(&self) -> Option<String>;
 }
 

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -45,9 +45,9 @@ impl FieldExt for Field {
 
     fn formatted_param_doc_comment(&self) -> Option<String> {
         if let Entities::Enumerator(enumerator) = self.parent().concrete_entity() {
-            // Check if this field's parent (enumerator) has a doc comment on it.
+            // Check if the enumerator has a doc comment on it.
             enumerator.comment().and_then(|comment| {
-                // If it did, search the comment for a '@param' tag with this parameter's identifier and return it.
+                // If it does, search the comment for a '@param' tag with this field's identifier and return it.
                 comment
                     .params
                     .iter()
@@ -65,7 +65,7 @@ pub trait ParameterExt {
 
     /// Returns the message of the `@param` tag corresponding to this parameter from the operation it's part of.
     /// If the operation has no doc comment, or a matching `@param` tag, this returns `None`.
-    fn formatted_parameter_doc_comment(&self) -> Option<String>;
+    fn formatted_param_doc_comment(&self) -> Option<String>;
 }
 
 impl ParameterExt for Parameter {
@@ -82,10 +82,10 @@ impl ParameterExt for Parameter {
         }
     }
 
-    fn formatted_parameter_doc_comment(&self) -> Option<String> {
-        // Check if this parameter's parent operation had a doc comment on it.
+    fn formatted_param_doc_comment(&self) -> Option<String> {
+        // Check if this parameter's parent operation has a doc comment on it.
         self.parent().comment().and_then(|comment| {
-            // If it did, search the comment for a '@param' tag with this parameter's identifier and return it.
+            // If it does, search the comment for a '@param' tag with this parameter's identifier and return it.
             comment
                 .params
                 .iter()


### PR DESCRIPTION
This PR updates slicec-cs to generate doc-comments (`<param name="..." ... />`) from @param doc comments on Slice enumerators.
