### PR TITLE
Use pwsh shell for template testing

### DIFF
--- a/.github/actions/test-templates/action.yaml
+++ b/.github/actions/test-templates/action.yaml
@@ -10,25 +10,25 @@ runs:
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/tcp/ProtobufClient
       dotnet build templates-test/tcp/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf Client Template with Quic
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/quic/ProtobufClient --transport quic
       dotnet build templates-test/quic/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf Client Template .NET 9
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/net9.0/tcp/ProtobufClient -F net9.0
       dotnet build templates-test/net9.0/tcp/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf Client Template with Quic and .NET9
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/net9.0/quic/ProtobufClient --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Protobuf Server template
 
@@ -36,25 +36,25 @@ runs:
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/tcp/ProtobufServer
       dotnet build templates-test/tcp/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
   
   - name: 🧪 Test IceRpc + Protobuf Server Template with Quic
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/quic/ProtobufServer --transport quic
       dotnet build templates-test/quic/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf Server Template .NET 9
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/net9.0/tcp/ProtobufServer -F net9.0
       dotnet build templates-test/net9.0/tcp/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf Server Template with Quic and .NET9
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/net9.0/quic/ProtobufServer --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Slice Client template
 
@@ -62,25 +62,25 @@ runs:
     run: |
       dotnet new icerpc-slice-client -o templates-test/tcp/SliceClient
       dotnet build templates-test/tcp/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice Client Template with Quic
     run: |
       dotnet new icerpc-slice-client -o templates-test/quic/SliceClient --transport quic
       dotnet build templates-test/quic/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice Client Template .NET 9
     run: |
       dotnet new icerpc-slice-client -o templates-test/net9.0/tcp/SliceClient -F net9.0
       dotnet build templates-test/net9.0/tcp/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
   
   - name: 🧪 Test IceRpc + Slice Client Template with Quic and .NET9
     run: |
       dotnet new icerpc-slice-client -o templates-test/net9.0/quic/SliceClient --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Slice Server template
 
@@ -88,25 +88,25 @@ runs:
     run: |
       dotnet new icerpc-slice-server -o templates-test/tcp/SliceServer
       dotnet build templates-test/tcp/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
   
   - name: 🧪 Test IceRpc + Slice Server Template with Quic
     run: |
       dotnet new icerpc-slice-server -o templates-test/quic/SliceServer --transport quic
       dotnet build templates-test/quic/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice Server Template .NET 9
     run: |
       dotnet new icerpc-slice-server -o templates-test/net9.0/tcp/SliceServer -F net9.0
       dotnet build templates-test/net9.0/tcp/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice Server Template with Quic and .NET9
     run: |
       dotnet new icerpc-slice-server -o templates-test/net9.0/quic/SliceServer --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Protobuf DI Client template
 
@@ -114,13 +114,13 @@ runs:
     run: |
       dotnet new icerpc-protobuf-di-client -o templates-test/ProtobufDIClient
       dotnet build templates-test/ProtobufDIClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf DI Client Template .NET 9
     run: |
       dotnet new icerpc-protobuf-di-client -o templates-test/net9.0/ProtobufDIClient -F net9.0
       dotnet build templates-test/net9.0/ProtobufDIClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Protobuf DI Server template
 
@@ -128,13 +128,13 @@ runs:
     run: |
       dotnet new icerpc-protobuf-di-server -o templates-test/ProtobufDIServer
       dotnet build templates-test/ProtobufDIServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Protobuf DI Server Template .NET 9
     run: |
       dotnet new icerpc-protobuf-di-server -o templates-test/net9.0/ProtobufDIServer -F net9.0
       dotnet build templates-test/net9.0/ProtobufDIServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
   
   # Slice DI Client template
 
@@ -142,13 +142,13 @@ runs:
     run: |
       dotnet new icerpc-slice-di-client -o templates-test/SliceDIClient
       dotnet build templates-test/SliceDIClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice DI Client Template .NET 9
     run: |
       dotnet new icerpc-slice-di-client -o templates-test/net9.0/SliceDIClient -F net9.0
       dotnet build templates-test/net9.0/SliceDIClient/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   # Slice DI Server template
 
@@ -156,10 +156,10 @@ runs:
     run: |
       dotnet new icerpc-slice-di-server -o templates-test/SliceDIServer
       dotnet build templates-test/SliceDIServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh
 
   - name: 🧪 Test IceRpc + Slice DI Server Template .NET 9
     run: |
       dotnet new icerpc-slice-di-server -o templates-test/net9.0/SliceDIServer -F net9.0
       dotnet build templates-test/net9.0/SliceDIServer/ /p:TreatWarningsAsErrors=true
-    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
+    shell: pwsh

--- a/.github/actions/test-templates/action.yaml
+++ b/.github/actions/test-templates/action.yaml
@@ -10,25 +10,25 @@ runs:
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/tcp/ProtobufClient
       dotnet build templates-test/tcp/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf Client Template with Quic
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/quic/ProtobufClient --transport quic
       dotnet build templates-test/quic/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf Client Template .NET 9
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/net9.0/tcp/ProtobufClient -F net9.0
       dotnet build templates-test/net9.0/tcp/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf Client Template with Quic and .NET9
     run: |
       dotnet new icerpc-protobuf-client -o templates-test/net9.0/quic/ProtobufClient --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/ProtobufClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Protobuf Server template
 
@@ -36,25 +36,25 @@ runs:
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/tcp/ProtobufServer
       dotnet build templates-test/tcp/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
   
   - name: 🧪 Test IceRpc + Protobuf Server Template with Quic
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/quic/ProtobufServer --transport quic
       dotnet build templates-test/quic/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf Server Template .NET 9
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/net9.0/tcp/ProtobufServer -F net9.0
       dotnet build templates-test/net9.0/tcp/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf Server Template with Quic and .NET9
     run: |
       dotnet new icerpc-protobuf-server -o templates-test/net9.0/quic/ProtobufServer --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/ProtobufServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Slice Client template
 
@@ -62,25 +62,25 @@ runs:
     run: |
       dotnet new icerpc-slice-client -o templates-test/tcp/SliceClient
       dotnet build templates-test/tcp/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice Client Template with Quic
     run: |
       dotnet new icerpc-slice-client -o templates-test/quic/SliceClient --transport quic
       dotnet build templates-test/quic/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice Client Template .NET 9
     run: |
       dotnet new icerpc-slice-client -o templates-test/net9.0/tcp/SliceClient -F net9.0
       dotnet build templates-test/net9.0/tcp/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
   
   - name: 🧪 Test IceRpc + Slice Client Template with Quic and .NET9
     run: |
       dotnet new icerpc-slice-client -o templates-test/net9.0/quic/SliceClient --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/SliceClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Slice Server template
 
@@ -88,25 +88,25 @@ runs:
     run: |
       dotnet new icerpc-slice-server -o templates-test/tcp/SliceServer
       dotnet build templates-test/tcp/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
   
   - name: 🧪 Test IceRpc + Slice Server Template with Quic
     run: |
       dotnet new icerpc-slice-server -o templates-test/quic/SliceServer --transport quic
       dotnet build templates-test/quic/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice Server Template .NET 9
     run: |
       dotnet new icerpc-slice-server -o templates-test/net9.0/tcp/SliceServer -F net9.0
       dotnet build templates-test/net9.0/tcp/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice Server Template with Quic and .NET9
     run: |
       dotnet new icerpc-slice-server -o templates-test/net9.0/quic/SliceServer --transport quic -F net9.0
       dotnet build templates-test/net9.0/quic/SliceServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Protobuf DI Client template
 
@@ -114,13 +114,13 @@ runs:
     run: |
       dotnet new icerpc-protobuf-di-client -o templates-test/ProtobufDIClient
       dotnet build templates-test/ProtobufDIClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf DI Client Template .NET 9
     run: |
       dotnet new icerpc-protobuf-di-client -o templates-test/net9.0/ProtobufDIClient -F net9.0
       dotnet build templates-test/net9.0/ProtobufDIClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Protobuf DI Server template
 
@@ -128,13 +128,13 @@ runs:
     run: |
       dotnet new icerpc-protobuf-di-server -o templates-test/ProtobufDIServer
       dotnet build templates-test/ProtobufDIServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Protobuf DI Server Template .NET 9
     run: |
       dotnet new icerpc-protobuf-di-server -o templates-test/net9.0/ProtobufDIServer -F net9.0
       dotnet build templates-test/net9.0/ProtobufDIServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
   
   # Slice DI Client template
 
@@ -142,13 +142,13 @@ runs:
     run: |
       dotnet new icerpc-slice-di-client -o templates-test/SliceDIClient
       dotnet build templates-test/SliceDIClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice DI Client Template .NET 9
     run: |
       dotnet new icerpc-slice-di-client -o templates-test/net9.0/SliceDIClient -F net9.0
       dotnet build templates-test/net9.0/SliceDIClient/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   # Slice DI Server template
 
@@ -156,10 +156,10 @@ runs:
     run: |
       dotnet new icerpc-slice-di-server -o templates-test/SliceDIServer
       dotnet build templates-test/SliceDIServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}
 
   - name: 🧪 Test IceRpc + Slice DI Server Template .NET 9
     run: |
       dotnet new icerpc-slice-di-server -o templates-test/net9.0/SliceDIServer -F net9.0
       dotnet build templates-test/net9.0/SliceDIServer/ /p:TreatWarningsAsErrors=true
-    shell: bash
+    shell: ${{ if eq(runner.os, 'Windows') }} cmd ${{ else }} bash ${{ end }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,7 @@ on:
 
 jobs:
   build_and_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `dotnet` command doesn't work well with the `bash` shell on Windows, updated to use `pwsh` (Powershell) works well across all platforms.