### PR TITLE
Use 0.4.* instead of 0.4.0

### DIFF
--- a/build/IceRpc.Examples.props
+++ b/build/IceRpc.Examples.props
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- The version of the IceRPC NuGet packages used by the examples. It must be available from nuget.org once this branch is released. -->
-    <IceRpcVersion Condition="'$(IceRpcVersion)' == ''">0.4.0</IceRpcVersion>
+    <!--
+      The version of the IceRPC NuGet packages used by the examples. It must be available from nuget.org once
+      this branch is released.
+    -->
+    <IceRpcVersion Condition="'$(IceRpcVersion)' == ''">0.4.*</IceRpcVersion>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisMode>All</AnalysisMode>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.*" />
     <!--#endif"-->
     <!--#if (Framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Protobuf" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Protobuf" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.*" />
     <!--#endif"-->
     <!--#if (Framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -12,12 +12,12 @@
     <!--#endif-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!--#if (transport=="quic") -->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.*" />
     <!--#endif-->
     <!--#if (Framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
            See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
     <!--#endif-->
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/.template.config/template.json
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/.template.config/template.json
@@ -66,12 +66,6 @@
                     "rename": {
                         "editorconfig": ".editorconfig"
                     }
-                },
-                {
-                    "condition": "(transport == 'tcp')",
-                    "exclude": [
-                        "certs/*"
-                    ]
                 }
             ]
         },

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -12,12 +12,12 @@
     <!--#endif"-->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="IceRpc.Slice" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Deadline" Version="0.4.0" />
-    <PackageReference Include="IceRpc.Logger" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Slice.Tools" Version="0.4.*" PrivateAssets="All" />
+    <PackageReference Include="IceRpc.Slice" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Deadline" Version="0.4.*" />
+    <PackageReference Include="IceRpc.Logger" Version="0.4.*" />
     <!--#if (transport=="quic")-->
-    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.0" />
+    <PackageReference Include="IceRpc.Transports.Quic" Version="0.4.*" />
     <!--#endif"-->
     <!--#if (Framework=="net8.0")-->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />


### PR DESCRIPTION
This PR updates the examples and templates to use IceRpc 0.4.* instead of 0.4.0.