### PR TITLE
slicec-cs Cleanup Pass 2

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -11,7 +11,7 @@ use slicec::grammar::*;
 use slicec::utils::code_gen_util::{get_bit_sequence_size, TypeContext};
 
 /// Compute how many bits are needed to decode the provided members, and if more than 0 bits are needed,
-/// This generates code that creates a new `BitSequenceReader` with the necessary capacity.
+/// this generates code that creates a new `BitSequenceReader` with the necessary capacity.
 fn initialize_bit_sequence_reader_for<T: Member>(members: &[&T], code: &mut CodeBlock, encoding: Encoding) {
     let bit_sequence_size = get_bit_sequence_size(encoding, members);
     if bit_sequence_size > 0 {
@@ -499,21 +499,21 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
 
     for parameter in get_sorted_members(&non_streamed_parameters) {
         let param_type = parameter.data_type();
-    
+
         // For optional value types we have to use the full type as the compiler cannot
         // disambiguate between null and the actual value type.
         let param_type_string = match param_type.is_optional && param_type.is_value_type() {
             true => param_type.cs_type_string(&namespace, TypeContext::IncomingParam, false),
             false => "var".to_owned(),
         };
-    
+
         let param_name = &parameter.parameter_name_with_prefix("sliceP_");
-    
+
         let decode = match parameter.is_tagged() {
             true => decode_tagged(parameter, &namespace, false, encoding),
             false => decode_member(parameter, &namespace, encoding),
         };
-    
+
         writeln!(code, "{param_type_string} {param_name} = {decode};")
     }
 

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -152,7 +152,6 @@ fn constructor(
 fn encode_and_decode(class_def: &Class) -> CodeBlock {
     let mut code = CodeBlock::default();
 
-    let namespace = &class_def.namespace();
     let fields = class_def.fields();
     let has_base_class = class_def.base_class().is_some();
 
@@ -168,11 +167,8 @@ fn encode_and_decode(class_def: &Class) -> CodeBlock {
                     .build(),
             );
 
-            code.writeln(&encode_fields(
-                &fields,
-                namespace,
-                Encoding::Slice1, // classes are Slice1 only
-            ));
+            // classes are Slice1 only
+            code.writeln(&encode_fields(&fields, Encoding::Slice1));
 
             if has_base_class {
                 code.writeln("encoder.EndSlice(false);");

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -117,7 +117,6 @@ fn enumerators(enum_def: &Enum) -> CodeBlock {
 
 fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
     let mut code = CodeBlock::default();
-    let namespace = enum_def.namespace();
 
     for enumerator in enum_def.enumerators() {
         let escaped_identifier = enumerator.escape_identifier();
@@ -169,11 +168,7 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                         }
                     }
 
-                    code.writeln(&encode_fields(
-                        &enumerator.fields(),
-                        &namespace,
-                        Encoding::Slice2,
-                    ));
+                    code.writeln(&encode_fields(&enumerator.fields(), Encoding::Slice2));
 
                     if !enum_def.is_compact {
                         code.writeln("encoder.EncodeVarInt32(Slice2Definitions.TagEndMarker);");

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -98,7 +98,6 @@ decoder.EndSlice();
 
 fn encode_core_method(exception_def: &Exception) -> CodeBlock {
     let fields = &exception_def.fields();
-    let namespace = &exception_def.namespace();
     let has_base = exception_def.base.is_some();
 
     FunctionBuilder::new("protected override", "void", "EncodeCore", FunctionType::BlockBody)
@@ -111,7 +110,7 @@ encoder.StartSlice(SliceTypeId);
 {encode_fields}
 encoder.EndSlice(lastSlice: {is_last_slice});
 {encode_base}",
-                encode_fields = encode_fields(fields, namespace, Encoding::Slice1),
+                encode_fields = encode_fields(fields, Encoding::Slice1),
                 is_last_slice = !has_base,
                 encode_base = if has_base { "base.EncodeCore(ref encoder);" } else { "" },
             )

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -71,12 +71,8 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
 
     // Decode constructor
     let mut decode_body = EncodingBlockBuilder::new("decoder.Encoding", struct_def.supported_encodings())
-        .add_encoding_block(Encoding::Slice1, || {
-            decode_fields(&fields, Encoding::Slice1)
-        })
-        .add_encoding_block(Encoding::Slice2, || {
-            decode_fields(&fields, Encoding::Slice2)
-        })
+        .add_encoding_block(Encoding::Slice1, || decode_fields(&fields, Encoding::Slice1))
+        .add_encoding_block(Encoding::Slice2, || decode_fields(&fields, Encoding::Slice2))
         .build();
 
     if !struct_def.is_compact {
@@ -105,12 +101,8 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
 
     // Encode method
     let mut encode_body = EncodingBlockBuilder::new("encoder.Encoding", struct_def.supported_encodings())
-        .add_encoding_block(Encoding::Slice1, || {
-            encode_fields(&fields, &namespace, Encoding::Slice1)
-        })
-        .add_encoding_block(Encoding::Slice2, || {
-            encode_fields(&fields, &namespace, Encoding::Slice2)
-        })
+        .add_encoding_block(Encoding::Slice1, || encode_fields(&fields, Encoding::Slice1))
+        .add_encoding_block(Encoding::Slice2, || encode_fields(&fields, Encoding::Slice2))
         .build();
 
     if !struct_def.is_compact {


### PR DESCRIPTION
This PR performs some more cleanup in slicec-cs. No logic or function is altered by this PR, it just cleans and refactors.
It removes 54 lines of code (for a running total of 140 lines).

I'm only opening a PR to make sure CI passes. But if you want to review it, go for it!
