### PR TITLE
Separate example and assembly version and update Cargo deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,21 @@ on:
 
 jobs:
   build_and_test:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Build
-      uses: ./.github/actions/build
-    - name: Publish
-      uses: ./.github/actions/publish
-    - name: Build Examples
-      uses: ./.github/actions/build-examples
-    - name: Run Tests
-      uses: ./.github/actions/test
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/actions/build
+      - name: Publish
+        uses: ./.github/actions/publish
+      - name: Build Examples
+        uses: ./.github/actions/build-examples
+      - name: Run Tests
+        uses: ./.github/actions/test
+
+  test_templates:
     - name: Test Templates
       uses: ./.github/actions/test-templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-    - name: Build Examples
+      - name: Build Examples
         uses: ./.github/actions/build-examples
 
   test_templates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         uses: ./.github/actions/build
+      - name: Publish
+        uses: ./.github/actions/publish
       - name: Run Tests
         uses: ./.github/actions/test
       - name: Test Templates
@@ -29,10 +31,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Examples
         uses: ./.github/actions/build-examples
-
-  test_templates:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         uses: ./.github/actions/build
-      - name: Publish
-        uses: ./.github/actions/publish
-      - name: Build Examples
-        uses: ./.github/actions/build-examples
       - name: Run Tests
         uses: ./.github/actions/test
+
+  # The examples use an already an published version of the IceRPC NuGet packages
+  build_examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+    - name: Build Examples
+        uses: ./.github/actions/build-examples
 
   test_templates:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Test Templates
         uses: ./.github/actions/test-templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         uses: ./.github/actions/build
       - name: Run Tests
         uses: ./.github/actions/test
+      - name: Test Templates
+        uses: ./.github/actions/test-templates
 
   # The examples use an already an published version of the IceRPC NuGet packages
   build_examples:
@@ -34,5 +36,3 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Test Templates
-        uses: ./.github/actions/test-templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,5 +23,8 @@ jobs:
         uses: ./.github/actions/test
 
   test_templates:
-    - name: Test Templates
-      uses: ./.github/actions/test-templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Test Templates
+        uses: ./.github/actions/test-templates

--- a/build/IceRpc.DocfxExamples.props
+++ b/build/IceRpc.DocfxExamples.props
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build"
-    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- The version of the IceRPC NuGet packages used by the docfx examples -->
         <Version Condition="'$(Version)' == ''">0.3.0</Version>

--- a/build/IceRpc.DocfxExamples.props
+++ b/build/IceRpc.DocfxExamples.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <!-- The version of the IceRPC NuGet packages used by the docfx examples -->
+        <!-- The version of the IceRPC NuGet packages used by the docfx examples. This version is already published on nuget.org. -->
         <Version Condition="'$(Version)' == ''">0.3.0</Version>
         <Nullable>enable</Nullable>
         <TargetFramework>net8.0</TargetFramework>

--- a/build/IceRpc.DocfxExamples.props
+++ b/build/IceRpc.DocfxExamples.props
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildThisFileDirectory)IceRpc.Version.props" />
+<Project ToolsVersion="14.0" DefaultTargets="Build"
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
+        <!-- The version of the IceRPC NuGet packages used by the docfx examples -->
+        <Version Condition="'$(Version)' == ''">0.3.0</Version>
         <Nullable>enable</Nullable>
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>12.0</LangVersion>

--- a/build/IceRpc.Examples.props
+++ b/build/IceRpc.Examples.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <!-- The version of the IceRPC NuGet packages used by the examples -->
+        <!-- The version of the IceRPC NuGet packages used by the docfx examples. This version is already published on nuget.org. -->
         <Version Condition="'$(Version)' == ''">0.3.0</Version>
         <WarningLevel>4</WarningLevel>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/build/IceRpc.Examples.props
+++ b/build/IceRpc.Examples.props
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildThisFileDirectory)IceRpc.Version.props" />
     <PropertyGroup>
+        <!-- The version of the IceRPC NuGet packages used by the examples -->
+        <Version Condition="'$(Version)' == ''">0.3.0</Version>
         <WarningLevel>4</WarningLevel>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AnalysisMode>All</AnalysisMode>

--- a/build/IceRpc.Version.props
+++ b/build/IceRpc.Version.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <!-- The version used by NuGet packages and assembly files -->
-        <Version Condition="'$(Version)' == ''">0.3.0</Version>
+        <!-- The version of the IceRPC assembly files  -->
+        <Version Condition="'$(Version)' == ''">0.3.1-preview1</Version>
     </PropertyGroup>
 </Project>

--- a/tools/slicec-cs/Cargo.lock
+++ b/tools/slicec-cs/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "slicec-cs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "convert_case",

--- a/tools/slicec-cs/Cargo.toml
+++ b/tools/slicec-cs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slicec-cs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["ZeroC Inc."]
 description = """
 The slicec-cs compiler, for compiling Slice files into C# code.


### PR DESCRIPTION
This PR separates the "version number" used for the examples and the IceRPC assemblies. It also updates the slices cargo dep.

Additionally it moves the testing of the examples to a separate step job independent of the src build.