### PR TITLE
Update version from '0.3.0-preview1' to '0.3.0'.

### DIFF
--- a/build/IceRpc.Version.props
+++ b/build/IceRpc.Version.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- The version used by NuGet packages and assembly files -->
-        <Version Condition="'$(Version)' == ''">0.3.0-preview1</Version>
+        <Version Condition="'$(Version)' == ''">0.3.0</Version>
     </PropertyGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -9,10 +9,10 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
   </ItemGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Protobuf" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Protobuf" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
+        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.json">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -9,10 +9,10 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
   </ItemGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -9,10 +9,10 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
   </ItemGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Slice" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0-preview1" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Slice" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
+        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.json">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -9,10 +9,10 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0-preview1" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
   </ItemGroup>

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "slicec-cs"
-version = "0.3.0-preview1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "convert_case",

--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slicec-cs"
-version = "0.3.0-preview1"
+version = "0.3.0"
 authors = ["ZeroC Inc."]
 description = """
 The slicec-cs compiler, for compiling Slice files into C# code.


### PR DESCRIPTION
All the issues are closed, everything seems green, so this PR updates `icerpc-csharp` `0.3.0` to no longer be a preview.