### PR TITLE
Specify TaskFactory=TaskHostFactory for source builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,7 +30,6 @@ build.cmd -help
     - [Slice tools](#slice-tools)
   - [Generating the API reference](#generating-the-api-reference)
   - [Generating the code coverage reports](#generating-the-code-coverage-reports)
-  - [Shutting down background MSBuild servers](#shutting-down-background-msbuild-servers)
   - [Updating Slice files](#updating-slice-files)
 
 ## Prerequisites
@@ -182,15 +181,6 @@ Windows
 
 ```shell
 build.cmd -coverage
-```
-
-## Shutting down background MSBuild servers
-
-You may occasionally encounter errors when cleaning and building because background MSBuild servers use/lock the
-`IceRpc.Slice.Tools` assembly. When this happens, you can shutdown these MSBuild servers with:
-
-```shell
-dotnet build-server shutdown
 ```
 
 ## Updating Slice files

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ build()
     run_command cargo "${arguments[@]}"
     popd
 
-    run_command dotnet "build" "-nr:false"$version_property "-c" "$dotnet_config"
+    run_command dotnet "build"$version_property "-c" "$dotnet_config"
 }
 
 clean()
@@ -49,10 +49,10 @@ clean()
     run_command cargo clean
     popd
 
-    run_command dotnet "clean" "-nr:false"$version_property
+    run_command dotnet "clean"$version_property
 
     pushd src/IceRpc.Templates
-    run_command dotnet "clean"$version_property "-nr:false"
+    run_command dotnet "clean"$version_property
     popd
 }
 
@@ -68,10 +68,10 @@ publish()
 {
     build
 
-    run_command dotnet "pack" "-nr:false"$version_property "-c" "$dotnet_config"
+    run_command dotnet "pack"$version_property "-c" "$dotnet_config"
 
     pushd src/IceRpc.Templates
-    run_command dotnet "pack" "-nr:false"$version_property "-c" "$dotnet_config"
+    run_command dotnet "pack"$version_property "-c" "$dotnet_config"
     popd
 
     global_packages=$(dotnet nuget locals -l global-packages)

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -31,7 +31,7 @@ function Build($config) {
 
     $dotnetConfiguration = DotnetConfiguration($config)
 
-    RunCommand "dotnet" @('build', '-nr:false', $versionProperty, '--configuration', $dotnetConfiguration)
+    RunCommand "dotnet" @('build', $versionProperty, '--configuration', $dotnetConfiguration)
 }
 
 function Clean($config) {
@@ -41,7 +41,7 @@ function Clean($config) {
 
     $dotnetConfiguration = DotnetConfiguration($config)
 
-    RunCommand "dotnet" @('clean', '-nr:false', $versionProperty, '--configuration', $dotnetConfiguration)
+    RunCommand "dotnet" @('clean', $versionProperty, '--configuration', $dotnetConfiguration)
 
     Push-Location "src\IceRpc.Templates"
     RunCommand "dotnet" @('clean', $versionProperty, '--configuration', $dotnetConfiguration)
@@ -87,10 +87,10 @@ function Publish($config) {
     Build $config
     $dotnetConfiguration = DotnetConfiguration($config)
 
-    RunCommand "dotnet"  @('pack', '-nr:false', $versionProperty, '--configuration', $dotnetConfiguration)
+    RunCommand "dotnet"  @('pack', $versionProperty, '--configuration', $dotnetConfiguration)
 
     Push-Location "src\IceRpc.Templates"
-    RunCommand "dotnet" @('pack', '-nr:false', $versionProperty, '--configuration', $dotnetConfiguration)
+    RunCommand "dotnet" @('pack', $versionProperty, '--configuration', $dotnetConfiguration)
     Pop-Location
 
     $global_packages = dotnet nuget locals -l global-packages

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
@@ -23,6 +23,9 @@
 
         <!-- Use local build of IceRpc.Protobuf.Tools -->
         <IceRpcProtobufToolsTaskAssembliesPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/net10.0/</IceRpcProtobufToolsTaskAssembliesPath>
+
+        <!-- Force task to run out of process to avoid issues with files in use -->
+        <IceRpcProtobufToolsTaskFactory>TaskHostFactory</IceRpcProtobufToolsTaskFactory>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -4,26 +4,31 @@
   <!-- Import Tasks -->
   <UsingTask
     TaskName="IceRpc.Protobuf.Tools.OutputFileNamesTask"
+    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
   <UsingTask
     TaskName="IceRpc.Protobuf.Tools.OutputHashTask"
+    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
   <UsingTask
     TaskName="IceRpc.Protobuf.Tools.ProtocTask"
+    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
   <UsingTask
     TaskName="IceRpc.Protobuf.Tools.UpToDateCheckTask"
+    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
   <UsingTask
     TaskName="IceRpc.Protobuf.Tools.BuildTelemetryTask"
+    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props
@@ -19,6 +19,9 @@
 
         <!-- Use tools assembly built from source -->
         <SliceToolsTaskAssembliesPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/net10.0/</SliceToolsTaskAssembliesPath>
+
+        <!-- Force task to run out of process to avoid issues with files in use -->
+        <SliceToolsTaskFactory>TaskHostFactory</SliceToolsTaskFactory>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -4,11 +4,13 @@
   <!-- Import Tasks -->
   <UsingTask
     TaskName="IceRpc.Slice.Tools.SliceCCSharpTask"
+    TaskFactory="$(SliceToolsTaskFactory)"
     AssemblyFile="$(SliceToolsTaskAssembliesPath)IceRpc.Slice.Tools.dll"
     Runtime="NET"
   />
   <UsingTask
     TaskName="IceRpc.Slice.Tools.BuildTelemetryTask"
+    TaskFactory="$(SliceToolsTaskFactory)"
     AssemblyFile="$(SliceToolsTaskAssembliesPath)IceRpc.Slice.Tools.dll"
     Runtime="NET"
   />


### PR DESCRIPTION
This PR updates the Tools tasks to specify TaskFactory=TaskHostFactory for source builds.

Also removes "-nr:false" from build scripts, and remove section of BUILDING.md about shutting down build servers.

Fixes #4243.