### PR TITLE
Create certificates as singletons in GenericHost examples

### DIFF
--- a/examples/protobuf/GenericHost/Server/Program.cs
+++ b/examples/protobuf/GenericHost/Server/Program.cs
@@ -27,22 +27,22 @@ IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args)
         string workingDirectory = Directory.GetCurrentDirectory();
         Console.WriteLine(workingDirectory);
 
+        // Load and register the server certificate as a singleton so it stays alive and gets disposed.
+        services.AddSingleton<X509Certificate2>(sp =>
+            X509CertificateLoader.LoadPkcs12FromFile(
+                Path.Combine(
+                    hostContext.HostingEnvironment.ContentRootPath,
+                    hostContext.Configuration.GetValue<string>("Certificate:File")!),
+                password: null,
+                keyStorageFlags: X509KeyStorageFlags.Exportable));
+
         // Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
         // callback to configure its authentication options.
         services
             .AddOptions<ServerOptions>()
             .Bind(hostContext.Configuration.GetSection("Server"))
-            .Configure(options =>
-            {
-                X509Certificate2 serverCertificate = X509CertificateLoader.LoadPkcs12FromFile(
-                    Path.Combine(
-                        hostContext.HostingEnvironment.ContentRootPath,
-                        hostContext.Configuration.GetValue<string>("Certificate:File")!),
-                    password: null,
-                    keyStorageFlags: X509KeyStorageFlags.Exportable);
-
-                options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate);
-            });
+            .Configure<X509Certificate2>((options, serverCertificate) =>
+                options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate));
 
         // Add the Chatbot service, which implements the Protobuf `Greeter` service, as a singleton.
         services.AddSingleton<IGreeterService, Chatbot>();


### PR DESCRIPTION
This PR updates the GenericHost examples to create certificates (root CA and server certificate) as singletons managed (and disposed) by the DI container.