### PR TITLE
Add new common auth to non-DI templates

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+// Provides helper methods to create the authentication options used by the examples.
+public static partial class Program
+{
+    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
+    /// specified root CA.</summary>
+    /// <param name="rootCA">The root CA certificate.</param>
+    /// <returns>The client authentication options.</returns>
+    public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
+        new()
+        {
+            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            {
+                if (certificate is X509Certificate2 peerCertificate)
+                {
+                    using var customChain = new X509Chain();
+                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    customChain.ChainPolicy.DisableCertificateDownloads = true;
+                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
+                    return customChain.Build(peerCertificate);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        };
+
+    /// <summary>Creates server authentication options for the specified server certificate.</summary>
+    /// <param name="serverCertificate">The server certificate. It must include a private key.</param>
+    /// <returns>The server authentication options.</returns>
+    /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
+    /// options.</remarks>
+    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
+    public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
+        X509Certificate2 serverCertificate) =>
+        new()
+        {
+            ServerCertificateContext =
+                SslStreamCertificateContext.Create(serverCertificate, additionalCertificates: null)
+        };
+}

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+// Provides helper methods to create the authentication options used by the examples.
+public static partial class Program
+{
+    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
+    /// specified root CA.</summary>
+    /// <param name="rootCA">The root CA certificate.</param>
+    /// <returns>The client authentication options.</returns>
+    public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
+        new()
+        {
+            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            {
+                if (certificate is X509Certificate2 peerCertificate)
+                {
+                    using var customChain = new X509Chain();
+                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    customChain.ChainPolicy.DisableCertificateDownloads = true;
+                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
+                    return customChain.Build(peerCertificate);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        };
+
+    /// <summary>Creates server authentication options for the specified server certificate.</summary>
+    /// <param name="serverCertificate">The server certificate. It must include a private key.</param>
+    /// <returns>The server authentication options.</returns>
+    /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
+    /// options.</remarks>
+    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
+    public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
+        X509Certificate2 serverCertificate) =>
+        new()
+        {
+            ServerCertificateContext =
+                SslStreamCertificateContext.Create(serverCertificate, additionalCertificates: null)
+        };
+}

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+// Provides helper methods to create the authentication options used by the examples.
+public static partial class Program
+{
+    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
+    /// specified root CA.</summary>
+    /// <param name="rootCA">The root CA certificate.</param>
+    /// <returns>The client authentication options.</returns>
+    public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
+        new()
+        {
+            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            {
+                if (certificate is X509Certificate2 peerCertificate)
+                {
+                    using var customChain = new X509Chain();
+                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    customChain.ChainPolicy.DisableCertificateDownloads = true;
+                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
+                    return customChain.Build(peerCertificate);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        };
+
+    /// <summary>Creates server authentication options for the specified server certificate.</summary>
+    /// <param name="serverCertificate">The server certificate. It must include a private key.</param>
+    /// <returns>The server authentication options.</returns>
+    /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
+    /// options.</remarks>
+    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
+    public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
+        X509Certificate2 serverCertificate) =>
+        new()
+        {
+            ServerCertificateContext =
+                SslStreamCertificateContext.Create(serverCertificate, additionalCertificates: null)
+        };
+}

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.cs
@@ -3,7 +3,6 @@ using IceRpc;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using IceRpc_Slice_Client;
 
@@ -14,40 +13,19 @@ using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
         .AddFilter("IceRpc", LogLevel.Information));
 
 // Path to the root CA certificate.
-using var rootCA = X509CertificateLoader.LoadCertificateFromFile("certs/cacert.der");
+using X509Certificate2 rootCA = X509CertificateLoader.LoadCertificateFromFile("certs/cacert.der");
 
-// Create Client authentication options with custom certificate validation.
-var clientAuthenticationOptions = new SslClientAuthenticationOptions
-{
-    RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
-    {
-        if (certificate is X509Certificate2 peerCertificate)
-        {
-            using var customChain = new X509Chain();
-            customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            customChain.ChainPolicy.DisableCertificateDownloads = true;
-            customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-            customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-            return customChain.Build(peerCertificate);
-        }
-        else
-        {
-            return false;
-        }
-    }
-};
-
-#if (transport == "quic")
 // Create a client connection that logs messages to a logger with category IceRpc.ClientConnection.
+#if (transport == "quic")
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
-    clientAuthenticationOptions,
+    clientAuthenticationOptions: CreateClientAuthenticationOptions(rootCA),
     multiplexedClientTransport: new QuicClientTransport(),
     logger: loggerFactory.CreateLogger<ClientConnection>());
 #else
 await using var connection = new ClientConnection(
     new Uri("icerpc://localhost"),
-    clientAuthenticationOptions,
+    clientAuthenticationOptions: CreateClientAuthenticationOptions(rootCA),
     logger: loggerFactory.CreateLogger<ClientConnection>());
 #endif
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+// Provides helper methods to create the authentication options used by the examples.
+public static partial class Program
+{
+    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
+    /// specified root CA.</summary>
+    /// <param name="rootCA">The root CA certificate.</param>
+    /// <returns>The client authentication options.</returns>
+    public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
+        new()
+        {
+            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            {
+                if (certificate is X509Certificate2 peerCertificate)
+                {
+                    using var customChain = new X509Chain();
+                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    customChain.ChainPolicy.DisableCertificateDownloads = true;
+                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
+                    return customChain.Build(peerCertificate);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        };
+
+    /// <summary>Creates server authentication options for the specified server certificate.</summary>
+    /// <param name="serverCertificate">The server certificate. It must include a private key.</param>
+    /// <returns>The server authentication options.</returns>
+    /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
+    /// options.</remarks>
+    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
+    public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
+        X509Certificate2 serverCertificate) =>
+        new()
+        {
+            ServerCertificateContext =
+                SslStreamCertificateContext.Create(serverCertificate, additionalCertificates: null)
+        };
+}

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.cs
@@ -4,7 +4,6 @@ using IceRpc.Slice;
 using IceRpc.Transports.Quic;
 #endif
 using Microsoft.Extensions.Logging;
-using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 using IceRpc_Slice_Server;
@@ -22,27 +21,22 @@ Router router = new Router()
     .UseDeadline()
     .Map<IGreeterService>(new Chatbot());
 
-var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
-{
-    ServerCertificateContext = SslStreamCertificateContext.Create(
-        X509CertificateLoader.LoadPkcs12FromFile(
-            "certs/server.p12",
-            password: null,
-            keyStorageFlags: X509KeyStorageFlags.Exportable),
-        additionalCertificates: null)
-};
+using X509Certificate2 serverCertificate = X509CertificateLoader.LoadPkcs12FromFile(
+    "certs/server.p12",
+    password: null,
+    keyStorageFlags: X509KeyStorageFlags.Exportable);
 
 // Create a server that logs message to a logger with category `IceRpc.Server`.
 #if (transport == "quic")
 await using var server = new Server(
     router,
-    sslServerAuthenticationOptions,
+    serverAuthenticationOptions: CreateServerAuthenticationOptions(serverCertificate),
     multiplexedServerTransport: new QuicServerTransport(),
     logger: loggerFactory.CreateLogger<Server>());
 #else
 await using var server = new Server(
     router,
-    sslServerAuthenticationOptions,
+    serverAuthenticationOptions: CreateServerAuthenticationOptions(serverCertificate),
     logger: loggerFactory.CreateLogger<Server>());
 #endif
 


### PR DESCRIPTION
The DI templates currently don't use SSL (or QUIC) at all.