### PR TITLE
Always Use Nullable Extension Methods for Tagged Slice1 Custom Types

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -70,5 +70,9 @@
     "rust",
     "softwareTerms",
     "en_US"
+  ],
+  "enableFiletypes": [
+    "ice",
+    "slice"
   ]
 }

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -72,7 +72,6 @@
     "en_US"
   ],
   "enableFiletypes": [
-    "ice",
     "slice"
   ]
 }

--- a/src/ZeroC.Slice/SliceEncoder.cs
+++ b/src/ZeroC.Slice/SliceEncoder.cs
@@ -354,7 +354,7 @@ public ref partial struct SliceEncoder
         int tag,
         TagFormat tagFormat,
         T v,
-        EncodeAction<T> encodeAction) where T : notnull
+        EncodeAction<T> encodeAction)
     {
         if (Encoding != SliceEncoding.Slice1)
         {

--- a/src/ZeroC.Slice/SliceEncoder.cs
+++ b/src/ZeroC.Slice/SliceEncoder.cs
@@ -354,7 +354,7 @@ public ref partial struct SliceEncoder
         int tag,
         TagFormat tagFormat,
         T v,
-        EncodeAction<T> encodeAction)
+        EncodeAction<T> encodeAction) where T : notnull
     {
         if (Encoding != SliceEncoding.Slice1)
         {

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -158,7 +158,7 @@ public class CustomTypeTests
         CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, myCustomType);
         CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, null);
         structWithCustomTypeField.Encode(ref encoder);
-        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, CustomTypeSliceEncoderExtensions.EncodeCustomType);
+        encoder.EncodeTagged<MyCustomType?>(1, TagFormat.FSize, myCustomType, CustomTypeSliceEncoderExtensions.EncodeNullableCustomType);
 
         encoder.EncodeUInt8(Slice1Definitions.TagEndMarker);
 
@@ -208,7 +208,7 @@ public class CustomTypeTests
         Assert.That(CustomTypeSliceDecoderExtensions.DecodeNullableCustomType(ref decoder), Is.Null);
         Assert.That(new StructWithCustomTypeField(ref decoder), Is.EqualTo(structWithCustomTypeField));
         Assert.That(
-            decoder.DecodeTagged(1, TagFormat.FSize, CustomTypeSliceDecoderExtensions.DecodeCustomType, useTagEndMarker: false),
+            decoder.DecodeTagged(1, TagFormat.FSize, CustomTypeSliceDecoderExtensions.DecodeNullableCustomType, useTagEndMarker: false),
             Is.EqualTo(myCustomType));
 
         Assert.That(decoder.DecodeUInt8(), Is.EqualTo(Slice1Definitions.TagEndMarker));

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -158,7 +158,7 @@ public class CustomTypeTests
         CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, myCustomType);
         CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, null);
         structWithCustomTypeField.Encode(ref encoder);
-        encoder.EncodeTagged<MyCustomType?>(1, TagFormat.FSize, myCustomType, CustomTypeSliceEncoderExtensions.EncodeNullableCustomType);
+        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
 
         encoder.EncodeUInt8(Slice1Definitions.TagEndMarker);
 

--- a/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
+++ b/tests/ZeroC.Slice.Tests/CustomTypeTests.cs
@@ -158,7 +158,12 @@ public class CustomTypeTests
         CustomTypeSliceEncoderExtensions.EncodeCustomType(ref encoder, myCustomType);
         CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, null);
         structWithCustomTypeField.Encode(ref encoder);
-        encoder.EncodeTagged(1, TagFormat.FSize, myCustomType, (ref SliceEncoder encoder, MyCustomType value) => CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
+        encoder.EncodeTagged(
+            1,
+            TagFormat.FSize,
+            myCustomType, 
+            (ref SliceEncoder encoder, MyCustomType value) =>
+                CustomTypeSliceEncoderExtensions.EncodeNullableCustomType(ref encoder, value));
 
         encoder.EncodeUInt8(Slice1Definitions.TagEndMarker);
 

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -388,6 +388,9 @@ fn encode_action_body(
                 custom_type_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let identifier = custom_type_ref.cs_identifier(Case::Pascal);
 
+            // We use the 'Nullable' encoding function here, even for tags, to ensure interop with Ice.
+            // Because an Ice client could send a tagged proxy that is 'set' to 'null', so we must use the 'Nullable'
+            // version on the decoding side. And so, for consistency, we also use the 'Nullable' version here.
             if type_ref.is_optional && encoding == Encoding::Slice1 {
                 format!("{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)").into()
             } else {

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -388,9 +388,9 @@ fn encode_action_body(
                 custom_type_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let identifier = custom_type_ref.cs_identifier(Case::Pascal);
 
-            // We use the 'Nullable' encoding function here, even for tags, to ensure interop with Ice.
-            // Because an Ice client could send a tagged proxy that is 'set' to 'null', so we must use the 'Nullable'
-            // version on the decoding side. And so, for consistency, we also use the 'Nullable' version here.
+            // We use the 'Nullable' encoding function here, even for tags, to be consistent with the decoding side.
+            // And the decoding side uses it to ensure interop with Ice, because an Ice client could send a tagged proxy
+            // that is 'set' to 'null', so we must use the 'Nullable' version.
             if type_ref.is_optional && encoding == Encoding::Slice1 {
                 format!("{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)").into()
             } else {

--- a/tools/slicec-cs/src/encoding.rs
+++ b/tools/slicec-cs/src/encoding.rs
@@ -344,10 +344,8 @@ fn encode_action_body(
     encoding: Encoding,
     is_tagged: bool,
 ) -> CodeBlock {
-    let is_optional_and_untagged = type_ref.is_optional && !is_tagged;
-
     let value = match (
-        is_optional_and_untagged,
+        type_ref.is_optional && !is_tagged,
         type_ref.is_value_type(),
         matches!(type_ref.concrete_type(), Types::CustomType(_)),
     ) {
@@ -360,7 +358,7 @@ fn encode_action_body(
     match &type_ref.concrete_typeref() {
         TypeRefs::Class(_) => {
             assert!(encoding == Encoding::Slice1);
-            if is_optional_and_untagged {
+            if type_ref.is_optional {
                 "encoder.EncodeNullableClass(value)".into()
             } else {
                 "encoder.EncodeClass(value)".into()
@@ -390,7 +388,7 @@ fn encode_action_body(
                 custom_type_ref.escape_scoped_identifier_with_suffix("SliceEncoderExtensions", namespace);
             let identifier = custom_type_ref.cs_identifier(Case::Pascal);
 
-            if is_optional_and_untagged && encoding == Encoding::Slice1 {
+            if type_ref.is_optional && encoding == Encoding::Slice1 {
                 format!("{encoder_extensions_class}.EncodeNullable{identifier}(ref encoder, value)").into()
             } else {
                 format!("{encoder_extensions_class}.Encode{identifier}(ref encoder, {value})").into()


### PR DESCRIPTION
The `EncodeTagged` and `DecodeTagged` functions take a function pointer, for performing the actual encoding/decoding.
Currently the signature of those functions assume they're working with non-null types, because the 'null-ness' is handled by being tagged (present or not present).

There's an exception to this though: Slice1 proxies sent by an Ice client. Because these can be 'set' to 'null'.
This PR fixes the code-gen to handle this case.

Proxies (and `ServiceAddress`) are just custom types. So now, for tagged Slice1 custom types, the code-generator will use `(Encode|Decode)NullableCustomType` instead of `(Encode|Decode)CustomType`.

This will add a slight performance hit (which is fine, since this is incredibly niche), and requires removing a `notnull` type restriction from the `Slice1` only overload for `DecodeTagged`. The other 2 overloads are fine as is, since they;re `Slice2` only and `VSize` specific respectively (custom types are _always FSize).