### PR TITLE
Remove check for QUIC in Default property

### DIFF
--- a/src/IceRpc/Transports/IMultiplexedClientTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedClientTransport.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Transports.Quic;
-using System.Net.Quic;
 using System.Net.Security;
 using System.Runtime.Versioning;
 
@@ -18,15 +17,10 @@ public interface IMultiplexedClientTransport
         {
             if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsWindows())
             {
-                if (QuicConnection.IsSupported)
-                {
-                    return _quicClientTransport;
-                }
-                throw new NotSupportedException(
-                    "The default QUIC client transport is not available on this system. Please review the Platform Dependencies for QUIC in the .NET documentation.");
+                return _quicClientTransport;
             }
             throw new PlatformNotSupportedException(
-                "The default QUIC client transport is not supported on this platform.");
+                "The default multiplexed client transport, QUIC, is only available on Linux, macOS, and Windows.");
         }
     }
 

--- a/src/IceRpc/Transports/IMultiplexedServerTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedServerTransport.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 using IceRpc.Transports.Quic;
-using System.Net.Quic;
 using System.Net.Security;
 using System.Runtime.Versioning;
 
@@ -18,15 +17,10 @@ public interface IMultiplexedServerTransport
         {
             if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsWindows())
             {
-                if (QuicListener.IsSupported)
-                {
-                    return _quicServerTransport;
-                }
-                throw new NotSupportedException(
-                    "The default QUIC server transport is not available on this system. Please review the Platform Dependencies for QUIC in the .NET documentation.");
+                return _quicServerTransport;
             }
             throw new PlatformNotSupportedException(
-                "The default QUIC server transport is not supported on this platform.");
+                "The default multiplexed server transport, QUIC, is only available on Linux, macOS, and Windows.");
         }
     }
 


### PR DESCRIPTION
This check was incorrect since it affects applications that don't use QUIC or multiplexed transports in general, such as the Ice interop tests.

Note that the QUIC transport implementation already performs this check  in Listen and ConnectAsync.