### PR TITLE
Remove useTagEndMarker parameter

### DIFF
--- a/src/IceRpc.Ice/Operations/Internal/IncomingFrameExtensions.cs
+++ b/src/IceRpc.Ice/Operations/Internal/IncomingFrameExtensions.cs
@@ -47,8 +47,7 @@ internal static class IncomingFrameExtensions
                 feature.MaxDepth);
             T value = decodeFunc(ref decoder);
 
-            // useTagEndMarker is false because we're decoding parameters or a return value, not class/exception fields.
-            decoder.SkipTagged(useTagEndMarker: false);
+            decoder.SkipTagged();
             decoder.CheckEndOfBuffer();
 
             frame.Payload.AdvanceTo(readResult.Buffer.End);
@@ -91,7 +90,7 @@ internal static class IncomingFrameExtensions
             {
                 // No need to pass maxCollectionAllocation since the only thing this decoding does is skip unknown tags.
                 var decoder = new IceDecoder(readResult.Buffer);
-                decoder.SkipTagged(useTagEndMarker: false); // false because we're decoding parameters, not class/exception fields
+                decoder.SkipTagged();
                 decoder.CheckEndOfBuffer();
             }
             frame.Payload.AdvanceTo(readResult.Buffer.End);

--- a/src/IceRpc/Ice/Codec/IceDecoder.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.cs
@@ -278,14 +278,12 @@ public ref partial struct IceDecoder
     /// <param name="tag">The tag.</param>
     /// <param name="tagFormat">The expected tag format of this tag when found in the underlying buffer.</param>
     /// <param name="decodeFunc">A decode function that decodes the value of this tag.</param>
-    /// <param name="useTagEndMarker">When <see langword="true" />, a tag end marker marks the end of the tagged fields.
-    /// When <see langword="false" />, the end of the buffer marks the end of the tagged fields.</param>
     /// <returns>The decoded value of the tagged field, or <see langword="null" /> if not found.</returns>
     /// <remarks>We return a T? and not a T to avoid ambiguities in the generated code with nullable reference types
     /// such as string?.</remarks>
-    public T? DecodeTagged<T>(int tag, TagFormat tagFormat, DecodeFunc<T> decodeFunc, bool useTagEndMarker)
+    public T? DecodeTagged<T>(int tag, TagFormat tagFormat, DecodeFunc<T> decodeFunc)
     {
-        if (DecodeTagHeader(tag, tagFormat, useTagEndMarker))
+        if (DecodeTagHeader(tag, tagFormat))
         {
             if (tagFormat == TagFormat.VSize)
             {
@@ -333,21 +331,11 @@ public ref partial struct IceDecoder
     }
 
     /// <summary>Skips the remaining tagged fields.</summary>
-    /// <param name="useTagEndMarker">Whether or not the tagged fields use a tag end marker.</param>
-    public void SkipTagged(bool useTagEndMarker = true)
+    public void SkipTagged()
     {
-        if (!useTagEndMarker && _classContext.Current.InstanceType != InstanceType.None)
-        {
-            throw new ArgumentException(
-                $"The {nameof(useTagEndMarker)} argument must be true when decoding a class/exception fields.",
-                nameof(useTagEndMarker));
-        }
-        else if (useTagEndMarker && _classContext.Current.InstanceType == InstanceType.None)
-        {
-            throw new ArgumentException(
-                $"The {nameof(useTagEndMarker)} argument must be false when decoding parameters.",
-                nameof(useTagEndMarker));
-        }
+        // True when decoding a class or exception, false when decoding parameters. Keep in mind we can't ever encounter
+        // a class when decoding a tagged parameter.
+        bool useTagEndMarker = _classContext.Current.InstanceType != InstanceType.None;
 
         while (true)
         {
@@ -384,20 +372,11 @@ public ref partial struct IceDecoder
         }
     }
 
-    private bool DecodeTagHeader(int tag, TagFormat expectedFormat, bool useTagEndMarker)
+    private bool DecodeTagHeader(int tag, TagFormat expectedFormat)
     {
-        if (!useTagEndMarker && _classContext.Current.InstanceType != InstanceType.None)
-        {
-            throw new ArgumentException(
-                $"The {nameof(useTagEndMarker)} argument must be true when decoding the fields of a class or exception.",
-                nameof(useTagEndMarker));
-        }
-        else if (useTagEndMarker && _classContext.Current.InstanceType == InstanceType.None)
-        {
-            throw new ArgumentException(
-                $"The {nameof(useTagEndMarker)} argument must be false when decoding parameters.",
-                nameof(useTagEndMarker));
-        }
+        // True when decoding a class or exception, false when decoding parameters. Keep in mind we can't ever encounter
+        // a class when decoding a tagged parameter.
+        bool useTagEndMarker = _classContext.Current.InstanceType != InstanceType.None;
 
         if (_classContext.Current.InstanceType != InstanceType.None)
         {

--- a/src/IceRpc/Ice/Codec/IceDecoder.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.cs
@@ -333,8 +333,8 @@ public ref partial struct IceDecoder
     /// <summary>Skips the remaining tagged fields.</summary>
     public void SkipTagged()
     {
-        // True when decoding a class or exception, false when decoding parameters. Keep in mind we can't ever encounter
-        // a class when decoding a tagged parameter.
+        // True when decoding a class or exception, false when decoding parameters. Keep in mind we never decode a
+        // class while decoding a tagged parameter.
         bool useTagEndMarker = _classContext.Current.InstanceType != InstanceType.None;
 
         while (true)
@@ -374,8 +374,8 @@ public ref partial struct IceDecoder
 
     private bool DecodeTagHeader(int tag, TagFormat expectedFormat)
     {
-        // True when decoding a class or exception, false when decoding parameters. Keep in mind we can't ever encounter
-        // a class when decoding a tagged parameter.
+        // True when decoding a class or exception, false when decoding parameters. Keep in mind we never decode a
+        // class while decoding a tagged parameter.
         bool useTagEndMarker = _classContext.Current.InstanceType != InstanceType.None;
 
         if (_classContext.Current.InstanceType != InstanceType.None)

--- a/tests/IceRpc.Ice.Generator.None.Tests/ClassTests.cs
+++ b/tests/IceRpc.Ice.Generator.None.Tests/ClassTests.cs
@@ -450,8 +450,7 @@ public sealed class ClassTests
                 decoder.DecodeTagged(
                     20,
                     TagFormat.OptimizedVSize,
-                    (ref IceDecoder decoder) => decoder.DecodeString(),
-                    useTagEndMarker: false),
+                    (ref IceDecoder decoder) => decoder.DecodeString()),
                 Is.EqualTo(b));
             Assert.That(decoder.DecodeByte(), Is.EqualTo(IceEncodingDefinitions.TagEndMarker));
         }
@@ -469,8 +468,7 @@ public sealed class ClassTests
                 decoder.DecodeTagged(
                     10,
                     TagFormat.F4,
-                    (ref IceDecoder decoder) => decoder.DecodeInt(),
-                    useTagEndMarker: false),
+                    (ref IceDecoder decoder) => decoder.DecodeInt()),
                 Is.EqualTo(a));
             Assert.That(decoder.DecodeByte(), Is.EqualTo(IceEncodingDefinitions.TagEndMarker));
             Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));

--- a/tests/IceRpc.Ice.Generator.None.Tests/TaggedTests.cs
+++ b/tests/IceRpc.Ice.Generator.None.Tests/TaggedTests.cs
@@ -269,48 +269,42 @@ public class TaggedTests
             decoder.DecodeTagged(
                 1,
                 TagFormat.F1,
-                (ref IceDecoder decoder) => decoder.DecodeByte() as byte?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeByte() as byte?),
             Is.EqualTo(c.A));
 
         Assert.That(
             decoder.DecodeTagged(
                 2,
                 TagFormat.F2,
-                (ref IceDecoder decoder) => decoder.DecodeShort() as short?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeShort() as short?),
             Is.EqualTo(c.B));
 
         Assert.That(
             decoder.DecodeTagged(
                 3,
                 TagFormat.F4,
-                (ref IceDecoder decoder) => decoder.DecodeInt() as int?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeInt() as int?),
             Is.EqualTo(c.C));
 
         Assert.That(
             decoder.DecodeTagged(
                 4,
                 TagFormat.F8,
-                (ref IceDecoder decoder) => decoder.DecodeLong() as long?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeLong() as long?),
             Is.EqualTo(c.D));
 
         Assert.That(
             decoder.DecodeTagged(
                 5,
                 TagFormat.VSize,
-                (ref IceDecoder decoder) => new FixedSizeStruct(ref decoder) as FixedSizeStruct?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => new FixedSizeStruct(ref decoder) as FixedSizeStruct?),
             Is.EqualTo(c.E));
 
         Assert.That(
             decoder.DecodeTagged(
                 6,
                 TagFormat.FSize,
-                (ref IceDecoder decoder) => new VarSizeStruct(ref decoder) as VarSizeStruct?,
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => new VarSizeStruct(ref decoder) as VarSizeStruct?),
             Is.EqualTo(c.F));
 
         Assert.That(
@@ -318,32 +312,28 @@ public class TaggedTests
                 7,
                 TagFormat.Size,
                 (ref IceDecoder decoder) =>
-                    MyEnumIceDecoderExtensions.DecodeMyEnum(ref decoder) as MyEnum?,
-                useTagEndMarker: false),
+                    MyEnumIceDecoderExtensions.DecodeMyEnum(ref decoder) as MyEnum?),
             Is.EqualTo(c.G));
 
         Assert.That(
             decoder.DecodeTagged(
                 8,
                 TagFormat.OptimizedVSize,
-                (ref IceDecoder decoder) => decoder.DecodeSequence<byte>(),
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeSequence<byte>()),
             Is.EqualTo(c.H));
 
         Assert.That(
             decoder.DecodeTagged(
                 9,
                 TagFormat.VSize,
-                (ref IceDecoder decoder) => decoder.DecodeSequence<int>(),
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeSequence<int>()),
             Is.EqualTo(c.I));
 
         Assert.That(
             decoder.DecodeTagged(
                 10,
                 TagFormat.OptimizedVSize,
-                (ref IceDecoder decoder) => decoder.DecodeString(),
-                useTagEndMarker: false),
+                (ref IceDecoder decoder) => decoder.DecodeString()),
             Is.EqualTo(c.J));
 
         if (hasTaggedFields)


### PR DESCRIPTION
This PR simplifies the Ice decoding of tagged fields by removing the useTageEndMarker parameter. It was not needed since we can compute it.

Note: this PR depends on the corresponding fix in slice2cs --icerpc.