### PR TITLE
Improve/clean-up the Ice duplex connection decorator

### DIFF
--- a/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
@@ -7,23 +7,23 @@ using System.Diagnostics;
 namespace IceRpc.Internal;
 
 /// <summary>Decorates <see cref="ReadAsync" /> to fail if no byte is received for over readIdleTimeout. Also decorates
-/// <see cref="WriteAsync" /> to schedule a keep alive action (writeIdleTimeout / 2) after a successful write. Both
-/// sides of the connection are expected to use the same idle timeouts.</summary>
+/// <see cref="WriteAsync" /> to send a heartbeat (writeIdleTimeout / 2) after a successful write. Both sides of the
+/// connection are expected to use the same idle timeouts.</summary>
 internal class IceDuplexConnectionDecorator : IDuplexConnection
 {
     private readonly IDuplexConnection _decoratee;
-    private readonly Timer _writerTimer;
     private readonly CancellationTokenSource _readCts = new();
     private readonly TimeSpan _readIdleTimeout;
     private readonly TimeSpan _writeIdleTimeout;
+    private readonly Timer _writeTimer;
 
     public async Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken)
     {
         TransportConnectionInformation connectionInformation = await _decoratee.ConnectAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Schedule or reschedule a keep alive after a successful connection establishment.
-        ResetWriteTimer();
+        // Schedule or reschedule a heartbeat after a successful connection establishment.
+        RescheduleWriteTimer();
         return connectionInformation;
     }
 
@@ -32,8 +32,8 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
         _decoratee.Dispose();
         _readCts.Dispose();
 
-        // Using Dispose is fine, there's no need to wait for the keep alive action to terminate if it's running.
-        _writerTimer.Dispose();
+        // Using Dispose is fine, there's no need to wait for the sendHeartbeat to complete if it's running.
+        _writeTimer.Dispose();
     }
 
     public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
@@ -78,32 +78,38 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
 
         async ValueTask PerformWriteAsync()
         {
+            // No need to send a heartbeat now since we're about to write.
+            CancelWriteTimer();
+
             await _decoratee.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-            // After each successful write, we (re)schedule one ping (heartbeat) at _writeIdleTimeout / 2 in the future.
-            // Since each ping is itself a write, if there is no application activity at all, we'll send successive
-            // pings at _writeIdleTimeout / 2 intervals.
-            ResetWriteTimer();
+            // After each successful write, we schedule a heartbeat at _writeIdleTimeout / 2 in the future.
+            // Since each heartbeat is itself a write, if there is no application activity at all, we'll send successive
+            // heartbeats at _writeIdleTimeout / 2 intervals.
+            RescheduleWriteTimer();
         }
     }
 
     /// <summary>Constructs a decorator that ensures a call to <see cref="ReadAsync" /> will fail after readIdleTimeout.
-    /// This decorator also schedules a keepAliveAction after each write (see <see cref="ResetWriteTimer" />).</summary>
+    /// This decorator also schedules a heartbeat after each write (see <see cref="RescheduleWriteTimer" />).</summary>
     internal IceDuplexConnectionDecorator(
         IDuplexConnection decoratee,
         TimeSpan readIdleTimeout,
         TimeSpan writeIdleTimeout,
-        Action keepAliveAction)
+        Action sendHeartbeat)
     {
         Debug.Assert(writeIdleTimeout != Timeout.InfiniteTimeSpan);
         _decoratee = decoratee;
         _readIdleTimeout = readIdleTimeout; // can be infinite i.e. disabled
         _writeIdleTimeout = writeIdleTimeout;
-        _writerTimer = new Timer(_ => keepAliveAction());
+        _writeTimer = new Timer(_ => sendHeartbeat());
 
         // We can't schedule a keep alive right away because the connection is not connected yet.
     }
 
-    /// <summary>Resets the write timer. We send a keep alive when this timer expires.</summary>
-    private void ResetWriteTimer() => _writerTimer.Change(_writeIdleTimeout / 2, Timeout.InfiniteTimeSpan);
+    /// <summary>Cancels the write timer.</summary>
+    private void CancelWriteTimer() => _writeTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+    /// <summary>Schedules or reschedules the write timer. We send a heartbeat when this timer expires.</summary>
+    private void RescheduleWriteTimer() => _writeTimer.Change(_writeIdleTimeout / 2, Timeout.InfiniteTimeSpan);
 }

--- a/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
@@ -26,7 +26,7 @@ public class IceIdleTimeoutTests
             sut.Client,
             readIdleTimeout: TimeSpan.FromMilliseconds(500),
             writeIdleTimeout: TimeSpan.FromMilliseconds(500),
-            keepAliveAction: () => { });
+            sendHeartbeat: () => { });
 
         // Write and read data to the connection
         await sut.Server.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);
@@ -46,7 +46,7 @@ public class IceIdleTimeoutTests
     }
 
     [Test]
-    public async Task Ice_keep_alive_action_is_called()
+    public async Task Ice_send_heartbeat_action_is_called()
     {
         // Arrange
         await using ServiceProvider provider = new ServiceCollection()
@@ -62,7 +62,7 @@ public class IceIdleTimeoutTests
             sut.Client,
             readIdleTimeout: Timeout.InfiniteTimeSpan,
             writeIdleTimeout: TimeSpan.FromMilliseconds(500),
-            keepAliveAction: () => semaphore.Release());
+            sendHeartbeat: () => semaphore.Release());
 
         // Write and read data.
         await clientConnection.WriteAsync(new ReadOnlySequence<byte>(new byte[1]), default);


### PR DESCRIPTION
This PR makes small updates to the IceDuplexConnectionDecorator and related code:
 - switch to the Ice terminology: heartbeat instead of "ping" and "keep alive"
 - cancels the write timer before writing anything (like we do in Ice 3.8)
