### PR TITLE
Split return task func

### DIFF
--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -312,7 +312,7 @@ request.DecodeArgsAsync(
 fn operation_declaration(operation: &Operation) -> CodeBlock {
     let mut builder = FunctionBuilder::new(
         "public",
-        &operation.return_task(true),
+        &operation.dispatch_return_task(),
         &operation.escape_identifier_with_suffix("Async"),
         FunctionType::Declaration,
     );

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -275,7 +275,7 @@ fn proxy_operation_impl(operation: &Operation) -> CodeBlock {
     let namespace = &operation.namespace();
     let operation_name = operation.escape_identifier();
     let async_operation_name = operation.escape_identifier_with_suffix("Async");
-    let return_task = operation.return_task(false);
+    let return_task = operation.invocation_return_task();
 
     let parameters = operation.non_streamed_parameters();
 
@@ -393,7 +393,7 @@ if ({features_parameter}?.Get<IceRpc.Features.ICompressFeature>() is null)
 
 fn proxy_base_operation_impl(operation: &Operation, namespace: &str) -> CodeBlock {
     let async_name = operation.escape_identifier_with_suffix("Async");
-    let return_task = operation.return_task(false);
+    let return_task = operation.invocation_return_task();
     let mut operation_params = operation
         .parameters()
         .iter()
@@ -427,7 +427,7 @@ fn proxy_interface_operations(interface_def: &Interface) -> CodeBlock {
     for operation in operations {
         let mut builder = FunctionBuilder::new(
             "",
-            &operation.return_task(false),
+            &operation.invocation_return_task(),
             &operation.escape_identifier_with_suffix("Async"),
             FunctionType::Declaration,
         );

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -51,10 +51,7 @@ impl OperationExt for Operation {
                     "global::System.IO.Pipelines.PipeReader".to_owned()
                 }
             } else {
-                match return_members.as_slice() {
-                    [] => unreachable!(),
-                    members => members.to_tuple_type(&namespace, TypeContext::OutgoingParam),
-                }
+                return_members.to_tuple_type(&namespace, TypeContext::OutgoingParam),
             };
             format!("global::System.Threading.Tasks.ValueTask<{return_type}>")
         }

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -26,12 +26,12 @@ impl OperationExt for Operation {
     }
 
     fn invocation_return_task(&self, task_type: &str) -> String {
-        let namespace = self.namespace();
+        let namespace = &self.namespace();
         let return_type = match self.return_members().as_slice() {
-            [] => return format!("global::System.Threading.Tasks.{task_type}"),
-            members => members.to_tuple_type(&namespace, TypeContext::IncomingParam),
+            [] => "".to_owned(),
+            members => format!("<{}>", members.to_tuple_type(namespace, TypeContext::IncomingParam)),
         };
-        format!("global::System.Threading.Tasks.{task_type}<{return_type}>")
+        format!("global::System.Threading.Tasks.{task_type}{return_type}")
     }
 
     fn dispatch_return_task(&self) -> String {
@@ -51,7 +51,7 @@ impl OperationExt for Operation {
                     "global::System.IO.Pipelines.PipeReader".to_owned()
                 }
             } else {
-                return_members.to_tuple_type(&namespace, TypeContext::OutgoingParam),
+                return_members.to_tuple_type(&namespace, TypeContext::OutgoingParam)
             };
             format!("global::System.Threading.Tasks.ValueTask<{return_type}>")
         }

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -3,7 +3,7 @@
 use super::{EntityExt, MemberExt, ParameterExt, ParameterSliceExt};
 use crate::code_gen_util::TypeContext;
 use crate::cs_attributes::CsEncodedReturn;
-use slicec::grammar::{AttributeFunctions, Contained, Operation};
+use slicec::grammar::{AttributeFunctions, Operation};
 
 pub trait OperationExt {
     /// Returns the format that classes should be encoded with.
@@ -26,18 +26,13 @@ impl OperationExt for Operation {
     }
 
     fn invocation_return_task(&self) -> String {
-        let return_members = self.return_members();
-        if return_members.is_empty() {
-            "global::System.Threading.Tasks.Task".to_owned()
-        } else {
-            let namespace = self.parent().namespace();
-            let return_type = match self.return_members().as_slice() {
-                [] => "void".to_owned(),
-                [member] => member.cs_type_string(&namespace, TypeContext::IncomingParam),
-                members => members.to_tuple_type(&namespace, TypeContext::IncomingParam),
-            };
-            format!("global::System.Threading.Tasks.Task<{return_type}>")
-        }
+        let namespace = self.namespace();
+        let return_type = match self.return_members().as_slice() {
+            [] => return "global::System.Threading.Tasks.Task".to_owned(),
+            [member] => member.cs_type_string(&namespace, TypeContext::IncomingParam),
+            members => members.to_tuple_type(&namespace, TypeContext::IncomingParam),
+        };
+        format!("global::System.Threading.Tasks.Task<{return_type}>")
     }
 
     fn dispatch_return_task(&self) -> String {
@@ -45,7 +40,7 @@ impl OperationExt for Operation {
         if return_members.is_empty() {
             "global::System.Threading.Tasks.ValueTask".to_owned()
         } else {
-            let namespace = self.parent().namespace();
+            let namespace = self.namespace();
             let return_type = if self.has_attribute::<CsEncodedReturn>() {
                 if let Some(stream_member) = self.streamed_return_member() {
                     format!(
@@ -57,8 +52,8 @@ impl OperationExt for Operation {
                     "global::System.IO.Pipelines.PipeReader".to_owned()
                 }
             } else {
-                match self.return_members().as_slice() {
-                    [] => "void".to_owned(),
+                match return_members.as_slice() {
+                    [] => unreachable!(),
                     [member] => member.cs_type_string(&namespace, TypeContext::OutgoingParam),
                     members => members.to_tuple_type(&namespace, TypeContext::OutgoingParam),
                 }

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -9,8 +9,8 @@ pub trait OperationExt {
     /// Returns the format that classes should be encoded with.
     fn get_class_format(&self, is_dispatch: bool) -> &str;
 
-    /// The operation return task.
-    fn return_task(&self, is_dispatch: bool) -> String;
+    fn invocation_return_task(&self) -> String;
+    fn dispatch_return_task(&self) -> String;
 }
 
 impl OperationExt for Operation {
@@ -25,29 +25,31 @@ impl OperationExt for Operation {
         }
     }
 
-    fn return_task(&self, is_dispatch: bool) -> String {
+    fn invocation_return_task(&self) -> String {
         let return_members = self.return_members();
         if return_members.is_empty() {
-            if is_dispatch {
-                "global::System.Threading.Tasks.ValueTask".to_owned()
-            } else {
-                "global::System.Threading.Tasks.Task".to_owned()
-            }
+            "global::System.Threading.Tasks.Task".to_owned()
         } else {
             let return_type = operation_return_type(
                 self,
-                is_dispatch,
-                if is_dispatch {
-                    TypeContext::OutgoingParam
-                } else {
-                    TypeContext::IncomingParam
-                },
+                false,
+                TypeContext::IncomingParam,
             );
-            if is_dispatch {
-                format!("global::System.Threading.Tasks.ValueTask<{return_type}>")
-            } else {
-                format!("global::System.Threading.Tasks.Task<{return_type}>")
-            }
+            format!("global::System.Threading.Tasks.Task<{return_type}>")
+        }
+    }
+
+    fn dispatch_return_task(&self) -> String {
+        let return_members = self.return_members();
+        if return_members.is_empty() {
+            "global::System.Threading.Tasks.ValueTask".to_owned()
+        } else {
+            let return_type = operation_return_type(
+                self,
+                true,
+                TypeContext::OutgoingParam,
+            );
+            format!("global::System.Threading.Tasks.ValueTask<{return_type}>")
         }
     }
 }

--- a/tools/slicec-cs/src/slicec_ext/operation_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/operation_ext.rs
@@ -9,7 +9,7 @@ pub trait OperationExt {
     /// Returns the format that classes should be encoded with.
     fn get_class_format(&self, is_dispatch: bool) -> &str;
 
-    fn invocation_return_task(&self) -> String;
+    fn invocation_return_task(&self, task_type: &str) -> String;
     fn dispatch_return_task(&self) -> String;
 }
 
@@ -25,14 +25,13 @@ impl OperationExt for Operation {
         }
     }
 
-    fn invocation_return_task(&self) -> String {
+    fn invocation_return_task(&self, task_type: &str) -> String {
         let namespace = self.namespace();
         let return_type = match self.return_members().as_slice() {
-            [] => return "global::System.Threading.Tasks.Task".to_owned(),
-            [member] => member.cs_type_string(&namespace, TypeContext::IncomingParam),
+            [] => return format!("global::System.Threading.Tasks.{task_type}"),
             members => members.to_tuple_type(&namespace, TypeContext::IncomingParam),
         };
-        format!("global::System.Threading.Tasks.Task<{return_type}>")
+        format!("global::System.Threading.Tasks.{task_type}<{return_type}>")
     }
 
     fn dispatch_return_task(&self) -> String {
@@ -54,7 +53,6 @@ impl OperationExt for Operation {
             } else {
                 match return_members.as_slice() {
                     [] => unreachable!(),
-                    [member] => member.cs_type_string(&namespace, TypeContext::OutgoingParam),
                     members => members.to_tuple_type(&namespace, TypeContext::OutgoingParam),
                 }
             };


### PR DESCRIPTION
We have a `return_task` function which takes an `is_dispatch` bool.
Almost everything in this function is just `if is_dispatch {} else {}`, so this PR just splits it into two separate functions:
`dispatch_return_task` and `invocation_return_task`.

We re-implemented this function in the body of `response_class`.
So, this PR also changes that logic to just call the new `invocation_return_task`.