### PR TITLE
Hardcode 'sliceP_' Prefix.

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -493,7 +493,7 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
             false => "var".to_owned(),
         };
 
-        let param_name = &parameter.parameter_name_with_prefix("sliceP_");
+        let param_name = &parameter.parameter_name_with_prefix();
 
         let decode = match parameter.is_tagged() {
             true => decode_tagged(parameter, &namespace, false, encoding),
@@ -503,7 +503,7 @@ pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
         writeln!(code, "{param_type_string} {param_name} = {decode};")
     }
 
-    writeln!(code, "return {};", non_streamed_parameters.to_argument_tuple("sliceP_"));
+    writeln!(code, "return {};", non_streamed_parameters.to_argument_tuple());
 
     code
 }

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -265,7 +265,7 @@ var {args} = await request.DecodeArgsAsync(
     {decode_func},
     defaultActivator: null,
     cancellationToken).ConfigureAwait(false);",
-                args = non_streamed_parameters.to_argument_tuple("sliceP_"),
+                args = non_streamed_parameters.to_argument_tuple(),
                 encoding = operation.encoding.to_cs_encoding(),
                 decode_func = request_decode_func(operation).indent(),
             );
@@ -275,7 +275,7 @@ var {args} = await request.DecodeArgsAsync(
                     writeln!(
                         code,
                         "var {} = IceRpc.IncomingFrameExtensions.DetachPayload(request);",
-                        stream_member.parameter_name_with_prefix("sliceP_"),
+                        stream_member.parameter_name_with_prefix(),
                     )
                 }
                 _ => writeln!(
@@ -284,12 +284,12 @@ var {args} = await request.DecodeArgsAsync(
 var payloadContinuation = IceRpc.IncomingFrameExtensions.DetachPayload(request);
 var {stream_parameter_name} = {decode_operation_stream}
 ",
-                    stream_parameter_name = stream_member.parameter_name_with_prefix("sliceP_"),
+                    stream_parameter_name = stream_member.parameter_name_with_prefix(),
                     decode_operation_stream =
                         decode_operation_stream(stream_member, namespace, operation.encoding, true),
                 ),
             }
-            writeln!(code, "return {};", operation.parameters().to_argument_tuple("sliceP_"));
+            writeln!(code, "return {};", operation.parameters().to_argument_tuple());
         }
     } else {
         writeln!(
@@ -410,7 +410,7 @@ await request.DecodeEmptyArgsAsync({encoding}, cancellationToken).ConfigureAwait
             writeln!(
                 check_and_decode,
                 "var {var_name} = await Request.Decode{async_operation_name}(request, cancellationToken).ConfigureAwait(false);",
-                var_name = parameter.parameter_name_with_prefix("sliceP_"),
+                var_name = parameter.parameter_name_with_prefix(),
             )
         }
         _ => {
@@ -425,7 +425,7 @@ await request.DecodeEmptyArgsAsync({encoding}, cancellationToken).ConfigureAwait
     let mut dispatch_and_return = CodeBlock::default();
 
     let mut args = match parameters.as_slice() {
-        [parameter] => vec![parameter.parameter_name_with_prefix("sliceP_")],
+        [parameter] => vec![parameter.parameter_name_with_prefix()],
         _ => parameters
             .into_iter()
             .map(|parameter| "args.".to_owned() + &parameter.field_name())

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -625,7 +625,7 @@ var {return_value} = await response.DecodeReturnValueAsync(
     defaultActivator: null,
     cancellationToken).ConfigureAwait(false);
 ",
-                return_value = non_streamed_members.to_argument_tuple("sliceP_"),
+                return_value = non_streamed_members.to_argument_tuple(),
                 encoding = operation.encoding.to_cs_encoding(),
                 return_value_decode_func = return_value_decode_func(operation).indent(),
             );
@@ -637,7 +637,7 @@ var {return_value} = await response.DecodeReturnValueAsync(
                 writeln!(
                     code,
                     "var {} = IceRpc.IncomingFrameExtensions.DetachPayload(response);",
-                    stream_member.parameter_name_with_prefix("sliceP_"),
+                    stream_member.parameter_name_with_prefix(),
                 )
             }
             _ => writeln!(
@@ -646,7 +646,7 @@ var {return_value} = await response.DecodeReturnValueAsync(
 var payloadContinuation = IceRpc.IncomingFrameExtensions.DetachPayload(response);
 var {stream_parameter_name} = {decode_operation_stream}
 ",
-                stream_parameter_name = stream_member.parameter_name_with_prefix("sliceP_"),
+                stream_parameter_name = stream_member.parameter_name_with_prefix(),
                 decode_operation_stream = decode_operation_stream(stream_member, namespace, operation.encoding, false),
             ),
         }
@@ -654,7 +654,7 @@ var {stream_parameter_name} = {decode_operation_stream}
         writeln!(
             code,
             "return {};",
-            operation.return_members().to_argument_tuple("sliceP_"),
+            operation.return_members().to_argument_tuple(),
         );
     } else if return_void {
         writeln!(

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -9,7 +9,7 @@ use slicec::utils::code_gen_util::TypeContext;
 
 pub trait MemberExt {
     fn parameter_name(&self) -> String;
-    fn parameter_name_with_prefix(&self, prefix: &str) -> String;
+    fn parameter_name_with_prefix(&self) -> String;
     fn field_name(&self) -> String;
 }
 
@@ -18,9 +18,9 @@ impl<T: Member> MemberExt for T {
         escape_keyword(&self.cs_identifier(Case::Camel))
     }
 
-    fn parameter_name_with_prefix(&self, prefix: &str) -> String {
-        let name = prefix.to_owned() + &self.cs_identifier(Case::Camel);
-        escape_keyword(&name)
+    /// Returns this parameter's C# identifier (in camel case) with a `sliceP_` prefix.
+    fn parameter_name_with_prefix(&self) -> String {
+        escape_keyword(&format!("sliceP_{}", self.cs_identifier(Case::Camel)))
     }
 
     fn field_name(&self) -> String {
@@ -104,19 +104,22 @@ impl ParameterExt for Parameter {
 }
 
 pub trait ParameterSliceExt {
-    fn to_argument_tuple(&self, prefix: &str) -> String;
+    fn to_argument_tuple(&self) -> String;
     fn to_tuple_type(&self, namespace: &str, context: TypeContext) -> String;
 }
 
 impl ParameterSliceExt for [&Parameter] {
-    fn to_argument_tuple(&self, prefix: &str) -> String {
+    /// Convert each parameter in this slice to it's argument representation.
+    /// This is the parameter's C# identifier (in camel case) with a `sliceP_` prefix.
+    /// If there are more than 1 parameters in this slice, it returns them wrapped in parenthesis (a tuple).
+    fn to_argument_tuple(&self) -> String {
         match self {
             [] => panic!("tuple type with no members"),
-            [member] => member.parameter_name_with_prefix(prefix),
+            [member] => member.parameter_name_with_prefix(),
             _ => format!(
                 "({})",
                 self.iter()
-                    .map(|m| m.parameter_name_with_prefix(prefix))
+                    .map(|m| m.parameter_name_with_prefix())
                     .collect::<Vec<String>>()
                     .join(", "),
             ),

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -20,7 +20,7 @@ impl<T: Member> MemberExt for T {
 
     /// Returns this parameter's C# identifier (in camel case) with a `sliceP_` prefix.
     fn parameter_name_with_prefix(&self) -> String {
-        escape_keyword(&format!("sliceP_{}", self.cs_identifier(Case::Camel)))
+        format!("sliceP_{}", self.cs_identifier(Case::Camel))
     }
 
     fn field_name(&self) -> String {


### PR DESCRIPTION
We have the function `parameter_name_with_prefix`, which accepts an arbitrary prefix and computes the
'parameter string representation' of a member, with that prefix.

This prefix is always `sliceP_` and this PR simplifies the logic by hard-coding this value.
It also adds doc comments to the 2 functions it touches.