### PR TITLE
Simplify `decode_sequence` function.

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -573,7 +573,7 @@ impl Builder for FunctionCallBuilder {
             None => "".to_owned(),
         };
 
-        let mut function_call = if self.arguments_on_newline && self.arguments.len() > 0 {
+        let mut function_call = if self.arguments_on_newline && !self.arguments.is_empty() {
             format!("{}{type_arg}(\n    {})", self.callable, self.arguments.join(",\n    "))
         } else {
             format!("{}{type_arg}({})", self.callable, self.arguments.join(", "))

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -514,6 +514,7 @@ impl Builder for FunctionBuilder {
 #[derive(Debug, Clone)]
 pub struct FunctionCallBuilder {
     callable: String,
+    type_argument: Option<String>,
     arguments: Vec<String>,
     arguments_on_newline: bool,
     use_semicolon: bool,
@@ -523,6 +524,7 @@ impl FunctionCallBuilder {
     pub fn new(callable: impl Into<String>) -> FunctionCallBuilder {
         FunctionCallBuilder {
             callable: callable.into(),
+            type_argument: None,
             arguments: vec![],
             arguments_on_newline: false,
             use_semicolon: true,
@@ -536,6 +538,11 @@ impl FunctionCallBuilder {
 
     pub fn use_semicolon(&mut self, use_semicolon: bool) -> &mut Self {
         self.use_semicolon = use_semicolon;
+        self
+    }
+
+    pub fn set_type_argument<T: ToString>(&mut self, type_argument: T) -> &mut Self {
+        self.type_argument = Some(type_argument.to_string());
         self
     }
 
@@ -561,10 +568,15 @@ impl FunctionCallBuilder {
 
 impl Builder for FunctionCallBuilder {
     fn build(&self) -> CodeBlock {
-        let mut function_call = if self.arguments_on_newline {
-            format!("{}(\n    {})", self.callable, self.arguments.join(",\n    "))
+        let type_arg = match &self.type_argument {
+            Some(arg) => format!("<{arg}>"),
+            None => "".to_owned(),
+        };
+
+        let mut function_call = if self.arguments_on_newline && self.arguments.len() > 0 {
+            format!("{}{type_arg}(\n    {})", self.callable, self.arguments.join(",\n    "))
         } else {
-            format!("{}({})", self.callable, self.arguments.join(", "))
+            format!("{}{type_arg}({})", self.callable, self.arguments.join(", "))
         };
 
         if self.use_semicolon {

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -260,7 +260,7 @@ new {sequence_type}(
 
     if has_cs_type_attribute {
         match element_type.concrete_type() {
-            Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !(element_type.is_optional && (encoding != Encoding::Slice1 || encoding == Encoding::Slice1)) => {
+            Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !uses_bit_sequence => {
                 builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 builder.add_argument_if(*primitive == Primitive::Bool, "checkElement: SliceDecoder.CheckBoolValue");
                 wrap_code_in_custom_constructor(builder)

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -258,16 +258,14 @@ new {sequence_type}(
 
 
 
-
-
     if has_cs_type_attribute {
         match element_type.concrete_type() {
-            Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !element_type.is_optional => {
+            Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !(element_type.is_optional && (encoding != Encoding::Slice1 || encoding == Encoding::Slice1)) => {
                 builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 builder.add_argument_if(*primitive == Primitive::Bool, "checkElement: SliceDecoder.CheckBoolValue");
                 wrap_code_in_custom_constructor(builder)
             }
-            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !element_type.is_optional => {
+            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !uses_bit_sequence => {
                 if enum_def.is_unchecked {
                     builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 } else {
@@ -295,7 +293,7 @@ new {sequence_type}(
                 builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 builder.add_argument_if(*primitive == Primitive::Bool, "checkElement: SliceDecoder.CheckBoolValue");
             }
-            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !element_type.is_optional => {
+            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !uses_bit_sequence => {
                 if enum_def.is_unchecked {
                     builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 } else {

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -210,7 +210,6 @@ decoder.DecodeResult(
     .into()
 }
 
-// TODO try and untangle this function.
 fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: Encoding) -> CodeBlock {
     let element_type = &sequence_ref.element_type;
     let element_type_string = element_type.field_type_string(namespace);

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -228,7 +228,7 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
         let sequence_type = remove_optional_modifier_from(sequence_ref.incoming_parameter_type_string(namespace));
 
         let arg: Option<String> = match element_type.concrete_type() {
-            Types::Primitive(primitive) if primitive.fixed_wire_size().is_some() && !element_type.is_optional => {
+            Types::Primitive(primitive) if element_type.fixed_wire_size().is_some() => {
                 // We always read an array even when mapped to a collection, as it's expected to be
                 // faster than decoding the collection elements one by one.
                 Some(format!(
@@ -241,10 +241,7 @@ fn decode_sequence(sequence_ref: &TypeRef<Sequence>, namespace: &str, encoding: 
                     }
                 ))
             }
-            Types::Enum(enum_def)
-                if enum_def.underlying.is_some()
-                    && enum_def.fixed_wire_size().is_some()
-                    && !element_type.is_optional =>
+            Types::Enum(enum_def) if element_type.fixed_wire_size().is_some() =>
             {
                 // We always read an array even when mapped to a collection, as it's expected to be
                 // faster than decoding the collection elements one by one.
@@ -326,7 +323,7 @@ decoder.DecodeSequenceOfOptionals(
                     }
                 )
             }
-            Types::Enum(enum_def) if enum_def.underlying.is_some() && enum_def.fixed_wire_size().is_some() => {
+            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() => {
                 if enum_def.is_unchecked {
                     write!(
                         code,

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -295,7 +295,7 @@ new {sequence_type}(
                 builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 builder.add_argument_if(*primitive == Primitive::Bool, "checkElement: SliceDecoder.CheckBoolValue");
             }
-            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && (!element_type.is_optional || encoding == Encoding::Slice1) => {
+            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !element_type.is_optional => {
                 if enum_def.is_unchecked {
                     builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 } else {

--- a/tools/slicec-cs/src/decoding.rs
+++ b/tools/slicec-cs/src/decoding.rs
@@ -295,7 +295,7 @@ new {sequence_type}(
                 builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 builder.add_argument_if(*primitive == Primitive::Bool, "checkElement: SliceDecoder.CheckBoolValue");
             }
-            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && !uses_bit_sequence => {
+            Types::Enum(enum_def) if enum_def.fixed_wire_size().is_some() && (!element_type.is_optional || encoding == Encoding::Slice1) => {
                 if enum_def.is_unchecked {
                     builder.set_type_argument(remove_optional_modifier_from(incoming_element_type_string));
                 } else {

--- a/tools/slicec-cs/src/slicec_ext/enum_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/enum_ext.rs
@@ -4,7 +4,7 @@ use crate::slicec_ext::primitive_ext::PrimitiveExt;
 use slicec::grammar::*;
 
 pub trait EnumExt {
-    fn get_underlying_cs_type(&self) -> String;
+    fn get_underlying_cs_type(&self) -> String; // TODO This could become 'str'!
 
     fn is_mapped_to_cs_enum(&self) -> bool;
 }


### PR DESCRIPTION
This PR untangles and simplifies the `decode_sequence` function.
Before this PR, it was (probably) the longest function in `slicec-cs` at 153 lines long. Now it's only 63 (and easier to read too).

I don't expect the changes to this function to be reviewable, but I'm _pretty_ sure no logic has been altered. So it's fine! 😉

What is worth reviewing are the smaller changes it makes to `FunctionCallBuilder`:
- Now you can specify type parameters for calling generic functions
- We no longer print arguments on multiple lines if there are 0 arguments.

