### PR TITLE
Build docfx examples against src build

### DIFF
--- a/.github/actions/build-examples/action.yaml
+++ b/.github/actions/build-examples/action.yaml
@@ -6,5 +6,4 @@ runs:
   - name: 🔨 Build Examples
     run: |
       for solution in examples/*/*/*.sln; do dotnet build "$solution"; done
-      dotnet build docfx/examples/Examples.sln
     shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,13 @@ jobs:
       - name: Run Tests
         uses: ./.github/actions/test
       - name: Install Templates
-        run: |
-          dotnet new install src/IceRpc.Templates/bin/Debug/IceRpc.Templates.*.nupkg
+        run: dotnet new install src/IceRpc.Templates/bin/Debug/IceRpc.Templates.*.nupkg
         shell: bash
       - name: Test Templates
         uses: ./.github/actions/test-templates
+      - name: Build DocFX Examples
+        run: dotnet build docfx/examples/Examples.sln
+        shell: bash
 
   # The examples use an already an published version of the IceRPC NuGet packages
   build_examples:

--- a/build/IceRpc.DocfxExamples.props
+++ b/build/IceRpc.DocfxExamples.props
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)IceRpc.Version.props" />
     <PropertyGroup>
-        <!-- The version of the IceRPC NuGet packages used by the docfx examples. This version is already published on nuget.org. -->
-        <Version Condition="'$(Version)' == ''">0.3.0</Version>
         <Nullable>enable</Nullable>
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>12.0</LangVersion>


### PR DESCRIPTION
This PR changes updates the ci workflow to build the docfx examples against the local src build instead of the published NuGet packages.