### PR TITLE
Fix dotnet_style_require_accessibility_modifiers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,7 +40,7 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
 
 # Expression-level preferences
 dotnet_style_coalesce_expression = true:suggestion


### PR DESCRIPTION
In particular, we don't specify "public" on abstract methods in public interfaces.