### PR TITLE
Increase upper limit to 3s in ShutdownRequested_completes_when_inactive_and_inactive_timeout_deferred_by_payload_write test

### DIFF
--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -491,7 +491,7 @@ public sealed class ProtocolConnectionTests
         // Assert
         Assert.That(
             TimeSpan.FromMilliseconds(Environment.TickCount64 - startTime),
-            Is.GreaterThan(TimeSpan.FromMilliseconds(990)).And.LessThan(TimeSpan.FromSeconds(2)));
+            Is.GreaterThan(TimeSpan.FromMilliseconds(990)).And.LessThan(TimeSpan.FromSeconds(3)));
     }
 
     /// <summary>Verifies that an abortive shutdown completes ShutdownRequested.</summary>


### PR DESCRIPTION
Fixes #4111 as suggested.