### PR TITLE
Simplify Slice exceptions and Slice activator

### DIFF
--- a/slice/IceRpc/Internal/IceDefinitions.slice
+++ b/slice/IceRpc/Internal/IceDefinitions.slice
@@ -97,19 +97,20 @@ enum ReplyStatus {
     /// The target object does not exist.
     ObjectNotExistException = 2
 
-    /// The target object does not support the facet.
+    /// The target object does not support the facet (treated like ObjectNotExistException by IceRPC).
     FacetNotExistException = 3
 
     /// The target object does not support the operation.
     OperationNotExistException = 4
 
-    /// The reply message carries an unknown Ice local exception.
+    /// The dispatch failed with an Ice local exception (not applicable with IceRPC).
     UnknownLocalException = 5
 
-    /// The reply message carries an unknown Ice user exception.
+    /// The dispatch failed with a Slice user exception does not conform to the exception specification of the Slice
+    // operation (not applicable with IceRPC).
     UnknownUserException = 6
 
-    /// The reply message carries an unknown exception.
+    /// The dispatch failed with some other exception.
     UnknownException = 7
 }
 

--- a/slice/IceRpc/Internal/IceDefinitions.slice
+++ b/slice/IceRpc/Internal/IceDefinitions.slice
@@ -106,7 +106,7 @@ enum ReplyStatus {
     /// The dispatch failed with an Ice local exception (not applicable with IceRPC).
     UnknownLocalException = 5
 
-    /// The dispatch failed with a Slice user exception does not conform to the exception specification of the Slice
+    /// The dispatch failed with a Slice user exception that does not conform to the exception specification of the Slice
     // operation (not applicable with IceRPC).
     UnknownUserException = 6
 

--- a/slice/IceRpc/Internal/IceDefinitions.slice
+++ b/slice/IceRpc/Internal/IceDefinitions.slice
@@ -106,8 +106,8 @@ enum ReplyStatus {
     /// The dispatch failed with an Ice local exception (not applicable with IceRPC).
     UnknownLocalException = 5
 
-    /// The dispatch failed with a Slice user exception that does not conform to the exception specification of the Slice
-    // operation (not applicable with IceRPC).
+    /// The dispatch failed with a Slice user exception that does not conform to the exception specification of the
+    /// operation (not applicable with IceRPC).
     UnknownUserException = 6
 
     /// The dispatch failed with some other exception.

--- a/src/IceRpc.Slice/IncomingResponseExtensions.cs
+++ b/src/IceRpc.Slice/IncomingResponseExtensions.cs
@@ -161,7 +161,7 @@ public static class IncomingResponseExtensions
                 activator,
                 maxDepth: feature.MaxDepth);
 
-            SliceException exception = decoder.DecodeException();
+            SliceException exception = decoder.DecodeException(response.ErrorMessage);
             decoder.CheckEndOfBuffer();
             return exception;
         }

--- a/src/IceRpc.Slice/IncomingResponseExtensions.cs
+++ b/src/IceRpc.Slice/IncomingResponseExtensions.cs
@@ -151,9 +151,7 @@ public static class IncomingResponseExtensions
 
         SliceException DecodeBuffer(ReadOnlySequence<byte> buffer)
         {
-            // If the error message is empty, we switch to null to get the default System exception message. This would
-            // typically happen when the Slice exception is received over ice.
-            string? errorMessage = response.ErrorMessage!.Length == 0 ? null : response.ErrorMessage;
+            // A Slice exception never sets Message, even when received over icerpc.
 
             var decoder = new SliceDecoder(
                 buffer,
@@ -163,7 +161,7 @@ public static class IncomingResponseExtensions
                 activator,
                 maxDepth: feature.MaxDepth);
 
-            SliceException exception = decoder.DecodeException(errorMessage);
+            SliceException exception = decoder.DecodeException();
             decoder.CheckEndOfBuffer();
             return exception;
         }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -748,8 +748,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
             SequencePosition consumed = buffer.GetPosition(headerSize);
 
             return replyStatus == ReplyStatus.Ok ? (StatusCode.Ok, null, consumed) :
-                // Set the error message to the empty string. We will convert this empty string to null when we
-                // decode the exception.
+                // Set the error message to the empty string, because null is not allowed for status code > Ok.
                 (StatusCode.ApplicationError, "", consumed);
         }
         else

--- a/src/ZeroC.Slice/IActivator.cs
+++ b/src/ZeroC.Slice/IActivator.cs
@@ -39,10 +39,9 @@ public interface IActivator
 
     /// <summary>Creates an instance of a Slice exception based on a type ID.</summary>
     /// <param name="typeId">The Slice type ID.</param>
-    /// <param name="message">The exception message.</param>
     /// <returns>A new instance of the class identified by <paramref name="typeId" />, or null if the implementation
     /// cannot find the corresponding class..</returns>
     /// <remarks>This implementation of this method can also throw an exception if the class is found but the activation
     /// of an instance fails.</remarks>
-    object? CreateExceptionInstance(string typeId, string? message);
+    object? CreateExceptionInstance(string typeId);
 }

--- a/src/ZeroC.Slice/IActivator.cs
+++ b/src/ZeroC.Slice/IActivator.cs
@@ -29,19 +29,11 @@ public interface IActivator
     public static IActivator FromAssemblies(params Assembly[] assemblies) =>
         Internal.Activator.Merge(assemblies.Select(ActivatorFactory.Instance.Get));
 
-    /// <summary>Creates an instance of a Slice class based on a type ID.</summary>
+    /// <summary>Creates an instance of a Slice class or Slice exception based on a type ID.</summary>
     /// <param name="typeId">The Slice type ID.</param>
     /// <returns>A new instance of the class identified by <paramref name="typeId" />, or null if the implementation
-    /// cannot find the corresponding class..</returns>
+    /// cannot find the corresponding C# class.</returns>
     /// <remarks>This implementation of this method can also throw an exception if the class is found but the activation
     /// of an instance fails.</remarks>
-    object? CreateClassInstance(string typeId);
-
-    /// <summary>Creates an instance of a Slice exception based on a type ID.</summary>
-    /// <param name="typeId">The Slice type ID.</param>
-    /// <returns>A new instance of the class identified by <paramref name="typeId" />, or null if the implementation
-    /// cannot find the corresponding class..</returns>
-    /// <remarks>This implementation of this method can also throw an exception if the class is found but the activation
-    /// of an instance fails.</remarks>
-    object? CreateExceptionInstance(string typeId);
+    object? CreateInstance(string typeId);
 }

--- a/src/ZeroC.Slice/Internal/Activator.cs
+++ b/src/ZeroC.Slice/Internal/Activator.cs
@@ -19,11 +19,7 @@ internal class Activator : IActivator
 
     private readonly IReadOnlyDictionary<string, Lazy<ActivateObject>> _dict;
 
-    public object? CreateClassInstance(string typeId) =>
-        _dict.TryGetValue(typeId, out Lazy<ActivateObject>? factory) ?
-            factory.Value() : null;
-
-    public object? CreateExceptionInstance(string typeId) =>
+    public object? CreateInstance(string typeId) =>
         _dict.TryGetValue(typeId, out Lazy<ActivateObject>? factory) ? factory.Value() : null;
 
     /// <summary>Merge activators into a single activator; duplicate entries are ignored.</summary>

--- a/src/ZeroC.Slice/Internal/Activator.cs
+++ b/src/ZeroC.Slice/Internal/Activator.cs
@@ -3,24 +3,19 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq.Expressions;
 using System.Reflection;
-
-// Instantiates a Slice class or exception.
-using ActivateObject = System.Func<object>;
 
 namespace ZeroC.Slice.Internal;
 
 /// <summary>The default implementation of <see cref="IActivator" />, which uses a dictionary.</summary>
 internal class Activator : IActivator
 {
-    internal static Activator Empty { get; } =
-        new Activator(ImmutableDictionary<string, Lazy<ActivateObject>>.Empty);
+    internal static Activator Empty { get; } = new Activator(ImmutableDictionary<string, Type>.Empty);
 
-    private readonly IReadOnlyDictionary<string, Lazy<ActivateObject>> _dict;
+    private readonly IReadOnlyDictionary<string, Type> _dict;
 
     public object? CreateInstance(string typeId) =>
-        _dict.TryGetValue(typeId, out Lazy<ActivateObject>? factory) ? factory.Value() : null;
+        _dict.TryGetValue(typeId, out Type? type) ? System.Activator.CreateInstance(type) : null;
 
     /// <summary>Merge activators into a single activator; duplicate entries are ignored.</summary>
     internal static Activator Merge(IEnumerable<Activator> activators)
@@ -31,11 +26,11 @@ internal class Activator : IActivator
         }
         else
         {
-            var dict = new Dictionary<string, Lazy<ActivateObject>>();
+            var dict = new Dictionary<string, Type>();
 
             foreach (Activator activator in activators)
             {
-                foreach ((string typeId, Lazy<ActivateObject> factory) in activator._dict)
+                foreach ((string typeId, Type factory) in activator._dict)
                 {
                     dict[typeId] = factory;
                 }
@@ -44,7 +39,7 @@ internal class Activator : IActivator
         }
     }
 
-    internal Activator(IReadOnlyDictionary<string, Lazy<ActivateObject>> dict) => _dict = dict;
+    internal Activator(IReadOnlyDictionary<string, Type> dict) => _dict = dict;
 }
 
 /// <summary>Creates activators from assemblies by processing types in those assemblies.</summary>
@@ -66,20 +61,18 @@ internal class ActivatorFactory
                 assembly,
                 assembly =>
                 {
-                    var dict = new Dictionary<string, Lazy<ActivateObject>>();
+                    var dict = new Dictionary<string, Type>();
 
                     foreach (Type type in assembly.GetTypes())
                     {
                         // We're only interested in generated Slice classes and exceptions.
                         if (type.IsClass && type.GetSliceTypeId() is string typeId)
                         {
-                            var lazy = new Lazy<ActivateObject>(() => CreateActivateObject(type));
-
-                            dict.Add(typeId, lazy);
+                            dict.Add(typeId, type);
 
                             if (type.GetCompactSliceTypeId() is int compactTypeId)
                             {
-                                dict.Add(compactTypeId.ToString(CultureInfo.InvariantCulture), lazy);
+                                dict.Add(compactTypeId.ToString(CultureInfo.InvariantCulture), type);
                             }
                         }
                     }
@@ -95,19 +88,6 @@ internal class ActivatorFactory
         {
             // We don't cache an assembly with no Slice attribute, and don't load/process its referenced assemblies.
             return Activator.Empty;
-        }
-
-        // This is a like a compiled version of System.Activator.CreateInstance(Type) that also works with non-public
-        // parameterless constructors.
-        static ActivateObject CreateActivateObject(Type type)
-        {
-            ConstructorInfo constructor = type.GetConstructor(
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                [],
-                null) ?? throw new InvalidOperationException($"Cannot find parameterless constructor for '{type}'.");
-            Expression expression = Expression.New(constructor);
-            return Expression.Lambda<ActivateObject>(expression).Compile();
         }
     }
 

--- a/src/ZeroC.Slice/SliceDecoder.Class.cs
+++ b/src/ZeroC.Slice/SliceDecoder.Class.cs
@@ -21,8 +21,10 @@ public ref partial struct SliceDecoder
            throw new InvalidDataException("Decoded a null class instance, but expected a non-null instance.");
 
     /// <summary>Decodes a Slice exception.</summary>
+    /// <param name="message">The error message. It's used only when this method fails to find an exception class to
+    /// instantiate.</param>
     /// <returns>The decoded Slice exception.</returns>
-    public SliceException DecodeException()
+    public SliceException DecodeException(string? message = null)
     {
         if (Encoding != SliceEncoding.Slice1)
         {
@@ -52,9 +54,12 @@ public ref partial struct SliceDecoder
             sliceException = activator.CreateInstance(typeId) as SliceException;
             if (sliceException is null && SkipSlice(typeId))
             {
-                // Cannot decode this exception.
+                // Cannot decode this exception. The message should be set only when the exception was received over
+                // icerpc.
                 throw new InvalidDataException(
-                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find.");
+                    message is null || message.Length == 0 ?
+                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find." :
+                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find. Error message = {message}");
             }
         }
         while (sliceException is null);

--- a/src/ZeroC.Slice/SliceDecoder.Class.cs
+++ b/src/ZeroC.Slice/SliceDecoder.Class.cs
@@ -50,7 +50,7 @@ public ref partial struct SliceDecoder
 
             DecodeIndirectionTableIntoCurrent(); // we decode the indirection table immediately.
 
-            sliceException = activator.CreateExceptionInstance(typeId, message) as SliceException;
+            sliceException = activator.CreateExceptionInstance(typeId) as SliceException;
             if (sliceException is null && SkipSlice(typeId))
             {
                 // Cannot decode this exception.

--- a/src/ZeroC.Slice/SliceDecoder.Class.cs
+++ b/src/ZeroC.Slice/SliceDecoder.Class.cs
@@ -21,9 +21,8 @@ public ref partial struct SliceDecoder
            throw new InvalidDataException("Decoded a null class instance, but expected a non-null instance.");
 
     /// <summary>Decodes a Slice exception.</summary>
-    /// <param name="message">The error message.</param>
     /// <returns>The decoded Slice exception.</returns>
-    public SliceException DecodeException(string? message = null)
+    public SliceException DecodeException()
     {
         if (Encoding != SliceEncoding.Slice1)
         {
@@ -50,14 +49,12 @@ public ref partial struct SliceDecoder
 
             DecodeIndirectionTableIntoCurrent(); // we decode the indirection table immediately.
 
-            sliceException = activator.CreateExceptionInstance(typeId) as SliceException;
+            sliceException = activator.CreateInstance(typeId) as SliceException;
             if (sliceException is null && SkipSlice(typeId))
             {
                 // Cannot decode this exception.
                 throw new InvalidDataException(
-                    message is null ?
-                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find." :
-                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find. Error message = {message}");
+                    $"The dispatch returned a Slice exception with type ID '{mostDerivedTypeId}' that the configured activator cannot find.");
             }
         }
         while (sliceException is null);
@@ -261,7 +258,7 @@ public ref partial struct SliceDecoder
             // not created yet.
             if (typeId is not null)
             {
-                instance = activator.CreateClassInstance(typeId) as SliceClass;
+                instance = activator.CreateInstance(typeId) as SliceClass;
             }
 
             if (instance is null && SkipSlice(typeId))

--- a/src/ZeroC.Slice/SliceException.cs
+++ b/src/ZeroC.Slice/SliceException.cs
@@ -18,7 +18,7 @@ public abstract class SliceException : Exception
     /// <summary>Decodes a Slice exception.</summary>
     /// <param name="decoder">The Slice decoder.</param>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    protected virtual void DecodeCore(ref SliceDecoder decoder) => throw new NotImplementedException();
+    protected abstract void DecodeCore(ref SliceDecoder decoder);
 
     /// <summary>Encodes this Slice exception.</summary>
     /// <param name="encoder">The Slice encoder.</param>

--- a/src/ZeroC.Slice/SliceException.cs
+++ b/src/ZeroC.Slice/SliceException.cs
@@ -7,19 +7,13 @@ namespace ZeroC.Slice;
 /// <summary>Represents the base class for exceptions defined in Slice.</summary>
 public abstract class SliceException : Exception
 {
+    // Uses the default parameterless constructor.
+
     /// <summary>Encodes this exception.</summary>
     /// <param name="encoder">The Slice encoder.</param>
     public void Encode(ref SliceEncoder encoder) => EncodeCore(ref encoder);
 
     internal void Decode(ref SliceDecoder decoder) => DecodeCore(ref decoder);
-
-    /// <summary>Constructs a Slice exception with the provided message and inner exception.</summary>
-    /// <param name="message">A message that describes the exception.</param>
-    /// <param name="innerException">The inner exception.</param>
-    protected SliceException(string? message = null, Exception? innerException = null)
-        : base(message, innerException)
-    {
-    }
 
     /// <summary>Decodes a Slice exception.</summary>
     /// <param name="decoder">The Slice decoder.</param>

--- a/tests/IceRpc.Slice.Tests/ExceptionTests.cs
+++ b/tests/IceRpc.Slice.Tests/ExceptionTests.cs
@@ -130,6 +130,17 @@ public sealed partial class ExceptionTests
         Assert.That(exception.InnerException, Is.InstanceOf<MyException>());
     }
 
+    /// <summary>Verifies that the user can define a custom message that uses the exception fields.</summary>
+    [Test]
+    public void Slice_exception_can_have_custom_message()
+    {
+        var invoker = new ColocInvoker(new SliceExceptionOperationsService(new MyException(5, 6)));
+        var proxy = new SliceExceptionOperationsProxy(invoker);
+
+        var exception = Assert.ThrowsAsync<MyException>(() => proxy.OpThrowsMyExceptionAsync());
+        Assert.That(exception.Message, Is.EqualTo("MyException: i=5, j=6"));
+    }
+
     [SliceService]
     private sealed partial class SliceExceptionOperationsService : ISliceExceptionOperationsService
     {
@@ -137,8 +148,9 @@ public sealed partial class ExceptionTests
 
         public SliceExceptionOperationsService(Exception exception) => _exception = exception;
 
-        public ValueTask OpThrowsMultipleExceptionsAsync(IFeatureCollection features, CancellationToken cancellationToken) =>
-            throw _exception;
+        public ValueTask OpThrowsMultipleExceptionsAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => throw _exception;
 
         public ValueTask OpThrowsMyExceptionAsync(IFeatureCollection features, CancellationToken cancellationToken) =>
             throw _exception;
@@ -146,4 +158,9 @@ public sealed partial class ExceptionTests
         public ValueTask OpThrowsNothingAsync(IFeatureCollection features, CancellationToken cancellationToken) =>
             throw _exception;
     }
+}
+
+public partial class MyException
+{
+    public override string Message => $"MyException: i={I}, j={J}";
 }

--- a/tests/IceRpc.Slice.Tests/ExceptionTests.slice
+++ b/tests/IceRpc.Slice.Tests/ExceptionTests.slice
@@ -25,6 +25,7 @@ exception EmptyException {}
 
 interface SliceExceptionOperations {
     opThrowsMultipleExceptions() throws (MyException, EmptyException)
+
     opThrowsMyException() throws MyException
 
     opThrowsNothing()
@@ -33,5 +34,6 @@ interface SliceExceptionOperations {
 // Just like SliceExceptionOperations, but with different exception specifications
 interface AltSliceExceptionOperations {
     opThrowsMultipleExceptions() throws MyException
+
     opThrowsMyException()
 }

--- a/tests/IceRpc.Slice.Tests/ExceptionTests.slice
+++ b/tests/IceRpc.Slice.Tests/ExceptionTests.slice
@@ -25,7 +25,6 @@ exception EmptyException {}
 
 interface SliceExceptionOperations {
     opThrowsMultipleExceptions() throws (MyException, EmptyException)
-
     opThrowsMyException() throws MyException
 
     opThrowsNothing()

--- a/tests/ZeroC.Slice.Tests/ActivatorTests.cs
+++ b/tests/ZeroC.Slice.Tests/ActivatorTests.cs
@@ -67,7 +67,7 @@ public class ActivatorTests
     public void Activator_cannot_create_instances_of_classes_defined_in_unknown_assemblies(string typeId)
     {
         var sut = IActivator.FromAssembly(typeof(SliceDecoder).Assembly);
-        object? instance = sut.CreateClassInstance(typeId);
+        object? instance = sut.CreateInstance(typeId);
 
         Assert.That(instance, Is.Null);
     }
@@ -77,7 +77,7 @@ public class ActivatorTests
     {
         var sut = IActivator.FromAssembly(typeof(SliceDecoder).Assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId);
+        object? instance = sut.CreateInstance(typeId);
 
         Assert.That(instance, Is.Null);
     }
@@ -90,7 +90,7 @@ public class ActivatorTests
     {
         var sut = IActivator.FromAssembly(assembly);
 
-        object? instance = sut.CreateClassInstance(typeId);
+        object? instance = sut.CreateInstance(typeId);
 
         Assert.That(instance, Is.Not.Null);
         Assert.That(instance!.GetType(), Is.EqualTo(expectedType));
@@ -105,7 +105,7 @@ public class ActivatorTests
         var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId);
+        object? instance = sut.CreateInstance(typeId);
 
         Assert.That(instance, Is.Not.Null);
         Assert.That(instance!.GetType(), Is.EqualTo(expectedType));

--- a/tests/ZeroC.Slice.Tests/ActivatorTests.cs
+++ b/tests/ZeroC.Slice.Tests/ActivatorTests.cs
@@ -77,7 +77,7 @@ public class ActivatorTests
     {
         var sut = IActivator.FromAssembly(typeof(SliceDecoder).Assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId, message: null);
+        object? instance = sut.CreateExceptionInstance(typeId);
 
         Assert.That(instance, Is.Null);
     }
@@ -105,7 +105,7 @@ public class ActivatorTests
         var decoder = new SliceDecoder(ReadOnlyMemory<byte>.Empty, SliceEncoding.Slice1);
         var sut = IActivator.FromAssembly(assembly);
 
-        object? instance = sut.CreateExceptionInstance(typeId, message: null);
+        object? instance = sut.CreateExceptionInstance(typeId);
 
         Assert.That(instance, Is.Not.Null);
         Assert.That(instance!.GetType(), Is.EqualTo(expectedType));

--- a/tests/ZeroC.Slice.Tests/SlicingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SlicingTests.cs
@@ -268,10 +268,7 @@ public class SlicingTests
             _excludeTypeId = excludeTypeId;
         }
 
-        public object? CreateClassInstance(string typeId) =>
-            _excludeTypeId == typeId ? null : _decoratee.CreateClassInstance(typeId);
-
-        public object? CreateExceptionInstance(string typeId) =>
-            _excludeTypeId == typeId ? null : _decoratee.CreateExceptionInstance(typeId);
+        public object? CreateInstance(string typeId) =>
+            _excludeTypeId == typeId ? null : _decoratee.CreateInstance(typeId);
     }
 }

--- a/tests/ZeroC.Slice.Tests/SlicingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SlicingTests.cs
@@ -271,7 +271,7 @@ public class SlicingTests
         public object? CreateClassInstance(string typeId) =>
             _excludeTypeId == typeId ? null : _decoratee.CreateClassInstance(typeId);
 
-        public object? CreateExceptionInstance(string typeId, string? message) =>
-            _excludeTypeId == typeId ? null : _decoratee.CreateExceptionInstance(typeId, message);
+        public object? CreateExceptionInstance(string typeId) =>
+            _excludeTypeId == typeId ? null : _decoratee.CreateExceptionInstance(typeId);
     }
 }

--- a/tests/ZeroC.Slice.Tests/TaggedTests.cs
+++ b/tests/ZeroC.Slice.Tests/TaggedTests.cs
@@ -538,10 +538,8 @@ public class TaggedTests
         private readonly string _replacementTypeId;
         private readonly string _typeId;
 
-        public object? CreateClassInstance(string typeId) =>
-            _decoratee.CreateClassInstance(typeId == _typeId ? _replacementTypeId : typeId);
-
-        public object? CreateExceptionInstance(string typeId) => _decoratee.CreateExceptionInstance(typeId);
+        public object? CreateInstance(string typeId) =>
+            _decoratee.CreateInstance(typeId == _typeId ? _replacementTypeId : typeId);
 
         internal TypeReplacementActivator(IActivator decoratee, string typeId, string replacementTypeId)
         {

--- a/tests/ZeroC.Slice.Tests/TaggedTests.cs
+++ b/tests/ZeroC.Slice.Tests/TaggedTests.cs
@@ -541,8 +541,7 @@ public class TaggedTests
         public object? CreateClassInstance(string typeId) =>
             _decoratee.CreateClassInstance(typeId == _typeId ? _replacementTypeId : typeId);
 
-        public object? CreateExceptionInstance(string typeId, string? message) =>
-            _decoratee.CreateExceptionInstance(typeId, message);
+        public object? CreateExceptionInstance(string typeId) => _decoratee.CreateExceptionInstance(typeId);
 
         internal TypeReplacementActivator(IActivator decoratee, string typeId, string replacementTypeId)
         {

--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -287,11 +287,6 @@ impl FunctionBuilder {
         self
     }
 
-    pub fn add_base_parameter(&mut self, argument: &str) -> &mut Self {
-        self.base_arguments.push(argument.to_owned());
-        self
-    }
-
     pub fn add_base_parameters(&mut self, arguments: &[String]) -> &mut Self {
         for arg in arguments {
             self.base_arguments.push(arg.to_owned());
@@ -336,22 +331,23 @@ impl FunctionBuilder {
             let parameter_type = parameter.cs_type_string(&operation.namespace(), context);
             let parameter_name = parameter.parameter_name();
 
-            let default_value = if context == TypeContext::OutgoingParam && (index >= trailing_optional_parameters_index) {
-                match parameter.data_type.concrete_typeref() {
-                    // Sequences of fixed-size numeric types are mapped to `ReadOnlyMemory<T>` and have to use
-                    // 'default' as their default value. Other optional types are mapped to nullable types and
-                    // can use 'null' as the default value, which makes it clear what the default is.
-                    TypeRefs::Sequence(sequence_ref)
-                        if sequence_ref.has_fixed_size_primitive_elements()
-                            && !sequence_ref.has_attribute::<CsType>() =>
-                    {
-                        Some("default")
+            let default_value =
+                if context == TypeContext::OutgoingParam && (index >= trailing_optional_parameters_index) {
+                    match parameter.data_type.concrete_typeref() {
+                        // Sequences of fixed-size numeric types are mapped to `ReadOnlyMemory<T>` and have to use
+                        // 'default' as their default value. Other optional types are mapped to nullable types and
+                        // can use 'null' as the default value, which makes it clear what the default is.
+                        TypeRefs::Sequence(sequence_ref)
+                            if sequence_ref.has_fixed_size_primitive_elements()
+                                && !sequence_ref.has_attribute::<CsType>() =>
+                        {
+                            Some("default")
+                        }
+                        _ => Some("null"),
                     }
-                    _ => Some("null"),
-                }
-            } else {
-                None
-            };
+                } else {
+                    None
+                };
 
             self.add_parameter(
                 &parameter_type,

--- a/tools/slicec-cs/src/generators/class_generator.rs
+++ b/tools/slicec-cs/src/generators/class_generator.rs
@@ -95,7 +95,8 @@ pub fn generate_class(class_def: &Class) -> CodeBlock {
 
     // parameterless constructor for decoding, generated only if the preceding constructors are not parameterless
     if non_nullable_fields.len() + non_nullable_base_fields.len() > 0 {
-        let mut decode_constructor = FunctionBuilder::new(access, "", &class_name, FunctionType::BlockBody);
+        // The constructor needs to be public for System.Activator.CreateInstance.
+        let mut decode_constructor = FunctionBuilder::new("public", "", &class_name, FunctionType::BlockBody);
         decode_constructor.add_never_editor_browsable_attribute();
         decode_constructor.add_comment(
             "summary",

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -62,10 +62,6 @@ pub fn generate_exception(exception_def: &Exception) -> CodeBlock {
                         &exception_name
                     ),
                 )
-                .add_parameter("string?", "message", None, None)
-                .add_base_parameter("message")
-                .add_parameter("global::System.Exception?", "innerException", None, None)
-                .add_base_parameter("innerException")
                 .set_body(initialize_required_fields(fields))
                 .build(),
         );
@@ -125,9 +121,6 @@ fn one_shot_constructor(exception_def: &Exception) -> CodeBlock {
 
     let all_fields = exception_def.all_fields();
 
-    let message_parameter_name = escape_parameter_name(&all_fields, "message");
-    let inner_exception_parameter_name = escape_parameter_name(&all_fields, "innerException");
-
     let base_parameters = if let Some(base) = exception_def.base_exception() {
         base.all_fields().iter().map(|m| m.parameter_name()).collect::<Vec<_>>()
     } else {
@@ -150,22 +143,6 @@ fn one_shot_constructor(exception_def: &Exception) -> CodeBlock {
         );
     }
     ctor_builder.add_base_parameters(&base_parameters);
-
-    ctor_builder
-        .add_parameter(
-            "string?",
-            &message_parameter_name,
-            Some("null"),
-            Some("A message that describes the exception.".to_owned()),
-        )
-        .add_base_parameter(&message_parameter_name)
-        .add_parameter(
-            "global::System.Exception?",
-            &inner_exception_parameter_name,
-            Some("null"),
-            Some("The exception that is the cause of the current exception.".to_owned()),
-        )
-        .add_base_parameter(&inner_exception_parameter_name);
 
     // ctor impl
     let mut ctor_body = CodeBlock::default();

--- a/tools/slicec-cs/src/generators/exception_generator.rs
+++ b/tools/slicec-cs/src/generators/exception_generator.rs
@@ -48,10 +48,10 @@ pub fn generate_exception(exception_def: &Exception) -> CodeBlock {
         format!("private static readonly string SliceTypeId = typeof({exception_name}).GetSliceTypeId()!;").into(),
     );
 
-    exception_class_builder.add_block(one_shot_constructor(exception_def));
-
-    // constructor for decoding, generated only if necessary
     if !exception_def.all_fields().is_empty() {
+        exception_class_builder.add_block(one_shot_constructor(exception_def));
+
+        // Also generate a parameterless constructor for decoding.
         exception_class_builder.add_block(
             FunctionBuilder::new("public", "", &exception_name, FunctionType::BlockBody)
                 .add_never_editor_browsable_attribute()


### PR DESCRIPTION
This PR simplifies Slice exceptions and the Slice activator (used to create class and exception instances from a Slice type ID).

Slice exceptions were more complicated than needed because for a while we wanted to use them with Slice2 too, but we abandoned this idea. So exceptions are:
 - Slice1-only
 - usually transmitted over the ice protocol
 - conceptually similar to the error component of a Slice2 Result

This means the exception message (not transmitted by Slice1) and the inner exception (not meaningful) don't matter much. Note that the error component of a Slice2 Result does have these either.

So this PR removes the message and innerException parameters from the generated exception constructors. As a result, both generated classes and exceptions rely on the same parameterless constructor for decoding.

This PR also adds a small test to demonstrate how users can create custom messages for generated exception (by overriding Message).