### PR TITLE
Fixes for dotnet 9.0

### DIFF
--- a/build/CodeAnalysis.Tests.globalconfig
+++ b/build/CodeAnalysis.Tests.globalconfig
@@ -1,5 +1,8 @@
 is_global = true
 
+# CA1515: Because an application's API isn't typically referenced from outside the assembly, types can be made internal
+dotnet_diagnostic.CA1515.severity = none
+
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 

--- a/src/IceRpc/Transports/Internal/FlagEnumExtensions.cs
+++ b/src/IceRpc/Transports/Internal/FlagEnumExtensions.cs
@@ -26,7 +26,7 @@ internal static class FlagEnumExtensions
     internal static bool HasFlag<T>(this ref int source, T flag) where T : Enum
     {
         int flagValue = Unsafe.As<T, int>(ref flag);
-        return (Thread.VolatileRead(ref source) & flagValue) == flagValue;
+        return (Volatile.Read(ref source) & flagValue) == flagValue;
     }
 
     internal static void ClearFlag<T>(this ref int source, T flag) where T : Enum

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -17,7 +17,7 @@ internal class SlicStream : IMultiplexedStream
     {
         get
         {
-            ulong id = Thread.VolatileRead(ref _id);
+            ulong id = Volatile.Read(ref _id);
             if (id == ulong.MaxValue)
             {
                 throw new InvalidOperationException("The stream ID isn't allocated yet.");
@@ -28,7 +28,7 @@ internal class SlicStream : IMultiplexedStream
         set
         {
             Debug.Assert(_id == ulong.MaxValue);
-            Thread.VolatileWrite(ref _id, value);
+            Volatile.Write(ref _id, value);
         }
     }
 
@@ -42,7 +42,7 @@ internal class SlicStream : IMultiplexedStream
     public bool IsRemote { get; }
 
     /// <inheritdoc/>
-    public bool IsStarted => Thread.VolatileRead(ref _id) != ulong.MaxValue;
+    public bool IsStarted => Volatile.Read(ref _id) != ulong.MaxValue;
 
     public PipeWriter Output =>
         _outputPipeWriter ?? throw new InvalidOperationException("A remote unidirectional stream has no Output.");

--- a/tests/IceRpc.Tests.Common/TransportOperations.cs
+++ b/tests/IceRpc.Tests.Common/TransportOperations.cs
@@ -36,7 +36,7 @@ public class TransportOperations<T> where T : struct, Enum
         {
             _holdOperations = value;
 
-            foreach (T operation in Enum.GetValues(typeof(T)))
+            foreach (T operation in Enum.GetValues<T>())
             {
                 if (!_holdOperationsTcsMap.TryGetValue(operation, out TaskCompletionSource? tcs))
                 {

--- a/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
+++ b/tests/ZeroC.Slice.Tests/EnumWithFieldsTests.cs
@@ -21,7 +21,7 @@ public class EnumWithFieldsTests
         var decoded = decoder.DecodeColor();
 
         // Assert
-        Assert.That(decoded, Is.InstanceOf(typeof(Color.Blue)));
+        Assert.That(decoded, Is.InstanceOf<Color.Blue>());
         Assert.That(decoder.Consumed, Is.EqualTo(encoder.EncodedByteCount));
 
         // 1 for the discriminant, 1 for the tag, 1 for the tagged value size, 2 for code, 1 for the tag end marker

--- a/tests/ZeroC.Slice.Tests/SequenceEncodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SequenceEncodingTests.cs
@@ -15,7 +15,7 @@ public class SequenceEncodingTests
     {
         get
         {
-            foreach (SliceEncoding encoding in Enum.GetValues(typeof(SliceEncoding)))
+            foreach (SliceEncoding encoding in Enum.GetValues<SliceEncoding>())
             {
                 foreach (int size in new int[] { 0, 256 })
                 {


### PR DESCRIPTION
These are a few fixes to build IceRPC C# with dotnet 9.0. This PR does not include the build system fixes.