### PR TITLE
Use casts instead of 'as' conversions for decoding.

### DIFF
--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -167,13 +167,7 @@ fn decode_dictionary(dictionary_ref: &TypeRef<Dictionary>, namespace: &str, enco
 
     // decode key
     let decode_key = decode_func(key_type, namespace, encoding);
-
-    // decode value
-    let mut decode_value = decode_func(value_type, namespace, encoding);
-    if matches!(value_type.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
-        write!(decode_value, " as {}", value_type.field_type_string(namespace, true));
-    }
-
+    let decode_value = decode_type_with_cast(value_type, namespace, encoding, false);
     let dictionary_type = dictionary_ref.incoming_parameter_type_string(namespace, true);
     let decode_key = decode_key.indent();
     let decode_value = decode_value.indent();
@@ -204,8 +198,8 @@ fn decode_result(result_type_ref: &TypeRef<ResultType>, namespace: &str, encodin
     let success_type = &result_type_ref.success_type;
     let failure_type = &result_type_ref.failure_type;
 
-    let decode_success = decode_result_field(success_type, namespace, encoding);
-    let decode_failure = decode_result_field(failure_type, namespace, encoding);
+    let decode_success = decode_type_with_cast(success_type, namespace, encoding, success_type.is_optional).indent();
+    let decode_failure = decode_type_with_cast(failure_type, namespace, encoding, failure_type.is_optional).indent();
 
     format!(
         "\
@@ -382,27 +376,25 @@ fn decode_stream_parameter(type_ref: &TypeRef, namespace: &str, encoding: Encodi
     }
 }
 
-fn decode_result_field(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {
-    let mut decode_func = match type_ref.is_optional {
-        true => decode_func_body(type_ref, namespace, encoding),
-        false => decode_func(type_ref, namespace, encoding),
+/// Used by `decode_dictionary` and `decode_result` to generate a decoding action that includes a cast for collections.
+fn decode_type_with_cast(type_ref: &TypeRef, namespace: &str, encoding: Encoding, is_optional: bool) -> CodeBlock {
+    let decode_func = decode_func_body(type_ref, namespace, encoding);
+    let cast = match type_ref.concrete_type() {
+        Types::Sequence(_) | Types::Dictionary(_) => format!("({})", type_ref.field_type_string(namespace, false)),
+        _ => "".to_owned(),
     };
 
-    // TODO: it's lame to have to do this here. We should provide a better API.
-    if matches!(type_ref.concrete_type(), Types::Sequence(_) | Types::Dictionary(_)) {
-        write!(decode_func, " as {}", type_ref.field_type_string(namespace, true));
-    }
-
-    if type_ref.is_optional {
-        decode_func = CodeBlock::from(format!(
+    if is_optional {
+        format!(
             "\
 (ref SliceDecoder decoder) => decoder.DecodeBool() ?
-    {decode_func}
+    {cast}{decode_func}
     : null",
-        ));
+        )
+    } else {
+        format!("(ref SliceDecoder decoder) => {cast}{decode_func}")
     }
-
-    decode_func.indent()
+    .into()
 }
 
 pub fn decode_func(type_ref: &TypeRef, namespace: &str, encoding: Encoding) -> CodeBlock {


### PR DESCRIPTION
Currently, in the decoding logic, we use a mix of casts and `as` conversions.
(Casts for decoding sequences, and `as` for dictionaries and results).

This PR changes the latter two to also use casts.
And in the process, consolidates this logic into a new function: `decode_type_with_cast`.