### PR TITLE
Add Slice oneway test

### DIFF
--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -114,6 +114,42 @@ public partial class OperationTests
     }
 
     [Test]
+    public async Task Operation_with_oneway_attribute()
+    {
+        // Arrange
+        Pipeline pipeline = new Pipeline()
+            .Use(next => new InlineInvoker((request, cancellationToken) =>
+                {
+                    Assert.That(request.IsOneway, Is.True);
+                    return next.InvokeAsync(request, cancellationToken);
+                }))
+            .Into(new ColocInvoker(new MyOperationsAService()));
+
+        var proxy = new MyOperationsAProxy(pipeline);
+
+        // Act & Assert
+        await proxy.OpWithOnewayAttributeAsync(42);
+    }
+
+    [Test]
+    public async Task Operation_without_oneway_attribute()
+    {
+        // Arrange
+        Pipeline pipeline = new Pipeline()
+            .Use(next => new InlineInvoker((request, cancellationToken) =>
+                {
+                    Assert.That(request.IsOneway, Is.False);
+                    return next.InvokeAsync(request, cancellationToken);
+                }))
+            .Into(new ColocInvoker(new MyOperationsAService()));
+
+        var proxy = new MyOperationsAProxy(pipeline);
+
+        // Act & Assert
+        await proxy.OpWithoutParametersAndVoidReturnAsync();
+    }
+
+    [Test]
     public async Task Operation_with_byte_stream_argument_and_return()
     {
         // Arrange
@@ -687,6 +723,11 @@ public partial class OperationTests
             int p,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new(p);
+
+        public ValueTask OpWithOnewayAttributeAsync(
+            int p,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => default;
 
         public ValueTask<PipeReader> OpWithByteStreamArgumentAndReturnAsync(
             PipeReader p,

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -117,36 +117,44 @@ public partial class OperationTests
     public async Task Operation_with_oneway_attribute()
     {
         // Arrange
+        bool isOneway = false;
         Pipeline pipeline = new Pipeline()
             .Use(next => new InlineInvoker((request, cancellationToken) =>
                 {
-                    Assert.That(request.IsOneway, Is.True);
+                    isOneway = request.IsOneway;
                     return next.InvokeAsync(request, cancellationToken);
                 }))
             .Into(new ColocInvoker(new MyOperationsAService()));
 
         var proxy = new MyOperationsAProxy(pipeline);
 
-        // Act & Assert
+        // Act
         await proxy.OpWithOnewayAttributeAsync(42);
+
+        // Assert
+        Assert.That(isOneway, Is.True);
     }
 
     [Test]
     public async Task Operation_without_oneway_attribute()
     {
         // Arrange
+        bool isOneway = true; // Initialize to true to verify that it gets set to false by the interceptor.
         Pipeline pipeline = new Pipeline()
             .Use(next => new InlineInvoker((request, cancellationToken) =>
                 {
-                    Assert.That(request.IsOneway, Is.False);
+                    isOneway = request.IsOneway;
                     return next.InvokeAsync(request, cancellationToken);
                 }))
             .Into(new ColocInvoker(new MyOperationsAService()));
 
         var proxy = new MyOperationsAProxy(pipeline);
 
-        // Act & Assert
+        // Act
         await proxy.OpWithoutParametersAndVoidReturnAsync();
+
+        // Assert
+        Assert.That(isOneway, Is.False);
     }
 
     [Test]

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
@@ -19,6 +19,9 @@ interface MyOperationsA {
     // Compress attribute
     [compress(Args, Return)] opWithCompressArgsAndReturnAttribute(p: int32) -> int32
 
+    // Oneway attribute
+    [oneway] opWithOnewayAttribute(p: int32)
+
     // Stream parameters and return alone
     opWithByteStreamArgumentAndReturn(p: stream uint8) -> stream uint8
     opWithOptionalByteStreamArgumentAndReturn(p: stream uint8?) -> stream uint8?


### PR DESCRIPTION
This test verifies the `[oneway]` attribute marks the outgoing request as oneway.