### PR TITLE
Replace cs::internal by cs::public

### DIFF
--- a/slice.toml
+++ b/slice.toml
@@ -12,7 +12,7 @@ include = ["Ice/Identity.ice", "Ice/Locator.ice", "Ice/LocatorRegistry.ice", "Ic
 
 [source.icerpc]
 repo    = "https://github.com/icerpc/icerpc-slice"
-rev     = "5eb3c8a7f878fc0ecf1f0a658faa84b2c57bcfe9"
+rev     = "8eb06182068babf62713852b68985bedafe1c178"
 dest    = "slice"
 include = ["**/*.slice", "**/*.ice"]
 

--- a/slice/IceRpc/CompressionFormat.slice
+++ b/slice/IceRpc/CompressionFormat.slice
@@ -3,6 +3,7 @@
 module IceRpc
 
 /// The compression format of a payload.
+[cs::public]
 unchecked enum CompressionFormat : uint8 {
     /// Reserved value which should not be encoded.
     NotCompressed = 0

--- a/slice/IceRpc/Internal/IceRpcDefinitions.slice
+++ b/slice/IceRpc/Internal/IceRpcDefinitions.slice
@@ -5,7 +5,6 @@ module IceRpc::Internal
 // These definitions help with the encoding of icerpc frames.
 
 /// Each icerpc control frame has a type identified by this enumeration.
-[cs::internal]
 enum IceRpcControlFrameType : uint8 {
     /// The Settings frame is sent by each peer on connection establishment to exchange settings.
     Settings = 0
@@ -19,7 +18,6 @@ enum IceRpcControlFrameType : uint8 {
 /// - a request header size (varuint62)
 /// - a request header (below)
 /// - a request payload
-[cs::internal]
 [cs::readonly]
 compact struct IceRpcRequestHeader {
     path: string
@@ -31,7 +29,6 @@ compact struct IceRpcRequestHeader {
 /// - a response header size (varuint62)
 /// - a response header (below)
 /// - a response payload
-[cs::internal]
 [cs::readonly]
 compact struct IceRpcResponseHeader {
     statusCode: StatusCode
@@ -40,14 +37,12 @@ compact struct IceRpcResponseHeader {
 }
 
 /// The settings frame is sent by each peer on connection establishment to exchange settings.
-[cs::internal]
 [cs::readonly]
 compact struct IceRpcSettings {
     value: Dictionary<IceRpcSettingKey, varuint62>
 }
 
 /// The keys for Settings entries.
-[cs::internal]
 unchecked enum IceRpcSettingKey : varuint62 {
     MaxHeaderSize = 0
 }
@@ -55,7 +50,6 @@ unchecked enum IceRpcSettingKey : varuint62 {
 /// The GoAway frame is sent on connection shutdown to notify the peer that it shouldn't send additional requests and to
 /// provide two stream IDs. Requests carried by streams with IDs greater or equal to these stream IDs were not accepted
 /// or otherwise processed, and as a result can be safely retried.
-[cs::internal]
 [cs::readonly]
 compact struct IceRpcGoAway {
     bidirectionalStreamId: varuint62

--- a/slice/IceRpc/RequestFieldKey.slice
+++ b/slice/IceRpc/RequestFieldKey.slice
@@ -3,6 +3,7 @@
 module IceRpc
 
 /// The keys of fields carried by icerpc request headers.
+[cs::public]
 unchecked enum RequestFieldKey : varuint62 {
     /// The string-string dictionary field.
     Context = 0

--- a/slice/IceRpc/ResponseFieldKey.slice
+++ b/slice/IceRpc/ResponseFieldKey.slice
@@ -3,6 +3,7 @@
 module IceRpc
 
 /// The keys of fields carried by icerpc response headers.
+[cs::public]
 unchecked enum ResponseFieldKey : varuint62 {
     /// The compression format of the payload.
     CompressionFormat = 2

--- a/slice/IceRpc/StatusCode.slice
+++ b/slice/IceRpc/StatusCode.slice
@@ -4,6 +4,7 @@ module IceRpc
 
 /// The status code indicates whether the dispatch of a request has completed successfully, and, if not, which error
 /// occurred. It's carried by responses.
+[cs::public]
 unchecked enum StatusCode : varuint62 {
     /// The dispatch completed successfully.
     Ok = 0

--- a/slice/IceRpc/Transports/Slic/Internal/SlicDefinitions.slice
+++ b/slice/IceRpc/Transports/Slic/Internal/SlicDefinitions.slice
@@ -4,7 +4,6 @@
 module IceRpc::Transports::Slic::Internal
 
 /// The Slic frame types.
-[cs::internal]
 enum FrameType : uint8 {
     // Initiates the connection establishment.
     Initialize = 1
@@ -50,7 +49,6 @@ enum FrameType : uint8 {
 
 /// The keys for supported connection parameters exchanged with the {@link FrameType::Initialize} and
 /// {@link FrameType::InitializeAck} frames.
-[cs::internal]
 unchecked enum ParameterKey : varuint62 {
     /// The maximum number of bidirectional streams. The peer shouldn't open more streams than the maximum defined
     /// by this parameter.
@@ -74,7 +72,6 @@ unchecked enum ParameterKey : varuint62 {
 typealias ParameterFields = Dictionary<ParameterKey, Sequence<uint8>>
 
 /// The {@link FrameType::Initialize} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct InitializeBody {
     /// The parameters.
@@ -82,7 +79,6 @@ compact struct InitializeBody {
 }
 
 /// The {@link FrameType::InitializeAck} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct InitializeAckBody {
     /// The parameters.
@@ -90,7 +86,6 @@ compact struct InitializeAckBody {
 }
 
 /// The {@link FrameType::Version} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct VersionBody {
     /// The supported versions.
@@ -98,7 +93,6 @@ compact struct VersionBody {
 }
 
 /// The {@link FrameType::Close} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct CloseBody {
     /// The application error code indicating the reason of the closure.
@@ -110,7 +104,6 @@ compact struct CloseBody {
 custom OpaqueData
 
 /// The {@link FrameType::Ping} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct PingBody {
     /// An opaque payload that will be returned by the {@link FrameType::Pong} frame.
@@ -118,7 +111,6 @@ compact struct PingBody {
 }
 
 /// The {@link FrameType::Pong} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct PongBody {
     /// The opaque payload from the {@link FrameType::Ping} frame.
@@ -126,7 +118,6 @@ compact struct PongBody {
 }
 
 /// The {@link FrameType::StreamWindowUpdate} frame body.
-[cs::internal]
 [cs::readonly]
 compact struct StreamWindowUpdateBody {
     /// The window size increment.

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/ClientHostedService.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/ClientHostedService.cs
@@ -4,7 +4,11 @@ using Microsoft.Extensions.Hosting;
 namespace IceRpc_Protobuf_DI_Client;
 
 /// <summary>The hosted client service is ran and managed by the .NET Generic Host.</summary>
-public class ClientHostedService : BackgroundService
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "This class is instantiated dynamically by the dependency injection container.")]
+internal class ClientHostedService : BackgroundService
 {
     // The host application lifetime is used to stop the .NET Generic Host.
     private readonly IHostApplicationLifetime _applicationLifetime;

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/ServerHostedService.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/ServerHostedService.cs
@@ -4,7 +4,11 @@ using Microsoft.Extensions.Hosting;
 namespace IceRpc_Protobuf_DI_Server;
 
 /// <summary>The server hosted service is ran and managed by the .NET Generic Host.</summary>
-public class ServerHostedService : IHostedService
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "This class is instantiated dynamically by the dependency injection container.")]
+internal class ServerHostedService : IHostedService
 {
     // The IceRPC server accepts connections from IceRPC clients.
     private readonly Server _server;

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/ClientHostedService.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/ClientHostedService.cs
@@ -4,7 +4,11 @@ using Microsoft.Extensions.Hosting;
 namespace IceRpc_Slice_DI_Client;
 
 /// <summary>The hosted client service is ran and managed by the .NET Generic Host.</summary>
-public class ClientHostedService : BackgroundService
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "This class is instantiated dynamically by the dependency injection container.")]
+internal class ClientHostedService : BackgroundService
 {
     // The host application lifetime is used to stop the .NET Generic Host.
     private readonly IHostApplicationLifetime _applicationLifetime;

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/ServerHostedService.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/ServerHostedService.cs
@@ -4,7 +4,11 @@ using Microsoft.Extensions.Hosting;
 namespace IceRpc_Slice_DI_Server;
 
 /// <summary>The server hosted service is ran and managed by the .NET Generic Host.</summary>
-public class ServerHostedService : IHostedService
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "This class is instantiated dynamically by the dependency injection container.")]
+internal class ServerHostedService : IHostedService
 {
     // The IceRPC server accepts connections from IceRPC clients.
     private readonly Server _server;

--- a/tests/ZeroC.Slice.Generator.Tests/EnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/EnumTests.cs
@@ -6,7 +6,7 @@ using ZeroC.Tests.Common;
 
 namespace ZeroC.Slice.Generator.Tests;
 
-public class EnumTests
+internal class EnumTests
 {
     [TestCase((int)MyEnum.Enum1, 0)]
     [TestCase((int)MyEnum.Enum2, 1)]

--- a/tests/ZeroC.Slice.Generator.Tests/StructTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/StructTests.cs
@@ -7,7 +7,7 @@ using ZeroC.Tests.Common;
 namespace ZeroC.Slice.Generator.Tests;
 
 [Parallelizable(ParallelScope.All)]
-public sealed class StructTests
+internal sealed class StructTests
 {
     [Test]
     public void Decode_compact_struct()

--- a/tests/ZeroC.Slice.Generator.Tests/StructTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/StructTests.slice
@@ -20,6 +20,7 @@ compact struct MyCompactStruct {
     j: int32
 }
 
+[cs::public]
 struct MyStructWithFieldAttributes {
     [cs::attribute("System.ComponentModel.Description(\"An integer\")")]
     i: int32,

--- a/tests/ZeroC.Slice.Generator.Tests/TaggedTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/TaggedTests.cs
@@ -6,7 +6,7 @@ using ZeroC.Tests.Common;
 
 namespace ZeroC.Slice.Generator.Tests;
 
-public class TaggedTests
+internal class TaggedTests
 {
     public static IEnumerable<TestCaseData> EncodeSliceTaggedFieldsSource
     {

--- a/tools/slicec-cs/src/cs_attributes/cs_public.rs
+++ b/tools/slicec-cs/src/cs_attributes/cs_public.rs
@@ -3,15 +3,15 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct CsInternal {}
+pub struct CsPublic {}
 
-impl CsInternal {
+impl CsPublic {
     pub fn parse_from(Unparsed { directive, args }: &Unparsed, span: &Span, diagnostics: &mut Diagnostics) -> Self {
         debug_assert_eq!(directive, Self::directive());
 
         check_that_no_arguments_were_provided(args, Self::directive(), span, diagnostics);
 
-        CsInternal {}
+        CsPublic {}
     }
 
     pub fn validate_on(&self, applied_on: Attributables, span: &Span, diagnostics: &mut Diagnostics) {
@@ -28,4 +28,4 @@ impl CsInternal {
     }
 }
 
-implement_attribute_kind_for!(CsInternal, "cs::internal", false);
+implement_attribute_kind_for!(CsPublic, "cs::public", false);

--- a/tools/slicec-cs/src/cs_attributes/mod.rs
+++ b/tools/slicec-cs/src/cs_attributes/mod.rs
@@ -3,16 +3,16 @@
 mod cs_attribute;
 mod cs_encoded_return;
 mod cs_identifier;
-mod cs_internal;
 mod cs_namespace;
+mod cs_public;
 mod cs_readonly;
 mod cs_type;
 
 pub use cs_attribute::*;
 pub use cs_encoded_return::*;
 pub use cs_identifier::*;
-pub use cs_internal::*;
 pub use cs_namespace::*;
+pub use cs_public::*;
 pub use cs_readonly::*;
 pub use cs_type::*;
 

--- a/tools/slicec-cs/src/cs_compile.rs
+++ b/tools/slicec-cs/src/cs_compile.rs
@@ -14,8 +14,8 @@ pub unsafe fn cs_patcher(compilation_state: &mut CompilationState) {
         CsAttribute,
         CsEncodedReturn,
         CsIdentifier,
-        CsInternal,
         CsNamespace,
+        CsPublic,
         CsReadonly,
         CsType,
     );

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -70,7 +70,7 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
         main_constructor.set_body({
             let mut code = CodeBlock::default();
             for field in &fields {
-                writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name(),);
+                writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name());
             }
             code
         });

--- a/tools/slicec-cs/src/generators/struct_generator.rs
+++ b/tools/slicec-cs/src/generators/struct_generator.rs
@@ -41,38 +41,41 @@ pub fn generate_struct(struct_def: &Struct) -> CodeBlock {
 
     let has_required_field = fields.iter().any(|f| f.is_required());
 
-    let mut main_constructor = FunctionBuilder::new(
-        struct_def.access_modifier(),
-        "",
-        &escaped_identifier,
-        FunctionType::BlockBody,
-    );
-
-    if has_required_field {
-        main_constructor.add_sets_required_members_attribute();
-    }
-
-    main_constructor.add_comment(
-        "summary",
-        format!(r#"Constructs a new instance of <see cref="{escaped_identifier}" />."#),
-    );
-
-    for field in &fields {
-        main_constructor.add_parameter(
-            &field.data_type().field_type_string(&namespace),
-            field.parameter_name().as_str(),
-            None,
-            field.formatted_doc_comment_summary(),
+    // We don't need to "override" the implicit public parameterless constructor.
+    if !fields.is_empty() {
+        let mut main_constructor = FunctionBuilder::new(
+            struct_def.access_modifier(),
+            "",
+            &escaped_identifier,
+            FunctionType::BlockBody,
         );
-    }
-    main_constructor.set_body({
-        let mut code = CodeBlock::default();
-        for field in &fields {
-            writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name(),);
+
+        if has_required_field {
+            main_constructor.add_sets_required_members_attribute();
         }
-        code
-    });
-    builder.add_block(main_constructor.build());
+
+        main_constructor.add_comment(
+            "summary",
+            format!(r#"Constructs a new instance of <see cref="{escaped_identifier}" />."#),
+        );
+
+        for field in &fields {
+            main_constructor.add_parameter(
+                &field.data_type().field_type_string(&namespace),
+                field.parameter_name().as_str(),
+                None,
+                field.formatted_doc_comment_summary(),
+            );
+        }
+        main_constructor.set_body({
+            let mut code = CodeBlock::default();
+            for field in &fields {
+                writeln!(code, "this.{} = {};", field.field_name(), field.parameter_name(),);
+            }
+            code
+        });
+        builder.add_block(main_constructor.build());
+    }
 
     // Decode constructor
     let mut decode_constructor = FunctionBuilder::new(

--- a/tools/slicec-cs/src/slicec_ext/entity_ext.rs
+++ b/tools/slicec-cs/src/slicec_ext/entity_ext.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use super::{scoped_identifier, InterfaceExt, MemberExt, ModuleExt};
-use crate::cs_attributes::{CsAttribute, CsIdentifier, CsInternal, CsType};
+use crate::cs_attributes::{CsAttribute, CsIdentifier, CsPublic, CsType};
 use crate::cs_util::{escape_keyword, CsCase};
 use convert_case::Case;
 use slicec::grammar::attributes::Deprecated;
@@ -84,12 +84,12 @@ pub trait EntityExt: Entity {
         format!(r#"SliceTypeId("::{}")"#, self.module_scoped_identifier())
     }
 
-    /// The C# access modifier to use. Returns "internal" if this entity has the cs::internal
-    /// attribute otherwise returns "public".
+    /// The C# access modifier to use. Returns "public" if this entity has the cs::public
+    /// attribute otherwise returns "internal".
     fn access_modifier(&self) -> &str {
-        match self.has_attribute::<CsInternal>() {
-            true => "internal",
-            false => "public",
+        match self.has_attribute::<CsPublic>() {
+            true => "public",
+            false => "internal",
         }
     }
 


### PR DESCRIPTION
This PR replaces cs::internal by cs::public (with the correct semantics changes).

Implements #4350.