### PR TITLE
Remove redundant cast in 'decode_func_body' for collections.

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -414,9 +414,9 @@ fn decode_func_body(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> 
     let mut code = CodeBlock::default();
     let type_name = type_ref.incoming_parameter_type_string(namespace, true);
 
-    // When we decode the type, we decode it as a non-optional.
-    // If the type is supposed to be optional, we cast it after decoding.
-    if type_ref.is_optional {
+    // When we decode the type, we decode it as a non-optional. If the type is supposed to be optional,
+    // we cast it after decoding. Except for sequences and dictionaries, because we always cast them anyways.
+    if type_ref.is_optional && !matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
         write!(code, "({type_name}?)");
     }
 


### PR DESCRIPTION
After investigating the way we cast sequences and dictionaries, I noticed we're accidentally generating a double cast for optional nested sequences and dictionaries. One that we always generate for lambdas, and another we always generate for sequences and dictionaries. This PR removes removes the double-cast:
```diff
                 size => new global::System.Collections.Generic.Dictionary<string, global::System.Collections.Generic.IDictionary<string, bool>?>(size),
                 (ref SliceDecoder decoder) => decoder.DecodeString(),
-                (ref SliceDecoder decoder) => (global::System.Collections.Generic.Dictionary<string, bool>?)decoder.DecodeDictionary(
+                (ref SliceDecoder decoder) => decoder.DecodeDictionary(
                     size => new global::System.Collections.Generic.Dictionary<string, bool>(size),
                     (ref SliceDecoder decoder) => decoder.DecodeString(),
```