### PR TITLE
Filter out Dunet-generated API from docfx since it has no doc-comments

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -13,6 +13,7 @@
         }
       ],
       "dest": "api",
+      "filter": "filterConfig.yml",
       "includePrivateMembers": false,
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
@@ -58,7 +59,7 @@
       "_appFaviconPath": "images/favicon.ico",
       "_appLogoPath": "images/logo.svg",
       "_appLogoUrl": "https://docs.icerpc.dev",
-      "_appFooter": "© 2023 ZeroC",
+      "_appFooter": "© 2024 ZeroC",
       "_enableSearch": true,
       "_googleAnalyticsTagId": "G-2D9VN5WR6Z",
       "_gitContribute": {

--- a/docfx/filterConfig.yml
+++ b/docfx/filterConfig.yml
@@ -1,0 +1,13 @@
+apiRules:
+- exclude:
+    uidRegex: ^ZeroC\.Slice\.ResultMatchExtensions
+    type: Type
+- exclude:
+    uidRegex: '^ZeroC\.Slice\.Result`2\.(Match|Unwrap).+$'
+    type: Method
+- exclude:
+    uidRegex: '^ZeroC\.Slice\.Result`2\.Failure\.(Match|Unwrap).+$'
+    type: Method
+- exclude:
+    uidRegex: '^ZeroC\.Slice\.Result`2\.Success\.(Match|Unwrap).+$'
+    type: Method

--- a/src/ZeroC.Slice/Result.cs
+++ b/src/ZeroC.Slice/Result.cs
@@ -6,13 +6,17 @@ namespace ZeroC.Slice;
 /// type of Slice operations.</summary>
 /// <typeparam name="TSuccess">The success type.</typeparam>
 /// <typeparam name="TFailure">The failure type.</typeparam>
-/// <remarks>The Slice Result type (a built-in generic type) maps to this generic class in C#.</remarks>
+/// <remarks>The Slice Result type (a built-in generic type) maps to this generic class in C#. The Dunet source
+/// generator provides many methods (Match, MatchSuccess, MatchFailure, MatchAsync, UnwrapSuccess, UnwrapFailure and
+/// more) for this generic class. See <see href="https://github.com/domn1995/dunet" /> for more information.</remarks>
 [Dunet.Union]
 public abstract partial record class Result<TSuccess, TFailure>
 {
     /// <summary>Represents a successful <see cref="Result{TSuccess, TFailure}" />.</summary>
+    /// <param name="Value">The value of type <typeparamref name="TSuccess"/>.</param>
     public partial record class Success(TSuccess Value);
 
     /// <summary>Represents a failed <see cref="Result{TSuccess, TFailure}" />.</summary>
+    /// <param name="Value">The value of type <typeparamref name="TFailure"/>.</param>
     public partial record class Failure(TFailure Value);
 }


### PR DESCRIPTION
This PR fixes #3892  (second option).