### PR TITLE
Fully qualify type names in enum variant nested record classes

### DIFF
--- a/tools/slicec-cs/src/builders.rs
+++ b/tools/slicec-cs/src/builders.rs
@@ -135,20 +135,6 @@ impl ContainerBuilder {
         self.fields.push(format!("{field_type} {field_name}"));
         self
     }
-
-    pub fn add_fields(&mut self, fields: &[&Field]) -> &mut Self {
-        for field in fields {
-            let type_string = field.data_type().field_type_string(&field.namespace());
-
-            self.add_field(
-                &field.field_name(),
-                &type_string,
-                field.formatted_param_doc_comment().as_deref(),
-            );
-        }
-
-        self
-    }
 }
 
 impl Builder for ContainerBuilder {

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -136,7 +136,7 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
         // We pass "" as the namespace to force fully qualified type names (global::...) for all
         // user-defined types. This avoids CS8910 errors where the nested record class name shadows
         // the field type name (e.g., `record class Enum(Enum V)` vs `record class Enum(global::...Enum V)`).
-        for field in &enumerator.fields() {
+        for field in enumerator.fields() {
             let type_string = field.data_type().field_type_string("");
             builder.add_field(
                 &field.field_name(),

--- a/tools/slicec-cs/src/generators/enum_generator.rs
+++ b/tools/slicec-cs/src/generators/enum_generator.rs
@@ -131,8 +131,19 @@ fn enumerators_as_nested_records(enum_def: &Enum) -> CodeBlock {
         builder
             .add_comments(enumerator.formatted_doc_comment_seealso())
             .add_obsolete_attribute(enumerator)
-            .add_base(enum_def.escape_identifier())
-            .add_fields(&enumerator.fields());
+            .add_base(enum_def.escape_identifier());
+
+        // We pass "" as the namespace to force fully qualified type names (global::...) for all
+        // user-defined types. This avoids CS8910 errors where the nested record class name shadows
+        // the field type name (e.g., `record class Enum(Enum V)` vs `record class Enum(global::...Enum V)`).
+        for field in &enumerator.fields() {
+            let type_string = field.data_type().field_type_string("");
+            builder.add_field(
+                &field.field_name(),
+                &type_string,
+                field.formatted_param_doc_comment().as_deref(),
+            );
+        }
 
         // Add cs::attribute
         for attribute in enumerator.cs_attributes() {


### PR DESCRIPTION
## Summary
- Fix CS8910 errors in generated C# code for Slice enums with fields, where the nested record class name shadows the field type name (e.g., `record class Enum(Enum V)`)
- Force fully qualified type names with `global::` prefix for all user-defined types in enum variant primary constructor parameters
- Remove the now-unused `ContainerBuilder::add_fields` method