### PR TITLE
Make authenticode signing conditional

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -9,6 +9,10 @@ on:
       channel:
         required: true
         type: string
+      authenticode_sign:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       icerpc_version:
@@ -18,6 +22,11 @@ on:
         description: "Release channel (e.g., stable, nightly)"
         required: true
         default: "nightly"
+      authenticode_sign:
+        description: "Whether to authenticode sign the assemblies"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-compiler:
@@ -91,6 +100,7 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Collect Files to Sign
+        if: inputs.authenticode_sign
         run: |
             # For each project in src, we sign the main assembly named after the project.
             $assemblies = Get-ChildItem -Path src -Directory | ForEach-Object {
@@ -103,9 +113,11 @@ jobs:
 
       # Shutdown the build server before signing to ensure MSBuild tasks are not loaded in the build server process.
       - name: Shutdown build server
+        if: inputs.authenticode_sign
         run: dotnet build-server shutdown
 
       - name: Sign .NET Assemblies and slicec-cs.exe compiler
+        if: inputs.authenticode_sign
         uses: azure/trusted-signing-action@v0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: false
+      authenticode_sign:
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -30,12 +34,18 @@ on:
         required: false
         default: false
         type: boolean
+      authenticode_sign:
+        description: "Whether to authenticode sign the assemblies"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
-  set-version:
+  configure:
     runs-on: ubuntu-24.04
     outputs:
       semver_version: ${{ steps.set-vars.outputs.semver_version }}
+      authenticode_sign: ${{ steps.set-vars.outputs.authenticode_sign }}
 
     steps:
       - name: Checkout repository
@@ -55,13 +65,21 @@ jobs:
           fi
           # else do not define version variables to use the version from the repository
 
+          # Always sign stable releases; otherwise honor the authenticode_sign input.
+          if [[ "${{ inputs.channel }}" == "stable" ]] || [[ "${{ inputs.authenticode_sign }}" == "true" ]]; then
+            echo "authenticode_sign=true" >> $GITHUB_OUTPUT
+          else
+            echo "authenticode_sign=false" >> $GITHUB_OUTPUT
+          fi
+
   build-packages:
     name: Build .NET Packages
     uses: ./.github/workflows/build-packages.yml
-    needs: set-version
+    needs: configure
     with:
-      icerpc_version: ${{ needs.set-version.outputs.semver_version }}
+      icerpc_version: ${{ needs.configure.outputs.semver_version }}
       channel: ${{ inputs.channel }}
+      authenticode_sign: ${{ needs.configure.outputs.authenticode_sign == 'true' }}
     secrets: inherit
 
   test-release:
@@ -69,10 +87,10 @@ jobs:
     uses: ./.github/workflows/test-release.yml
     with:
       channel: ${{ inputs.channel }}
-      icerpc_version: ${{ needs.set-version.outputs.semver_version }}
+      icerpc_version: ${{ needs.configure.outputs.semver_version }}
       run_id: ${{ github.run_id }}
     needs:
-      - set-version
+      - configure
       - build-packages
     secrets: inherit
 


### PR DESCRIPTION
Add an authenticode_sign input to build-packages and build-release workflows. Stable channel releases always sign; nightly builds skip signing by default.

Fixes #4227