### PR TITLE
Use SSL with Protobuf and Slice templates

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -24,14 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
+    <!-- Required for X509CertificateLoader with .NET 8-->
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
     <!--#else"-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <!--#if (Framework=="net8.0" && transport=="quic")-->
-    <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
-    <!--#endif"-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.cs
@@ -3,10 +3,8 @@ using IceRpc;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-#if (transport == "quic")
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using IceRpc_Protobuf_Client;
 
 // Create a simple console logger factory and configure the log level for category IceRpc.

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.cs
@@ -15,7 +15,6 @@ using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
         .AddSimpleConsole()
         .AddFilter("IceRpc", LogLevel.Information));
 
-#if (transport == "quic")
 // Path to the root CA certificate.
 using var rootCA = X509CertificateLoader.LoadCertificateFromFile("certs/cacert.der");
 
@@ -33,6 +32,7 @@ var clientAuthenticationOptions = new SslClientAuthenticationOptions
     }
 };
 
+#if (transport == "quic")
 // Create a client connection that logs messages to a logger with category IceRpc.ClientConnection.
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
@@ -42,6 +42,7 @@ await using var connection = new ClientConnection(
 #else
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
+    clientAuthenticationOptions,
     logger: loggerFactory.CreateLogger<ClientConnection>());
 #endif
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -24,14 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
+    <!-- Required for X509CertificateLoader with .NET 8-->
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <!--#if (Framework=="net8.0" && transport=="quic")-->
-    <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
-    <!--#endif"-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.cs
@@ -24,8 +24,6 @@ Router router = new Router()
     .UseDeadline()
     .Map<IGreeterService>(new Chatbot());
 
-// Create a server that logs message to a logger with category `IceRpc.Server`.
-#if (transport == "quic")
 var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
 {
     ServerCertificateContext = SslStreamCertificateContext.Create(
@@ -36,13 +34,18 @@ var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
         additionalCertificates: null)
 };
 
+// Create a server that logs message to a logger with category `IceRpc.Server`.
+#if (transport == "quic")
 await using var server = new Server(
     router,
     sslServerAuthenticationOptions,
     multiplexedServerTransport: new QuicServerTransport(),
     logger: loggerFactory.CreateLogger<Server>());
 #else
-await using var server = new Server(router, logger: loggerFactory.CreateLogger<Server>());
+await using var server = new Server(
+    router,
+    sslServerAuthenticationOptions,
+    logger: loggerFactory.CreateLogger<Server>());
 #endif
 
 server.Listen();

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.cs
@@ -4,10 +4,8 @@ using IceRpc.Protobuf;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-#if (transport == "quic")
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-#endif
 
 using IceRpc_Protobuf_Server;
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -24,14 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
+    <!-- Required for X509CertificateLoader with .NET 8-->
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <!--#if (Framework=="net8.0" && transport=="quic")-->
-    <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
-    <!--#endif"-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
@@ -15,7 +15,6 @@ using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
         .AddSimpleConsole()
         .AddFilter("IceRpc", LogLevel.Information));
 
-#if (transport == "quic")
 // Path to the root CA certificate.
 using var rootCA = X509CertificateLoader.LoadCertificateFromFile("certs/cacert.der");
 
@@ -33,6 +32,7 @@ var clientAuthenticationOptions = new SslClientAuthenticationOptions
     }
 };
 
+#if (transport == "quic")
 // Create a client connection that logs messages to a logger with category IceRpc.ClientConnection.
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
@@ -42,6 +42,7 @@ await using var connection = new ClientConnection(
 #else
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
+    clientAuthenticationOptions,
     logger: loggerFactory.CreateLogger<ClientConnection>());
 #endif
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
@@ -3,10 +3,8 @@ using IceRpc;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-#if (transport == "quic")
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using IceRpc_Slice_Client;
 
 // Create a simple console logger factory and configure the log level for category IceRpc.

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -24,14 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
+    <!-- Required for X509CertificateLoader with .NET 8-->
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
     <!--#else-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <!--#if (Framework=="net8.0" && transport=="quic")-->
-    <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
-    <!--#endif"-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
@@ -4,10 +4,8 @@ using IceRpc.Slice;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-#if (transport == "quic")
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-#endif
 
 using IceRpc_Slice_Server;
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
@@ -24,8 +24,6 @@ Router router = new Router()
     .UseDeadline()
     .Map<IGreeterService>(new Chatbot());
 
-// Create a server that logs message to a logger with category `IceRpc.Server`.
-#if (transport == "quic")
 var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
 {
     ServerCertificateContext = SslStreamCertificateContext.Create(
@@ -36,13 +34,18 @@ var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
         additionalCertificates: null)
 };
 
+// Create a server that logs message to a logger with category `IceRpc.Server`.
+#if (transport == "quic")
 await using var server = new Server(
     router,
     sslServerAuthenticationOptions,
     multiplexedServerTransport: new QuicServerTransport(),
     logger: loggerFactory.CreateLogger<Server>());
 #else
-await using var server = new Server(router, logger: loggerFactory.CreateLogger<Server>());
+await using var server = new Server(
+    router,
+    sslServerAuthenticationOptions,
+    logger: loggerFactory.CreateLogger<Server>());
 #endif
 
 server.Listen();


### PR DESCRIPTION
This PR updates templates to setup SSL with tcp transport.