### PR TITLE
Merge `request_decode_func` and `return_value_decode_func`

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -514,10 +514,10 @@ pub fn decode_non_streamed_parameters_func(non_streamed_parameters: &[&Parameter
             let body_content = code.indent();
             format!(
                 "\
-    (ref SliceDecoder decoder) =>
-    {{
-        {body_content}
-    }}",
+(ref SliceDecoder decoder) =>
+{{
+    {body_content}
+}}",
             )
             .into()
         }


### PR DESCRIPTION
This PR merges `request_decode_func` and `return_value_decode_func` into a single function, since they were actually identical functions. This new function is named: `decode_non_streamed_parameters_func`.

It was fairly small, and after this change, `decode_non_streamed_parameters` was only called in one spot, in this function, so I also went ahead and inlined the function there.