### PR TITLE
Rename property to enable/disable build telemetry

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder
     >$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <DisableBuildTelemetry>true</DisableBuildTelemetry>
+    <IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.*" PrivateAssets="All" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,6 +7,6 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.Tests.globalconfig" />
   </ItemGroup>
   <PropertyGroup>
-    <DisableBuildTelemetry>true</DisableBuildTelemetry>
+    <IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>
   </PropertyGroup>
 </Project>

--- a/tools/IceRpc.BuildTelemetry.Reporter/README.md
+++ b/tools/IceRpc.BuildTelemetry.Reporter/README.md
@@ -27,7 +27,7 @@ csharp project file:
 
 ```xml
 <PropertyGroup>
- <DisableBuildTelemetry>true</DisableBuildTelemetry>
+ <IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>
 </PropertyGroup>
 ```
 

--- a/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
+++ b/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
@@ -18,8 +18,8 @@
         <IceRpcProtocPath>$(MSBuildThisFileDirectory)obj/tools/</IceRpcProtocPath>
         <IceRpcProtocGenPath
         >$(MSBuildThisFileDirectory)../IceRpc.ProtocGen/bin/$(Configuration)/net8.0/</IceRpcProtocGenPath>
-        <TelemetryScriptPath
-        >$(MSBuildThisFileDirectory)../IceRpc.BuildTelemetry.Reporter/bin/$(Configuration)/net8.0/</TelemetryScriptPath>
+        <IceRpcBuildTelemetryScriptPath
+        >$(MSBuildThisFileDirectory)../IceRpc.BuildTelemetry.Reporter/bin/$(Configuration)/net8.0/</IceRpcBuildTelemetryScriptPath>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -27,7 +27,7 @@
       <PropertyGroup>
         <IceRpcProtocPath>$(MSBuildThisFileDirectory)../tools/</IceRpcProtocPath>
         <IceRpcProtocGenPath>$(MSBuildThisFileDirectory)../tools/</IceRpcProtocGenPath>
-        <TelemetryScriptPath>$(MSBuildThisFileDirectory)../tools/</TelemetryScriptPath>
+        <IceRpcBuildTelemetryScriptPath>$(MSBuildThisFileDirectory)../tools/</IceRpcBuildTelemetryScriptPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/tools/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -69,17 +69,17 @@
       Sources="%(_ProtoFile.Identity)"
       Condition="'%(_ProtoFile.UpToDate)' != 'true'"
     />
-    <OutputHashTask Sources="@(ProtoFile)" Condition="'$(DisableBuildTelemetry)' != 'true'">
+    <OutputHashTask Sources="@(ProtoFile)" Condition="'$(IceRpcBuildTelemetry)' != 'false'">
       <Output PropertyName="Hash" TaskParameter="CompilationHash" />
       <Output PropertyName="FileCount" TaskParameter="FileCount" />
     </OutputHashTask>
 
-    <!-- Run telemetry -->
+    <!-- Run build telemetry -->
     <TelemetryTask
-      WorkingDirectory="$(TelemetryScriptPath)"
+      WorkingDirectory="$(IceRpcBuildTelemetryScriptPath)"
       CompilationHash="$(Hash)"
       SourceFileCount="$(FileCount)"
-      Condition="'$(DisableBuildTelemetry)' != 'true'"
+      Condition="'$(IceRpcBuildTelemetry)' != 'false'"
       Idl="protobuf"
       ContinueOnError="true"
     />

--- a/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
+++ b/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
@@ -20,15 +20,15 @@
         <SliceCompilerPath
           Condition="'$(Configuration)' == 'Release'"
         >$(MSBuildThisFileDirectory)../slicec-cs/target/release</SliceCompilerPath>
-        <TelemetryScriptPath
-        >$(MSBuildThisFileDirectory)../IceRpc.BuildTelemetry.Reporter/bin/$(Configuration)/net8.0/</TelemetryScriptPath>
+        <IceRpcBuildTelemetryScriptPath
+        >$(MSBuildThisFileDirectory)../IceRpc.BuildTelemetry.Reporter/bin/$(Configuration)/net8.0/</IceRpcBuildTelemetryScriptPath>
       </PropertyGroup>
     </When>
     <Otherwise>
       <!-- Use the Slice compiler from this NuGet package -->
       <PropertyGroup>
         <SliceCompilerPath>$(MSBuildThisFileDirectory)../tools/$(IceRpcOSName)-$(IceRpcOSArch)</SliceCompilerPath>
-        <TelemetryScriptPath>$(MSBuildThisFileDirectory)../tools/</TelemetryScriptPath>
+        <IceRpcBuildTelemetryScriptPath>$(MSBuildThisFileDirectory)../tools/</IceRpcBuildTelemetryScriptPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/tools/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -74,14 +74,14 @@
 
     <!-- Run telemetry -->
     <TelemetryTask
-      WorkingDirectory="$(TelemetryScriptPath)"
+      WorkingDirectory="$(IceRpcBuildTelemetryScriptPath)"
       CompilationHash="$(Hash)"
       ContainsSlice1="$(ContainsSlice1)"
       ContainsSlice2="$(ContainsSlice2)"
       SourceFileCount="$(SourceFileCount)"
       ReferenceFileCount="$(ReferenceFileCount)"
       Idl="slice"
-      Condition="'$(DisableBuildTelemetry)' != 'true'"
+      Condition="'$(IceRpcBuildTelemetry)' != 'false'"
       ContinueOnError="true"
     />
 


### PR DESCRIPTION
This PR renames two build telemetry properties:

 - DisableBuildTelemetry => IceRpcBuildTelemetry
 - TelemetryScriptPath => IceRpcTelemetryScriptPath

Fixes #4015 