### PR TITLE
Make HostedService constructor public

### DIFF
--- a/examples/protobuf/GenericHost/Client/ClientHostedService.cs
+++ b/examples/protobuf/GenericHost/Client/ClientHostedService.cs
@@ -21,6 +21,17 @@ internal class ClientHostedService : BackgroundService
     // The IGreeter managed by the DI container.
     private readonly IGreeter _greeter;
 
+    // All the parameters are injected by the DI container.
+    public ClientHostedService(
+        IGreeter greeter,
+        ClientConnection connection,
+        IHostApplicationLifetime applicationLifetime)
+    {
+        _applicationLifetime = applicationLifetime;
+        _connection = connection;
+        _greeter = greeter;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
@@ -37,16 +48,5 @@ internal class ClientHostedService : BackgroundService
 
         // Stop the generic host once the invocation is done.
         _applicationLifetime.StopApplication();
-    }
-
-    // All the parameters are injected by the DI container.
-    internal ClientHostedService(
-        IGreeter greeter,
-        ClientConnection connection,
-        IHostApplicationLifetime applicationLifetime)
-    {
-        _applicationLifetime = applicationLifetime;
-        _connection = connection;
-        _greeter = greeter;
     }
 }

--- a/examples/protobuf/GenericHost/Server/ServerHostedService.cs
+++ b/examples/protobuf/GenericHost/Server/ServerHostedService.cs
@@ -15,6 +15,8 @@ internal class ServerHostedService : IHostedService
     // The IceRPC server accepts connections from IceRPC clients.
     private readonly Server _server;
 
+    public ServerHostedService(Server server) => _server = server;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         // Start listening for client connections.
@@ -25,6 +27,4 @@ internal class ServerHostedService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken) =>
         // Shuts down the IceRPC server when the hosted service is stopped.
         _server.ShutdownAsync(cancellationToken);
-
-    internal ServerHostedService(Server server) => _server = server;
 }

--- a/examples/slice/GenericHost/Client/ClientHostedService.cs
+++ b/examples/slice/GenericHost/Client/ClientHostedService.cs
@@ -21,6 +21,17 @@ internal class ClientHostedService : BackgroundService
     // The IGreeter managed by the DI container.
     private readonly IGreeter _greeter;
 
+    // All the parameters are injected by the DI container.
+    public ClientHostedService(
+        IGreeter greeter,
+        ClientConnection connection,
+        IHostApplicationLifetime applicationLifetime)
+    {
+        _applicationLifetime = applicationLifetime;
+        _connection = connection;
+        _greeter = greeter;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
@@ -36,16 +47,5 @@ internal class ClientHostedService : BackgroundService
 
         // Stop the generic host once the invocation is done.
         _applicationLifetime.StopApplication();
-    }
-
-    // All the parameters are injected by the DI container.
-    internal ClientHostedService(
-        IGreeter greeter,
-        ClientConnection connection,
-        IHostApplicationLifetime applicationLifetime)
-    {
-        _applicationLifetime = applicationLifetime;
-        _connection = connection;
-        _greeter = greeter;
     }
 }

--- a/examples/slice/GenericHost/Server/ServerHostedService.cs
+++ b/examples/slice/GenericHost/Server/ServerHostedService.cs
@@ -15,6 +15,8 @@ internal class ServerHostedService : IHostedService
     // The IceRPC server accepts connections from IceRPC clients.
     private readonly Server _server;
 
+    public ServerHostedService(Server server) => _server = server;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         // Start listening for client connections.
@@ -25,6 +27,4 @@ internal class ServerHostedService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken) =>
         // Shuts down the IceRPC server when the hosted service is stopped.
         _server.ShutdownAsync(cancellationToken);
-
-    internal ServerHostedService(Server server) => _server = server;
 }


### PR DESCRIPTION
This PR fixes the GenericHost examples. They failed to start with an hard-to-decipher error (see below).

The fix is to make the HostedService constructors public (they were internal). Fortunately, the constructors are already public in the templates.

```
% dotnet run
/Users/bernard/builds/icerpc-csharp/examples/slice/GenericHost/Server
dbug: Microsoft.Extensions.Hosting.Internal.Host[1]
      Hosting starting
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      System.InvalidOperationException: A suitable constructor for type 'GenericHostServer.ServerHostedService' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.
         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache lifetime, ServiceIdentifier serviceIdentifier, Type implementationType, CallSiteChain callSiteChain)
         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateEnumerable(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
         at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
         at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
         at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
         at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
         at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
         at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
         at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
Unhandled exception. System.InvalidOperationException: A suitable constructor for type 'GenericHostServer.ServerHostedService' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.
```