### PR TITLE
Avoid running ProtoClean after the task assembly was removed by clean

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -103,7 +103,7 @@
       />
     </ItemGroup>
   </Target>
-  <Target Name="ProtoClean" BeforeTargets="Clean">
+  <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
     <OutputFileNamesTask Sources="@(ProtoFile)">
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
     </OutputFileNamesTask>


### PR DESCRIPTION
Fix #4261 