### PR TITLE
Update IceRPC version used in project templates

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.*" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.*" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Protobuf" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
       <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
       <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.*" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Protobuf" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.*" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
     <!--#if (transport=="quic") -->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.*" />
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
     <!--#if (transport=="quic") -->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
       <!-- The 1.2 beta version is required for supporting the latest language features.
            See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -11,11 +11,11 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-      <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
-      <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+      <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.*" PrivateAssets="All" />
+      <PackageReference Include="IceRpc.Slice" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.*" />
+      <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
       <!-- The 1.2 beta version is required for supporting the latest language features.
            See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.*" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Slice" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
-        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
-        <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
-        <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
+        <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+        <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+        <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.1-preview1" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.3.1-preview1" />
-    <PackageReference Include="IceRpc.Logger" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.3.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.3.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.3.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.1-preview1" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.3.*" />
     <!--#endif"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />


### PR DESCRIPTION
The templates should use the IceRpc assemblies built in this repository, as defined in `build/IceRpc.Version.props`.