### PR TITLE
`slicec-cs` Cleanup Pass 1

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -483,11 +483,7 @@ impl Builder for FunctionBuilder {
 
         match self.base_arguments.as_slice() {
             [] => {}
-            _ => write!(
-                code,
-                "\n    : base({})",
-                self.base_arguments.join(", "),
-            ),
+            _ => write!(code, "\n    : base({})", self.base_arguments.join(", ")),
         }
 
         match self.function_type {

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -643,41 +643,41 @@ impl<'a> Builder for EncodingBlockBuilder<'a> {
             [] => panic!("No supported encodings"),
             [encoding] => self.encoding_blocks[encoding](),
             _ => {
-                let mut slice1_blocks = self.encoding_blocks[&Encoding::Slice1]();
-                let mut slice2_blocks = self.encoding_blocks[&Encoding::Slice2]();
+                let mut slice1_block = self.encoding_blocks[&Encoding::Slice1]();
+                let mut slice2_block = self.encoding_blocks[&Encoding::Slice2]();
 
-                // Only write one encoding block if `slice1_blocks` and `slice2_blocks` are the same.
-                if slice1_blocks.to_string() == slice2_blocks.to_string() {
-                    return slice2_blocks;
+                // Only write one encoding block if `slice1_block` and `slice2_block` are the same.
+                if slice1_block.to_string() == slice2_block.to_string() {
+                    return slice2_block;
                 }
 
-                if slice1_blocks.is_empty() && !slice2_blocks.is_empty() {
+                if slice1_block.is_empty() && !slice2_block.is_empty() {
                     format!(
                         "\
 if ({encoding_variable} != SliceEncoding.Slice1) // Slice2 only
 {{
-    {slice2_blocks}
+    {slice2_block}
 }}
 ",
                         encoding_variable = self.encoding_variable,
-                        slice2_blocks = slice2_blocks.indent(),
+                        slice2_block = slice2_block.indent(),
                     )
                     .into()
-                } else if !slice1_blocks.is_empty() && !slice2_blocks.is_empty() {
+                } else if !slice1_block.is_empty() && !slice2_block.is_empty() {
                     format!(
                         "\
 if ({encoding_variable} == SliceEncoding.Slice1)
 {{
-    {slice1_blocks}
+    {slice1_block}
 }}
 else // Slice2
 {{
-    {slice2_blocks}
+    {slice2_block}
 }}
 ",
                         encoding_variable = self.encoding_variable,
-                        slice1_blocks = slice1_blocks.indent(),
-                        slice2_blocks = slice2_blocks.indent(),
+                        slice1_block = slice1_block.indent(),
+                        slice2_block = slice2_block.indent(),
                     )
                     .into()
                 } else {

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -241,7 +241,6 @@ pub struct FunctionBuilder {
     return_type: String,
     parameters: Vec<String>,
     body: CodeBlock,
-    base_constructor: String,
     base_arguments: Vec<String>,
     comments: Vec<CommentTag>,
     attributes: Vec<String>,
@@ -251,16 +250,6 @@ pub struct FunctionBuilder {
 
 impl FunctionBuilder {
     pub fn new(access: &str, return_type: &str, name: &str, function_type: FunctionType) -> FunctionBuilder {
-        Self::new_with_base_constructor(access, return_type, name, "base", function_type)
-    }
-
-    pub fn new_with_base_constructor(
-        access: &str,
-        return_type: &str,
-        name: &str,
-        base_constructor: &str,
-        function_type: FunctionType,
-    ) -> FunctionBuilder {
         FunctionBuilder {
             parameters: Vec::new(),
             access: access.to_owned(),
@@ -269,7 +258,6 @@ impl FunctionBuilder {
             body: CodeBlock::default(),
             comments: Vec::new(),
             attributes: Vec::new(),
-            base_constructor: base_constructor.to_owned(),
             base_arguments: Vec::new(),
             function_type,
             inherit_doc: false,
@@ -497,8 +485,7 @@ impl Builder for FunctionBuilder {
             [] => {}
             _ => write!(
                 code,
-                "\n    : {}({})",
-                self.base_constructor,
+                "\n    : base({})",
                 self.base_arguments.join(", "),
             ),
         }

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -167,7 +167,7 @@ fn decode_member(member: &impl Member, namespace: &str, encoding: Encoding) -> C
     code
 }
 
-pub fn decode_tagged(member: &impl Member, namespace: &str, constructed_type: bool, encoding: Encoding) -> CodeBlock {
+fn decode_tagged(member: &impl Member, namespace: &str, constructed_type: bool, encoding: Encoding) -> CodeBlock {
     let data_type = member.data_type();
 
     assert!(data_type.is_optional);
@@ -186,7 +186,7 @@ pub fn decode_tagged(member: &impl Member, namespace: &str, constructed_type: bo
     decode
 }
 
-pub fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, encoding: Encoding) -> CodeBlock {
+fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, encoding: Encoding) -> CodeBlock {
     let key_type = &dictionary_ref.key_type;
     let value_type = &dictionary_ref.value_type;
 
@@ -228,7 +228,7 @@ decoder.DecodeDictionary(
     .into()
 }
 
-pub fn decode_result(result_type_ref: &TypeRef<ResultType>, namespace: &str, encoding: Encoding) -> CodeBlock {
+fn decode_result(result_type_ref: &TypeRef<ResultType>, namespace: &str, encoding: Encoding) -> CodeBlock {
     assert!(encoding != Encoding::Slice1);
     let success_type = &result_type_ref.success_type;
     let failure_type = &result_type_ref.failure_type;
@@ -245,7 +245,7 @@ decoder.DecodeResult(
     .into()
 }
 
-pub fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: Encoding) -> CodeBlock {
+fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
     let element_type = &sequence_ref.element_type;
 

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -549,7 +549,7 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
             // disambiguate between null and the actual value type.
             param_type = match member.data_type().is_optional && member.data_type().is_value_type() {
                 true => member.data_type().cs_type_string(namespace, TypeContext::IncomingParam, false),
-                false => String::from("var"),
+                false => "var".to_owned(),
             },
             param_name = &member.parameter_name_with_prefix("sliceP_"),
             decode = decode_member(member, namespace, operation.encoding),
@@ -564,7 +564,7 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
             // disambiguate between null and the actual value type.
             param_type = match member.data_type().is_value_type() {
                 true => member.data_type().cs_type_string(namespace, TypeContext::IncomingParam, false),
-                false => String::from("var"),
+                false => "var".to_owned(),
             },
             param_name = &member.parameter_name_with_prefix("sliceP_"),
             decode = decode_tagged(

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -3,88 +3,65 @@
 use crate::builders::{Builder, FunctionCallBuilder};
 use crate::cs_attributes::CsType;
 use crate::cs_util::*;
+use crate::member_util::get_sorted_members;
 use crate::slicec_ext::*;
 use convert_case::Case;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
+use slicec::utils::code_gen_util::{get_bit_sequence_size, TypeContext};
 
-pub fn decode_fields(fields: &[&Field], namespace: &str, encoding: Encoding) -> CodeBlock {
-    let mut code = CodeBlock::default();
-
-    let (required_fields, tagged_fields) = get_sorted_members(fields);
-
-    let bit_sequence_size = get_bit_sequence_size(encoding, fields);
-
+/// Compute how many bits are needed to decode the provided members, and if more than 0 bits are needed,
+/// This generates code that creates a new `BitSequenceReader` with the necessary capacity.
+fn initialize_bit_sequence_reader_for<T: Member>(members: &[&T], code: &mut CodeBlock, encoding: Encoding) {
+    let bit_sequence_size = get_bit_sequence_size(encoding, members);
     if bit_sequence_size > 0 {
         writeln!(
             code,
             "var bitSequenceReader = decoder.GetBitSequenceReader({bit_sequence_size});",
         );
     }
+}
 
-    // Decode required fields
-    for field in required_fields {
-        writeln!(
-            code,
-            "this.{param} = {decode};",
-            param = field.field_name(),
-            decode = decode_member(field, namespace, encoding),
-        );
-    }
+pub fn decode_fields(fields: &[&Field], encoding: Encoding) -> CodeBlock {
+    let mut code = CodeBlock::default();
+    initialize_bit_sequence_reader_for(fields, &mut code, encoding);
 
-    // Decode tagged data fields
-    for field in tagged_fields {
-        writeln!(
-            code,
-            "this.{param} = {decode};",
-            param = field.field_name(),
-            decode = decode_tagged(field, namespace, true, encoding),
-        );
-    }
+    let action = |field_name, field_value| {
+        writeln!(code, "this.{field_name} = {field_value};")
+    };
 
+    decode_fields_core(fields, encoding, action);
     code
 }
 
-pub fn decode_enum_fields(fields: &[&Field], enum_class: &str, namespace: &str, encoding: Encoding) -> CodeBlock {
+pub fn decode_enum_fields(fields: &[&Field], enum_class: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
-
-    let (required_fields, tagged_fields) = get_sorted_members(fields);
-
-    let bit_sequence_size = get_bit_sequence_size(encoding, fields);
-
-    if bit_sequence_size > 0 {
-        writeln!(
-            code,
-            "var bitSequenceReader = decoder.GetBitSequenceReader({bit_sequence_size});",
-        );
-    }
+    initialize_bit_sequence_reader_for(fields, &mut code, encoding);
 
     let mut new_instance_builder = FunctionCallBuilder::new(format!("new {enum_class}"));
     new_instance_builder.arguments_on_newline(fields.len() > 1);
+    let action = |field_name, field_value| {
+        new_instance_builder.add_argument(&format!("{field_name}: {field_value}"));
+    };
 
-    // Decode required fields. It's critical to specify the field name as we may not
-    // be decoding in declaration order.
-    for field in required_fields {
-        new_instance_builder.add_argument(&format!(
-            "{field_name}: {field_value}",
-            field_name = field.field_name(),
-            field_value = decode_member(field, namespace, encoding),
-        ));
-    }
-
-    // Decode tagged data fields
-    for field in tagged_fields {
-        new_instance_builder.add_argument(&format!(
-            "{field_name}: {field_value}",
-            field_name = field.field_name(),
-            field_value = decode_tagged(field, namespace, true, encoding),
-        ));
-    }
-
+    decode_fields_core(fields, encoding, action);
     writeln!(code, "var result = {}", new_instance_builder.build());
-
     code
+}
+
+/// Generates code for each of the provided fields by calling the provided `action` for each field.
+fn decode_fields_core(fields: &[&Field], encoding: Encoding, mut action: impl FnMut(String, CodeBlock)) {
+    for field in get_sorted_members(fields) {
+        let namespace = field.namespace();
+
+        let field_name = field.field_name();
+        let field_value = match field.is_tagged() {
+            true => decode_tagged(field, &namespace, true, encoding),
+            false => decode_member(field, &namespace, encoding),
+        };
+
+        action(field_name, field_value);
+    }
 }
 
 pub fn default_activator(encoding: Encoding) -> &'static str {
@@ -416,42 +393,31 @@ fn decode_stream_parameter(type_ref: &TypeRef, namespace: &str, encoding: Encodi
 }
 
 fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
+    let mut decode_func = match type_ref.is_optional {
+        true => decode_func_body(type_ref, namespace, encoding),
+        false => decode_func(type_ref, namespace, encoding),
+    };
+
+    // TODO: it's lame to have to do this here. We should provide a better API.
+    if matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
+        write!(
+            decode_func,
+            " as {}",
+            type_ref.cs_type_string(namespace, TypeContext::Field, false),
+        );
+    }
+
     if type_ref.is_optional {
-        let mut decode_func_body = decode_func_body(type_ref, namespace, encoding);
-
-        // TODO: it's lame to have to do this here. We should provide a better API.
-        if matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
-            write!(
-                decode_func_body,
-                " as {}",
-                type_ref.cs_type_string(namespace, TypeContext::Field, false),
-            );
-        }
-
-        let mut decode_func = CodeBlock::from(format!(
+        decode_func = CodeBlock::from(format!(
             "\
 (ref SliceDecoder decoder) => decoder.DecodeBool() ?
-    {decode_func_body}
+    {decode_func}
     : null",
         ));
-
-        decode_func.indent();
-        decode_func
-    } else {
-        let mut decode_func = decode_func(type_ref, namespace, encoding);
-
-        // Ditto
-        if matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
-            write!(
-                decode_func,
-                " as {}",
-                type_ref.cs_type_string(namespace, TypeContext::Field, false),
-            );
-        }
-
-        decode_func.indent();
-        decode_func
     }
+
+    decode_func.indent();
+    decode_func
 }
 
 pub fn decode_func(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
@@ -519,64 +485,39 @@ fn decode_func_body(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> 
 
 pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
     let mut code = CodeBlock::default();
+    let namespace = operation.namespace();
+    let encoding = operation.encoding;
 
-    let namespace = &operation.namespace();
-
-    let non_streamed_members = if dispatch {
+    let non_streamed_parameters = if dispatch {
         operation.non_streamed_parameters()
     } else {
         operation.non_streamed_return_members()
     };
+    assert!(!non_streamed_parameters.is_empty());
 
-    assert!(!non_streamed_members.is_empty());
+    initialize_bit_sequence_reader_for(&non_streamed_parameters, &mut code, operation.encoding);
 
-    let (required_members, tagged_members) = get_sorted_members(&non_streamed_members);
-
-    let bit_sequence_size = get_bit_sequence_size(operation.encoding, &non_streamed_members);
-
-    if bit_sequence_size > 0 {
-        writeln!(
-            code,
-            "var bitSequenceReader = decoder.GetBitSequenceReader({bit_sequence_size});",
-        );
+    for parameter in get_sorted_members(&non_streamed_parameters) {
+        let param_type = parameter.data_type();
+    
+        // For optional value types we have to use the full type as the compiler cannot
+        // disambiguate between null and the actual value type.
+        let param_type_string = match param_type.is_optional && param_type.is_value_type() {
+            true => param_type.cs_type_string(&namespace, TypeContext::IncomingParam, false),
+            false => "var".to_owned(),
+        };
+    
+        let param_name = &parameter.parameter_name_with_prefix("sliceP_");
+    
+        let decode = match parameter.is_tagged() {
+            true => decode_tagged(parameter, &namespace, false, encoding),
+            false => decode_member(parameter, &namespace, encoding),
+        };
+    
+        writeln!(code, "{param_type_string} {param_name} = {decode};")
     }
 
-    for member in required_members {
-        writeln!(
-            code,
-            "{param_type} {param_name} = {decode};",
-            // For optional value types we have to use the full type as the compiler cannot
-            // disambiguate between null and the actual value type.
-            param_type = match member.data_type().is_optional && member.data_type().is_value_type() {
-                true => member.data_type().cs_type_string(namespace, TypeContext::IncomingParam, false),
-                false => "var".to_owned(),
-            },
-            param_name = &member.parameter_name_with_prefix("sliceP_"),
-            decode = decode_member(member, namespace, operation.encoding),
-        )
-    }
-
-    for member in tagged_members {
-        writeln!(
-            code,
-            "{param_type} {param_name} = {decode};",
-            // For optional value types we have to use the full type as the compiler cannot
-            // disambiguate between null and the actual value type.
-            param_type = match member.data_type().is_value_type() {
-                true => member.data_type().cs_type_string(namespace, TypeContext::IncomingParam, false),
-                false => "var".to_owned(),
-            },
-            param_name = &member.parameter_name_with_prefix("sliceP_"),
-            decode = decode_tagged(
-                member,
-                namespace,
-                false, // not a constructed type
-                operation.encoding
-            ),
-        )
-    }
-
-    writeln!(code, "return {};", non_streamed_members.to_argument_tuple("sliceP_"));
+    writeln!(code, "return {};", non_streamed_parameters.to_argument_tuple("sliceP_"));
 
     code
 }

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -14,7 +14,6 @@ pub fn encode_fields(fields: &[&Field], namespace: &str, encoding: Encoding) -> 
     let (required_fields, tagged_fields) = get_sorted_members(fields);
 
     let bit_sequence_size = get_bit_sequence_size(encoding, &required_fields);
-
     if bit_sequence_size > 0 {
         writeln!(
             code,
@@ -456,7 +455,17 @@ fn encode_result(
     .into()
 }
 
-pub fn encode_stream_parameter(
+pub fn encode_stream_parameter(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
+    encode_type_with_bit_sequence_optimization(type_ref, TypeContext::OutgoingParam, namespace, encoding)
+}
+
+fn encode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
+    encode_type_with_bit_sequence_optimization(type_ref, TypeContext::Field, namespace, encoding)
+}
+
+/// This function returns a `encode_action` lambda function. This includes the code for handling optional types.
+/// Instead of using a whole bit-sequence, it encodes the optionality on a single bool however.
+fn encode_type_with_bit_sequence_optimization(
     type_ref: &TypeRef,
     type_context: TypeContext,
     namespace: &str,
@@ -478,26 +487,6 @@ pub fn encode_stream_parameter(
         ))
     } else {
         encode_action(type_ref, type_context, namespace, encoding, false)
-    }
-}
-
-fn encode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
-    let value_type = type_ref.cs_type_string(namespace, TypeContext::Field, false);
-    if type_ref.is_optional {
-        CodeBlock::from(format!(
-            "\
-(ref SliceEncoder encoder, {value_type} value) =>
-{{
-    encoder.EncodeBool(value is not null);
-    if (value is not null)
-    {{
-        {encode_action_body};
-    }}
-}}",
-            encode_action_body = encode_action_body(type_ref, TypeContext::Field, namespace, encoding, false).indent()
-        ))
-    } else {
-        encode_action(type_ref, TypeContext::Field, namespace, encoding, false)
     }
 }
 

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -481,7 +481,7 @@ pub fn encode_stream_parameter(
     }
 }
 
-pub fn encode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
+fn encode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
     let value_type = type_ref.cs_type_string(namespace, TypeContext::Field, false);
     if type_ref.is_optional {
         CodeBlock::from(format!(

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -193,7 +193,6 @@ fn encode_and_decode(class_def: &Class) -> CodeBlock {
             code.writeln("decoder.StartSlice();");
             code.writeln(&decode_fields(
                 &fields,
-                namespace,
                 Encoding::Slice1, // classes are Slice1 only
             ));
             code.writeln("decoder.EndSlice();");

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -567,8 +567,7 @@ fn payload_continuation(operation: &Operation, encoding: &str) -> CodeBlock {
     {encoding},
     {encode_options})",
                     encode_stream_parameter =
-                        encode_stream_parameter(stream_type, TypeContext::OutgoingParam, namespace, operation.encoding)
-                            .indent(),
+                        encode_stream_parameter(stream_type, namespace, operation.encoding).indent(),
                     use_segments = stream_type.fixed_wire_size().is_none(),
                     encode_options = "request.Features.Get<ISliceFeature>()?.EncodeOptions",
                 )

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -419,7 +419,6 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
     let access = enum_def.access_modifier();
     let escaped_identifier = enum_def.escape_identifier();
     let cs_type = enum_def.get_underlying_cs_type();
-    let namespace = enum_def.namespace();
 
     let mut builder = ContainerBuilder::new(
         &format!("{access} static class"),
@@ -520,7 +519,6 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
                         code.writeln(&decode_enum_fields(
                             &enumerator.fields(),
                             &decoded_type,
-                            &namespace,
                             Encoding::Slice2,
                         ));
 

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -83,7 +83,7 @@ decoder.StartSlice();
 {decode_fields}
 decoder.EndSlice();
 {decode_base}",
-                    decode_fields = decode_fields(fields, namespace, Encoding::Slice1),
+                    decode_fields = decode_fields(fields, Encoding::Slice1),
                     decode_base = if has_base { "base.DecodeCore(ref decoder);" } else { "" },
                 )
                 .into(),

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -350,10 +350,7 @@ if ({features_parameter}?.Get<IceRpc.Features.ICompressFeature>() is null)
                         stream_type.cs_type_string(namespace, TypeContext::OutgoingParam, false),
                     ))
                     .use_semicolon(false)
-                    .add_argument(
-                        encode_stream_parameter(stream_type, TypeContext::OutgoingParam, namespace, operation.encoding)
-                            .indent(),
-                    )
+                    .add_argument(encode_stream_parameter(stream_type, namespace, operation.encoding).indent())
                     .add_argument(stream_type.fixed_wire_size().is_none())
                     .add_argument(encoding)
                     .add_argument("this.EncodeOptions")

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -72,10 +72,10 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     // Decode constructor
     let mut decode_body = EncodingBlockBuilder::new("decoder.Encoding", struct_def.supported_encodings())
         .add_encoding_block(Encoding::Slice1, || {
-            decode_fields(&fields, &namespace, Encoding::Slice1)
+            decode_fields(&fields, Encoding::Slice1)
         })
         .add_encoding_block(Encoding::Slice2, || {
-            decode_fields(&fields, &namespace, Encoding::Slice2)
+            decode_fields(&fields, Encoding::Slice2)
         })
         .build();
 

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -6,6 +6,14 @@ use slicec::code_block::CodeBlock;
 use slicec::grammar::{Contained, Field, Member};
 use slicec::utils::code_gen_util::TypeContext;
 
+/// Takes a list of members and sorts them in the following order: [required members][tagged members]
+/// Required members are left in the provided order. Tagged members are sorted so tag values are in increasing order.
+pub fn get_sorted_members<'a, T: Member + ?Sized>(members: &[&'a T]) -> impl Iterator<Item = &'a T> {
+    let (mut tagged, required): (Vec<&T>, Vec<&T>) = members.iter().partition(|member| member.is_tagged());
+    tagged.sort_by_key(|member| member.tag().unwrap());
+    required.into_iter().chain(tagged)
+}
+
 pub fn escape_parameter_name(parameters: &[&impl Member], name: &str) -> String {
     if parameters.iter().any(|p| p.parameter_name() == name) {
         name.to_owned() + "_"


### PR DESCRIPTION
This PR performs some cleanup in `slicec-cs`. No logic or function is altered by this PR, it just cleans and refactors.
It removes 86 lines of code.

I'm only opening a PR to make sure CI passes. But if you want to review it, go for it!