### PR TITLE
Fix Tagged Custom Types with Slice1

### DIFF
--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -102,7 +102,7 @@ public class CustomTypeTests
         };
         encoder.EncodeSequence(
             expected,
-            (ref SliceEncoder encoder, MyCustomType? value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
+            CustomTypeSliceEncoderExtensions.EncodeNullableCustomType);
         var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
 
         // Act

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -251,7 +251,7 @@ public static class CustomTypeSliceDecoderExtensions
 
     public static MyCustomType? DecodeNullableCustomType(this ref SliceDecoder decoder)
     {
-        Assert.That(encoder.Encoding, Is.EqualTo(SliceEncoding.Slice1));
+        Assert.That(decoder.Encoding, Is.EqualTo(SliceEncoding.Slice1));
 
         return decoder.DecodeString() switch
         {

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -84,7 +84,7 @@ public class CustomTypeTests
 
         // Assert
         var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
-        var value = decoder.DecodeSequence((ref SliceDecoder decoder) => CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder));
+        var value = decoder.DecodeSequence(CustomTypeSliceDecoderExtensions.DecodeCustomType);
         Assert.That(expected.S, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -155,7 +155,7 @@ public class CustomTypeTests
         CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, myCustomType);
         CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, null);
         structWithCustomTypeField.Encode(ref encoder);
-        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
+        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, CustomTypeSliceEncoderExtensions.EncodeCustomType);
 
         encoder.EncodeUInt8(Slice1Definitions.TagEndMarker);
 

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -205,7 +205,7 @@ public class CustomTypeTests
         Assert.That(CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder), Is.Null);
         Assert.That(new StructWithCustomTypeField(ref decoder), Is.EqualTo(structWithCustomTypeField));
         Assert.That(
-            decoder.DecodeTagged(1, TagFormat.FSize, (ref SliceDecoder decoder) => CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder), useTagEndMarker: false),
+            decoder.DecodeTagged(1, TagFormat.FSize, CustomTypeSliceDecoderExtensions.DecodeCustomType, useTagEndMarker: false),
             Is.EqualTo(myCustomType));
 
         Assert.That(decoder.DecodeUInt8(), Is.EqualTo(Slice1Definitions.TagEndMarker));

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using ZeroC.Slice.Internal;
 
 namespace ZeroC.Slice.Tests;
 
@@ -9,14 +10,17 @@ public class CustomTypeTests
     [Test]
     public void Decode_custom_type()
     {
+        // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
         var expected = new MyCustomType { Flag = true, Value = 10 };
         encoder.EncodeCustomType(expected);
         var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
 
+        // Act
         var value = new StructWithCustomTypeField(ref decoder);
 
+        // Assert
         Assert.That(value.M, Is.EqualTo(expected));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
@@ -24,15 +28,187 @@ public class CustomTypeTests
     [Test]
     public void Encode_custom_type()
     {
+        // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
         var expected = new StructWithCustomTypeField(new MyCustomType { Flag = true, Value = 10 });
 
+        // Act
         expected.Encode(ref encoder);
 
+        // Assert
         var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
         var value = decoder.DecodeCustomType();
         Assert.That(expected.M, Is.EqualTo(value));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Decode_sequence_of_custom_types()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var expected = new [] {
+            new MyCustomType { Flag = true, Value = 79 },
+            new MyCustomType { Flag = false, Value = 97 },
+            new MyCustomType { Flag = true, Value = 7997 },
+        };
+        encoder.EncodeSequence(
+            expected,
+            (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+
+        // Act
+        var value = new StructWithSequenceOfCustomTypes(ref decoder);
+
+        // Assert
+        Assert.That(value.S, Is.EqualTo(expected));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Encode_sequence_of_custom_types()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var expected = new StructWithSequenceOfCustomTypes(new [] {
+            new MyCustomType { Flag = true, Value = 79 },
+            new MyCustomType { Flag = false, Value = 97 },
+            new MyCustomType { Flag = true, Value = 7997 },
+        });
+
+        // Act
+        expected.Encode(ref encoder);
+
+        // Assert
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var value = decoder.DecodeSequence((ref SliceDecoder decoder) => CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder));
+        Assert.That(expected.S, Is.EqualTo(value));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Decode_sequence_of_optional_custom_types()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var expected = new MyCustomType? [] {
+            new MyCustomType { Flag = false, Value = 7997 },
+            null,
+            new MyCustomType { Flag = true, Value = 79 },
+        };
+        encoder.EncodeSequence(
+            expected,
+            (ref SliceEncoder encoder, MyCustomType? value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+
+        // Act
+        var value = new StructWithSequenceOfOptionalCustomTypes(ref decoder);
+
+        // Assert
+        Assert.That(value.S, Is.EqualTo(expected));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Encode_sequence_of_optional_custom_types()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var expected = new StructWithSequenceOfOptionalCustomTypes(new MyCustomType? [] {
+            new MyCustomType { Flag = false, Value = 7997 },
+            null,
+            new MyCustomType { Flag = true, Value = 79 },
+        });
+
+        // Act
+        expected.Encode(ref encoder);
+
+        // Assert
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var value = decoder.DecodeSequence((ref SliceDecoder decoder) => (MyCustomType?)CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder));
+        Assert.That(expected.S, Is.EqualTo(value));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Decode_custom_type_fields()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+
+        var myCustomType = new MyCustomType { Flag = false, Value = 79 };
+        var structWithCustomTypeField = new StructWithCustomTypeField(myCustomType);
+
+        encoder.EncodeSize(1); // Instance marker
+        encoder.EncodeUInt8(
+            (byte)Slice1Definitions.TypeIdKind.String |
+            (byte)Slice1Definitions.SliceFlags.IsLastSlice |
+            (byte)Slice1Definitions.SliceFlags.HasTaggedFields);
+        encoder.EncodeString(typeof(ClassWithCustomTypeFields).GetSliceTypeId()!);
+
+        CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, myCustomType);
+        CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, null);
+        structWithCustomTypeField.Encode(ref encoder);
+        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
+
+        encoder.EncodeUInt8(Slice1Definitions.TagEndMarker);
+
+        var decoder = new SliceDecoder(
+            buffer.WrittenMemory,
+            SliceEncoding.Slice1,
+            activator: IActivator.FromAssembly(typeof(ClassWithCustomTypeFields).Assembly));
+
+        // Act
+        var value = decoder.DecodeClass<ClassWithCustomTypeFields>();
+
+        // Assert
+        Assert.That(value.A, Is.EqualTo(myCustomType));
+        Assert.That(value.B, Is.Null);
+        Assert.That(value.C, Is.EqualTo(myCustomType));
+        Assert.That(value.D, Is.EqualTo(structWithCustomTypeField));
+
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Encode_custom_type_fields()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+
+        var myCustomType = new MyCustomType { Flag = false, Value = 79 };
+        var structWithCustomTypeField = new StructWithCustomTypeField(myCustomType);
+
+        // Act
+        encoder.EncodeClass(new ClassWithCustomTypeFields(myCustomType, null, myCustomType, structWithCustomTypeField));
+
+        // Assert
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+
+        Assert.That(decoder.DecodeSize(), Is.EqualTo(1)); // Instance marker
+        Assert.That(
+            decoder.DecodeUInt8(),
+            Is.EqualTo(
+                (byte)Slice1Definitions.TypeIdKind.String |
+                (byte)Slice1Definitions.SliceFlags.IsLastSlice |
+                (byte)Slice1Definitions.SliceFlags.HasTaggedFields));
+        Assert.That(decoder.DecodeString(), Is.EqualTo(typeof(ClassWithCustomTypeFields).GetSliceTypeId()));
+
+        Assert.That(CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder), Is.EqualTo(myCustomType));
+        Assert.That(CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder), Is.Null);
+        Assert.That(new StructWithCustomTypeField(ref decoder), Is.EqualTo(structWithCustomTypeField));
+        Assert.That(
+            decoder.DecodeTagged(1, TagFormat.FSize, (ref SliceDecoder decoder) => CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder), useTagEndMarker: false),
+            Is.EqualTo(myCustomType));
+
+        Assert.That(decoder.DecodeUInt8(), Is.EqualTo(Slice1Definitions.TagEndMarker));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 }
@@ -50,6 +226,15 @@ public static class CustomTypeSliceEncoderExtensions
         encoder.EncodeBool(myCustom.Flag);
         encoder.EncodeInt32(myCustom.Value);
     }
+
+    public static void EncodeNullableCustomType(this ref SliceEncoder encoder, MyCustomType? myCustom)
+    {
+        encoder.EncodeString(myCustom is null ? "nope" : "yep!");
+        if (myCustom is not null)
+        {
+            encoder.EncodeCustomType(myCustom.Value);
+        }
+    }
 }
 
 public static class CustomTypeSliceDecoderExtensions
@@ -60,5 +245,15 @@ public static class CustomTypeSliceDecoderExtensions
         myCustom.Flag = decoder.DecodeBool();
         myCustom.Value = decoder.DecodeInt32();
         return myCustom;
+    }
+
+    public static MyCustomType? DecodeNullableCustomType(this ref SliceDecoder decoder)
+    {
+        switch(decoder.DecodeString())
+        {
+            case "nope": return null;
+            case "yep!": return decoder.DecodeCustomType();
+            default: throw new InvalidDataException("decoded invalid custom type");
+        }
     }
 }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -8,14 +8,14 @@ namespace ZeroC.Slice.Tests;
 public class CustomTypeTests
 {
     [Test]
-    public void Decode_custom_type()
+    public void Decode_custom_type([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new MyCustomType { Flag = true, Value = 10 };
         encoder.EncodeCustomType(expected);
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
 
         // Act
         var value = new StructWithCustomTypeField(ref decoder);
@@ -26,29 +26,29 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Encode_custom_type()
+    public void Encode_custom_type([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new StructWithCustomTypeField(new MyCustomType { Flag = true, Value = 10 });
 
         // Act
         expected.Encode(ref encoder);
 
         // Assert
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
         var value = decoder.DecodeCustomType();
         Assert.That(expected.M, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
     [Test]
-    public void Decode_sequence_of_custom_types()
+    public void Decode_sequence_of_custom_types([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new [] {
             new MyCustomType { Flag = true, Value = 79 },
             new MyCustomType { Flag = false, Value = 97 },
@@ -57,7 +57,7 @@ public class CustomTypeTests
         encoder.EncodeSequence(
             expected,
             (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
 
         // Act
         var value = new StructWithSequenceOfCustomTypes(ref decoder);
@@ -68,11 +68,11 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Encode_sequence_of_custom_types()
+    public void Encode_sequence_of_custom_types([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new StructWithSequenceOfCustomTypes(new [] {
             new MyCustomType { Flag = true, Value = 79 },
             new MyCustomType { Flag = false, Value = 97 },
@@ -83,18 +83,18 @@ public class CustomTypeTests
         expected.Encode(ref encoder);
 
         // Assert
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
         var value = decoder.DecodeSequence((ref SliceDecoder decoder) => CustomTypeSliceDecoderExtensions.DecodeCustomType(ref decoder));
         Assert.That(expected.S, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
     [Test]
-    public void Decode_sequence_of_optional_custom_types()
+    public void Decode_sequence_of_optional_custom_types([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new MyCustomType? [] {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
@@ -103,7 +103,7 @@ public class CustomTypeTests
         encoder.EncodeSequence(
             expected,
             (ref SliceEncoder encoder, MyCustomType? value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
 
         // Act
         var value = new StructWithSequenceOfOptionalCustomTypes(ref decoder);
@@ -114,11 +114,11 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Encode_sequence_of_optional_custom_types()
+    public void Encode_sequence_of_optional_custom_types([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
+        var encoder = new SliceEncoder(buffer, encoding);
         var expected = new StructWithSequenceOfOptionalCustomTypes(new MyCustomType? [] {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
@@ -129,14 +129,14 @@ public class CustomTypeTests
         expected.Encode(ref encoder);
 
         // Assert
-        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
         var value = decoder.DecodeSequence((ref SliceDecoder decoder) => (MyCustomType?)CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder));
         Assert.That(expected.S, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
     [Test]
-    public void Decode_custom_type_fields()
+    public void Decode_class_with_custom_type_fields()
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -177,7 +177,7 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Encode_custom_type_fields()
+    public void Encode_class_with_custom_type_fields()
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -229,6 +229,8 @@ public static class CustomTypeSliceEncoderExtensions
 
     public static void EncodeNullableCustomType(this ref SliceEncoder encoder, MyCustomType? myCustom)
     {
+        Assert.That(encoder.Encoding, Is.EqualTo(SliceEncoding.Slice1));
+
         encoder.EncodeString(myCustom is null ? "nope" : "yep!");
         if (myCustom is not null)
         {
@@ -249,11 +251,13 @@ public static class CustomTypeSliceDecoderExtensions
 
     public static MyCustomType? DecodeNullableCustomType(this ref SliceDecoder decoder)
     {
-        switch(decoder.DecodeString())
+        Assert.That(encoder.Encoding, Is.EqualTo(SliceEncoding.Slice1));
+
+        return decoder.DecodeString() switch
         {
-            case "nope": return null;
-            case "yep!": return decoder.DecodeCustomType();
-            default: throw new InvalidDataException("decoded invalid custom type");
-        }
+            "nope" => null,
+            "yep!" => (MyCustomType?)decoder.DecodeCustomType(),
+            _ => throw new InvalidDataException("decoded invalid custom type"),
+        };
     }
 }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -56,7 +56,7 @@ public class CustomTypeTests
         };
         encoder.EncodeSequence(
             expected,
-            (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, value));
+            CustomTypeSliceEncoderExtensions.EncodeCustomType);
         var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
 
         // Act

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -49,7 +49,8 @@ public class CustomTypeTests
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, encoding);
-        var expected = new [] {
+        var expected = new[]
+        {
             new MyCustomType { Flag = true, Value = 79 },
             new MyCustomType { Flag = false, Value = 97 },
             new MyCustomType { Flag = true, Value = 7997 },
@@ -73,7 +74,8 @@ public class CustomTypeTests
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, encoding);
-        var expected = new StructWithSequenceOfCustomTypes(new [] {
+        var expected = new StructWithSequenceOfCustomTypes(new[]
+        {
             new MyCustomType { Flag = true, Value = 79 },
             new MyCustomType { Flag = false, Value = 97 },
             new MyCustomType { Flag = true, Value = 7997 },
@@ -95,7 +97,8 @@ public class CustomTypeTests
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
-        var expected = new MyCustomType? [] {
+        var expected = new MyCustomType?[]
+        {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
             new MyCustomType { Flag = true, Value = 79 },
@@ -117,7 +120,8 @@ public class CustomTypeTests
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
-        var expected = new StructWithSequenceOfOptionalCustomTypes(new MyCustomType? [] {
+        var expected = new StructWithSequenceOfOptionalCustomTypes(new MyCustomType?[]
+        {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
             new MyCustomType { Flag = true, Value = 79 },

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -90,20 +90,18 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Decode_sequence_of_optional_custom_types([Values] SliceEncoding encoding)
+    public void Decode_slice1_sequence_of_optional_custom_types()
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, encoding);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
         var expected = new MyCustomType? [] {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
             new MyCustomType { Flag = true, Value = 79 },
         };
-        encoder.EncodeSequence(
-            expected,
-            CustomTypeSliceEncoderExtensions.EncodeNullableCustomType);
-        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
+        encoder.EncodeSequence(expected, CustomTypeSliceEncoderExtensions.EncodeNullableCustomType);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
 
         // Act
         var value = new StructWithSequenceOfOptionalCustomTypes(ref decoder);
@@ -114,11 +112,11 @@ public class CustomTypeTests
     }
 
     [Test]
-    public void Encode_sequence_of_optional_custom_types([Values] SliceEncoding encoding)
+    public void Encode_slice1_sequence_of_optional_custom_types()
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
-        var encoder = new SliceEncoder(buffer, encoding);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice1);
         var expected = new StructWithSequenceOfOptionalCustomTypes(new MyCustomType? [] {
             new MyCustomType { Flag = false, Value = 7997 },
             null,
@@ -129,8 +127,9 @@ public class CustomTypeTests
         expected.Encode(ref encoder);
 
         // Assert
-        var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
+        var decoder = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice1);
         var value = decoder.DecodeSequence((ref SliceDecoder decoder) => decoder.DecodeNullableCustomType());
+
         Assert.That(expected.S, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -130,7 +130,7 @@ public class CustomTypeTests
 
         // Assert
         var decoder = new SliceDecoder(buffer.WrittenMemory, encoding);
-        var value = decoder.DecodeSequence((ref SliceDecoder decoder) => (MyCustomType?)CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder));
+        var value = decoder.DecodeSequence((ref SliceDecoder decoder) => decoder.DecodeNullableCustomType());
         Assert.That(expected.S, Is.EqualTo(value));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.slice
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.slice
@@ -6,11 +6,27 @@ module ZeroC::Slice::Tests
 [cs::type("MyCustomType")]
 custom CustomType
 
+class ClassWithCustomTypeFields {
+    a: CustomType,
+    b: CustomType?,
+    tag(1) c: CustomType?,
+
+    d: StructWithCustomTypeField,
+}
+
+// Ensures that the generated code doesn't produce a warning for uninitialized non-nullable custom types.
+exception ExceptionWithCustomTypeField {
+    m: CustomType
+}
+
 compact struct StructWithCustomTypeField {
     m: CustomType
 }
 
-// Ensures that the generated code doesn't produce a warning for uninitialized non-nullable custom types.
-exception ExceptionWithCustomField {
-    m: CustomType
+compact struct StructWithSequenceOfCustomTypes {
+    s: Sequence<CustomType>,
+}
+
+compact struct StructWithSequenceOfOptionalCustomTypes {
+    s: Sequence<CustomType?>,
 }

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.slice
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.slice
@@ -14,11 +14,6 @@ class ClassWithCustomTypeFields {
     d: StructWithCustomTypeField,
 }
 
-// Ensures that the generated code doesn't produce a warning for uninitialized non-nullable custom types.
-exception ExceptionWithCustomTypeField {
-    m: CustomType
-}
-
 compact struct StructWithCustomTypeField {
     m: CustomType
 }
@@ -29,4 +24,9 @@ compact struct StructWithSequenceOfCustomTypes {
 
 compact struct StructWithSequenceOfOptionalCustomTypes {
     s: Sequence<CustomType?>,
+}
+
+// Ensures that the generated code doesn't produce a warning for uninitialized non-nullable custom types.
+exception ExceptionWithCustomTypeField {
+    m: CustomType
 }

--- a/tests/ZeroC.Slice.Tests/DictionaryDecodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/DictionaryDecodingTests.cs
@@ -9,7 +9,7 @@ namespace ZeroC.Slice.Tests;
 public class DictionaryDecodingTests
 {
     [Test]
-    public void Decode_dictionary([Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_dictionary([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[1024 * 256]);

--- a/tests/ZeroC.Slice.Tests/DictionaryEncodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/DictionaryEncodingTests.cs
@@ -8,7 +8,7 @@ namespace ZeroC.Slice.Tests;
 public class DictionaryEncodingTests
 {
     [Test]
-    public void Encode_dictionary([Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Encode_dictionary([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[1024 * 256]);

--- a/tests/ZeroC.Slice.Tests/NumericTypesEncodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/NumericTypesEncodingTests.cs
@@ -185,7 +185,7 @@ public class NumericTypesEncodingTests
     }
 
     [Test]
-    public void Encode_negative_size_fails([Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Encode_negative_size_fails([Values] SliceEncoding encoding)
     {
         var bufferWriter = new MemoryBufferWriter(new byte[256]);
 

--- a/tests/ZeroC.Slice.Tests/SequenceDecodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SequenceDecodingTests.cs
@@ -10,8 +10,7 @@ namespace ZeroC.Slice.Tests;
 public class SequenceDecodingTests
 {
     [Test]
-    public void Decode_bool_sequence_data_member(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_bool_sequence_data_member([Values] SliceEncoding encoding)
     {
         // Arrange
         bool[] expected = [false, true, false];
@@ -30,8 +29,7 @@ public class SequenceDecodingTests
     }
 
     [Test]
-    public void Decode_bool_sequence_data_member_with_invalid_values(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_bool_sequence_data_member_with_invalid_values([Values] SliceEncoding encoding)
     {
         // Arrange
         var buffer = new MemoryBufferWriter(new byte[256]);
@@ -52,8 +50,7 @@ public class SequenceDecodingTests
     /// fixed-size numeric value type.</summary>
     /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the decoding.</param>
     [Test]
-    public void Decode_fixed_sized_numeric_sequence(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_fixed_sized_numeric_sequence([Values] SliceEncoding encoding)
     {
         int[] expected = Enumerable.Range(0, 256).Select(i => i).ToArray();
         var buffer = new MemoryBufferWriter(new byte[1024 * 1024]);
@@ -75,8 +72,7 @@ public class SequenceDecodingTests
     /// string sequence.</summary>
     /// <param name="encoding">The <see cref="SliceEncoding" /> to use for the decoding.</param>
     [Test]
-    public void Decode_string_sequence(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_string_sequence([Values] SliceEncoding encoding)
     {
         string[] expected = Enumerable.Range(0, 256).Select(i => $"string-{i}").ToArray();
         var buffer = new MemoryBufferWriter(new byte[1024 * 1024]);

--- a/tests/ZeroC.Slice.Tests/StructTests.cs
+++ b/tests/ZeroC.Slice.Tests/StructTests.cs
@@ -8,8 +8,7 @@ namespace ZeroC.Slice.Tests;
 public sealed class StructTests
 {
     [Test]
-    public void Decode_compact_struct(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Decode_compact_struct([Values] SliceEncoding encoding)
     {
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, encoding);
@@ -89,8 +88,7 @@ public sealed class StructTests
     }
 
     [Test]
-    public void Encode_compact_struct(
-        [Values(SliceEncoding.Slice1, SliceEncoding.Slice2)] SliceEncoding encoding)
+    public void Encode_compact_struct([Values] SliceEncoding encoding)
     {
         var buffer = new MemoryBufferWriter(new byte[256]);
         var encoder = new SliceEncoder(buffer, encoding);

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -345,10 +345,10 @@ fn encode_action_body(
     is_tagged: bool,
 ) -> CodeBlock {
     let mut code = CodeBlock::default();
-    let is_optional = type_ref.is_optional && !is_tagged;
+    let is_optional_and_untagged = type_ref.is_optional && !is_tagged;
 
     let value = match (
-        is_optional,
+        is_optional_and_untagged,
         type_ref.is_value_type(),
         matches!(type_ref.concrete_type(), Types::CustomType(_)),
     ) {
@@ -361,7 +361,7 @@ fn encode_action_body(
     match &type_ref.concrete_typeref() {
         TypeRefs::Class(_) => {
             assert!(encoding == Encoding::Slice1);
-            if is_optional {
+            if is_optional_and_untagged {
                 write!(code, "encoder.EncodeNullableClass(value)");
             } else {
                 write!(code, "encoder.EncodeClass(value)");
@@ -403,7 +403,7 @@ fn encode_action_body(
                 custom_type_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let identifier = custom_type_ref.cs_identifier(Case::Pascal);
 
-            if type_ref.is_optional && encoding == Encoding::Slice1 {
+            if is_optional_and_untagged && encoding == Encoding::Slice1 {
                 write!(
                     code,
                     "{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)",


### PR DESCRIPTION
This PR adds more comprehensive testing for custom types in Slice1 contexts and fixes #3918,
which caused `slicec-cs` to treat tagged custom types as _optional_ (untagged) custom types.

The only way to test this was with classes (the only Slice1 type that can hold tags).
But, this means the class encoding bleeds into what should be a test purely for custom types.
Maybe this is just how it is, but if anyone has any ideas to avoid this, they'd be welcome!