### PR TITLE
Add server certificate setup to AddIceRpcServer docfx examples

### DIFF
--- a/docfx/examples/IceRpc.Extensions.DependencyInjection.Examples/AddIceRpcServerExamples.cs
+++ b/docfx/examples/IceRpc.Extensions.DependencyInjection.Examples/AddIceRpcServerExamples.cs
@@ -54,7 +54,8 @@ public static class AddIceRpcServerExamples
         IHostBuilder builder = Host.CreateDefaultBuilder(args);
         builder.UseContentRoot(AppContext.BaseDirectory).ConfigureServices((hostContext, services) =>
         {
-            // Load and register the server certificate as a singleton so it stays alive and gets disposed.
+            // Load the server certificate from the path specified in the "Certificate" configuration section,
+            // and register it as a singleton so it stays alive and gets disposed.
             services.AddSingleton<X509Certificate2>(sp =>
                 X509CertificateLoader.LoadPkcs12FromFile(
                     Path.Combine(
@@ -138,7 +139,8 @@ public static class AddIceRpcServerExamples
         IHostBuilder builder = Host.CreateDefaultBuilder(args);
         builder.UseContentRoot(AppContext.BaseDirectory).ConfigureServices((hostContext, services) =>
         {
-            // Load and register the server certificate as a singleton so it stays alive and gets disposed.
+            // Load the server certificate from the path specified in the "Certificate" configuration section,
+            // and register it as a singleton so it stays alive and gets disposed.
             services.AddSingleton<X509Certificate2>(sp =>
                 X509CertificateLoader.LoadPkcs12FromFile(
                     Path.Combine(


### PR DESCRIPTION
The QUIC-based examples were incomplete without TLS certificate configuration. Fixes #4218.