### PR TITLE
Remove `TypeContext`

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -365,17 +365,17 @@ impl FunctionBuilder {
 
         if is_dispatch {
             self.add_parameter(
-                "IceRpc.Features.IFeatureCollection",
-                &escape_parameter_name(&parameters, "features"),
-                None,
-                Some("The dispatch features.".to_owned()),
-            );
-        } else {
-            self.add_parameter(
                 "IceRpc.Features.IFeatureCollection?",
                 &escape_parameter_name(&parameters, "features"),
                 Some("null"),
                 Some("The invocation features.".to_owned()),
+            );
+        } else {
+            self.add_parameter(
+                "IceRpc.Features.IFeatureCollection",
+                &escape_parameter_name(&parameters, "features"),
+                None,
+                Some("The dispatch features.".to_owned()),
             );
         }
 

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -232,11 +232,7 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
     if !has_cs_type_attribute && matches!(element_type.concrete_type(), Types::Sequence(_)) {
         // For nested sequences we want to cast Foo[][] returned by DecodeSequence to IList<Foo>[]
         // used in the request and response decode methods.
-        write!(
-            code,
-            "({}[])",
-            element_type.field_type_string(namespace, false),
-        );
+        write!(code, "({}[])", element_type.field_type_string(namespace, false));
     };
 
     if has_cs_type_attribute {
@@ -401,11 +397,7 @@ fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) 
 
     // TODO: it's lame to have to do this here. We should provide a better API.
     if matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
-        write!(
-            decode_func,
-            " as {}",
-            type_ref.field_type_string(namespace, false),
-        );
+        write!(decode_func, " as {}", type_ref.field_type_string(namespace, false));
     }
 
     if type_ref.is_optional {

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -8,7 +8,7 @@ use crate::slicec_ext::*;
 use convert_case::Case;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::{get_bit_sequence_size, TypeContext};
+use slicec::utils::code_gen_util::get_bit_sequence_size;
 
 /// Compute how many bits are needed to decode the provided members, and if more than 0 bits are needed,
 /// this generates code that creates a new `BitSequenceReader` with the necessary capacity.
@@ -75,7 +75,7 @@ pub fn default_activator(encoding: Encoding) -> &'static str {
 fn decode_member(member: &impl Member, namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
     let data_type = member.data_type();
-    let type_string = data_type.cs_type_string(namespace, TypeContext::IncomingParam, true);
+    let type_string = data_type.incoming_type_string(namespace, true);
 
     if data_type.is_optional {
         match data_type.concrete_type() {
@@ -176,11 +176,11 @@ fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, enco
         write!(
             decode_value,
             " as {}",
-            value_type.cs_type_string(namespace, TypeContext::Field, true),
+            value_type.field_type_string(namespace, true),
         );
     }
 
-    let dictionary_type = dictionary_ref.cs_type_string(namespace, TypeContext::IncomingParam, true);
+    let dictionary_type = dictionary_ref.incoming_type_string(namespace, true);
     let decode_key = decode_key.indent();
     let decode_value = decode_value.indent();
 
@@ -234,12 +234,12 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
         write!(
             code,
             "({}[])",
-            element_type.cs_type_string(namespace, TypeContext::Field, false),
+            element_type.field_type_string(namespace, false),
         );
     };
 
     if has_cs_type_attribute {
-        let sequence_type = sequence_ref.cs_type_string(namespace, TypeContext::IncomingParam, true);
+        let sequence_type = sequence_ref.incoming_type_string(namespace, true);
 
         let arg: Option<String> = match element_type.concrete_type() {
             Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !element_type.is_optional => {
@@ -247,7 +247,7 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
                 // faster than decoding the collection elements one by one.
                 Some(format!(
                     "decoder.DecodeSequence<{}>({})",
-                    element_type.cs_type_string(namespace, TypeContext::IncomingParam, true),
+                    element_type.incoming_type_string(namespace, true),
                     if matches!(primitive, Primitive::Bool) {
                         "checkElement: SliceDecoder.CheckBoolValue"
                     } else {
@@ -265,14 +265,14 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
                 if enum_def.is_unchecked {
                     Some(format!(
                         "decoder.DecodeSequence<{}>()",
-                        element_type.cs_type_string(namespace, TypeContext::IncomingParam, true),
+                        element_type.incoming_type_string(namespace, true),
                     ))
                 } else {
                     Some(format!(
                         "\
 decoder.DecodeSequence(
     ({enum_type_name} e) => _ = {underlying_extensions_class}.As{name}(({underlying_type})e))",
-                        enum_type_name = element_type.cs_type_string(namespace, TypeContext::IncomingParam, false),
+                        enum_type_name = element_type.incoming_type_string(namespace, false),
                         underlying_extensions_class = enum_def.escape_scoped_identifier_with_suffix(
                             &format!(
                                 "{}Extensions",
@@ -332,7 +332,7 @@ decoder.DecodeSequenceOfOptionals(
                 write!(
                     code,
                     "decoder.DecodeSequence<{}>({})",
-                    element_type.cs_type_string(namespace, TypeContext::IncomingParam, true),
+                    element_type.incoming_type_string(namespace, true),
                     if matches!(primitive, Primitive::Bool) {
                         "checkElement: SliceDecoder.CheckBoolValue"
                     } else {
@@ -345,7 +345,7 @@ decoder.DecodeSequenceOfOptionals(
                     write!(
                         code,
                         "decoder.DecodeSequence<{}>()",
-                        element_type.cs_type_string(namespace, TypeContext::IncomingParam, true),
+                        element_type.incoming_type_string(namespace, true),
                     )
                 } else {
                     write!(
@@ -353,7 +353,7 @@ decoder.DecodeSequenceOfOptionals(
                         "\
 decoder.DecodeSequence(
     ({enum_type} e) => _ = {underlying_extensions_class}.As{name}(({underlying_type})e))",
-                        enum_type = element_type.cs_type_string(namespace, TypeContext::IncomingParam, false),
+                        enum_type = element_type.incoming_type_string(namespace, false),
                         underlying_extensions_class = enum_def.escape_scoped_identifier_with_suffix(
                             &format!(
                                 "{}Extensions",
@@ -403,7 +403,7 @@ fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) 
         write!(
             decode_func,
             " as {}",
-            type_ref.cs_type_string(namespace, TypeContext::Field, false),
+            type_ref.field_type_string(namespace, false),
         );
     }
 
@@ -427,7 +427,7 @@ pub fn decode_func(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> C
 
 fn decode_func_body(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();
-    let type_name = type_ref.cs_type_string(namespace, TypeContext::IncomingParam, true);
+    let type_name = type_ref.incoming_type_string(namespace, true);
 
     // When we decode the type, we decode it as a non-optional.
     // If the type is supposed to be optional, we cast it after decoding.
@@ -503,7 +503,7 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
         // For optional value types we have to use the full type as the compiler cannot
         // disambiguate between null and the actual value type.
         let param_type_string = match param_type.is_optional && param_type.is_value_type() {
-            true => param_type.cs_type_string(&namespace, TypeContext::IncomingParam, false),
+            true => param_type.incoming_type_string(&namespace, false),
             false => "var".to_owned(),
         };
 
@@ -530,7 +530,7 @@ pub fn decode_operation_stream(
 ) -> CodeBlock {
     let cs_encoding = encoding.to_cs_encoding();
     let param_type = stream_member.data_type();
-    let param_type_str = param_type.cs_type_string(namespace, TypeContext::IncomingParam, false);
+    let param_type_str = param_type.incoming_type_string(namespace, false);
     let fixed_wire_size = param_type.fixed_wire_size();
 
     match param_type.concrete_type() {

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -176,6 +176,7 @@ fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, enco
         write!(
             decode_value,
             " as {}",
+            // TODO change this to a cast, so we can pass `ignore_optional = false`.
             value_type.field_type_string(namespace, true),
         );
     }

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -9,7 +9,6 @@ use crate::member_util::*;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::{Class, Encoding, Field};
-use slicec::utils::code_gen_util::TypeContext;
 
 pub fn generate_class(class_def: &Class) -> CodeBlock {
     let class_name = class_def.escape_identifier();
@@ -129,7 +128,7 @@ fn constructor(
 
     for field in base_fields.iter().chain(fields.iter()) {
         builder.add_parameter(
-            &field.data_type.cs_type_string(namespace, TypeContext::Field, false),
+            &field.data_type.field_type_string(namespace, false),
             &field.parameter_name(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -7,7 +7,7 @@ use crate::encoding::*;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
+use slicec::utils::code_gen_util::get_bit_sequence_size;
 
 pub fn generate_dispatch(interface_def: &Interface) -> CodeBlock {
     let namespace = interface_def.namespace();
@@ -108,7 +108,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
             },
             &format!(
                 "global::System.Threading.Tasks.ValueTask<{}>",
-                &parameters.to_tuple_type(namespace, TypeContext::IncomingParam, false),
+                &parameters.to_tuple_type(namespace, false, false),
             ),
             &operation.escape_identifier_with_prefix_and_suffix("Decode", "Async"),
             function_type,
@@ -192,7 +192,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         match non_streamed_returns.as_slice() {
             [param] => {
                 builder.add_parameter(
-                    &param.cs_type_string(namespace, TypeContext::OutgoingParam, false),
+                    &param.cs_type_string(namespace, false, true),
                     "returnValue",
                     None,
                     Some("The operation return value.".to_owned()),
@@ -201,7 +201,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
             _ => {
                 for param in &non_streamed_returns {
                     builder.add_parameter(
-                        &param.cs_type_string(namespace, TypeContext::OutgoingParam, false),
+                        &param.cs_type_string(namespace, false, true),
                         &param.parameter_name(),
                         None,
                         param.formatted_param_doc_comment(),
@@ -345,7 +345,7 @@ fn operation_declaration(operation: &Operation) -> CodeBlock {
         builder.add_comment("summary", summary);
     }
     builder
-        .add_operation_parameters(operation, TypeContext::IncomingParam)
+        .add_operation_parameters(operation, false)
         .add_comments(operation.formatted_doc_comment_seealso())
         .build()
 }

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -7,7 +7,6 @@ use crate::member_util::*;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::{Encoding, Exception, Member};
-use slicec::utils::code_gen_util::TypeContext;
 
 pub fn generate_exception(exception_def: &Exception) -> CodeBlock {
     let exception_name = exception_def.escape_identifier();
@@ -144,7 +143,7 @@ fn one_shot_constructor(exception_def: &Exception) -> CodeBlock {
 
     for field in &all_fields {
         ctor_builder.add_parameter(
-            &field.data_type().cs_type_string(namespace, TypeContext::Field, false),
+            &field.data_type().field_type_string(namespace, false),
             field.parameter_name().as_str(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -10,7 +10,7 @@ use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::attributes::Oneway;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
+use slicec::utils::code_gen_util::get_bit_sequence_size;
 
 pub fn generate_proxy(interface_def: &Interface) -> CodeBlock {
     let namespace = interface_def.namespace();
@@ -293,7 +293,7 @@ fn proxy_operation_impl(operation: &Operation) -> CodeBlock {
     let mut builder = FunctionBuilder::new("public", &return_task, &async_operation_name, body_type);
     builder.set_inherit_doc(true);
     builder.add_obsolete_attribute(operation);
-    builder.add_operation_parameters(operation, TypeContext::OutgoingParam);
+    builder.add_operation_parameters(operation, true);
 
     let mut body = CodeBlock::default();
 
@@ -347,7 +347,7 @@ if ({features_parameter}?.Get<IceRpc.Features.ICompressFeature>() is null)
                 invocation_builder.add_argument(
                     FunctionCallBuilder::new(format!(
                         "{stream_parameter_name}.ToPipeReader<{}>",
-                        stream_type.cs_type_string(namespace, TypeContext::OutgoingParam, false),
+                        stream_type.outgoing_type_string(namespace, false),
                     ))
                     .use_semicolon(false)
                     .add_argument(encode_stream_parameter(stream_type, namespace, operation.encoding).indent())
@@ -406,7 +406,7 @@ fn proxy_base_operation_impl(operation: &Operation, namespace: &str) -> CodeBloc
     let mut builder = FunctionBuilder::new("public", &return_task, &async_name, FunctionType::ExpressionBody);
     builder.set_inherit_doc(true);
     builder.add_obsolete_attribute(operation);
-    builder.add_operation_parameters(operation, TypeContext::OutgoingParam);
+    builder.add_operation_parameters(operation, true);
 
     builder.set_body(
         format!(
@@ -435,7 +435,7 @@ fn proxy_interface_operations(interface_def: &Interface) -> CodeBlock {
             builder.add_comment("summary", summary);
         }
         builder
-            .add_operation_parameters(operation, TypeContext::OutgoingParam)
+            .add_operation_parameters(operation, true)
             .add_comments(operation.formatted_doc_comment_seealso())
             .add_obsolete_attribute(operation);
         code.add_block(&builder.build());
@@ -486,7 +486,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
 
         for param in &params {
             builder.add_parameter(
-                &param.cs_type_string(namespace, TypeContext::OutgoingParam, false),
+                &param.cs_type_string(namespace, false, true),
                 &param.parameter_name(),
                 None,
                 param.formatted_param_doc_comment(),
@@ -554,7 +554,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         } else {
             format!(
                 "global::System.Threading.Tasks.ValueTask<{}>",
-                members.to_tuple_type(namespace, TypeContext::IncomingParam, false),
+                members.to_tuple_type(namespace, false, false),
             )
         };
 

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -10,7 +10,6 @@ use crate::member_util::*;
 use crate::slicec_ext::{CommentExt, EntityExt, MemberExt, TypeRefExt};
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
 
 pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     let escaped_identifier = struct_def.escape_identifier();
@@ -54,7 +53,7 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
 
     for field in &fields {
         main_constructor.add_parameter(
-            &field.data_type().cs_type_string(&namespace, TypeContext::Field, false),
+            &field.data_type().field_type_string(&namespace, false),
             field.parameter_name().as_str(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -4,7 +4,6 @@ use crate::comments::CommentTag;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::{Contained, Field, Member};
-use slicec::utils::code_gen_util::TypeContext;
 
 /// Takes a list of members and sorts them in the following order: [required members][tagged members]
 /// Required members are left in the provided order. Tagged members are sorted so tag values are in increasing order.
@@ -23,9 +22,7 @@ pub fn escape_parameter_name(parameters: &[&impl Member], name: &str) -> String 
 }
 
 pub fn field_declaration(field: &Field) -> String {
-    let type_string = field
-        .data_type()
-        .cs_type_string(&field.namespace(), TypeContext::Field, false);
+    let type_string = field.data_type().field_type_string(&field.namespace(), false);
     let mut prelude = CodeBlock::default();
 
     if let Some(summary) = field.formatted_doc_comment_summary() {

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -62,7 +62,7 @@ impl FieldExt for Field {
 }
 
 pub trait ParameterExt {
-    fn cs_type_string(&self, namespace: &str, ignore_optional: bool, is_dispatch: bool) -> String;
+    fn cs_type_string(&self, namespace: &str, ignore_optional: bool, is_outgoing: bool) -> String;
 
     /// Returns the message of the `@param` tag corresponding to this parameter from the operation it's part of.
     /// If the operation has no doc comment, or a matching `@param` tag, this returns `None`.
@@ -70,8 +70,8 @@ pub trait ParameterExt {
 }
 
 impl ParameterExt for Parameter {
-    fn cs_type_string(&self, namespace: &str, ignore_optional: bool, is_dispatch: bool) -> String {
-        let type_string = match is_dispatch {
+    fn cs_type_string(&self, namespace: &str, ignore_optional: bool, is_outgoing: bool) -> String {
+        let type_string = match is_outgoing {
             true => self.data_type().outgoing_type_string(namespace, ignore_optional),
             false => self.data_type().incoming_type_string(namespace, ignore_optional),
         };
@@ -102,7 +102,7 @@ impl ParameterExt for Parameter {
 
 pub trait ParameterSliceExt {
     fn to_argument_tuple(&self, prefix: &str) -> String;
-    fn to_tuple_type(&self, namespace: &str, ignore_optional: bool, is_dispatch: bool) -> String;
+    fn to_tuple_type(&self, namespace: &str, ignore_optional: bool, is_outgoing: bool) -> String;
 }
 
 impl ParameterSliceExt for [&Parameter] {
@@ -120,14 +120,14 @@ impl ParameterSliceExt for [&Parameter] {
         }
     }
 
-    fn to_tuple_type(&self, namespace: &str, ignore_optional: bool, is_dispatch: bool) -> String {
+    fn to_tuple_type(&self, namespace: &str, ignore_optional: bool, is_outgoing: bool) -> String {
         match self {
             [] => panic!("tuple type with no members"),
-            [member] => member.cs_type_string(namespace, ignore_optional, is_dispatch),
+            [member] => member.cs_type_string(namespace, ignore_optional, is_outgoing),
             _ => format!(
                 "({})",
                 self.iter()
-                    .map(|m| m.cs_type_string(namespace, ignore_optional, is_dispatch) + " " + &m.field_name())
+                    .map(|m| m.cs_type_string(namespace, ignore_optional, is_outgoing) + " " + &m.field_name())
                     .collect::<Vec<String>>()
                     .join(", "),
             ),

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -3,7 +3,6 @@
 use super::{EntityExt, MemberExt, ParameterExt, ParameterSliceExt};
 use crate::cs_attributes::CsEncodedReturn;
 use slicec::grammar::{AttributeFunctions, Contained, Operation};
-use slicec::utils::code_gen_util::TypeContext;
 
 pub trait OperationExt {
     /// Returns the format that classes should be encoded with.
@@ -34,15 +33,7 @@ impl OperationExt for Operation {
                 "global::System.Threading.Tasks.Task".to_owned()
             }
         } else {
-            let return_type = operation_return_type(
-                self,
-                is_dispatch,
-                if is_dispatch {
-                    TypeContext::OutgoingParam
-                } else {
-                    TypeContext::IncomingParam
-                },
-            );
+            let return_type = operation_return_type(self, is_dispatch);
             if is_dispatch {
                 format!("global::System.Threading.Tasks.ValueTask<{return_type}>")
             } else {
@@ -52,13 +43,13 @@ impl OperationExt for Operation {
     }
 }
 
-fn operation_return_type(operation: &Operation, is_dispatch: bool, context: TypeContext) -> String {
+fn operation_return_type(operation: &Operation, is_dispatch: bool) -> String {
     let namespace = operation.parent().namespace();
     if is_dispatch && operation.has_attribute::<CsEncodedReturn>() {
         if let Some(stream_member) = operation.streamed_return_member() {
             format!(
                 "(global::System.IO.Pipelines.PipeReader Payload, {} {})",
-                stream_member.cs_type_string(&namespace, context, false),
+                stream_member.cs_type_string(&namespace, false, is_dispatch),
                 stream_member.field_name(),
             )
         } else {
@@ -67,8 +58,8 @@ fn operation_return_type(operation: &Operation, is_dispatch: bool, context: Type
     } else {
         match operation.return_members().as_slice() {
             [] => "void".to_owned(),
-            [member] => member.cs_type_string(&namespace, context, false),
-            members => members.to_tuple_type(&namespace, context, false),
+            [member] => member.cs_type_string(&namespace, false, is_dispatch),
+            members => members.to_tuple_type(&namespace, false, is_dispatch),
         }
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -52,40 +52,30 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
             }
         };
 
-        if self.is_optional && !ignore_optional {
-            type_string + "?"
-        } else {
-            type_string
-        }
+        set_optional_modifier_for(type_string, self.is_optional && !ignore_optional)
     }
 
     fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String {
         let type_string = match &self.concrete_typeref() {
             TypeRefs::Sequence(sequence_ref) => {
                 let element_type = sequence_ref.element_type.field_type_string(namespace, false);
-                let cs_type_attribute = sequence_ref.find_attribute::<CsType>();
-                match cs_type_attribute {
-                    Some(arg) => arg.type_string.clone(),
+                match sequence_ref.find_attribute::<CsType>() {
+                    Some(argument) => argument.type_string.clone(),
                     None => format!("{element_type}[]"),
                 }
             }
             TypeRefs::Dictionary(dictionary_ref) => {
                 let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
                 let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
-                let cs_type_attribute = dictionary_ref.find_attribute::<CsType>();
-                match cs_type_attribute {
-                    Some(arg) => arg.type_string.clone(),
+                match dictionary_ref.find_attribute::<CsType>() {
+                    Some(argument) => argument.type_string.clone(),
                     None => format!("global::System.Collections.Generic.Dictionary<{key_type}, {value_type}>"),
                 }
             }
             _ => self.field_type_string(namespace, true),
         };
 
-        if self.is_optional && !ignore_optional {
-            type_string + "?"
-        } else {
-            type_string
-        }
+        set_optional_modifier_for(type_string, self.is_optional && !ignore_optional)
     }
 
     fn outgoing_type_string(&self, namespace: &str, mut ignore_optional: bool) -> String {
@@ -112,10 +102,13 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
             _ => self.field_type_string(namespace, true),
         };
 
-        if self.is_optional && !ignore_optional {
-            type_string + "?"
-        } else {
-            type_string
-        }
+        set_optional_modifier_for(type_string, self.is_optional && !ignore_optional)
+    }
+}
+
+fn set_optional_modifier_for(type_string: String, is_optional: bool) -> String {
+    match is_optional {
+        true => type_string + "?",
+        false => type_string
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -111,6 +111,6 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
 fn set_optional_modifier_for(type_string: String, is_optional: bool) -> String {
     match is_optional {
         true => type_string + "?",
-        false => type_string
+        false => type_string,
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -3,15 +3,13 @@
 use super::{EntityExt, EnumExt, PrimitiveExt};
 use crate::cs_attributes::CsType;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::TypeContext;
 
 pub trait TypeRefExt {
     /// Is this type known to map to a C# value type?
     fn is_value_type(&self) -> bool;
 
-    /// The C# mapped type for this type reference.
-    fn cs_type_string(&self, namespace: &str, context: TypeContext, ignore_optional: bool) -> String;
-
+    // TODO add comments
+    // TODO the functions have some shared logic that can be pulled out!
     fn field_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
     fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
     fn outgoing_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
@@ -118,14 +116,6 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
             type_string + "?"
         } else {
             type_string
-        }
-    }
-
-    fn cs_type_string(&self, namespace: &str, context: TypeContext, ignore_optional: bool) -> String {
-        match context {
-            TypeContext::Field => self.field_type_string(namespace, ignore_optional),
-            TypeContext::IncomingParam => self.incoming_type_string(namespace, ignore_optional),
-            TypeContext::OutgoingParam => self.outgoing_type_string(namespace, ignore_optional),
         }
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -11,6 +11,10 @@ pub trait TypeRefExt {
 
     /// The C# mapped type for this type reference.
     fn cs_type_string(&self, namespace: &str, context: TypeContext, ignore_optional: bool) -> String;
+
+    fn field_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
+    fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
+    fn outgoing_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
 }
 
 impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
@@ -23,100 +27,105 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
         }
     }
 
-    fn cs_type_string(&self, namespace: &str, context: TypeContext, mut ignore_optional: bool) -> String {
-        let type_str = match &self.concrete_typeref() {
+    fn field_type_string(&self, namespace: &str, ignore_optional: bool) -> String {
+        let type_string = match &self.concrete_typeref() {
+            TypeRefs::Primitive(primitive_ref) => primitive_ref.cs_type().to_owned(),
             TypeRefs::Struct(struct_ref) => struct_ref.escape_scoped_identifier(namespace),
             TypeRefs::Class(class_ref) => class_ref.escape_scoped_identifier(namespace),
             TypeRefs::Enum(enum_ref) => enum_ref.escape_scoped_identifier(namespace),
-            TypeRefs::ResultType(result_type_ref) => result_type_to_string(result_type_ref, namespace),
             TypeRefs::CustomType(custom_type_ref) => {
                 let attribute = custom_type_ref.definition().find_attribute::<CsType>();
-                attribute.unwrap().type_string.clone()
+                let attribute = attribute.expect("called 'type_string' on custom type with no 'cs::type' attribute!");
+                attribute.type_string.clone()
+            }
+            TypeRefs::ResultType(result_type_ref) => {
+                let success_type = result_type_ref.success_type.field_type_string(namespace, false);
+                let failure_type = result_type_ref.failure_type.field_type_string(namespace, false);
+                format!("Result<{success_type}, {failure_type}>")
             }
             TypeRefs::Sequence(sequence_ref) => {
-                // For readonly sequences of fixed size numeric elements the mapping is the
-                // same for optional an non optional types.
-                if context == TypeContext::OutgoingParam
-                    && sequence_ref.has_fixed_size_primitive_elements()
-                    && !self.has_attribute::<CsType>()
-                {
-                    ignore_optional = true;
-                }
-                sequence_type_to_string(sequence_ref, namespace, context)
+                let element_type = sequence_ref.element_type.field_type_string(namespace, false);
+                format!("global::System.Collections.Generic.IList<{element_type}>")
             }
-            TypeRefs::Dictionary(dictionary_ref) => dictionary_type_to_string(dictionary_ref, namespace, context),
-            TypeRefs::Primitive(primitive_ref) => primitive_ref.cs_type().to_owned(),
+            TypeRefs::Dictionary(dictionary_ref) => {
+                let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
+                let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
+                format!("global::System.Collections.Generic.IDictionary<{key_type}, {value_type}>")
+            }
         };
 
         if self.is_optional && !ignore_optional {
-            type_str + "?"
+            type_string + "?"
         } else {
-            type_str
+            type_string
         }
     }
-}
 
-/// Helper method to convert a sequence type into a string
-fn sequence_type_to_string(sequence_ref: &TypeRef<Sequence>, namespace: &str, context: TypeContext) -> String {
-    let element_type = sequence_ref
-        .element_type
-        .cs_type_string(namespace, TypeContext::Field, false);
-
-    let cs_type_attribute = sequence_ref.find_attribute::<CsType>();
-
-    match context {
-        TypeContext::Field => {
-            format!("global::System.Collections.Generic.IList<{element_type}>")
-        }
-        TypeContext::IncomingParam => match cs_type_attribute {
-            Some(arg) => arg.type_string.clone(),
-            None => format!("{element_type}[]"),
-        },
-        TypeContext::OutgoingParam => {
-            // If the underlying type is of fixed size, we map to `ReadOnlyMemory` instead.
-            if sequence_ref.has_fixed_size_primitive_elements() && cs_type_attribute.is_none() {
-                format!("global::System.ReadOnlyMemory<{element_type}>")
-            } else {
-                format!("global::System.Collections.Generic.IEnumerable<{element_type}>")
+    fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String {
+        let type_string = match &self.concrete_typeref() {
+            TypeRefs::Sequence(sequence_ref) => {
+                let element_type = sequence_ref.element_type.field_type_string(namespace, false);
+                let cs_type_attribute = sequence_ref.find_attribute::<CsType>();
+                match cs_type_attribute {
+                    Some(arg) => arg.type_string.clone(),
+                    None => format!("{element_type}[]"),
+                }
             }
+            TypeRefs::Dictionary(dictionary_ref) => {
+                let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
+                let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
+                let cs_type_attribute = dictionary_ref.find_attribute::<CsType>();
+                match cs_type_attribute {
+                    Some(arg) => arg.type_string.clone(),
+                    None => format!("global::System.Collections.Generic.Dictionary<{key_type}, {value_type}>"),
+                }
+            }
+            _ => self.field_type_string(namespace, true),
+        };
+
+        if self.is_optional && !ignore_optional {
+            type_string + "?"
+        } else {
+            type_string
         }
     }
-}
 
-/// Helper method to convert a dictionary type into a string
-fn dictionary_type_to_string(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, context: TypeContext) -> String {
-    let key_type = dictionary_ref
-        .key_type
-        .cs_type_string(namespace, TypeContext::Field, false);
-    let value_type = dictionary_ref
-        .value_type
-        .cs_type_string(namespace, TypeContext::Field, false);
+    fn outgoing_type_string(&self, namespace: &str, mut ignore_optional: bool) -> String {
+        let type_string = match &self.concrete_typeref() {
+            TypeRefs::Sequence(sequence_ref) => {
+                let element_type = sequence_ref.element_type.field_type_string(namespace, false);
+                let has_cs_type_attribute = self.has_attribute::<CsType>();
+                if sequence_ref.has_fixed_size_primitive_elements() && !has_cs_type_attribute {
+                    // If the underlying type is of fixed size, we map to `ReadOnlyMemory` instead,
+                    // and the mapping is the same for optional and non-optional types.
+                    ignore_optional = true;
+                    format!("global::System.ReadOnlyMemory<{element_type}>")
+                } else {
+                    format!("global::System.Collections.Generic.IEnumerable<{element_type}>")
+                }
+            }
+            TypeRefs::Dictionary(dictionary_ref) => {
+                let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
+                let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
+                format!(
+                    "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<{key_type}, {value_type}>>"
+                )
+            }
+            _ => self.field_type_string(namespace, true),
+        };
 
-    let cs_type_attribute = dictionary_ref.find_attribute::<CsType>();
-
-    match context {
-        TypeContext::Field => {
-            format!("global::System.Collections.Generic.IDictionary<{key_type}, {value_type}>")
+        if self.is_optional && !ignore_optional {
+            type_string + "?"
+        } else {
+            type_string
         }
-        TypeContext::IncomingParam => match cs_type_attribute {
-            Some(arg) => arg.type_string.clone(),
-            None => format!("global::System.Collections.Generic.Dictionary<{key_type}, {value_type}>"),
-        },
-        TypeContext::OutgoingParam =>
-            format!(
-                "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<{key_type}, {value_type}>>"
-            )
     }
-}
 
-/// Helper method to convert a result type into a string
-fn result_type_to_string(result_type_ref: &TypeRef<ResultType>, namespace: &str) -> String {
-    let success_type = result_type_ref
-        .success_type
-        .cs_type_string(namespace, TypeContext::Field, false);
-    let failure_type = result_type_ref
-        .failure_type
-        .cs_type_string(namespace, TypeContext::Field, false);
-
-    format!("Result<{success_type}, {failure_type}>")
+    fn cs_type_string(&self, namespace: &str, context: TypeContext, ignore_optional: bool) -> String {
+        match context {
+            TypeContext::Field => self.field_type_string(namespace, ignore_optional),
+            TypeContext::IncomingParam => self.incoming_type_string(namespace, ignore_optional),
+            TypeContext::OutgoingParam => self.outgoing_type_string(namespace, ignore_optional),
+        }
+    }
 }

--- a/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/type_ref_ext.rs
@@ -8,8 +8,6 @@ pub trait TypeRefExt {
     /// Is this type known to map to a C# value type?
     fn is_value_type(&self) -> bool;
 
-    // TODO add comments
-    // TODO the functions have some shared logic that can be pulled out!
     fn field_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
     fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
     fn outgoing_type_string(&self, namespace: &str, ignore_optional: bool) -> String;
@@ -58,18 +56,22 @@ impl<T: Type + ?Sized> TypeRefExt for TypeRef<T> {
     fn incoming_type_string(&self, namespace: &str, ignore_optional: bool) -> String {
         let type_string = match &self.concrete_typeref() {
             TypeRefs::Sequence(sequence_ref) => {
-                let element_type = sequence_ref.element_type.field_type_string(namespace, false);
                 match sequence_ref.find_attribute::<CsType>() {
                     Some(argument) => argument.type_string.clone(),
-                    None => format!("{element_type}[]"),
+                    None => {
+                        let element_type = sequence_ref.element_type.field_type_string(namespace, false);
+                        format!("{element_type}[]")
+                    }
                 }
             }
             TypeRefs::Dictionary(dictionary_ref) => {
-                let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
-                let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
                 match dictionary_ref.find_attribute::<CsType>() {
                     Some(argument) => argument.type_string.clone(),
-                    None => format!("global::System.Collections.Generic.Dictionary<{key_type}, {value_type}>"),
+                    None => {
+                        let key_type = dictionary_ref.key_type.field_type_string(namespace, false);
+                        let value_type = dictionary_ref.value_type.field_type_string(namespace, false);
+                        format!("global::System.Collections.Generic.Dictionary<{key_type}, {value_type}>")
+                    }
                 }
             }
             _ => self.field_type_string(namespace, true),


### PR DESCRIPTION
This PR Removes the need for ‘TypeContext’ from `slicec-cs`. It’s purely refactoring; there should be no changes to the logic. We used this enum for 2 purposes:

## Purpose 1

`cs_type_string` would change the mapping of sequences and dictionaries based on this field. 
Now, instead of 1 function which matches 3 possible TypeContexts, we have 3 separate functions:
`cs_type_string(… TypeContext::Field) -> field_type_string `
`cs_type_string(… TypeContext::IncomingParam) -> incoming_type_string`
` cs_type_string(… TypeContext::OutgoingParam) -> outgoing_type_string`

`incoming_type_string` and `outgoing_type_string` just delegate to `field_type_string`, for types other than seuqence or dictionary.

## Purpose 2

 Various parameter-code used it to tell whether we were on the dispatch side or not.

Now, we just pass a bool named `is_dispatch` which we already had in some functions anyways.
`IncomingParam -> false`, `OutgoingParam -> true`
Usually these matches matched `TypeContext::Field` to `unreachable!`.
This change lets us remove all these dead branches.

Additionally, in `encoding.rs` we used `TypeContext` to tell whether we generated for fields or parameters.
Instead of TypeContext, these functions now also take a bool: `is_outgoing_param`
`OutgoingParam -> true` and `Field -> false`.
Because this is all encoding code, we never encounter `IncomingParam`.