### PR TITLE
Remove Socket.ConnectAsync cancellation workaround

### DIFF
--- a/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
@@ -331,10 +331,6 @@ internal class TcpClientConnection : TcpConnection
             // Connect to the peer.
             await Socket.ConnectAsync(_addr, cancellationToken).ConfigureAwait(false);
 
-            // Workaround: a canceled Socket.ConnectAsync call can return successfully but the Socket is closed because
-            // of the cancellation. See https://github.com/dotnet/runtime/issues/75889.
-            cancellationToken.ThrowIfCancellationRequested();
-
             if (_authenticationOptions is not null)
             {
                 _sslStream = new SslStream(new NetworkStream(Socket, false), false);


### PR DESCRIPTION
The workaround for dotnet/runtime#75889 is no longer needed since the issue was fixed in .NET 10 (dotnet/runtime#116943).

Fixes #4259