### PR TITLE
Do not exclude certificates when using tcp transport

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },


### PR DESCRIPTION
The 0.4.0 templates has an exclude condition for the certificates when using TCP transport, this PR removes it. 