### PR TITLE
Move ALPN to the protocol layer (#4317)

### DIFF
--- a/src/IceRpc/ClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/ClientProtocolConnectionFactory.cs
@@ -43,6 +43,7 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
         _duplexClientTransport = duplexClientTransport ?? IDuplexClientTransport.Default;
         _duplexConnectionOptions = new DuplexConnectionOptions
         {
+            ApplicationProtocol = Protocol.Ice.Name,
             Pool = connectionOptions.Pool,
             MinSegmentSize = connectionOptions.MinSegmentSize,
         };
@@ -53,6 +54,7 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
         // which is accepted locally is the control stream created by the peer.
         _multiplexedConnectionOptions = new MultiplexedConnectionOptions
         {
+            ApplicationProtocol = Protocol.IceRpc.Name,
             HandshakeTimeout = connectTimeout,
 
             MaxBidirectionalStreams = connectionOptions.Dispatcher is null ? 0 :

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -101,6 +101,7 @@ public sealed class Server : IAsyncDisposable
                     _serverAddress,
                     new DuplexConnectionOptions
                     {
+                        ApplicationProtocol = _serverAddress.Protocol.Name,
                         MinSegmentSize = options.ConnectionOptions.MinSegmentSize,
                         Pool = options.ConnectionOptions.Pool,
                     },
@@ -116,6 +117,7 @@ public sealed class Server : IAsyncDisposable
                     _serverAddress,
                     new MultiplexedConnectionOptions
                     {
+                        ApplicationProtocol = _serverAddress.Protocol.Name,
                         HandshakeTimeout = options.ConnectTimeout,
                         MaxBidirectionalStreams = options.ConnectionOptions.MaxIceRpcBidirectionalStreams,
                         // Add an additional stream for the icerpc protocol control stream.

--- a/src/IceRpc/Transports/DuplexConnectionOptions.cs
+++ b/src/IceRpc/Transports/DuplexConnectionOptions.cs
@@ -7,6 +7,11 @@ namespace IceRpc.Transports;
 /// <summary>A property bag used to configure a <see cref="IDuplexConnection" />.</summary>
 public record class DuplexConnectionOptions
 {
+    /// <summary>Gets or sets the application protocol for ALPN (Application-Layer Protocol Negotiation).</summary>
+    /// <value>The application protocol name, or <see langword="null" /> if no application protocol is configured.
+    /// Defaults to <see langword="null" />.</value>
+    public string? ApplicationProtocol { get; set; }
+
     /// <summary>Gets or sets the minimum size of the segment requested from the <see cref="Pool" />.</summary>
     /// <value>The minimum size in bytes of the segment requested from the <see cref="Pool" />. It cannot be less than
     /// <c>1</c> KB. Defaults to <c>4</c> KB.</value>

--- a/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
+++ b/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
@@ -7,6 +7,11 @@ namespace IceRpc.Transports;
 /// <summary>A property bag used to configure a <see cref="IMultiplexedConnection" />.</summary>
 public record class MultiplexedConnectionOptions
 {
+    /// <summary>Gets or sets the application protocol for ALPN (Application-Layer Protocol Negotiation).</summary>
+    /// <value>The application protocol name, or <see langword="null" /> if no application protocol is configured.
+    /// Defaults to <see langword="null" />.</value>
+    public string? ApplicationProtocol { get; set; }
+
     /// <summary>Gets or sets the minimum amount of time the multiplexed transport must allow for a connection
     /// establishment handshake to complete.</summary>
     /// <value>The handshake timeout. The default is 10 seconds.</value>

--- a/src/IceRpc/Transports/Quic/Internal/QuicMultiplexedListener.cs
+++ b/src/IceRpc/Transports/Quic/Internal/QuicMultiplexedListener.cs
@@ -55,9 +55,9 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
         _options = options;
 
         authenticationOptions = authenticationOptions.Clone();
-        authenticationOptions.ApplicationProtocols ??= new List<SslApplicationProtocol> // Mandatory with Quic
+        authenticationOptions.ApplicationProtocols ??= new List<SslApplicationProtocol>
         {
-            new SslApplicationProtocol(serverAddress.Protocol.Name)
+            new SslApplicationProtocol(options.ApplicationProtocol!)
         };
 
         _quicServerOptions = new QuicServerConnectionOptions
@@ -81,7 +81,7 @@ internal class QuicMultiplexedListener : IListener<IMultiplexedConnection>
                 {
                     ListenEndPoint = new IPEndPoint(ipAddress, serverAddress.Port),
                     ListenBacklog = quicTransportOptions.ListenBacklog,
-                    ApplicationProtocols = authenticationOptions.ApplicationProtocols,
+                    ApplicationProtocols = authenticationOptions.ApplicationProtocols!,
                     ConnectionOptionsCallback = (connection, sslInfo, cancellationToken) => new(_quicServerOptions)
                 },
                 CancellationToken.None);

--- a/src/IceRpc/Transports/Quic/QuicClientTransport.cs
+++ b/src/IceRpc/Transports/Quic/QuicClientTransport.cs
@@ -48,6 +48,13 @@ public class QuicClientTransport : IMultiplexedClientTransport
                 nameof(serverAddress));
         }
 
+        if (options.ApplicationProtocol is null)
+        {
+            throw new ArgumentException(
+                "The QUIC client transport requires the multiplexed connection options to have ApplicationProtocol set.",
+                nameof(options));
+        }
+
         if (serverAddress.Transport is null)
         {
             serverAddress = serverAddress with { Transport = Name };
@@ -57,8 +64,7 @@ public class QuicClientTransport : IMultiplexedClientTransport
         clientAuthenticationOptions.TargetHost ??= serverAddress.Host;
         clientAuthenticationOptions.ApplicationProtocols ??=
         [
-            // Mandatory with Quic
-            new(serverAddress.Protocol.Name)
+            new(options.ApplicationProtocol!)
         ];
 
         EndPoint endpoint = IPAddress.TryParse(serverAddress.Host, out IPAddress? ipAddress) ?

--- a/src/IceRpc/Transports/Quic/QuicServerTransport.cs
+++ b/src/IceRpc/Transports/Quic/QuicServerTransport.cs
@@ -54,6 +54,13 @@ public class QuicServerTransport : IMultiplexedServerTransport
                 "The QUIC server transport requires the SSL server authentication options to be set.");
         }
 
+        if (options.ApplicationProtocol is null)
+        {
+            throw new ArgumentException(
+                "The QUIC server transport requires the multiplexed connection options to have ApplicationProtocol set.",
+                nameof(options));
+        }
+
         if (serverAddress.Transport is null)
         {
             serverAddress = serverAddress with { Transport = Name };

--- a/src/IceRpc/Transports/Tcp/Internal/TcpListener.cs
+++ b/src/IceRpc/Transports/Tcp/Internal/TcpListener.cs
@@ -69,14 +69,16 @@ internal sealed class TcpListener : IListener<IDuplexConnection>
         _minSegmentSize = options.MinSegmentSize;
         _pool = options.Pool;
 
-        if (_authenticationOptions is not null && _authenticationOptions.ApplicationProtocols is null)
+        if (_authenticationOptions is not null &&
+            _authenticationOptions.ApplicationProtocols is null &&
+            options.ApplicationProtocol is string applicationProtocol)
         {
-            // Set ApplicationProtocols to "ice" or "icerpc" in the common situation where the application does not
-            // specify any application protocol. This way, a connection request that carries an ALPN protocol ID can
-            // only succeed if this protocol ID is a match.
+            // Set ApplicationProtocols in the common situation where the application does not specify any application
+            // protocol. This way, a connection request that carries an ALPN protocol ID can only succeed if this
+            // protocol ID is a match.
             _authenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol>
             {
-                new SslApplicationProtocol(serverAddress.Protocol.Name)
+                new SslApplicationProtocol(applicationProtocol)
             };
         }
 

--- a/src/IceRpc/Transports/Tcp/TcpClientTransport.cs
+++ b/src/IceRpc/Transports/Tcp/TcpClientTransport.cs
@@ -59,19 +59,14 @@ public class TcpClientTransport : IDuplexClientTransport
 
             authenticationOptions.TargetHost ??= serverAddress.Host;
 
-            // Set ApplicationProtocols to "ice" or "icerpc" in the common situation where the application does not
-            // specify any application protocol. This way, a proxy server listening on a port shared by multiple
-            // application protocols can use this ALPN protocol ID to forward all ice/icerpc traffic to an ice/icerpc
-            // back-end server.
-            // We do this only when the port is not the default port for ice or icerpc; when we use the IANA-registered
-            // default port, the server can and should use this port number to identify the application protocol when no
-            // ALPN protocol ID is provided.
+            // Set ApplicationProtocols when the application does not specify any application protocol and the
+            // connection options provide one.
             if (authenticationOptions.ApplicationProtocols is null &&
-                serverAddress.Port != serverAddress.Protocol.DefaultPort)
+                options.ApplicationProtocol is string applicationProtocol)
             {
                 authenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol>
                 {
-                    new SslApplicationProtocol(serverAddress.Protocol.Name)
+                    new SslApplicationProtocol(applicationProtocol)
                 };
             }
         }

--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedListenerConformanceTests.cs
@@ -182,7 +182,10 @@ public abstract class MultiplexedListenerConformanceTests
         IceRpcException? exception = Assert.Throws<IceRpcException>(
             () => serverTransport.Listen(
                 listener.ServerAddress,
-                new MultiplexedConnectionOptions(),
+                new MultiplexedConnectionOptions
+                {
+                    ApplicationProtocol = listener.ServerAddress.Protocol.Name
+                },
                 provider.GetService<SslServerAuthenticationOptions>()));
         Assert.That(
             exception!.IceRpcError,

--- a/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
+++ b/tests/IceRpc.Tests.Common/ServiceCollectionExtensions.cs
@@ -92,22 +92,33 @@ public static class ServiceCollectionExtensions
     /// specified server address.</summary>
     public static IServiceCollection AddMultiplexedTransportTest(
         this IServiceCollection services,
-        Uri? serverAddressUri = null) => services
+        Uri? serverAddressUri = null)
+    {
+        var serverAddress = new ServerAddress(serverAddressUri ?? new Uri("icerpc://colochost"));
+
+        return services
             .AddSingleton(provider =>
-                provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
-                    new ServerAddress(serverAddressUri ?? new Uri("icerpc://colochost")),
-                    provider.GetService<IOptions<MultiplexedConnectionOptions>>()?.Value ?? new(),
-                    serverAuthenticationOptions: provider.GetService<SslServerAuthenticationOptions>()))
+            {
+                var options = provider.GetService<IOptions<MultiplexedConnectionOptions>>()?.Value ?? new();
+                options.ApplicationProtocol ??= serverAddress.Protocol.Name;
+                return provider.GetRequiredService<IMultiplexedServerTransport>().Listen(
+                    serverAddress,
+                    options,
+                    serverAuthenticationOptions: provider.GetService<SslServerAuthenticationOptions>());
+            })
             .AddSingleton(provider =>
             {
                 var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
                 var clientTransport = provider.GetRequiredService<IMultiplexedClientTransport>();
+                var options = provider.GetService<IOptions<MultiplexedConnectionOptions>>()?.Value ?? new();
+                options.ApplicationProtocol ??= serverAddress.Protocol.Name;
                 var connection = clientTransport.CreateConnection(
                     listener.ServerAddress,
-                    provider.GetService<IOptions<MultiplexedConnectionOptions>>()?.Value ?? new(),
+                    options,
                     provider.GetService<SslClientAuthenticationOptions>());
                 return new ClientServerMultiplexedConnection(connection, listener);
             });
+    }
 
     /// <summary>Installs a transport decorator for the last registered transport.</summary>
     internal static void AddSingletonTransportDecorator<TTransportService, TTransportDecoratorService>(


### PR DESCRIPTION
Add ApplicationProtocol property to DuplexConnectionOptions and MultiplexedConnectionOptions so the protocol layer can communicate the ALPN value to the transport layer without touching SSL authentication options directly.

The protocol layer (ClientProtocolConnectionFactory and Server) sets ApplicationProtocol on the transport connection options. The transport layer uses this value instead of serverAddress.Protocol.Name when configuring SSL ApplicationProtocols.

QUIC transports now validate that ApplicationProtocol is set, since ALPN is mandatory for QUIC.