### PR TITLE
Fix Missing `TAG_END_MARKER` in `GeneratedFile` Struct

### DIFF
--- a/src/ZeroC.Slice.Generator/GeneratorDriver.cs
+++ b/src/ZeroC.Slice.Generator/GeneratorDriver.cs
@@ -123,12 +123,7 @@ internal static class GeneratorDriver
         var encoder = new SliceEncoder(writer);
         encoder.EncodeSequence(
             generatedFiles,
-            (ref encoder, file) =>
-            {
-                encoder.EncodeString(file.Path);
-                encoder.EncodeString(file.Contents);
-            });
-
+            (ref encoder, file) => file.Encode(ref encoder));
         encoder.EncodeSequence(
             diagnostics,
             (ref encoder, diagnostic) => diagnostic.Encode(ref encoder));


### PR DESCRIPTION
Tried hooking together `slicec` and the C# code-generator for real, but kept getting decoding failures in `slicec`.
After digging through the hex-dumps, the hand-encoding of `GeneratedFile` forgot to emit a `TAG_END_MARKER`.

We already have the generated encoding code, which was including the marker. So, I removed the hand-written encoding, and now we just use the `Encode` method that is generated on `GeneratedFile` instead.

It took me a little while to realize the generated encoding method (which looked fine) wasn't being used <_<