### PR TITLE
Simplify 'encode_action_body'.

### DIFF
--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -13,15 +13,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is-terminal",
  "utf8parse",
 ]
 
@@ -46,17 +47,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -109,19 +110,20 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
 dependencies = [
  "clap_builder",
  "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -131,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -143,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -163,7 +165,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -294,7 +296,7 @@ checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -621,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -766,6 +768,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-clap = { version = "4.3.15", features = ["derive"] }
+clap = { version = "~4.3.15", features = ["derive"] }
 convert_case = "0.6.0"
 in_definite = "1.0.0"
 slicec = "0.3.0"

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -344,7 +344,6 @@ fn encode_action_body(
     encoding: Encoding,
     is_tagged: bool,
 ) -> CodeBlock {
-    let mut code = CodeBlock::default();
     let is_optional_and_untagged = type_ref.is_optional && !is_tagged;
 
     let value = match (
@@ -362,62 +361,42 @@ fn encode_action_body(
         TypeRefs::Class(_) => {
             assert!(encoding == Encoding::Slice1);
             if is_optional_and_untagged {
-                write!(code, "encoder.EncodeNullableClass(value)");
+                "encoder.EncodeNullableClass(value)".into()
             } else {
-                write!(code, "encoder.EncodeClass(value)");
+                "encoder.EncodeClass(value)".into()
             }
         }
-        TypeRefs::Primitive(primitive_ref) => write!(code, " encoder.Encode{}({value})", primitive_ref.type_suffix()),
+        TypeRefs::Primitive(primitive_ref) => format!("encoder.Encode{}({value})", primitive_ref.type_suffix()).into(),
         TypeRefs::Enum(enum_ref) => {
             let encoder_extensions_class =
                 enum_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let name = enum_ref.cs_identifier(Case::Pascal);
-            write!(code, "{encoder_extensions_class}.Encode{name}(ref encoder, {value})")
+            format!("{encoder_extensions_class}.Encode{name}(ref encoder, {value})").into()
         }
         TypeRefs::ResultType(result_type_ref) => {
-            write!(
-                code,
-                "{}",
                 encode_result(result_type_ref, namespace, "value", "encoder", encoding)
-            )
         }
         TypeRefs::Dictionary(dictionary_ref) => {
-            write!(
-                code,
-                "{}",
                 encode_dictionary(dictionary_ref, namespace, value, "encoder", encoding)
-            )
         }
         TypeRefs::Sequence(sequence_ref) => {
             // We generate the sequence encoder inline, so this function must not be called when
             // the top-level object is not cached.
-            write!(
-                code,
-                "{}",
-                encode_sequence(sequence_ref, namespace, value, type_context, "encoder", encoding),
-            )
+                encode_sequence(sequence_ref, namespace, value, type_context, "encoder", encoding)
         }
-        TypeRefs::Struct(_) => write!(code, "{value}.Encode(ref encoder)"),
+        TypeRefs::Struct(_) => format!("{value}.Encode(ref encoder)").into(),
         TypeRefs::CustomType(custom_type_ref) => {
             let encoder_extensions_class =
                 custom_type_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let identifier = custom_type_ref.cs_identifier(Case::Pascal);
 
             if is_optional_and_untagged && encoding == Encoding::Slice1 {
-                write!(
-                    code,
-                    "{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)",
-                )
+                format!("{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)").into()
             } else {
-                write!(
-                    code,
-                    "{encoder_extensions_class}.Encode{identifier}(ref encoder, {value})",
-                )
+                format!("{encoder_extensions_class}.Encode{identifier}(ref encoder, {value})").into()
             }
         }
     }
-
-    code
 }
 
 fn encode_result(


### PR DESCRIPTION
This PR simplifies the logic of `encode_action_body` and fixes a bug with
the encoding of tagged custom types (which map to C# value types) in Slice1 mode (quite niche).

----

For example, take this snippet:
```slice
class Hello {
    tag(1) d1: CustomType?
}
```
We currently generate this:
```
encoder.StartSlice(SliceTypeId);
if (this.D1 is MyCustomType d1_)
{
    encoder.EncodeTagged(1, TagFormat.FSize, d1_, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
}
encoder.EndSlice(true);
```
Notably, this calls `EncodeNullableCustomType` which is incorrect. We know here that `value` is non-null.
Even the type of the lambda is `MyCustomType`, with no `?` suffix.

This PR fixes this to call the non-nullable function:
```
encoder.StartSlice(SliceTypeId);
if (this.D1 is MyCustomType d1_)
{
    encoder.EncodeTagged(1, TagFormat.FSize, d1_, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
}
encoder.EndSlice(true);
```