### PR TITLE
Pull in latest 'slicec'.

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -27,36 +27,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -97,9 +97,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cfg-if"
@@ -109,9 +109,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.10"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.9"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -155,15 +155,15 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -253,9 +253,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -276,9 +276,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "in_definite"
@@ -288,9 +288,9 @@ checksum = "b5bd47a3c8188d842aa7ff4dd65a9732f740fcbe04689ecfbfef43c465b381de"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -298,13 +298,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lalrpop"
@@ -358,9 +358,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libredox"
@@ -368,16 +368,16 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -397,9 +397,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -409,9 +409,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
@@ -463,18 +463,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -536,15 +536,15 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -555,9 +555,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "scopeguard"
@@ -567,18 +567,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -605,7 +605,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "slicec"
 version = "0.2.1"
-source = "git+https://github.com/icerpc/slicec?branch=main#482782223bd0c1c60e41f8974475cd1eff6bb963"
+source = "git+https://github.com/icerpc/slicec?branch=main#b201fa8c4465c9194e68c75670f991fbe246a898"
 dependencies = [
  "clap",
  "console",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "string_cache"
@@ -655,9 +655,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -710,18 +710,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -797,44 +797,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -869,12 +836,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -884,12 +845,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -905,12 +860,6 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -920,12 +869,6 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -941,12 +884,6 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -959,12 +896,6 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -974,12 +905,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+use crate::code_gen_util::TypeContext;
 use crate::comments::CommentTag;
 use crate::cs_attributes::CsType;
 use crate::cs_util::*;
@@ -7,7 +8,6 @@ use crate::member_util::escape_parameter_name;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::TypeContext;
 
 pub trait Builder {
     fn build(&self) -> CodeBlock;
@@ -181,7 +181,7 @@ impl Builder for ContainerBuilder {
             },
         );
 
-        let mut body_content: CodeBlock = self.contents.iter().cloned().collect();
+        let body_content: CodeBlock = self.contents.iter().cloned().collect();
 
         if body_content.is_empty() {
             code.writeln("{\n}");

--- a/tools/slicec-cs/src/code_gen_util.rs
+++ b/tools/slicec-cs/src/code_gen_util.rs
@@ -1,0 +1,27 @@
+// Copyright (c) ZeroC, Inc.
+
+use slicec::grammar::{Encoding, Member};
+
+/// The context that a type is being used in while generating code. This is used primarily by the
+/// `type_to_string` methods in each of the language mapping's code generators.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum TypeContext {
+    /// Used when generating the types of fields in structs, classes, and exceptions, or when generating types that are
+    /// parts of other types, such as the element type of a sequence, or the success & failure types of results.
+    Field,
+    /// Used when generating the types of operation parameters and return types in places where they're being decoded.
+    IncomingParam,
+    /// Used when generating the types of operation parameters and return types in places where they're being encoded.
+    OutgoingParam,
+}
+
+pub fn get_bit_sequence_size<T: Member>(encoding: Encoding, members: &[&T]) -> usize {
+    if encoding == Encoding::Slice1 {
+        return 0;
+    }
+
+    members
+        .iter()
+        .filter(|member| !member.is_tagged() && member.data_type().is_optional)
+        .count()
+}

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::builders::{Builder, FunctionCallBuilder};
+use crate::code_gen_util::get_bit_sequence_size;
 use crate::cs_attributes::CsType;
 use crate::cs_util::*;
 use crate::member_util::get_sorted_members;
@@ -8,7 +9,6 @@ use crate::slicec_ext::*;
 use convert_case::Case;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::get_bit_sequence_size;
 
 /// Compute how many bits are needed to decode the provided members, and if more than 0 bits are needed,
 /// this generates code that creates a new `BitSequenceReader` with the necessary capacity.
@@ -166,7 +166,7 @@ fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, enco
     let value_type = &dictionary_ref.value_type;
 
     // decode key
-    let mut decode_key = decode_func(key_type, namespace, encoding);
+    let decode_key = decode_func(key_type, namespace, encoding);
 
     // decode value
     let mut decode_value = decode_func(value_type, namespace, encoding);
@@ -402,8 +402,7 @@ fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) 
         ));
     }
 
-    decode_func.indent();
-    decode_func
+    decode_func.indent()
 }
 
 pub fn decode_func(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -1,13 +1,13 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::builders::{Builder, FunctionCallBuilder};
+use crate::code_gen_util::{get_bit_sequence_size, TypeContext};
 use crate::cs_attributes::CsType;
 use crate::member_util::get_sorted_members;
 use crate::slicec_ext::*;
 use convert_case::Case;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::{get_bit_sequence_size, TypeContext};
 
 pub fn encode_fields(fields: &[&Field], encoding: Encoding) -> CodeBlock {
     let mut code = CodeBlock::default();

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -143,7 +143,7 @@ fn constructor(
         code
     });
 
-    code.add_block(&builder.build());
+    code.add_block(builder.build());
 
     code
 }
@@ -199,8 +199,8 @@ fn encode_and_decode(class_def: &Class) -> CodeBlock {
         .add_never_editor_browsable_attribute()
         .build();
 
-    code.add_block(&encode_class);
-    code.add_block(&decode_class);
+    code.add_block(encode_class);
+    code.add_block(decode_class);
 
     code
 }

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -1,13 +1,13 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::builders::{AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, FunctionBuilder, FunctionType};
+use crate::code_gen_util::{get_bit_sequence_size, TypeContext};
 use crate::cs_attributes::CsEncodedReturn;
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
 
 pub fn generate_dispatch(interface_def: &Interface) -> CodeBlock {
     let namespace = interface_def.namespace();

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -12,14 +12,14 @@ use slicec::grammar::*;
 
 pub fn generate_enum(enum_def: &Enum) -> CodeBlock {
     let mut code = CodeBlock::default();
-    code.add_block(&enum_declaration(enum_def));
+    code.add_block(enum_declaration(enum_def));
 
     if enum_def.is_mapped_to_cs_enum() {
-        code.add_block(&enum_underlying_extensions(enum_def));
+        code.add_block(enum_underlying_extensions(enum_def));
     }
 
-    code.add_block(&enum_encoder_extensions(enum_def));
-    code.add_block(&enum_decoder_extensions(enum_def));
+    code.add_block(enum_encoder_extensions(enum_def));
+    code.add_block(enum_decoder_extensions(enum_def));
     code
 }
 
@@ -110,7 +110,7 @@ fn enumerators(enum_def: &Enum) -> CodeBlock {
             enumerator.value()
         );
 
-        code.add_block(&declaration);
+        code.add_block(declaration);
     }
     code
 }
@@ -183,7 +183,7 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                 .build()
         );
 
-        code.add_block(&builder.build());
+        code.add_block(builder.build());
     }
 
     if enum_def.is_unchecked {
@@ -217,7 +217,7 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
                     .build(),
             );
 
-        code.add_block(&builder.build());
+        code.add_block(builder.build());
     }
 
     code
@@ -461,7 +461,7 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
                         "{escaped_identifier}.{enumerator_name}.Discriminant => Decode{enumerator_name}(ref decoder),",
                     )
                 }
-                cases.indent();
+                cases = cases.indent();
 
                 let fallback = if enum_def.is_unchecked {
                     format!("int value => new {escaped_identifier}.Unknown(value, decoder.DecodeSequence<byte>())")
@@ -472,7 +472,7 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
                     )
                 };
 
-                &format!(
+                format!(
                     r#"return decoder.DecodeVarInt32() switch
 {{
     {cases}
@@ -486,7 +486,7 @@ fn enum_decoder_extensions(enum_def: &Enum) -> CodeBlock {
                 let enumerator_name = enumerator.escape_identifier();
                 let decoded_type = format!("{escaped_identifier}.{enumerator_name}");
                 body.add_block(
-                    &FunctionBuilder::new(
+                    FunctionBuilder::new(
                         "static",
                         &decoded_type,
                         &format!("Decode{enumerator_name}"),

--- a/tools/slicec-cs/src/generators/mod.rs
+++ b/tools/slicec-cs/src/generators/mod.rs
@@ -22,34 +22,34 @@ struct Generator<'a> {
 impl Visitor for Generator<'_> {
     fn visit_struct(&mut self, struct_def: &Struct) {
         if !self.for_interfaces {
-            self.code.add_block(&struct_generator::generate_struct(struct_def));
+            self.code.add_block(struct_generator::generate_struct(struct_def));
         }
     }
 
     fn visit_class(&mut self, class_def: &Class) {
         if !self.for_interfaces {
-            self.code.add_block(&class_generator::generate_class(class_def));
+            self.code.add_block(class_generator::generate_class(class_def));
         }
     }
 
     fn visit_exception(&mut self, exception_def: &Exception) {
         if !self.for_interfaces {
             self.code
-                .add_block(&exception_generator::generate_exception(exception_def));
+                .add_block(exception_generator::generate_exception(exception_def));
         }
     }
 
     fn visit_interface(&mut self, interface_def: &Interface) {
         if self.for_interfaces {
-            self.code.add_block(&proxy_generator::generate_proxy(interface_def));
+            self.code.add_block(proxy_generator::generate_proxy(interface_def));
             self.code
-                .add_block(&dispatch_generator::generate_dispatch(interface_def));
+                .add_block(dispatch_generator::generate_dispatch(interface_def));
         }
     }
 
     fn visit_enum(&mut self, enum_def: &Enum) {
         if !self.for_interfaces {
-            self.code.add_block(&enum_generator::generate_enum(enum_def));
+            self.code.add_block(enum_generator::generate_enum(enum_def));
         }
     }
 }
@@ -64,14 +64,14 @@ pub fn generate_from_slice_file(slice_file: &SliceFile, for_interfaces: bool, _o
         generated_code.add_block("using IceRpc.Slice;\nusing ZeroC.Slice;");
     } else {
         generated_code.add_block("using ZeroC.Slice;");
-        generated_code.add_block(&format!("[assembly:Slice(\"{filename}.slice\")]"));
+        generated_code.add_block(format!("[assembly:Slice(\"{filename}.slice\")]"));
     }
 
     // If the slice file wasn't empty, generate code for its contents.
     if let Some(module_ptr) = &slice_file.module {
         // First generate the file's namespace declaration.
         let namespace = module_ptr.borrow().as_namespace();
-        generated_code.add_block(&format!("namespace {namespace};"));
+        generated_code.add_block(format!("namespace {namespace};"));
 
         // Then generate code for the user's slice definitions.
         let mut generator = Generator {

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -3,6 +3,7 @@
 use crate::builders::{
     AttributeBuilder, Builder, CommentBuilder, ContainerBuilder, FunctionBuilder, FunctionCallBuilder, FunctionType,
 };
+use crate::code_gen_util::{get_bit_sequence_size, TypeContext};
 use crate::decoding::*;
 use crate::encoding::*;
 use crate::member_util::*;
@@ -10,7 +11,6 @@ use crate::slicec_ext::*;
 use slicec::code_block::CodeBlock;
 use slicec::grammar::attributes::Oneway;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::*;
 
 pub fn generate_proxy(interface_def: &Interface) -> CodeBlock {
     let namespace = interface_def.namespace();
@@ -42,7 +42,7 @@ pub fn generate_proxy(interface_def: &Interface) -> CodeBlock {
         .add_comments(interface_def.formatted_doc_comment_seealso())
         .add_bases(&interface_bases)
         .add_block(proxy_interface_operations(interface_def));
-    code.add_block(&proxy_interface_builder.build());
+    code.add_block(proxy_interface_builder.build());
 
     let mut proxy_impl_builder =
         ContainerBuilder::new(&format!("{access} readonly partial record struct"), &proxy_impl);
@@ -118,7 +118,7 @@ public static implicit operator {base_impl}({proxy_impl} proxy) =>
         proxy_impl_builder.add_block(proxy_operation_impl(operation));
     }
 
-    code.add_block(&proxy_impl_builder.build());
+    code.add_block(proxy_impl_builder.build());
 
     let mut proxy_encoder_builder = ContainerBuilder::new(
         &format!("{access} static class"),
@@ -170,7 +170,7 @@ Provides an extension method for <see cref="SliceEncoder" /> to encode a <see cr
         );
     }
 
-    code.add_block(&proxy_encoder_builder.build());
+    code.add_block(proxy_encoder_builder.build());
 
     let mut proxy_decoder_builder = ContainerBuilder::new(
         &format!("{access} static class"),
@@ -222,7 +222,7 @@ Provides an extension method for <see cref="SliceDecoder" /> to decode a <see cr
         );
     }
 
-    code.add_block(&proxy_decoder_builder.build());
+    code.add_block(proxy_decoder_builder.build());
 
     code
 }
@@ -438,7 +438,7 @@ fn proxy_interface_operations(interface_def: &Interface) -> CodeBlock {
             .add_operation_parameters(operation, TypeContext::OutgoingParam)
             .add_comments(operation.formatted_doc_comment_seealso())
             .add_obsolete_attribute(operation);
-        code.add_block(&builder.build());
+        code.add_block(builder.build());
     }
 
     code
@@ -651,11 +651,7 @@ var {stream_parameter_name} = {decode_operation_stream}
             ),
         }
 
-        writeln!(
-            code,
-            "return {};",
-            operation.return_members().to_argument_tuple(),
-        );
+        writeln!(code, "return {};", operation.return_members().to_argument_tuple());
     } else if return_void {
         writeln!(
             code,

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -9,7 +9,6 @@ use crate::slicec_ext::{CommentExt, EntityExt, MemberExt, TypeRefExt};
 use slicec::code_block::CodeBlock;
 use slicec::grammar::*;
 use slicec::supported_encodings::SupportedEncodings;
-use slicec::utils::code_gen_util::TypeContext;
 
 pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
     let escaped_identifier = struct_def.escape_identifier();
@@ -134,8 +133,8 @@ fn generate_encoding_blocks(
         [] => unreachable!("No supported encodings"),
         [encoding] => encoding_fn(fields, encoding),
         _ => {
-            let mut slice1_block = encoding_fn(fields, Encoding::Slice1);
-            let mut slice2_block = encoding_fn(fields, Encoding::Slice2);
+            let slice1_block = encoding_fn(fields, Encoding::Slice1);
+            let slice2_block = encoding_fn(fields, Encoding::Slice2);
 
             // The encoding blocks are only empty for empty structs. But `Slice1` doesn't support empty structs.
             // So this branch of the match statement is never hit, since it's for structs that support both encodings.

--- a/tools/slicec-cs/src/main.rs
+++ b/tools/slicec-cs/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 mod builders;
+mod code_gen_util;
 mod comments;
 mod cs_attributes;
 mod cs_compile;

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -1,11 +1,11 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{EntityExt, TypeRefExt};
+use crate::code_gen_util::TypeContext;
 use crate::cs_attributes::CsReadonly;
 use crate::cs_util::{escape_keyword, format_comment_message};
 use convert_case::Case;
 use slicec::grammar::*;
-use slicec::utils::code_gen_util::TypeContext;
 
 pub trait MemberExt {
     fn parameter_name(&self) -> String;

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -1,9 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{EntityExt, MemberExt, ParameterExt, ParameterSliceExt};
+use crate::code_gen_util::TypeContext;
 use crate::cs_attributes::CsEncodedReturn;
 use slicec::grammar::{AttributeFunctions, Contained, Operation};
-use slicec::utils::code_gen_util::TypeContext;
 
 pub trait OperationExt {
     /// Returns the format that classes should be encoded with.


### PR DESCRIPTION
This PR pulls in the latest changes from `slicec`.

These include a simplified CodeBlock API, that saves us a `mut` and `&` in places,
and it moves the `code_gen_util` types out of `slicec` and into `slicec-cs`.
