### PR TITLE
Use default source link setup

### DIFF
--- a/build/IceRpc.Src.props
+++ b/build/IceRpc.Src.props
@@ -2,10 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-    <!-- Source Link Settings -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RepositoryUrl>https://github.com/icerpc/icerpc-csharp</RepositoryUrl>
     <!-- Symbol Packages -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,6 @@
     <IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.*" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)../build/StyleCop.json" Link="stylecop.json" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.Base.globalconfig" />
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)../build/CodeAnalysis.Src.globalconfig" />


### PR DESCRIPTION
With .NET 8 is no longer required to setup source link, see https://github.com/dotnet/sourcelink/blob/main/README.md#using-source-link-in-net-projects

Fix #4017 