### PR TITLE
Improve max collection allocation tests for decode methods

### DIFF
--- a/tests/ZeroC.Slice.Codec.Tests/DictionaryDecodingTests.cs
+++ b/tests/ZeroC.Slice.Codec.Tests/DictionaryDecodingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Runtime.CompilerServices;
 using ZeroC.Tests.Common;
 
 namespace ZeroC.Slice.Codec.Tests;
@@ -33,5 +34,63 @@ public class DictionaryDecodingTests
         // Assert
         Assert.That(decoded, Is.EqualTo(expected));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_dictionary_exceeds_max_collection_allocation(int count)
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * (Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>()) + 256]);
+        var encoder = new SliceEncoder(buffer);
+        var dict = Enumerable.Range(0, count).ToDictionary(k => k, v => (long)v);
+        encoder.EncodeDictionary(
+            dict,
+            (ref SliceEncoder encoder, int key) => encoder.EncodeInt32(key),
+            (ref SliceEncoder encoder, long value) => encoder.EncodeInt64(value));
+
+        int allocationLimit = (count - 1) * (Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>());
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeDictionary(
+                    count => new Dictionary<int, long>(count),
+                    (ref SliceDecoder decoder) => decoder.DecodeInt32(),
+                    (ref SliceDecoder decoder) => decoder.DecodeInt64());
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_dictionary_within_max_collection_allocation(int count)
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * (Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>()) + 256]);
+        var encoder = new SliceEncoder(buffer);
+        var dict = Enumerable.Range(0, count).ToDictionary(k => k, v => (long)v);
+        encoder.EncodeDictionary(
+            dict,
+            (ref SliceEncoder encoder, int key) => encoder.EncodeInt32(key),
+            (ref SliceEncoder encoder, long value) => encoder.EncodeInt64(value));
+
+        int allocationLimit = count * (Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>());
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeDictionary(
+                    count => new Dictionary<int, long>(count),
+                    (ref SliceDecoder decoder) => decoder.DecodeInt32(),
+                    (ref SliceDecoder decoder) => decoder.DecodeInt64());
+            },
+            Throws.Nothing);
     }
 }

--- a/tests/ZeroC.Slice.Codec.Tests/SequenceDecodingTests.cs
+++ b/tests/ZeroC.Slice.Codec.Tests/SequenceDecodingTests.cs
@@ -84,20 +84,26 @@ public class SequenceDecodingTests
         Assert.That(decoded, Is.EqualTo(expected));
     }
 
-    [Test]
-    public void Decode_sequence_with_bit_sequence_exceeds_default_max_collection_allocation()
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_sequence_with_bit_sequence_exceeds_max_collection_allocation(int count)
     {
-        var buffer = new MemoryBufferWriter(new byte[256]);
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * Unsafe.SizeOf<long?>() + 256]);
         var encoder = new SliceEncoder(buffer);
-        long?[] seq = new long?[100];
+        long?[] seq = new long?[count];
         encoder.EncodeSequenceOfOptionals(
             seq,
             (ref SliceEncoder encoder, long? value) => encoder.EncodeInt64(value!.Value));
 
+        int allocationLimit = (count - 1) * Unsafe.SizeOf<long?>();
+
+        // Act/Assert
         Assert.That(
             () =>
             {
-                var sut = new SliceDecoder(buffer.WrittenMemory);
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
                 _ = sut.DecodeSequenceOfOptionals<long?>((ref SliceDecoder decoder) => decoder.DecodeInt64());
             },
             Throws.InstanceOf<InvalidDataException>());
@@ -141,23 +147,75 @@ public class SequenceDecodingTests
         Assert.That(checkedValues, Is.EqualTo(expected));
     }
 
-    [Test]
-    public void Decode_sequence_with_bit_sequence_and_custom_max_collection_allocation()
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_sequence_with_bit_sequence_within_max_collection_allocation(int count)
     {
-        var buffer = new MemoryBufferWriter(new byte[256]);
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * Unsafe.SizeOf<long?>() + 256]);
         var encoder = new SliceEncoder(buffer);
-        long?[] seq = new long?[100];
+        long?[] seq = new long?[count];
         encoder.EncodeSequenceOfOptionals(
             seq,
             (ref SliceEncoder encoder, long? value) => encoder.EncodeInt64(value!.Value));
 
+        int allocationLimit = count * Unsafe.SizeOf<long?>();
+
+        // Act/Assert
         Assert.That(
             () =>
             {
-                var sut = new SliceDecoder(
-                    buffer.WrittenMemory,
-                    maxCollectionAllocation: seq.Length * Unsafe.SizeOf<long?>());
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
                 _ = sut.DecodeSequenceOfOptionals<long?>((ref SliceDecoder decoder) => decoder.DecodeInt64());
+            },
+            Throws.Nothing);
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_sequence_exceeds_max_collection_allocation(int count)
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * Unsafe.SizeOf<int>() + 256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeSequence(
+            Enumerable.Range(0, count),
+            (ref SliceEncoder encoder, int value) => encoder.EncodeInt32(value));
+
+        int allocationLimit = (count - 1) * Unsafe.SizeOf<int>();
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeSequence((ref SliceDecoder decoder) => decoder.DecodeInt32());
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_sequence_within_max_collection_allocation(int count)
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[count * Unsafe.SizeOf<int>() + 256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeSequence(
+            Enumerable.Range(0, count),
+            (ref SliceEncoder encoder, int value) => encoder.EncodeInt32(value));
+
+        int allocationLimit = count * Unsafe.SizeOf<int>();
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeSequence((ref SliceDecoder decoder) => decoder.DecodeInt32());
             },
             Throws.Nothing);
     }

--- a/tests/ZeroC.Slice.Codec.Tests/StringDecodingTests.cs
+++ b/tests/ZeroC.Slice.Codec.Tests/StringDecodingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Runtime.CompilerServices;
 using ZeroC.Tests.Common;
 
 namespace ZeroC.Slice.Codec.Tests;
@@ -41,5 +42,51 @@ public class DecodeStringTests
 
             _ = sut.DecodeString();
         }, Throws.InstanceOf<InvalidDataException>());
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_string_exceeds_max_collection_allocation(int length)
+    {
+        // Arrange
+        string testString = new('a', length);
+        var buffer = new MemoryBufferWriter(new byte[length + 256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeString(testString);
+
+        int allocationLimit = (length - 1) * Unsafe.SizeOf<char>();
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeString();
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
+    [TestCase(10)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Decode_string_within_max_collection_allocation(int length)
+    {
+        // Arrange
+        string testString = new('a', length);
+        var buffer = new MemoryBufferWriter(new byte[length + 256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeString(testString);
+
+        int allocationLimit = length * Unsafe.SizeOf<char>();
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, maxCollectionAllocation: allocationLimit);
+                _ = sut.DecodeString();
+            },
+            Throws.Nothing);
     }
 }


### PR DESCRIPTION
Parameterize existing bit-sequence allocation tests with multiple sizes (10, 50, 100) and explicit maxCollectionAllocation limits. Add new exceeds/within allocation tests for DecodeSequence, DecodeDictionary, and DecodeString.

Fixes #4335