### PR TITLE
Clear interceptor/middleware stack

### DIFF
--- a/src/IceRpc/Pipeline.cs
+++ b/src/IceRpc/Pipeline.cs
@@ -83,6 +83,7 @@ public sealed class Pipeline : IInvoker
         {
             pipeline = interceptor(pipeline);
         }
+        _interceptorStack.Clear(); // we no longer need these functions
         return pipeline;
     }
 }

--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -206,6 +206,7 @@ public sealed class Router : IDispatcher
         {
             dispatchPipeline = middleware(dispatchPipeline);
         }
+        _middlewareStack.Clear(); // we no longer need these functions
         return dispatchPipeline;
     }
 }


### PR DESCRIPTION
This little clean-up PR cleans the interceptor and middleware stack once the pipeline in created.

This way, any memory held by these functions can be GCed immediately.