### PR TITLE
Upgrade Protobuf version to 3.26.0

### DIFF
--- a/src/IceRpc.Protobuf/IceRpc.Protobuf.csproj
+++ b/src/IceRpc.Protobuf/IceRpc.Protobuf.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/IceRpc/IceRpc.csproj" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.0" />
     <!-- Includes the analyzer in the package without consuming it. -->
     <ProjectReference
       Include="../IceRpc.Protobuf.Generators/IceRpc.Protobuf.Generators.csproj"

--- a/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -33,7 +33,7 @@
    <ItemGroup>
       <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" />
       <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
-      <PackageReference Include="Google.Protobuf.Tools" Version="3.25.2" />
+      <PackageReference Include="Google.Protobuf.Tools" Version="3.26.0" />
    </ItemGroup>
    <ItemGroup>
       <Compile Include="../Common/IceRpc.CaseConverter.Internal/Converter.cs" />

--- a/tools/IceRpc.ProtocGen/IceRpc.ProtocGen.csproj
+++ b/tools/IceRpc.ProtocGen/IceRpc.ProtocGen.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Compile Include="../Common/IceRpc.CaseConverter.Internal/Converter.cs" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.0" />
     <None Include="protoc-gen-icerpc-csharp.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This PR upgrades the Protobuf version used by IceRpc to the latest released 26.0 (3.26.0 NuGet package)