### PR TITLE
Simplify GenericHost examples

### DIFF
--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -11,11 +11,13 @@ using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
-// Configure the host.
-HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
-
-// Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
-hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
+// Configure the host with the content root path set to the build directory (e.g.: Client/bin/Debug/net10.0).
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
+    new HostApplicationBuilderSettings
+    {
+        Args = args,
+        ContentRootPath = AppContext.BaseDirectory,
+    });
 
 var services = hostBuilder.Services;
 

--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -12,46 +12,43 @@ using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
 // Configure the host.
-IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args)
-    // Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
-    .UseContentRoot(AppContext.BaseDirectory)
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
 
-    // Configures the .NET Generic Host services.
-    .ConfigureServices((hostContext, services) =>
-    {
-        // Add the ClientHostedService to the hosted services of the .NET Generic Host.
-        services.AddHostedService<ClientHostedService>();
+// Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
+hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
 
-        // Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
-        services.AddSingleton<X509Certificate2>(sp =>
-            X509CertificateLoader.LoadCertificateFromFile(
-                Path.Combine(
-                    hostContext.HostingEnvironment.ContentRootPath,
-                    hostContext.Configuration.GetValue<string>("CertificateAuthoritiesFile")!)));
+var services = hostBuilder.Services;
 
-        // Bind the client connection options to the "appsettings.json" configuration "Client" section,
-        // and add a Configure callback to configure its authentication options.
-        services
-            .AddOptions<ClientConnectionOptions>()
-            .Bind(hostContext.Configuration.GetSection("Client"))
-            .Configure<X509Certificate2>((options, rootCA) =>
-                options.ClientAuthenticationOptions = CreateClientAuthenticationOptions(rootCA));
+// Add the ClientHostedService to the hosted services of the .NET Generic Host.
+services.AddHostedService<ClientHostedService>();
 
-        services
-            // The activity source used by the telemetry interceptor.
-            .AddSingleton(_ => new ActivitySource("IceRpc"))
-            // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
-            // the IOptions<ClientConnectionOptions> configured/bound above.
-            .AddIceRpcClientConnection()
-            // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
-            // flows into the ClientConnection singleton.
-            .AddIceRpcInvoker(builder => builder.UseTelemetry().UseLogger().Into<ClientConnection>())
-            // Add an IGreeter singleton that uses the invoker singleton registered above.
-            .AddSingleton<IGreeter>(provider => provider.CreateProtobufClient<GreeterClient>());
-    });
+// Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
+services.AddSingleton<X509Certificate2>(sp =>
+    X509CertificateLoader.LoadCertificateFromFile(
+        Path.Combine(
+            hostBuilder.Environment.ContentRootPath,
+            hostBuilder.Configuration.GetValue<string>("CertificateAuthoritiesFile")!)));
 
-// Build the host.
+// Bind the client connection options to the "appsettings.json" configuration "Client" section, and add a Configure
+// callback to configure its authentication options.
+services
+    .AddOptions<ClientConnectionOptions>()
+    .Bind(hostBuilder.Configuration.GetSection("Client"))
+    .Configure<X509Certificate2>((options, rootCA) =>
+        options.ClientAuthenticationOptions = CreateClientAuthenticationOptions(rootCA));
+
+services
+    // The activity source used by the telemetry interceptor.
+    .AddSingleton(_ => new ActivitySource("IceRpc"))
+    // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
+    // the IOptions<ClientConnectionOptions> configured/bound above.
+    .AddIceRpcClientConnection()
+    // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
+    // flows into the ClientConnection singleton.
+    .AddIceRpcInvoker(builder => builder.UseTelemetry().UseLogger().Into<ClientConnection>())
+    // Add an IGreeter singleton that uses the invoker singleton registered above.
+    .AddSingleton<IGreeter>(provider => provider.CreateProtobufClient<GreeterClient>());
+
+// Build and run the host.
 using IHost host = hostBuilder.Build();
-
-// Run hosted program.
 host.Run();

--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -25,7 +25,7 @@ var services = hostBuilder.Services;
 services.AddHostedService<ClientHostedService>();
 
 // Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
-services.AddSingleton<X509Certificate2>(sp =>
+services.AddSingleton<X509Certificate2>(_ =>
     X509CertificateLoader.LoadCertificateFromFile(
         Path.Combine(
             hostBuilder.Environment.ContentRootPath,

--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -3,7 +3,6 @@
 using GenericHostClient;
 using IceRpc;
 using IceRpc.Extensions.DependencyInjection;
-using IceRpc.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,7 +18,7 @@ HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
         ContentRootPath = AppContext.BaseDirectory,
     });
 
-var services = hostBuilder.Services;
+IServiceCollection services = hostBuilder.Services;
 
 // Add the ClientHostedService to the hosted services of the .NET Generic Host.
 services.AddHostedService<ClientHostedService>();

--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -42,8 +42,8 @@ services
 services
     // The activity source used by the telemetry interceptor.
     .AddSingleton(_ => new ActivitySource("IceRpc"))
-    // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
-    // the IOptions<ClientConnectionOptions> configured/bound above.
+    // Add a ClientConnection singleton. This ClientConnection uses the ClientConnectionOptions provided by the
+    // IOptions<ClientConnectionOptions> configured/bound above.
     .AddIceRpcClientConnection()
     // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
     // flows into the ClientConnection singleton.

--- a/examples/protobuf/GenericHost/Server/Program.cs
+++ b/examples/protobuf/GenericHost/Server/Program.cs
@@ -11,53 +11,47 @@ using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
 // Configure the host.
-IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args)
-    // Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
-    .UseContentRoot(AppContext.BaseDirectory)
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
 
-    // Configure the .NET Generic Host services.
-    .ConfigureServices((hostContext, services) =>
-    {
-        // Add the ServerHostedService to the hosted services of the .NET Generic Host.
-        services.AddHostedService<ServerHostedService>();
+// Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
+hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
 
-        // The activity source used by the telemetry interceptor.
-        services.AddSingleton(sp => new ActivitySource("IceRpc"));
+var services = hostBuilder.Services;
 
-        string workingDirectory = Directory.GetCurrentDirectory();
-        Console.WriteLine(workingDirectory);
+// Add the ServerHostedService to the hosted services of the .NET Generic Host.
+services.AddHostedService<ServerHostedService>();
 
-        // Load and register the server certificate as a singleton so it stays alive and gets disposed.
-        services.AddSingleton<X509Certificate2>(sp =>
-            X509CertificateLoader.LoadPkcs12FromFile(
-                Path.Combine(
-                    hostContext.HostingEnvironment.ContentRootPath,
-                    hostContext.Configuration.GetValue<string>("Certificate:File")!),
-                password: null,
-                keyStorageFlags: X509KeyStorageFlags.Exportable));
+// The activity source used by the telemetry interceptor.
+services.AddSingleton(_ => new ActivitySource("IceRpc"));
 
-        // Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
-        // callback to configure its authentication options.
-        services
-            .AddOptions<ServerOptions>()
-            .Bind(hostContext.Configuration.GetSection("Server"))
-            .Configure<X509Certificate2>((options, serverCertificate) =>
-                options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate));
+// Load and register the server certificate as a singleton so it stays alive and gets disposed.
+services.AddSingleton<X509Certificate2>(sp =>
+    X509CertificateLoader.LoadPkcs12FromFile(
+        Path.Combine(
+            hostBuilder.Environment.ContentRootPath,
+            hostBuilder.Configuration.GetValue<string>("Certificate:File")!),
+        password: null,
+        keyStorageFlags: X509KeyStorageFlags.Exportable));
 
-        // Add the Chatbot service, which implements the Protobuf `Greeter` service, as a singleton.
-        services.AddSingleton<IGreeterService, Chatbot>();
+// Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
+// callback to configure its authentication options.
+services
+    .AddOptions<ServerOptions>()
+    .Bind(hostBuilder.Configuration.GetSection("Server"))
+    .Configure<X509Certificate2>((options, serverCertificate) =>
+        options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate));
 
-        // Add a server and configure the dispatcher using a dispatcher builder. The server uses the ServerOptions
-        // provided by the IOptions<ServerOptions> singleton configured/bound above.
-        services.AddIceRpcServer(
-            builder => builder
-                .UseTelemetry()
-                .UseLogger()
-                .Map<IGreeterService>());
-    });
+// Add the Chatbot service, which implements the Protobuf `Greeter` service, as a singleton.
+services.AddSingleton<IGreeterService, Chatbot>();
 
-// Build the host.
+// Add a server and configure the dispatcher using a dispatcher builder. The server uses the ServerOptions
+// provided by the IOptions<ServerOptions> singleton configured/bound above.
+services.AddIceRpcServer(
+    builder => builder
+        .UseTelemetry()
+        .UseLogger()
+        .Map<IGreeterService>());
+
+// Build and run the host.
 using IHost host = hostBuilder.Build();
-
-// Run hosted program.
 host.Run();

--- a/examples/protobuf/GenericHost/Server/Program.cs
+++ b/examples/protobuf/GenericHost/Server/Program.cs
@@ -27,7 +27,7 @@ services.AddHostedService<ServerHostedService>();
 services.AddSingleton(_ => new ActivitySource("IceRpc"));
 
 // Load and register the server certificate as a singleton so it stays alive and gets disposed.
-services.AddSingleton<X509Certificate2>(sp =>
+services.AddSingleton<X509Certificate2>(_ =>
     X509CertificateLoader.LoadPkcs12FromFile(
         Path.Combine(
             hostBuilder.Environment.ContentRootPath,

--- a/examples/protobuf/GenericHost/Server/Program.cs
+++ b/examples/protobuf/GenericHost/Server/Program.cs
@@ -10,11 +10,13 @@ using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
-// Configure the host.
-HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
-
-// Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
-hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
+// Configure the host with the content root path set to the build directory (e.g.: Server/bin/Debug/net10.0).
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
+    new HostApplicationBuilderSettings
+    {
+        Args = args,
+        ContentRootPath = AppContext.BaseDirectory,
+    });
 
 var services = hostBuilder.Services;
 

--- a/examples/protobuf/GenericHost/Server/Program.cs
+++ b/examples/protobuf/GenericHost/Server/Program.cs
@@ -18,7 +18,7 @@ HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
         ContentRootPath = AppContext.BaseDirectory,
     });
 
-var services = hostBuilder.Services;
+IServiceCollection services = hostBuilder.Services;
 
 // Add the ServerHostedService to the hosted services of the .NET Generic Host.
 services.AddHostedService<ServerHostedService>();

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -11,11 +11,13 @@ using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
-// Configure the host.
-HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
-
-// Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
-hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
+// Configure the host with the content root path set to the build directory (e.g.: Client/bin/Debug/net10.0).
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
+    new HostApplicationBuilderSettings
+    {
+        Args = args,
+        ContentRootPath = AppContext.BaseDirectory,
+    });
 
 var services = hostBuilder.Services;
 

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -25,7 +25,7 @@ var services = hostBuilder.Services;
 services.AddHostedService<ClientHostedService>();
 
 // Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
-services.AddSingleton<X509Certificate2>(sp =>
+services.AddSingleton<X509Certificate2>(_ =>
     X509CertificateLoader.LoadCertificateFromFile(
         Path.Combine(
             hostBuilder.Environment.ContentRootPath,

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -42,8 +42,8 @@ services
 services
     // The activity source used by the telemetry interceptor.
     .AddSingleton(_ => new ActivitySource("IceRpc"))
-    // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
-    // the IOptions<ClientConnectionOptions> configured/bound above.
+    // Add a ClientConnection singleton. This ClientConnection uses the ClientConnectionOptions provided by the
+    // IOptions<ClientConnectionOptions> configured/bound above.
     .AddIceRpcClientConnection()
     // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
     // flows into the ClientConnection singleton.

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -3,7 +3,6 @@
 using GenericHostClient;
 using IceRpc;
 using IceRpc.Extensions.DependencyInjection;
-using IceRpc.Slice;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,7 +18,7 @@ HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
         ContentRootPath = AppContext.BaseDirectory,
     });
 
-var services = hostBuilder.Services;
+IServiceCollection services = hostBuilder.Services;
 
 // Add the ClientHostedService to the hosted services of the .NET Generic Host.
 services.AddHostedService<ClientHostedService>();

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -12,46 +12,43 @@ using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
 // Configure the host.
-IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args)
-    // Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
-    .UseContentRoot(AppContext.BaseDirectory)
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
 
-    // Configures the .NET Generic Host services.
-    .ConfigureServices((hostContext, services) =>
-    {
-        // Add the ClientHostedService to the hosted services of the .NET Generic Host.
-        services.AddHostedService<ClientHostedService>();
+// Set the content root path to the build directory of the client (e.g.: Client/bin/Debug/net10.0)
+hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
 
-        // Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
-        services.AddSingleton<X509Certificate2>(sp =>
-            X509CertificateLoader.LoadCertificateFromFile(
-                Path.Combine(
-                    hostContext.HostingEnvironment.ContentRootPath,
-                    hostContext.Configuration.GetValue<string>("CertificateAuthoritiesFile")!)));
+var services = hostBuilder.Services;
 
-        // Bind the client connection options to the "appsettings.json" configuration "Client" section,
-        // and add a Configure callback to configure its authentication options.
-        services
-            .AddOptions<ClientConnectionOptions>()
-            .Bind(hostContext.Configuration.GetSection("Client"))
-            .Configure<X509Certificate2>((options, rootCA) =>
-                options.ClientAuthenticationOptions = CreateClientAuthenticationOptions(rootCA));
+// Add the ClientHostedService to the hosted services of the .NET Generic Host.
+services.AddHostedService<ClientHostedService>();
 
-        services
-            // The activity source used by the telemetry interceptor.
-            .AddSingleton(_ => new ActivitySource("IceRpc"))
-            // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
-            // the IOptions<ClientConnectionOptions> configured/bound above.
-            .AddIceRpcClientConnection()
-            // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
-            // flows into the ClientConnection singleton.
-            .AddIceRpcInvoker(builder => builder.UseTelemetry().UseLogger().Into<ClientConnection>())
-            // Add an IGreeter singleton that uses the invoker singleton registered above.
-            .AddSingleton<IGreeter>(provider => provider.CreateSliceProxy<GreeterProxy>());
-    });
+// Load and register the root CA certificate as a singleton so it stays alive and gets disposed.
+services.AddSingleton<X509Certificate2>(sp =>
+    X509CertificateLoader.LoadCertificateFromFile(
+        Path.Combine(
+            hostBuilder.Environment.ContentRootPath,
+            hostBuilder.Configuration.GetValue<string>("CertificateAuthoritiesFile")!)));
 
-// Build the host.
+// Bind the client connection options to the "appsettings.json" configuration "Client" section, and add a Configure
+// callback to configure its authentication options.
+services
+    .AddOptions<ClientConnectionOptions>()
+    .Bind(hostBuilder.Configuration.GetSection("Client"))
+    .Configure<X509Certificate2>((options, rootCA) =>
+        options.ClientAuthenticationOptions = CreateClientAuthenticationOptions(rootCA));
+
+services
+    // The activity source used by the telemetry interceptor.
+    .AddSingleton(_ => new ActivitySource("IceRpc"))
+    // Add a ClientConnection singleton. This ClientConnections uses the ClientConnectionOptions provided by the
+    // the IOptions<ClientConnectionOptions> configured/bound above.
+    .AddIceRpcClientConnection()
+    // Add an invoker singleton; this invoker corresponds to the invocation pipeline. This invocation pipeline
+    // flows into the ClientConnection singleton.
+    .AddIceRpcInvoker(builder => builder.UseTelemetry().UseLogger().Into<ClientConnection>())
+    // Add an IGreeter singleton that uses the invoker singleton registered above.
+    .AddSingleton<IGreeter>(provider => provider.CreateSliceProxy<GreeterProxy>());
+
+// Build and run the host.
 using IHost host = hostBuilder.Build();
-
-// Run hosted program.
 host.Run();

--- a/examples/slice/GenericHost/Server/Program.cs
+++ b/examples/slice/GenericHost/Server/Program.cs
@@ -27,7 +27,7 @@ services.AddHostedService<ServerHostedService>();
 services.AddSingleton(_ => new ActivitySource("IceRpc"));
 
 // Load and register the server certificate as a singleton so it stays alive and gets disposed.
-services.AddSingleton<X509Certificate2>(sp =>
+services.AddSingleton<X509Certificate2>(_ =>
     X509CertificateLoader.LoadPkcs12FromFile(
         Path.Combine(
             hostBuilder.Environment.ContentRootPath,

--- a/examples/slice/GenericHost/Server/Program.cs
+++ b/examples/slice/GenericHost/Server/Program.cs
@@ -10,11 +10,13 @@ using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
-// Configure the host.
-HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
-
-// Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
-hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
+// Configure the host with the content root path set to the build directory (e.g.: Server/bin/Debug/net10.0).
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
+    new HostApplicationBuilderSettings
+    {
+        Args = args,
+        ContentRootPath = AppContext.BaseDirectory,
+    });
 
 var services = hostBuilder.Services;
 

--- a/examples/slice/GenericHost/Server/Program.cs
+++ b/examples/slice/GenericHost/Server/Program.cs
@@ -11,53 +11,47 @@ using System.Security.Cryptography.X509Certificates;
 using VisitorCenter;
 
 // Configure the host.
-IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args)
-    // Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
-    .UseContentRoot(AppContext.BaseDirectory)
+HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);
 
-    // Configure the .NET Generic Host services.
-    .ConfigureServices((hostContext, services) =>
-    {
-        // Add the ServerHostedService to the hosted services of the .NET Generic Host.
-        services.AddHostedService<ServerHostedService>();
+// Set the content root path to the build directory of the server (e.g.: Server/bin/Debug/net10.0)
+hostBuilder.Environment.ContentRootPath = AppContext.BaseDirectory;
 
-        // The activity source used by the telemetry interceptor.
-        services.AddSingleton(sp => new ActivitySource("IceRpc"));
+var services = hostBuilder.Services;
 
-        string workingDirectory = Directory.GetCurrentDirectory();
-        Console.WriteLine(workingDirectory);
+// Add the ServerHostedService to the hosted services of the .NET Generic Host.
+services.AddHostedService<ServerHostedService>();
 
-        // Load and register the server certificate as a singleton so it stays alive and gets disposed.
-        services.AddSingleton<X509Certificate2>(sp =>
-            X509CertificateLoader.LoadPkcs12FromFile(
-                Path.Combine(
-                    hostContext.HostingEnvironment.ContentRootPath,
-                    hostContext.Configuration.GetValue<string>("Certificate:File")!),
-                password: null,
-                keyStorageFlags: X509KeyStorageFlags.Exportable));
+// The activity source used by the telemetry interceptor.
+services.AddSingleton(_ => new ActivitySource("IceRpc"));
 
-        // Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
-        // callback to configure its authentication options.
-        services
-            .AddOptions<ServerOptions>()
-            .Bind(hostContext.Configuration.GetSection("Server"))
-            .Configure<X509Certificate2>((options, serverCertificate) =>
-                options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate));
+// Load and register the server certificate as a singleton so it stays alive and gets disposed.
+services.AddSingleton<X509Certificate2>(sp =>
+    X509CertificateLoader.LoadPkcs12FromFile(
+        Path.Combine(
+            hostBuilder.Environment.ContentRootPath,
+            hostBuilder.Configuration.GetValue<string>("Certificate:File")!),
+        password: null,
+        keyStorageFlags: X509KeyStorageFlags.Exportable));
 
-        // Add the service that implements Slice interface `Greeter`, as a singleton.
-        services.AddSingleton<IGreeterService, Chatbot>();
+// Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
+// callback to configure its authentication options.
+services
+    .AddOptions<ServerOptions>()
+    .Bind(hostBuilder.Configuration.GetSection("Server"))
+    .Configure<X509Certificate2>((options, serverCertificate) =>
+        options.ServerAuthenticationOptions = CreateServerAuthenticationOptions(serverCertificate));
 
-        // Add a server and configure the dispatcher using a dispatcher builder. The server uses the ServerOptions
-        // provided by the IOptions<ServerOptions> singleton configured/bound above.
-        services.AddIceRpcServer(
-            builder => builder
-                .UseTelemetry()
-                .UseLogger()
-                .Map<IGreeterService>());
-    });
+// Add the service that implements Slice interface `Greeter`, as a singleton.
+services.AddSingleton<IGreeterService, Chatbot>();
 
-// Build the host.
+// Add a server and configure the dispatcher using a dispatcher builder. The server uses the ServerOptions
+// provided by the IOptions<ServerOptions> singleton configured/bound above.
+services.AddIceRpcServer(
+    builder => builder
+        .UseTelemetry()
+        .UseLogger()
+        .Map<IGreeterService>());
+
+// Build and run the host.
 using IHost host = hostBuilder.Build();
-
-// Run hosted program.
 host.Run();

--- a/examples/slice/GenericHost/Server/Program.cs
+++ b/examples/slice/GenericHost/Server/Program.cs
@@ -18,7 +18,7 @@ HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(
         ContentRootPath = AppContext.BaseDirectory,
     });
 
-var services = hostBuilder.Services;
+IServiceCollection services = hostBuilder.Services;
 
 // Add the ServerHostedService to the hosted services of the .NET Generic Host.
 services.AddHostedService<ServerHostedService>();


### PR DESCRIPTION
This PR simplifies the GenericHost examples:
 - calls Host.CreateApplicationBuilder
 - uses a flatter structure

Fixes #2781.