### PR TITLE
Fix / work around for System.Text.Json NuGet Audit error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      # TODO workaround for https://github.com/icerpc/icerpc-csharp/issues/4020
-      NuGetAudit: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,6 @@ on:
 
 jobs:
   analyze:
-    env:
-      # TODO workaround for https://github.com/icerpc/icerpc-csharp/issues/4020
-      NuGetAudit: false
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/docfx/examples/IceRpc.Compressor.Examples/IceRpc.Compressor.Examples.csproj
+++ b/docfx/examples/IceRpc.Compressor.Examples/IceRpc.Compressor.Examples.csproj
@@ -7,7 +7,6 @@
     <Compile Include="../Chatbot.cs" />
     <SliceFile Include="../Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Compressor" Version="$(Version)" />

--- a/docfx/examples/IceRpc.Deadline.Examples/IceRpc.Deadline.Examples.csproj
+++ b/docfx/examples/IceRpc.Deadline.Examples/IceRpc.Deadline.Examples.csproj
@@ -7,7 +7,6 @@
     <Compile Include="../Chatbot.cs" />
     <SliceFile Include="../Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Deadline" Version="$(Version)" />

--- a/docfx/examples/IceRpc.Examples/IceRpc.Examples.csproj
+++ b/docfx/examples/IceRpc.Examples/IceRpc.Examples.csproj
@@ -13,6 +13,8 @@
     <Compile Include="../Chatbot.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />
     <PackageReference Include="IceRpc.Compressor" Version="$(Version)" />

--- a/docfx/examples/IceRpc.Extensions.DependencyInjection.Examples/IceRpc.Extensions.DependencyInjection.Examples.csproj
+++ b/docfx/examples/IceRpc.Extensions.DependencyInjection.Examples/IceRpc.Extensions.DependencyInjection.Examples.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="IceRpc.Telemetry" Version="$(Version)" />
     <PackageReference Include="IceRpc.Transports.Quic" Version="$(Version)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
   </ItemGroup>
 </Project>

--- a/docfx/examples/IceRpc.Logger.Examples/IceRpc.Logger.Examples.csproj
+++ b/docfx/examples/IceRpc.Logger.Examples/IceRpc.Logger.Examples.csproj
@@ -8,6 +8,8 @@
     <SliceFile Include="../Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />

--- a/docfx/examples/IceRpc.Retry.Examples/IceRpc.Retry.Examples.csproj
+++ b/docfx/examples/IceRpc.Retry.Examples/IceRpc.Retry.Examples.csproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Logger" Version="$(Version)" />

--- a/docfx/examples/IceRpc.Telemetry.Examples/IceRpc.Telemetry.Examples.csproj
+++ b/docfx/examples/IceRpc.Telemetry.Examples/IceRpc.Telemetry.Examples.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <PackageReference Include="IceRpc" Version="$(Version)" />
     <PackageReference Include="IceRpc.Slice" Version="$(Version)" />
     <PackageReference Include="IceRpc.Telemetry" Version="$(Version)" />

--- a/examples/protobuf/GenericHost/Client/Client.csproj
+++ b/examples/protobuf/GenericHost/Client/Client.csproj
@@ -25,6 +25,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/GenericHost/Server/Server.csproj
+++ b/examples/protobuf/GenericHost/Server/Server.csproj
@@ -25,6 +25,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/Logger/Client/Client.csproj
+++ b/examples/protobuf/Logger/Client/Client.csproj
@@ -12,6 +12,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/Logger/Server/Server.csproj
+++ b/examples/protobuf/Logger/Server/Server.csproj
@@ -12,6 +12,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/Retry/Client/Client.csproj
+++ b/examples/protobuf/Retry/Client/Client.csproj
@@ -12,6 +12,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/TcpFallback/Client/Client.csproj
+++ b/examples/protobuf/TcpFallback/Client/Client.csproj
@@ -14,6 +14,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/TcpFallback/Server/Server.csproj
+++ b/examples/protobuf/TcpFallback/Server/Server.csproj
@@ -14,6 +14,8 @@
     <ProtoFile Include="../proto/greeter.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Protobuf" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Transports.Quic" Version="$(IceRpcVersion)" />

--- a/examples/protobuf/Thermostat/Client/Client.csproj
+++ b/examples/protobuf/Thermostat/Client/Client.csproj
@@ -12,6 +12,8 @@
     <ProtoFile Include="../proto/reading.proto;../proto/set_point.proto; ../proto/thermostat.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/examples/protobuf/Thermostat/Device/Device.csproj
+++ b/examples/protobuf/Thermostat/Device/Device.csproj
@@ -14,6 +14,8 @@
     />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/examples/protobuf/Thermostat/Server/Server.csproj
+++ b/examples/protobuf/Thermostat/Server/Server.csproj
@@ -12,6 +12,8 @@
     <ProtoFile Include="../proto/*.proto" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/examples/slice/GenericHost/Client/Client.csproj
+++ b/examples/slice/GenericHost/Client/Client.csproj
@@ -25,6 +25,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />

--- a/examples/slice/GenericHost/Server/Server.csproj
+++ b/examples/slice/GenericHost/Server/Server.csproj
@@ -25,6 +25,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="$(IceRpcVersion)" />

--- a/examples/slice/InteropIceGrid/Client/Client.csproj
+++ b/examples/slice/InteropIceGrid/Client/Client.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/Hello.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/slice/Logger/Client/Client.csproj
+++ b/examples/slice/Logger/Client/Client.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/slice/Logger/Server/Server.csproj
+++ b/examples/slice/Logger/Server/Server.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/slice/Retry/Client/Client.csproj
+++ b/examples/slice/Retry/Client/Client.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/slice/TcpFallback/Client/Client.csproj
+++ b/examples/slice/TcpFallback/Client/Client.csproj
@@ -14,6 +14,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />

--- a/examples/slice/TcpFallback/Server/Server.csproj
+++ b/examples/slice/TcpFallback/Server/Server.csproj
@@ -14,6 +14,8 @@
     <SliceFile Include="../slice/Greeter.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Transports.Quic" Version="$(IceRpcVersion)" />

--- a/examples/slice/Thermostat/Client/Client.csproj
+++ b/examples/slice/Thermostat/Client/Client.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/Reading.slice; ../slice/Thermostat.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/examples/slice/Thermostat/Device/Device.csproj
+++ b/examples/slice/Thermostat/Device/Device.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/ThermoControl.slice;../slice/Reading.slice; ../slice/ThermoHome.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/examples/slice/Thermostat/Server/Server.csproj
+++ b/examples/slice/Thermostat/Server/Server.csproj
@@ -12,6 +12,8 @@
     <SliceFile Include="../slice/*.slice" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="IceRpc.Deadline" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Logger" Version="$(IceRpcVersion)" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" PrivateAssets="All" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -22,6 +22,8 @@
     <!--#if (framework=="net8.0)"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -12,6 +12,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -12,6 +12,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -22,6 +22,8 @@
     <!--#if (framework="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -22,6 +22,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -12,6 +12,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -12,6 +12,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -22,6 +22,8 @@
     <!--#if (framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />

--- a/tests/IceRpc.Tests.Common/IceRpc.Tests.Common.csproj
+++ b/tests/IceRpc.Tests.Common/IceRpc.Tests.Common.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
+    <!-- Required to avoid NuGet Audit error: see #4032 -->
+    <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes #4032 
Fixes #4020

It appears that Microsoft.Extensions.Logging.Console and other Microsoft extensions pull 8.0.0 version of System.Text.Json, which triggers a NuGet Audit error.

Adding an explicit dependency on System.Text.Json=8.0.* solves this issue.