### PR TITLE
Do not use deprecated certificate constructor

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -39,6 +39,7 @@
     "parameterless",
     "peekable",
     "pingable",
+    "Pkcs",
     "Proto",
     "Protobuf",
     "Protoc",

--- a/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
+++ b/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="../../src/IceRpc/IceRpc.csproj" />
     <ProjectReference Include="../../src/IceRpc.Transports.Quic/IceRpc.Transports.Quic.csproj" />

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -19,10 +19,10 @@ public static class QuicTransportServiceCollectionExtensions
     {
         services.AddSingleton(provider => new SslClientAuthenticationOptions
         {
-            ClientCertificates = new X509CertificateCollection
-                    {
+            ClientCertificates =
+                    [
                         X509CertificateLoader.LoadCertificateFromFile("client.p12")
-                    },
+                    ],
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
                 certificate?.Issuer.Contains("IceRPC Tests CA", StringComparison.Ordinal) ?? false
         })

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class QuicTransportServiceCollectionExtensions
         {
             ClientCertificates =
                     [
-                        X509CertificateLoader.LoadPkcs12FromFile("client.p12", null)
+                        X509CertificateLoader.LoadPkcs12FromFile("client.p12", password: null)
                     ],
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
                 certificate?.Issuer.Contains("IceRPC Tests CA", StringComparison.Ordinal) ?? false
@@ -29,7 +29,7 @@ public static class QuicTransportServiceCollectionExtensions
             .AddSingleton(provider => new SslServerAuthenticationOptions
             {
                 ClientCertificateRequired = false,
-                ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", null)
+                ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", password: null)
             })
             .AddSingleton<IMultiplexedServerTransport>(provider =>
                 new QuicServerTransport(

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class QuicTransportServiceCollectionExtensions
         {
             ClientCertificates = new X509CertificateCollection
                     {
-                        new X509Certificate2("client.p12")
+                        X509CertificateLoader.LoadCertificateFromFile("client.p12")
                     },
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
                 certificate?.Issuer.Contains("IceRPC Tests CA", StringComparison.Ordinal) ?? false
@@ -29,7 +29,7 @@ public static class QuicTransportServiceCollectionExtensions
             .AddSingleton(provider => new SslServerAuthenticationOptions
             {
                 ClientCertificateRequired = false,
-                ServerCertificate = new X509Certificate2("server.p12")
+                ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server.p12")
             })
             .AddSingleton<IMultiplexedServerTransport>(provider =>
                 new QuicServerTransport(

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class QuicTransportServiceCollectionExtensions
         {
             ClientCertificates =
                     [
-                        X509CertificateLoader.LoadCertificateFromFile("client.p12")
+                        X509CertificateLoader.LoadPkcs12FromFile("client.p12", null)
                     ],
             RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
                 certificate?.Issuer.Contains("IceRPC Tests CA", StringComparison.Ordinal) ?? false
@@ -29,7 +29,7 @@ public static class QuicTransportServiceCollectionExtensions
             .AddSingleton(provider => new SslServerAuthenticationOptions
             {
                 ClientCertificateRequired = false,
-                ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server.p12")
+                ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", null)
             })
             .AddSingleton<IMultiplexedServerTransport>(provider =>
                 new QuicServerTransport(

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
@@ -67,14 +67,14 @@ public class QuicTransportSslAuthenticationTests
                 {
                     ClientCertificateRequired = true,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => false,
-                    ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server.p12"),
+                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", null),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions
                 {
                     ClientCertificates =
                     [
-                        X509CertificateLoader.LoadCertificateFromFile("client-untrusted.p12")
+                        X509CertificateLoader.LoadPkcs12FromFile("client-untrusted.p12", null)
                     ],
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true
                 })

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
@@ -32,7 +32,7 @@ public class QuicTransportSslAuthenticationTests
             .AddSingleton(
                 new SslServerAuthenticationOptions
                 {
-                    ServerCertificate = new X509Certificate2("server-untrusted.p12"),
+                    ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server-untrusted.p12"),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions
@@ -67,15 +67,15 @@ public class QuicTransportSslAuthenticationTests
                 {
                     ClientCertificateRequired = true,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => false,
-                    ServerCertificate = new X509Certificate2("server.p12"),
+                    ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server.p12"),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions
                 {
-                    ClientCertificates = new X509CertificateCollection()
-                    {
-                        new X509Certificate2("client-untrusted.p12")
-                    },
+                    ClientCertificates =
+                    [
+                        X509CertificateLoader.LoadCertificateFromFile("client-untrusted.p12")
+                    ],
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true
                 })
             .BuildServiceProvider(validateScopes: true);

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
@@ -32,7 +32,7 @@ public class QuicTransportSslAuthenticationTests
             .AddSingleton(
                 new SslServerAuthenticationOptions
                 {
-                    ServerCertificate = X509CertificateLoader.LoadCertificateFromFile("server-untrusted.p12"),
+                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server-untrusted.p12", null),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions

--- a/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
+++ b/tests/IceRpc.Quic.Tests/Transports/QuicTransportSslAuthenticationTests.cs
@@ -32,7 +32,7 @@ public class QuicTransportSslAuthenticationTests
             .AddSingleton(
                 new SslServerAuthenticationOptions
                 {
-                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server-untrusted.p12", null),
+                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server-untrusted.p12", password: null),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions
@@ -67,14 +67,14 @@ public class QuicTransportSslAuthenticationTests
                 {
                     ClientCertificateRequired = true,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => false,
-                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", null),
+                    ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("server.p12", password: null),
                 })
             .AddSingleton(
                 new SslClientAuthenticationOptions
                 {
                     ClientCertificates =
                     [
-                        X509CertificateLoader.LoadPkcs12FromFile("client-untrusted.p12", null)
+                        X509CertificateLoader.LoadPkcs12FromFile("client-untrusted.p12", password: null)
                     ],
                     RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true
                 })


### PR DESCRIPTION
This PR fixes CI failures related to use the deprecated X509Certificate2 constructor.

It uses the new [X509CertificateLoader](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificateloader?view=net-8.0) which is part of .NET 9 and available for .NET 8 in Microsoft.Bcl.Cryptography NuGet package.