### PR TITLE
Upgrade packages for .NET 9 builds

### DIFF
--- a/examples/protobuf/GenericHost/Server/Server.csproj
+++ b/examples/protobuf/GenericHost/Server/Server.csproj
@@ -24,7 +24,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/protobuf/Quic/Server/Server.csproj
+++ b/examples/protobuf/Quic/Server/Server.csproj
@@ -13,7 +13,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/protobuf/Secure/Server/Server.csproj
+++ b/examples/protobuf/Secure/Server/Server.csproj
@@ -11,7 +11,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/protobuf/TcpFallback/Server/Server.csproj
+++ b/examples/protobuf/TcpFallback/Server/Server.csproj
@@ -13,7 +13,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/slice/GenericHost/Server/Server.csproj
+++ b/examples/slice/GenericHost/Server/Server.csproj
@@ -24,7 +24,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/slice/Quic/Server/Server.csproj
+++ b/examples/slice/Quic/Server/Server.csproj
@@ -13,7 +13,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/slice/Secure/Server/Server.csproj
+++ b/examples/slice/Secure/Server/Server.csproj
@@ -11,7 +11,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/slice/TcpFallback/Server/Server.csproj
+++ b/examples/slice/TcpFallback/Server/Server.csproj
@@ -13,7 +13,7 @@
 
   <!-- Required for X509CertificateLoader with .NET 8-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -25,10 +25,10 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
     <!--#else"-->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*" />
     <!--#endif-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -15,8 +15,8 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*" />
     <!--#endif-->
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.5.0-preview1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.5.0-preview1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -15,8 +15,8 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*" />
     <!--#endif-->
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.5.0-preview1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.5.0-preview1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -25,10 +25,10 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*" />
     <!--#endif-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -25,10 +25,10 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*" />
     <!--#endif-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -15,8 +15,8 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*" />
     <!--#endif-->
     <PackageReference Include="IceRpc.Slice.Tools" Version="0.5.0-preview1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="0.5.0-preview1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -15,8 +15,8 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.*" />
     <!--#endif-->
     <PackageReference Include="IceRpc.Slice.Tools" Version="0.5.0-preview1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="0.5.0-preview1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -25,10 +25,10 @@
     <!-- Required to avoid NuGet Audit error: see #4032 -->
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
     <!-- Required for X509CertificateLoader with .NET 8-->
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
     <!--#else-->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.*" />
     <!--#endif-->
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/tests/IceRpc.Conformance.Tests/IceRpc.Conformance.Tests.csproj
+++ b/tests/IceRpc.Conformance.Tests/IceRpc.Conformance.Tests.csproj
@@ -15,9 +15,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <!-- Required to avoid version conflicts: see #4088 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -31,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <!-- NuGet package contents-->

--- a/tests/IceRpc.Logger.Tests/IceRpc.Logger.Tests.csproj
+++ b/tests/IceRpc.Logger.Tests/IceRpc.Logger.Tests.csproj
@@ -10,9 +10,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <!-- Required to avoid version conflicts: see #4088 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
+++ b/tests/IceRpc.Quic.Tests/IceRpc.Quic.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IceRpc.Retry.Tests/IceRpc.Retry.Tests.csproj
+++ b/tests/IceRpc.Retry.Tests/IceRpc.Retry.Tests.csproj
@@ -10,9 +10,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <!-- Required to avoid version conflicts: see #4088 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/IceRpc.Tests/IceRpc.Tests.csproj
+++ b/tests/IceRpc.Tests/IceRpc.Tests.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="../IceRpc.Tests.Common/IceRpc.Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../certs/*.p12">


### PR DESCRIPTION
Upgrade to use `9.0.*` packages instead of `9.0.0-preview.*` ones.