### PR TITLE
Add NonParallelizable attribute to some time sensistive tests

### DIFF
--- a/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicIdleTimeoutTests.cs
@@ -44,6 +44,7 @@ public class SlicIdleTimeoutTests
     }
 
     [Test]
+    [NonParallelizable]
     public async Task Slic_send_pings_are_called()
     {
         // Arrange

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -529,6 +529,7 @@ public class SlicTransportTests
 
     /// <summary>Verifies that disabling the idle timeout doesn't abort the connection if it's idle.</summary>
     [Test]
+    [NonParallelizable]
     public async Task Connection_with_no_idle_timeout_is_not_aborted_when_idle()
     {
         // Arrange
@@ -556,6 +557,7 @@ public class SlicTransportTests
 
     /// <summary>Verifies that setting the idle timeout doesn't abort the connection if it's idle.</summary>
     [Test]
+    [NonParallelizable]
     public async Task Connection_with_idle_timeout_is_not_aborted_when_idle([Values] bool serverIdleTimeout)
     {
         // Arrange
@@ -589,6 +591,7 @@ public class SlicTransportTests
     /// <summary>Verifies that setting the idle timeout doesn't abort the connection when there is slow write activity
     /// from client to server.</summary>
     [Test]
+    [NonParallelizable]
     public async Task Connection_with_idle_timeout_and_slow_write_is_not_aborted([Values] bool serverIdleTimeout)
     {
         // Arrange


### PR DESCRIPTION
Fix #4097 and #4098