### PR TITLE
Rename Newline => NewLine

### DIFF
--- a/src/IceRpc.Slice.Generators/Internal/Emitter.cs
+++ b/src/IceRpc.Slice.Generators/Internal/Emitter.cs
@@ -112,7 +112,7 @@ internal class Emitter
         {
             FunctionCallBuilder withCallBuilder =
                 new FunctionCallBuilder("IceRpc.Features.FeatureCollectionExtensions.With")
-                .ArgumentsOnNewline(true)
+                .ArgumentsOnNewLine(true)
                 .AddArgument("request.Features")
                 .AddArgument("IceRpc.Features.CompressFeature.Compress");
 
@@ -140,7 +140,7 @@ internal class Emitter
         }
 
         FunctionCallBuilder dispatchCallBuilder = new FunctionCallBuilder("request.DispatchOperationAsync")
-            .ArgumentsOnNewline(true)
+            .ArgumentsOnNewLine(true)
             .AddArgument(
                 $"decodeArgs: global::{serviceMethod.FullInterfaceName}.Request.Decode{serviceMethod.DispatchMethodName}Async")
             .AddArgument($"method: {method}");

--- a/src/ZeroC.CodeBuilder/FunctionCallBuilder.cs
+++ b/src/ZeroC.CodeBuilder/FunctionCallBuilder.cs
@@ -7,7 +7,7 @@ public sealed class FunctionCallBuilder : IBuilder
 {
     private readonly List<string> _arguments = [];
     private readonly string _callable;
-    private bool _argumentsOnNewline;
+    private bool _argumentsOnNewLine;
     private string? _typeArgument;
     private bool _useSemicolon = true;
 
@@ -62,11 +62,11 @@ public sealed class FunctionCallBuilder : IBuilder
     }
 
     /// <summary>Sets whether arguments should be placed on separate lines.</summary>
-    /// <param name="argumentsOnNewline">True to place arguments on new lines.</param>
+    /// <param name="argumentsOnNewLine">True to place arguments on new lines.</param>
     /// <returns>This builder instance for method chaining.</returns>
-    public FunctionCallBuilder ArgumentsOnNewline(bool argumentsOnNewline = true)
+    public FunctionCallBuilder ArgumentsOnNewLine(bool argumentsOnNewLine = true)
     {
-        _argumentsOnNewline = argumentsOnNewline;
+        _argumentsOnNewLine = argumentsOnNewLine;
         return this;
     }
 
@@ -76,7 +76,7 @@ public sealed class FunctionCallBuilder : IBuilder
         string typeArg = _typeArgument is not null ? $"<{_typeArgument}>" : string.Empty;
 
         string functionCall =
-            _argumentsOnNewline && _arguments.Count > 0
+            _argumentsOnNewLine && _arguments.Count > 0
                 ? $"{_callable}{typeArg}(\n    {string.Join($",\n    ", _arguments)})"
                 : $"{_callable}{typeArg}({string.Join(", ", _arguments)})";
 

--- a/tools/IceRpc.ProtocGen/ClientGenerator.cs
+++ b/tools/IceRpc.ProtocGen/ClientGenerator.cs
@@ -140,7 +140,7 @@ It's implemented by <c>{service.Name.ToPascalCase()}Client</c>.")
 
         FunctionCallBuilder functionCallBuilder =
             new FunctionCallBuilder($"Invoker.{invokeAsyncMethod}")
-                .ArgumentsOnNewline()
+                .ArgumentsOnNewLine()
                 .AddArgument("ServiceAddress")
                 .AddArgument($@"""{method.Name}""")
                 .AddArgument(method.IsClientStreaming ? "stream" : "message")


### PR DESCRIPTION
This PR updates the C# code to use NewLine (or newLine) instead of Newline/newline. The 2-words spelling is more common in C#.