### PR TITLE
Don't Escape Single-Quote Characters

### DIFF
--- a/tools/slicec-cs/src/cs_util.rs
+++ b/tools/slicec-cs/src/cs_util.rs
@@ -210,7 +210,7 @@ pub fn format_comment_message(message: &Message, namespace: &str) -> String {
 }
 
 fn xml_escape(text: &str) -> String {
-    // We don't need to escape single-quote characters because 'slicec-cs' always generates double-quoted strings.
+    // We don't need to escape the single-quote character because 'slicec-cs' always generates double-quoted strings.
     text.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")


### PR DESCRIPTION
After some discussion on #3984, it seems like `slicec-cs` never needs to escape single-quotes.
So this PR removes our escaping of it, so that doc-comments are more human-readable.