### PR TITLE
Remove `ignore_optional` Flag from `xxx_type_string` Functions

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -139,7 +139,7 @@ impl ContainerBuilder {
 
     pub fn add_fields(&mut self, fields: &[&Field]) -> &mut Self {
         for field in fields {
-            let type_string = field.data_type().field_type_string(&field.namespace(), false);
+            let type_string = field.data_type().field_type_string(&field.namespace());
 
             self.add_field(
                 &field.field_name(),

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -552,9 +552,14 @@ int startPos_ = encoder_.EncodedByteCount;",
 
 // TODO temporary bridging code while cleaning up the type_string functions.
 fn get_type_string(type_ref: &TypeRef, namespace: &str, context: TypeContext, ignore_optional: bool) -> String {
-    match context {
-        TypeContext::OutgoingParam => type_ref.outgoing_parameter_type_string(namespace, ignore_optional),
-        TypeContext::Field => type_ref.field_type_string(namespace, ignore_optional),
+    let type_string = match context {
+        TypeContext::OutgoingParam => type_ref.outgoing_parameter_type_string(namespace),
+        TypeContext::Field => type_ref.field_type_string(namespace),
         TypeContext::IncomingParam => unreachable!(),
+    };
+
+    match ignore_optional {
+        true => remove_optional_modifier_from(type_string),
+        false => type_string,
     }
 }

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -128,7 +128,7 @@ fn constructor(
 
     for field in base_fields.iter().chain(fields.iter()) {
         builder.add_parameter(
-            &field.data_type.field_type_string(namespace, false),
+            &field.data_type.field_type_string(namespace),
             &field.parameter_name(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/generators/dispatch_generator.rs
+++ b/tools/slicec-cs/src/generators/dispatch_generator.rs
@@ -192,7 +192,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
         match non_streamed_returns.as_slice() {
             [param] => {
                 builder.add_parameter(
-                    &param.data_type().outgoing_parameter_type_string(namespace, false),
+                    &param.data_type().outgoing_parameter_type_string(namespace),
                     "returnValue",
                     None,
                     Some("The operation return value.".to_owned()),
@@ -201,7 +201,7 @@ fn response_class(interface_def: &Interface) -> CodeBlock {
             _ => {
                 for param in &non_streamed_returns {
                     builder.add_parameter(
-                        &param.data_type().outgoing_parameter_type_string(namespace, false),
+                        &param.data_type().outgoing_parameter_type_string(namespace),
                         &param.parameter_name(),
                         None,
                         param.formatted_param_doc_comment(),

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -143,7 +143,7 @@ fn one_shot_constructor(exception_def: &Exception) -> CodeBlock {
 
     for field in &all_fields {
         ctor_builder.add_parameter(
-            &field.data_type().field_type_string(namespace, false),
+            &field.data_type().field_type_string(namespace),
             field.parameter_name().as_str(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/generators/proxy_generator.rs
+++ b/tools/slicec-cs/src/generators/proxy_generator.rs
@@ -347,7 +347,7 @@ if ({features_parameter}?.Get<IceRpc.Features.ICompressFeature>() is null)
                 invocation_builder.add_argument(
                     FunctionCallBuilder::new(format!(
                         "{stream_parameter_name}.ToPipeReader<{}>",
-                        stream_type.outgoing_parameter_type_string(namespace, false),
+                        stream_type.outgoing_parameter_type_string(namespace),
                     ))
                     .use_semicolon(false)
                     .add_argument(encode_stream_parameter(stream_type, namespace, operation.encoding).indent())
@@ -486,7 +486,7 @@ fn request_class(interface_def: &Interface) -> CodeBlock {
 
         for param in &non_streamed_parameters {
             builder.add_parameter(
-                &param.data_type().outgoing_parameter_type_string(namespace, false),
+                &param.data_type().outgoing_parameter_type_string(namespace),
                 &param.parameter_name(),
                 None,
                 param.formatted_param_doc_comment(),

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -52,7 +52,7 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
 
     for field in &fields {
         main_constructor.add_parameter(
-            &field.data_type().field_type_string(&namespace, false),
+            &field.data_type().field_type_string(&namespace),
             field.parameter_name().as_str(),
             None,
             field.formatted_doc_comment_summary(),

--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -22,7 +22,7 @@ pub fn escape_parameter_name(parameters: &[&impl Member], name: &str) -> String 
 }
 
 pub fn field_declaration(field: &Field) -> String {
-    let type_string = field.data_type().field_type_string(&field.namespace(), false);
+    let type_string = field.data_type().field_type_string(&field.namespace());
     let mut prelude = CodeBlock::default();
 
     if let Some(summary) = field.formatted_doc_comment_summary() {

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -74,8 +74,8 @@ impl ParameterExt for Parameter {
     fn cs_type_string(&self, namespace: &str, context: TypeContext) -> String {
         // TODO this can be further simplified.
         let type_str = match context {
-            TypeContext::OutgoingParam => self.data_type().outgoing_parameter_type_string(namespace, false),
-            TypeContext::IncomingParam => self.data_type().incoming_parameter_type_string(namespace, false),
+            TypeContext::OutgoingParam => self.data_type().outgoing_parameter_type_string(namespace),
+            TypeContext::IncomingParam => self.data_type().incoming_parameter_type_string(namespace),
             TypeContext::Field => unreachable!(),
         };
 

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -22,6 +22,16 @@ pub use primitive_ext::PrimitiveExt;
 pub use slice_encoding_ext::EncodingExt;
 pub use type_ref_ext::TypeRefExt;
 
+/// If the provided type string is optional (it ends with a '?' character), that character is removed.
+/// This does not affect nested types that are optional.
+pub fn remove_optional_modifier_from(mut type_string: String) -> String {
+    if type_string.ends_with('?') {
+        type_string.pop();
+    }
+    type_string
+}
+
+
 fn scoped_identifier(identifier: String, identifier_namespace: String, current_namespace: &str) -> String {
     if current_namespace == identifier_namespace {
         identifier

--- a/tools/slicec-cs/src/slicec_ext/mod.rs
+++ b/tools/slicec-cs/src/slicec_ext/mod.rs
@@ -31,7 +31,6 @@ pub fn remove_optional_modifier_from(mut type_string: String) -> String {
     type_string
 }
 
-
 fn scoped_identifier(identifier: String, identifier_namespace: String, current_namespace: &str) -> String {
     if current_namespace == identifier_namespace {
         identifier


### PR DESCRIPTION
This PR does what the title says.
In the handful of places where we actually set this to `true`, we now have a new function: `remove_optional_modifier_from`.
We get the fully typed string (optional and all), and if we don't want the optional part, we call this function on it.