### PR TITLE
Invalidate cloud front cache, after upload coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           aws s3 sync ./coveragereport s3://${{ secrets.AWS_S3_BUCKET }}/csharp/${{ github.ref_name }}/coverage --delete
           aws cloudfront create-invalidation \
             --distribution-id ${{ vars.CODE_DISTRIBUTION_ID }} \
-            --paths "/csharp/main/coverage/*"
+            --paths "/csharp/${{ github.ref_name }}/coverage/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Fix #4328
