### PR TITLE
Remove `is_dispatch` flag from `decode_operation`

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -475,9 +475,9 @@ pub fn decode_non_streamed_parameters(non_streamed_parameters: &[&Parameter], en
 
     let mut code = CodeBlock::default();
 
-    initialize_bit_sequence_reader_for(&non_streamed_parameters, &mut code, encoding);
+    initialize_bit_sequence_reader_for(non_streamed_parameters, &mut code, encoding);
 
-    for parameter in get_sorted_members(&non_streamed_parameters) {
+    for parameter in get_sorted_members(non_streamed_parameters) {
         let param_type = parameter.data_type();
         let namespace = parameter.namespace();
 

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -468,22 +468,18 @@ fn decode_func_body(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> 
     code
 }
 
-pub fn decode_operation(operation: &Operation, dispatch: bool) -> CodeBlock {
-    let mut code = CodeBlock::default();
-    let namespace = operation.namespace();
-    let encoding = operation.encoding;
-
-    let non_streamed_parameters = if dispatch {
-        operation.non_streamed_parameters()
-    } else {
-        operation.non_streamed_return_members()
-    };
+pub fn decode_non_streamed_parameters(non_streamed_parameters: &[&Parameter], encoding: Encoding) -> CodeBlock {
+    // Ensure that the parameters are all non-streamed, and there's at least one of them.
+    assert!(non_streamed_parameters.iter().all(|p| !p.is_streamed));
     assert!(!non_streamed_parameters.is_empty());
 
-    initialize_bit_sequence_reader_for(&non_streamed_parameters, &mut code, operation.encoding);
+    let mut code = CodeBlock::default();
+
+    initialize_bit_sequence_reader_for(&non_streamed_parameters, &mut code, encoding);
 
     for parameter in get_sorted_members(&non_streamed_parameters) {
         let param_type = parameter.data_type();
+        let namespace = parameter.namespace();
 
         // For optional value types we have to use the full type as the compiler cannot
         // disambiguate between null and the actual value type.

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -311,24 +311,25 @@ request.DecodeArgsAsync(
 
 fn request_decode_func(operation: &Operation) -> CodeBlock {
     let namespace = &operation.namespace();
+    let encoding = operation.encoding;
 
     let parameters = operation.non_streamed_parameters();
     assert!(!parameters.is_empty());
 
     let use_default_decode_func = parameters.len() == 1
-        && get_bit_sequence_size(operation.encoding, &parameters) == 0
+        && get_bit_sequence_size(encoding, &parameters) == 0
         && !parameters.first().unwrap().is_tagged();
 
     if use_default_decode_func {
         let param = parameters.first().unwrap();
-        decode_func(param.data_type(), namespace, operation.encoding)
+        decode_func(param.data_type(), namespace, encoding)
     } else {
         format!(
             "(ref SliceDecoder decoder) =>
 {{
     {}
 }}",
-            decode_operation(operation, true).indent(),
+            decode_non_streamed_parameters(&parameters, encoding).indent(),
         )
         .into()
     }

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -733,15 +733,17 @@ catch {catch_expression}
 
 fn return_value_decode_func(operation: &Operation) -> CodeBlock {
     let namespace = &operation.namespace();
+    let encoding = operation.encoding;
+
     // vec of members
     let members = operation.non_streamed_return_members();
     assert!(!members.is_empty());
 
     if members.len() == 1
-        && get_bit_sequence_size(operation.encoding, &members) == 0
+        && get_bit_sequence_size(encoding, &members) == 0
         && !members.first().unwrap().is_tagged()
     {
-        decode_func(members.first().unwrap().data_type(), namespace, operation.encoding)
+        decode_func(members.first().unwrap().data_type(), namespace, encoding)
     } else {
         format!(
             "\
@@ -749,7 +751,7 @@ fn return_value_decode_func(operation: &Operation) -> CodeBlock {
 {{
     {decode}
 }}",
-            decode = decode_operation(operation, false).indent(),
+            decode = decode_non_streamed_parameters(&members, encoding).indent(),
         )
         .into()
     }


### PR DESCRIPTION
This PR reworks and renames `decode_operation`, so it not longer takes a random bool parameter.

This parameter was only used to pick either the parameters, or return members from an operation. Now this is left up to caller to pass in.