### PR TITLE
Use github.ref_name instead of hardcoded branch name

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,9 +36,9 @@ jobs:
           license: ${{ secrets.REPORT_GENERATOR_LICENSE }}
 
       - name: Sync Coverage Report to S3
-        run: aws s3 sync ./coveragereport s3://${{ secrets.AWS_S3_BUCKET }}/csharp/main/coverage --delete
+        run: aws s3 sync ./coveragereport s3://${{ secrets.AWS_S3_BUCKET }}/csharp/${{ github.ref_name }}/coverage --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,4 +41,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
             ./build.sh --doc
 
       - name: Sync to S3
-        run: aws s3 sync ./docfx/_site s3://${{ secrets.AWS_S3_BUCKET }}/csharp/main/api --delete
+        run: aws s3 sync ./docfx/_site s3://${{ secrets.AWS_S3_BUCKET }}/csharp/${{ github.ref_name }}/api --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,4 +28,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'


### PR DESCRIPTION
This PR updates the coverage and doc workflows to use `github.ref_name` instead of a hard coded branch name for the s3 path. 

This way there's nothing to update in this part of the workflows when we create a new branch of off `main`.