### PR TITLE
Additional Ice tests

### DIFF
--- a/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
@@ -1,0 +1,378 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Features;
+using IceRpc.Ice.Derived.Generator.Tests;
+using IceRpc.Tests.Common;
+using NUnit.Framework;
+using System.IO.Pipelines;
+
+namespace IceRpc.Ice.Generator.Tests;
+
+[Parallelizable(scope: ParallelScope.All)]
+public partial class OperationTests
+{
+    [Test]
+    public void Operation_without_parameters_and_void_return()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await proxy.OpWithoutParametersAndVoidReturnAsync(), Throws.Nothing);
+    }
+
+    [Test]
+    public void Operation_without_parameters_and_void_return_on_derived_interface()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyDerivedOperationsAService());
+        var proxy = new MyDerivedOperationsAProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await proxy.OpDerivedWithoutParametersAndVoidReturnAsync(), Throws.Nothing);
+    }
+
+    [Test]
+    public void Operation_from_base_class()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyDerivedOperationsAService());
+        var proxy = new MyDerivedOperationsAProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await proxy.OpWithoutParametersAndVoidReturnAsync(), Throws.Nothing);
+    }
+
+    [Test]
+    public async Task Operation_with_single_parameter_and_return_value()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        int r = await proxy.OpWithSingleParameterAndReturnValueAsync(10);
+
+        Assert.That(r, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task Operation_with_single_parameter_and_return_value_on_derived_interface()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyDerivedOperationsAService());
+        var proxy = new MyDerivedOperationsAProxy(invoker);
+
+        int r = await proxy.OpDerivedWithSingleParameterAndReturnValueAsync(10);
+
+        Assert.That(r, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task Operation_with_multiple_parameters_and_return_values()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        (int r1, int r2) = await proxy.OpWithMultipleParametersAndReturnValuesAsync(10, 20);
+
+        Assert.That(r1, Is.EqualTo(10));
+        Assert.That(r2, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Operation_with_special_parameter_names()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act/Assert
+        Assert.That(
+            async () => await proxy.OpWithSpecialParameterNamesAsync(
+                cancel: 1,
+                features: 2),
+            Throws.Nothing);
+    }
+
+    [Test]
+    public async Task Operation_with_single_return_value_and_marshaled_result_attribute()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act
+        var r = await proxy.OpWithSingleReturnValueAndMarshaledResultAttributeAsync();
+
+        // Assert
+        Assert.That(r, Is.EqualTo(new int[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public async Task Operation_with_multiple_return_values_and_marshaled_result_attribute()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act
+        (int[] r1, int[] r2) = await proxy.OpWithMultipleReturnValuesAndMarshaledResultAttributeAsync();
+
+        // Assert
+        Assert.That(r1, Is.EqualTo(new int[] { 1, 2, 3 }));
+        Assert.That(r2, Is.EqualTo(new int[] { 1, 2, 3 }));
+    }
+
+    /// <summary>Verifies that sequence of fixed size numeric values outgoing parameter is mapped to
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming parameter is not affected.</summary>
+    [Test]
+    public void Ice_operation_encode_with_readonly_memory_param()
+    {
+        // Arrange
+        var readOnlyMemory = new ReadOnlyMemory<int>(new int[] { 1, 2, 3 });
+
+        // Act
+        PipeReader payload = MyOperationsAProxy.Request.EncodeOpReadOnlyMemory(readOnlyMemory);
+
+        // Assert
+        Assert.That(
+            async () => await IMyOperationsAService.Request.DecodeOpReadOnlyMemoryAsync(
+                new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+                {
+                    Payload = payload
+                },
+                default),
+            Is.EqualTo(new int[] { 1, 2, 3 }));
+    }
+
+    /// <summary>Verifies that sequence of fixed size numeric values outgoing return value is mapped to
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming return value is not affected.</summary>
+    [Test]
+    public void Ice_operation_encode_with_readonly_memory_return()
+    {
+        // Arrange
+        var readOnlyMemory = new ReadOnlyMemory<int>(new int[] { 1, 2, 3 });
+
+        // Act
+        PipeReader payload = IMyOperationsAService.Response.EncodeOpReadOnlyMemory(readOnlyMemory);
+
+        // Assert
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
+        var response = new IncomingResponse(request, FakeConnectionContext.Instance)
+        {
+            Payload = payload
+        };
+        Assert.That(
+            async () => await MyOperationsAProxy.Response.DecodeOpReadOnlyMemoryAsync(
+                response,
+                request,
+                InvalidProxy.Instance,
+                default),
+            Is.EqualTo(new int[] { 1, 2, 3 }));
+    }
+
+    /// <summary>Verifies that an optional sequence of fixed size numeric values outgoing tagged parameter is mapped to
+    /// a <see cref="ReadOnlyMemory{T}" /> the mapping for the incoming parameter is not affected.</summary>
+    [Test]
+    public void Ice_operation_encode_with_readonly_memory_tagged_param(
+        [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
+    {
+        // Arrange
+        PipeReader payload = MyOperationsAProxy.Request.EncodeOpReadOnlyMemoryTagged(new ReadOnlyMemory<int>(p));
+
+        // Act/Assert
+        Assert.That(
+            async () => await IMyOperationsAService.Request.DecodeOpReadOnlyMemoryTaggedAsync(
+                new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+                {
+                    Payload = payload
+                },
+                default),
+            Is.EqualTo(p));
+    }
+
+    /// <summary>Verifies that sequence of fixed size numeric values outgoing tagged return value is mapped to
+    /// <see cref="ReadOnlyMemory{T}" /> the mapping for the optional incoming return value is not affected.</summary>
+    [Test]
+    public void Ice_operation_encode_with_readonly_memory_tagged_return(
+        [Values(new int[] { 1, 2, 3 }, null)] int[]? p)
+    {
+        // Arrange
+        var readOnlyMemory = new ReadOnlyMemory<int>(p);
+
+        // Act
+        PipeReader payload = IMyOperationsAService.Response.EncodeOpReadOnlyMemoryTagged(readOnlyMemory);
+
+        // Assert
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
+        var response = new IncomingResponse(request, FakeConnectionContext.Instance)
+        {
+            Payload = payload
+        };
+        Assert.That(
+            async () => await MyOperationsAProxy.Response.DecodeOpReadOnlyMemoryTaggedAsync(
+                response,
+                request,
+                InvalidProxy.Instance,
+                default),
+            Is.EqualTo(p));
+    }
+
+    /// <summary>Verifies that tagged parameters are correctly skipped. The interface MyTaggedOperationsV0 doesn't
+    /// support any of the tagged parameters used by MyTaggedOperations interface.</summary>
+    [Test]
+    public void Skip_tagged_parameters()
+    {
+        // Arrange
+        var service = new MyTaggedOperationsV0Service();
+        var invoker = new ColocInvoker(service);
+        var proxy = new MyTaggedOperationsProxy(invoker);
+
+        // Act/Assert
+        Assert.That(() => proxy.OpAsync(10, 1, 12), Throws.Nothing);
+    }
+
+    [Test]
+    public async Task Proxy_decoded_from_incoming_response_has_the_invoker_of_the_proxy_that_sent_the_request()
+    {
+        // Arrange
+        var service = new MyOperationsAService();
+        var invoker = new ColocInvoker(service);
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act
+        PingableProxy? receivedProxy = await proxy.OpWithProxyReturnValueAsync();
+
+        // Assert
+        Assert.That(receivedProxy, Is.Not.Null);
+        Assert.That(receivedProxy!.Value.Invoker, Is.EqualTo(((IIceProxy)proxy).Invoker));
+    }
+
+    [Test]
+    public async Task Proxy_decoded_from_incoming_request_has_invalid_invoker()
+    {
+        // Arrange
+        var service = new MyOperationsAService();
+        var invoker = new ColocInvoker(service);
+        var proxy = new MyOperationsAProxy(invoker);
+
+        // Act
+        await proxy.OpWithProxyParameterAsync(new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc:/hello")));
+
+        // Assert
+        Assert.That(service.ReceivedProxy, Is.Not.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(InvalidInvoker.Instance));
+    }
+
+    [Test]
+    public void Call_operation_defined_in_base_interface_defined_in_non_parent_module()
+    {
+        // Arrange
+        var service = new MyDerivedOperationsService();
+        var invoker = new ColocInvoker(service);
+        var proxy = new MyDerivedOperationsProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await proxy.OpAsync(), Throws.Nothing);
+    }
+
+    [Service]
+    private partial class MyOperationsAService : IMyOperationsAService
+    {
+        public PingableProxy? ReceivedProxy;
+
+        public ValueTask ContinueAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+
+        public ValueTask OpWithoutParametersAndVoidReturnAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => default;
+
+        public ValueTask<int> OpWithSingleParameterAndReturnValueAsync(
+            int p,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p);
+
+        public ValueTask<(int ReturnValue, int R2)> OpWithMultipleParametersAndReturnValuesAsync(
+            int p1,
+            int p2,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new((p1, p2));
+
+        public ValueTask IdempotentOpAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => default;
+
+        public ValueTask OpWithSpecialParameterNamesAsync(
+            int cancel,
+            int features,
+            IFeatureCollection features_,
+            CancellationToken cancellationToken) => default;
+
+        public ValueTask<PipeReader> OpWithSingleReturnValueAndMarshaledResultAttributeAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) =>
+            new(IMyOperationsAService.Response.EncodeOpWithSingleReturnValueAndMarshaledResultAttribute(
+                new int[] { 1, 2, 3 },
+                features.Get<IIceFeature>()?.EncodeOptions));
+
+        public ValueTask<PipeReader> OpWithMultipleReturnValuesAndMarshaledResultAttributeAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) =>
+            new(IMyOperationsAService.Response.EncodeOpWithMultipleReturnValuesAndMarshaledResultAttribute(
+                new int[] { 1, 2, 3 },
+                new int[] { 1, 2, 3 },
+                features.Get<IIceFeature>()?.EncodeOptions));
+
+        public ValueTask<ReadOnlyMemory<int>> OpReadOnlyMemoryAsync(
+            int[] p1,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p1);
+
+        public ValueTask<ReadOnlyMemory<int>> OpReadOnlyMemoryTaggedAsync(
+            int[]? p1,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p1);
+
+        public ValueTask OpWithProxyParameterAsync(
+            PingableProxy? service,
+            IFeatureCollection features,
+            CancellationToken cancellationToken)
+        {
+            ReceivedProxy = service;
+            return default;
+        }
+
+        public ValueTask<PingableProxy?> OpWithProxyReturnValueAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) =>
+            new(new PingableProxy(InvalidInvoker.Instance, new Uri("icerpc:/hello")));
+    }
+
+    [Service]
+    private sealed partial class MyDerivedOperationsAService : MyOperationsAService, IMyDerivedOperationsAService
+    {
+        public ValueTask OpDerivedWithoutParametersAndVoidReturnAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => default;
+
+        public ValueTask<int> OpDerivedWithSingleParameterAndReturnValueAsync(
+            int p,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p);
+    }
+
+    [Service]
+    private sealed partial class MyTaggedOperationsV0Service : IMyTaggedOperationsV0Service
+    {
+        public ValueTask OpAsync(int y, IFeatureCollection features, CancellationToken cancellationToken) => default;
+    }
+
+    [Service]
+    private sealed partial class MyDerivedOperationsService : IMyDerivedOperationsService
+    {
+        public ValueTask OpAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+        public ValueTask OpDerivedAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+    }
+}

--- a/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
@@ -51,8 +51,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyOperationsAService());
         var proxy = new MyOperationsAProxy(invoker);
 
+        // Act
         int r = await proxy.OpWithSingleParameterAndReturnValueAsync(10);
 
+        // Assert
         Assert.That(r, Is.EqualTo(10));
     }
 
@@ -63,8 +65,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyDerivedOperationsAService());
         var proxy = new MyDerivedOperationsAProxy(invoker);
 
+        // Act
         int r = await proxy.OpDerivedWithSingleParameterAndReturnValueAsync(10);
 
+        // Assert
         Assert.That(r, Is.EqualTo(10));
     }
 
@@ -75,8 +79,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyOperationsAService());
         var proxy = new MyOperationsAProxy(invoker);
 
+        // Act
         (int r1, int r2) = await proxy.OpWithMultipleParametersAndReturnValuesAsync(10, 20);
 
+        // Assert
         Assert.That(r1, Is.EqualTo(10));
         Assert.That(r2, Is.EqualTo(20));
     }

--- a/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
@@ -231,7 +231,7 @@ public partial class OperationTests
         var proxy = new MyTaggedOperationsProxy(invoker);
 
         // Act/Assert
-        Assert.That(() => proxy.OpAsync(10, 1, 12), Throws.Nothing);
+        Assert.That(async () => await proxy.OpAsync(10, 1, 12), Throws.Nothing);
     }
 
     [Test]

--- a/tests/IceRpc.Ice.Generator.Tests/OperationTests.ice
+++ b/tests/IceRpc.Ice.Generator.Tests/OperationTests.ice
@@ -1,0 +1,84 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "ProxyTests.ice"
+
+module IceRpc::Ice::Generator::Tests
+{
+    sequence<int> IntSeq;
+
+    interface MyOperationsA
+    {
+        // No parameters and void return
+        void opWithoutParametersAndVoidReturn();
+
+        // Single parameter and return
+        int opWithSingleParameterAndReturnValue(int p);
+
+        // Multiple parameters, a return value and an out parameter
+        int opWithMultipleParametersAndReturnValues(int p1, int p2, out int r2);
+
+        // idempotent operation
+        idempotent void idempotentOp();
+
+        // cancel and features as regular parameter names
+        void opWithSpecialParameterNames(int cancel, int features);
+
+        // Marshaled result
+        ["marshaled-result"] IntSeq opWithSingleReturnValueAndMarshaledResultAttribute();
+        ["marshaled-result"] IntSeq opWithMultipleReturnValuesAndMarshaledResultAttribute(out IntSeq r2);
+
+        // C# keyword as operation name
+        void continue();
+
+        // ReadOnlyMemory input parameters and return values
+        IntSeq opReadOnlyMemory(IntSeq p1);
+
+        // ReadOnlyMemory tagged input parameters and return values
+        optional(2) IntSeq opReadOnlyMemoryTagged(optional(1) IntSeq p1);
+
+        // Proxy parameter and return value
+        void opWithProxyParameter(Pingable* service);
+        Pingable* opWithProxyReturnValue();
+    }
+
+    interface MyDerivedOperationsA : MyOperationsA
+    {
+        // No parameters and void return
+        void opDerivedWithoutParametersAndVoidReturn();
+
+        // Single parameter and return
+        int opDerivedWithSingleParameterAndReturnValue(int p);
+    }
+
+    interface MyTaggedOperations
+    {
+        void op(optional(1) int x, int y, optional(2) int z);
+    }
+
+    // A prior version of MyTaggedOperations which doesn't contain any of the tagged parameters.
+    interface MyTaggedOperationsV0
+    {
+        void op(int y);
+    }
+
+    interface MyBaseOperations
+    {
+        void op();
+    }
+
+    interface NoOperation {}
+
+    // Make sure the generated code does not generate a "new" for Request and Response in the service class.
+    interface DerivedFromNoOperation : NoOperation
+    {
+        int op(int x);
+    }
+}
+
+module IceRpc::Ice::Derived::Generator::Tests
+{
+    interface MyDerivedOperations : IceRpc::Ice::Generator::Tests::MyBaseOperations
+    {
+        void opDerived();
+    }
+}

--- a/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
@@ -181,9 +181,9 @@ public partial class ProxyTests
     {
         // Arrange
         var service = new SendProxyTestService();
-        var pipeline = new Pipeline();
         var router = new Router();
         router.Map<ISendProxyTestService>(service);
+        var pipeline = new Pipeline();
         var baseProxy = new SendProxyTestProxy(pipeline);
         router.UseFeature<IIceFeature>(new IceFeature(baseProxy: baseProxy));
 

--- a/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Features;
 using IceRpc.Ice.Codec;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
@@ -157,6 +158,61 @@ public partial class ProxyTests
         Assert.That(derived, Is.Null);
     }
 
+    /// <summary>Verifies that a proxy decoded from an incoming request has the invalid invoker by default.</summary>
+    [Test]
+    public async Task Proxy_decoded_from_an_incoming_request_has_invalid_invoker()
+    {
+        // Arrange
+        var service = new SendProxyTestService();
+        var proxy = new SendProxyTestProxy(new ColocInvoker(service));
+
+        // Act
+        await proxy.SendProxyAsync(proxy);
+
+        // Assert
+        Assert.That(service.ReceivedProxy, Is.Not.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(InvalidInvoker.Instance));
+    }
+
+    /// <summary>Verifies that the invoker of a proxy decoded from an incoming request can be set using the Ice
+    /// feature.</summary>
+    [Test]
+    public async Task Proxy_decoded_from_an_incoming_request_can_have_invoker_set_through_an_ice_feature()
+    {
+        // Arrange
+        var service = new SendProxyTestService();
+        var pipeline = new Pipeline();
+        var router = new Router();
+        router.Map<ISendProxyTestService>(service);
+        var baseProxy = new SendProxyTestProxy(pipeline);
+        router.UseFeature<IIceFeature>(new IceFeature(baseProxy: baseProxy));
+
+        var proxy = new SendProxyTestProxy(new ColocInvoker(router));
+
+        // Act
+        await proxy.SendProxyAsync(proxy);
+
+        // Assert
+        Assert.That(service.ReceivedProxy, Is.Not.Null);
+        Assert.That(service.ReceivedProxy!.Value.Invoker, Is.EqualTo(pipeline));
+    }
+
+    /// <summary>Verifies that a proxy decoded from an incoming response inherits the caller's invoker.</summary>
+    [Test]
+    public async Task Proxy_decoded_from_an_incoming_response_inherits_the_callers_invoker()
+    {
+        // Arrange
+        IInvoker invoker = new ColocInvoker(new ReceiveProxyTestService());
+        var proxy = new ReceiveProxyTestProxy(invoker);
+
+        // Act
+        ReceiveProxyTestProxy? received = await proxy.ReceiveProxyAsync();
+
+        // Assert
+        Assert.That(received, Is.Not.Null);
+        Assert.That(received!.Value.Invoker, Is.EqualTo(invoker));
+    }
+
     [Service]
     private partial class MyBaseInterfaceService : IMyBaseInterfaceService, IIceObjectService
     {
@@ -165,5 +221,29 @@ public partial class ProxyTests
     [Service]
     private sealed partial class MyDerivedInterfaceService : MyBaseInterfaceService, IMyDerivedInterfaceService
     {
+    }
+
+    [Service]
+    private sealed partial class ReceiveProxyTestService : IReceiveProxyTestService
+    {
+        public ValueTask<ReceiveProxyTestProxy?> ReceiveProxyAsync(
+            IFeatureCollection features,
+            CancellationToken cancellationToken) =>
+            new(new ReceiveProxyTestProxy(InvalidInvoker.Instance, new Uri("icerpc:/hello")));
+    }
+
+    [Service]
+    private sealed partial class SendProxyTestService : ISendProxyTestService
+    {
+        public SendProxyTestProxy? ReceivedProxy { get; private set; }
+
+        public ValueTask SendProxyAsync(
+            SendProxyTestProxy? proxy,
+            IFeatureCollection features,
+            CancellationToken cancellationToken)
+        {
+            ReceivedProxy = proxy;
+            return default;
+        }
     }
 }

--- a/tests/IceRpc.Ice.Generator.Tests/ProxyTests.ice
+++ b/tests/IceRpc.Ice.Generator.Tests/ProxyTests.ice
@@ -10,4 +10,14 @@ module IceRpc::Ice::Generator::Tests
     interface MyBaseInterface {}
 
     interface MyDerivedInterface : MyBaseInterface {}
+
+    interface ReceiveProxyTest
+    {
+        ReceiveProxyTest* receiveProxy();
+    }
+
+    interface SendProxyTest
+    {
+        void sendProxy(SendProxyTest* proxy);
+    }
 }

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -589,7 +589,7 @@ public partial class OperationTests
         var proxy = new MyTaggedOperationsProxy(invoker);
 
         // Act/Assert
-        Assert.That(() => proxy.OpAsync(10, 1, 12), Throws.Nothing);
+        Assert.That(async () => await proxy.OpAsync(10, 1, 12), Throws.Nothing);
     }
 
     [Test]

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -53,8 +53,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyOperationsAService());
         var proxy = new MyOperationsAProxy(invoker);
 
+        // Act
         int r = await proxy.OpWithSingleParameterAndReturnValueAsync(10);
 
+        // Assert
         Assert.That(r, Is.EqualTo(10));
     }
 
@@ -65,8 +67,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyDerivedOperationsAService());
         var proxy = new MyDerivedOperationsAProxy(invoker);
 
+        // Act
         int r = await proxy.OpDerivedWithSingleParameterAndReturnValueAsync(10);
 
+        // Assert
         Assert.That(r, Is.EqualTo(10));
     }
 
@@ -77,8 +81,10 @@ public partial class OperationTests
         var invoker = new ColocInvoker(new MyOperationsAService());
         var proxy = new MyOperationsAProxy(invoker);
 
+        // Act
         (int r1, int r2) = await proxy.OpWithMultipleParametersAndReturnValuesAsync(10, 20);
 
+        // Assert
         Assert.That(r1, Is.EqualTo(10));
         Assert.That(r2, Is.EqualTo(20));
     }

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
@@ -2,7 +2,6 @@
 
 module IceRpc::Slice::Generator::Tests
 
-// Used for testing the generated code corresponding to proxy and dispatch visitors.
 interface MyOperationsA {
     // No parameters and void return
     opWithoutParametersAndVoidReturn()

--- a/tests/IceRpc.Slice.Generator.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/ProxyTests.cs
@@ -79,9 +79,9 @@ public partial class ProxyTests
     {
         // Arrange
         var service = new SendProxyTestService();
-        var pipeline = new Pipeline();
         var router = new Router();
         router.Map<ISendProxyTestService>(service);
+        var pipeline = new Pipeline();
         var baseProxy = new SendProxyTestProxy(pipeline);
         router.UseFeature<ISliceFeature>(new SliceFeature(baseProxy: baseProxy));
 


### PR DESCRIPTION
This PR adds a number of Ice tests (the Slice equivalent already exist). I missed them in previous PR. 

Note: the marshaled-result tests depend on a bug fix in slice2cs (already merged).