### PR TITLE
Update client IceProtocolConnection to schedule first heartbeat only …

### DIFF
--- a/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
@@ -100,7 +100,7 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
         // the connection is connected at the ice protocol level.
     }
 
-    /// <summary>Schedules the initial heartbeat. Called by a client IceProtocolConnection once it receives the
+    /// <summary>Schedules the initial heartbeat. Called by a client IceProtocolConnection after it receives the
     /// initial ValidateConnection frame from the server.</summary>
     internal void ScheduleHeartbeat() => RescheduleWriteTimer();
 

--- a/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
+++ b/src/IceRpc/Internal/IceDuplexConnectionDecorator.cs
@@ -96,8 +96,8 @@ internal class IceDuplexConnectionDecorator : IDuplexConnection
         _readIdleTimeout = readIdleTimeout; // can be infinite i.e. disabled
         _writeIdleTimeout = writeIdleTimeout;
         _writeTimer = new Timer(_ => sendHeartbeat());
-
-        // We can't schedule a heartbeat right away because the connection is not connected yet.
+        // We can't schedule the initial heartbeat yet. The heartbeat is an ice protocol frame; we can send it only once
+        // the connection is connected at the ice protocol level.
     }
 
     /// <summary>Schedules the initial heartbeat. Called by a client IceProtocolConnection once it receives the

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -117,8 +117,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                     // Send ValidateConnection frame.
                     await SendControlFrameAsync(EncodeValidateConnectionFrame, connectCts.Token).ConfigureAwait(false);
 
-                    // The SendControlFrameAsync is a "write" that schedules a keep-alive when the idle timeout is not
-                    // infinite.
+                    // The SendControlFrameAsync is a "write" that schedules a heartbeat when the idle timeout is not
+                    // infinite. So no need to call scheduleHeartbeat.
                 }
                 else
                 {
@@ -139,6 +139,12 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                     {
                         throw new InvalidDataException(
                             $"Expected '{nameof(IceFrameType.ValidateConnection)}' frame but received frame type '{validateConnectionFrame.FrameType}'.");
+                    }
+
+                    // The client connection is now connected, so we schedule the first heartbeat.
+                    if (_duplexConnection is IceDuplexConnectionDecorator decorator)
+                    {
+                        decorator.ScheduleHeartbeat();
                     }
                 }
             }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -118,7 +118,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                     await SendControlFrameAsync(EncodeValidateConnectionFrame, connectCts.Token).ConfigureAwait(false);
 
                     // The SendControlFrameAsync is a "write" that schedules a heartbeat when the idle timeout is not
-                    // infinite. So no need to call scheduleHeartbeat.
+                    // infinite. So no need to call ScheduleHeartbeat.
                 }
                 else
                 {

--- a/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
@@ -89,7 +89,7 @@ public class IceIdleTimeoutTests
     {
         var connectionOptions = new ConnectionOptions
         {
-            IceIdleTimeout = TimeSpan.FromMilliseconds(100)
+            IceIdleTimeout = TimeSpan.FromMilliseconds(300)
         };
 
         await using ServiceProvider provider = new ServiceCollection()
@@ -104,7 +104,7 @@ public class IceIdleTimeoutTests
         (Task clientShutdownRequested, Task serverShutdownRequested) = await sut.ConnectAsync();
 
         // Act
-        await Task.Delay(TimeSpan.FromMilliseconds(400)); // plenty of time for the idle monitor to kick in.
+        await Task.Delay(TimeSpan.FromMilliseconds(900)); // plenty of time for the idle monitor to kick in.
 
         // Assert
         Assert.That(serverShutdownRequested.IsCompleted, Is.False);

--- a/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
@@ -84,13 +84,12 @@ public class IceIdleTimeoutTests
     /// <remarks>This test also verifies that the client idle monitor does not abort the connection when the server
     /// does not write anything; it's less interesting since the server always writes a ValidateConnection frame after
     /// accepting the connection from the client.</remarks>
-    [Test]
+    [Test][NonParallelizable]
     public async Task Server_idle_monitor_does_not_abort_connection_when_client_does_not_write_anything()
     {
         var connectionOptions = new ConnectionOptions
         {
-            // We need a fairly long timeout since these tests run in parallel.
-            IceIdleTimeout = TimeSpan.FromMilliseconds(200)
+            IceIdleTimeout = TimeSpan.FromMilliseconds(100)
         };
 
         await using ServiceProvider provider = new ServiceCollection()
@@ -105,7 +104,7 @@ public class IceIdleTimeoutTests
         (Task clientShutdownRequested, Task serverShutdownRequested) = await sut.ConnectAsync();
 
         // Act
-        await Task.Delay(TimeSpan.FromMilliseconds(800)); // plenty of time for the idle monitor to kick in.
+        await Task.Delay(TimeSpan.FromMilliseconds(400)); // plenty of time for the idle monitor to kick in.
 
         // Assert
         Assert.That(serverShutdownRequested.IsCompleted, Is.False);

--- a/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
+++ b/tests/IceRpc.Tests/IceIdleTimeoutTests.cs
@@ -1,11 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Internal;
 using IceRpc.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System.Buffers;
 
-namespace IceRpc.Internal;
+namespace IceRpc.Tests;
 
 [Parallelizable(scope: ParallelScope.All)]
 public class IceIdleTimeoutTests
@@ -76,5 +77,43 @@ public class IceIdleTimeoutTests
         Assert.That(
             TimeSpan.FromMilliseconds(Environment.TickCount64) - startTime,
             Is.LessThan(TimeSpan.FromMilliseconds(500)));
+    }
+
+    /// <summary>Verifies that a connection where the client does not write anything is not aborted by the server
+    /// connection idle monitor.</summary>
+    /// <remarks>This test also verifies that the client idle monitor does not abort the connection when the server
+    /// does not write anything; it's less interesting since the server always writes a ValidateConnection frame after
+    /// accepting the connection from the client.</remarks>
+    [Test]
+    public async Task Server_idle_monitor_does_not_abort_connection_when_client_does_not_write_anything()
+    {
+        var connectionOptions = new ConnectionOptions
+        {
+            // We need a fairly long timeout since these tests run in parallel.
+            IceIdleTimeout = TimeSpan.FromMilliseconds(200)
+        };
+
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(
+                Protocol.Ice,
+                dispatcher: null,
+                connectionOptions,
+                connectionOptions)
+            .BuildServiceProvider(validateScopes: true);
+
+        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        (Task clientShutdownRequested, Task serverShutdownRequested) = await sut.ConnectAsync();
+
+        // Act
+        await Task.Delay(TimeSpan.FromMilliseconds(800)); // plenty of time for the idle monitor to kick in.
+
+        // Assert
+        Assert.That(serverShutdownRequested.IsCompleted, Is.False);
+        Assert.That(clientShutdownRequested.IsCompleted, Is.False);
+
+        // Graceful shutdown.
+        Task clientShutdown = sut.Client.ShutdownAsync();
+        Task serverShutdown = sut.Server.ShutdownAsync();
+        Assert.That(async () => await Task.WhenAll(clientShutdown, serverShutdown), Throws.Nothing);
     }
 }

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -549,44 +549,6 @@ public sealed class IceProtocolConnectionTests
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
     }
 
-    /// <summary>Verifies that a connection where the client does not write anything is not aborted by the server
-    /// connection idle monitor.</summary>
-    /// <remarks>This test also verifies that the client idle monitor does not abort the connection when the server
-    /// does not write anything; it's less interesting since the server always writes a ValidateConnection frame after
-    /// accepting the connection from the client.</remarks>
-    [Test]
-    public async Task Server_idle_monitor_does_not_abort_connection_when_client_does_not_write_anything()
-    {
-        var connectionOptions = new ConnectionOptions
-        {
-            // We need a fairly long timeout since these tests run in parallel.
-            IceIdleTimeout = TimeSpan.FromMilliseconds(200)
-        };
-
-        await using ServiceProvider provider = new ServiceCollection()
-            .AddProtocolTest(
-                Protocol.Ice,
-                dispatcher: null,
-                connectionOptions,
-                connectionOptions)
-            .BuildServiceProvider(validateScopes: true);
-
-        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
-        (Task clientShutdownRequested, Task serverShutdownRequested) = await sut.ConnectAsync();
-
-        // Act
-        await Task.Delay(TimeSpan.FromMilliseconds(800)); // plenty of time for the idle monitor to kick in.
-
-        // Assert
-        Assert.That(serverShutdownRequested.IsCompleted, Is.False);
-        Assert.That(clientShutdownRequested.IsCompleted, Is.False);
-
-        // Graceful shutdown.
-        Task clientShutdown = sut.Client.ShutdownAsync();
-        Task serverShutdown = sut.Server.ShutdownAsync();
-        Assert.That(async () => await Task.WhenAll(clientShutdown, serverShutdown), Throws.Nothing);
-    }
-
     /// <summary>Verifies that canceling an invocation while the request is being written does not interrupt the write.
     /// The connection remains active and subsequent request are not affected.</summary>
     [Test]

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -559,7 +559,8 @@ public sealed class IceProtocolConnectionTests
     {
         var connectionOptions = new ConnectionOptions
         {
-            IceIdleTimeout = TimeSpan.FromMilliseconds(100)
+            // We need a fairly long timeout since these tests run in parallel.
+            IceIdleTimeout = TimeSpan.FromMilliseconds(200)
         };
 
         await using ServiceProvider provider = new ServiceCollection()
@@ -574,7 +575,7 @@ public sealed class IceProtocolConnectionTests
         (Task clientShutdownRequested, Task serverShutdownRequested) = await sut.ConnectAsync();
 
         // Act
-        await Task.Delay(TimeSpan.FromMilliseconds(400)); // plenty of time for the idle monitor to kick in.
+        await Task.Delay(TimeSpan.FromMilliseconds(800)); // plenty of time for the idle monitor to kick in.
 
         // Assert
         Assert.That(serverShutdownRequested.IsCompleted, Is.False);


### PR DESCRIPTION
…once connected

This is a small fix to the "send heartbeat" logic in IceProtocolConnection.

Prior to this PR, an Ice client connection could send heartbeats before receiving the initial ValidateConnection frame from the server. That's a minor violation of the `ice` protocol that neither Ice nor IceRPC would detect. It's also very unlikely. Nevertheless, a small bug.

I also added a test to verify that an `ice` client connection that doesn't write anything is not aborted by the server connection idle monitor.