### PR TITLE
Use required fields in classes and exceptions

### DIFF
--- a/tools/slicec-cs/src/member_util.rs
+++ b/tools/slicec-cs/src/member_util.rs
@@ -40,26 +40,10 @@ pub fn field_declaration(field: &Field) -> String {
     format!(
         "\
 {prelude}
-{access} {type_string} {name} {{ get; {setter}; }}",
+{access}{required} {type_string} {name} {{ get; {setter}; }}",
         access = field.parent().access_modifier(),
+        required = if field.is_required() { " required" } else { "" },
         name = field.field_name(),
         setter = if field.is_cs_readonly() { "init" } else { "set" },
     )
-}
-
-pub fn initialize_required_fields(fields: &[&Field]) -> CodeBlock {
-    // This helper should only be used for classes and exceptions
-
-    let mut code = CodeBlock::default();
-
-    for field in fields {
-        let data_type = field.data_type();
-        if !data_type.is_optional && !data_type.is_value_type() {
-            // This is to suppress compiler warnings for non-nullable fields.
-            // We don't need it for value fields since they are initialized to default.
-            writeln!(code, "this.{} = default!;", field.field_name());
-        }
-    }
-
-    code
 }

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -32,7 +32,7 @@ pub trait FieldExt {
     /// Check if this field, or its parent struct, are marked with `cs::readonly`.
     fn is_cs_readonly(&self) -> bool;
 
-    /// Check if this field is mapped to a required filed.
+    /// Check if this field is mapped to a required field.
     fn is_required(&self) -> bool;
 
     /// Returns the value of the `@param` doc-comment tag for this enumerator field, if a tag with this field name is

--- a/tools/slicec-cs/src/slicec_ext/member_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/member_ext.rs
@@ -32,6 +32,9 @@ pub trait FieldExt {
     /// Check if this field, or its parent struct, are marked with `cs::readonly`.
     fn is_cs_readonly(&self) -> bool;
 
+    /// Check if this field is mapped to a required filed.
+    fn is_required(&self) -> bool;
+
     /// Returns the value of the `@param` doc-comment tag for this enumerator field, if a tag with this field name is
     /// present. Panics if this field is not an enumerator field.
     fn formatted_param_doc_comment(&self) -> Option<String>;
@@ -43,6 +46,12 @@ impl FieldExt for Field {
             .concat()
             .into_iter()
             .any(|a| a.downcast::<CsReadonly>().is_some())
+    }
+
+    fn is_required(&self) -> bool {
+        return !self.data_type().is_optional
+            && !self.data_type().is_value_type()
+            && !matches!(self.parent().concrete_entity(), Entities::Struct(_));
     }
 
     fn formatted_param_doc_comment(&self) -> Option<String> {


### PR DESCRIPTION
This PR updates the C# mapping for Slice classes and exceptions to use 'required' fields for non-nullable reference types.

Fixes #4014.
