### PR TITLE
Disable docfx edit this page links

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -61,6 +61,7 @@
       "_appLogoUrl": "https://docs.icerpc.dev",
       "_appFooter": "© 2024 ZeroC",
       "_enableSearch": true,
+      "_disableContribution": true,
       "_gitContribute": {
         "repo": "https://github.com/icerpc/icerpc-csharp",
         "branch": "main",


### PR DESCRIPTION
Fix #3993

`_gitContribute | object | Defines the repo and branch property of git links.` from https://dotnet.github.io/docfx/docs/template.html?tabs=modern

This is a template global setting disabled for all pages.