### PR TITLE
Fix working directory for running build telemetry task

### DIFF
--- a/tools/IceRpc.Slice.Tools/BuildTelemetryTask.cs
+++ b/tools/IceRpc.Slice.Tools/BuildTelemetryTask.cs
@@ -70,6 +70,9 @@ public class BuildTelemetryTask : ToolTask
     /// <inheritdoc/>
     protected override string GenerateFullPathToTool() => ToolName;
 
+    /// <inheritdoc/>
+    protected override string GetWorkingDirectory() => WorkingDirectory;
+
     /// <summary>
     /// Overriding this method to suppress any warnings or errors.
     /// </summary>


### PR DESCRIPTION
This fixes a problem where the build telemetry failed to run because the current working directory was not correctly set.