### PR TITLE
Add EnforceCodeStyleInBuild in examples and fix issues

### DIFF
--- a/build/IceRpc.Examples.props
+++ b/build/IceRpc.Examples.props
@@ -9,6 +9,11 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisMode>All</AnalysisMode>
+
+    <!-- Required by Roslyn to warn about unused using directives-->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
     <!-- TODO update to 1.2 stable release https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187#issuecomment-1043221630 -->
     <StyleCopAnalyzersVersion>1.2.0-beta.556</StyleCopAnalyzersVersion>
 

--- a/build/IceRpc.Examples.props
+++ b/build/IceRpc.Examples.props
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisMode>All</AnalysisMode>
 
-    <!-- Required by Roslyn to warn about unused using directives-->
+    <!-- Required by Roslyn to warn about unused using directives -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 

--- a/examples/common/Program.Authentication.cs
+++ b/examples/common/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/examples/common/Program.CancelKeyPressed.cs
+++ b/examples/common/Program.CancelKeyPressed.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-// Extends Program to provide the CancelKeyPressed property.
-public static partial class Program
+/// <summary>Extends Program to provide the CancelKeyPressed property.</summary>
+internal static partial class Program
 {
     /// <summary>Gets a task that completes when the console receives a Ctrl+C.</summary>
     public static Task CancelKeyPressed => _cancelKeyPressedTcs.Task;

--- a/examples/json/CurrentWeather/Server/WebService.cs
+++ b/examples/json/CurrentWeather/Server/WebService.cs
@@ -2,7 +2,6 @@
 
 using IceRpc;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Text;
 

--- a/examples/protobuf/GenericHost/Client/Program.cs
+++ b/examples/protobuf/GenericHost/Client/Program.cs
@@ -3,7 +3,6 @@
 using GenericHostClient;
 using IceRpc;
 using IceRpc.Extensions.DependencyInjection;
-using IceRpc.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/examples/slice/GenericHost/Client/Program.cs
+++ b/examples/slice/GenericHost/Client/Program.cs
@@ -3,7 +3,6 @@
 using GenericHostClient;
 using IceRpc;
 using IceRpc.Extensions.DependencyInjection;
-using IceRpc.Slice;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.cs
@@ -1,6 +1,5 @@
 using IceRpc;
 using IceRpc.Extensions.DependencyInjection;
-using IceRpc.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.CancelKeyPressed.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.CancelKeyPressed.cs
@@ -1,5 +1,7 @@
-// Extends Program to provide the CancelKeyPressed property.
-public static partial class Program
+// Copyright (c) ZeroC, Inc.
+
+/// <summary>Extends Program to provide the CancelKeyPressed property.</summary>
+internal static partial class Program
 {
     /// <summary>Gets a task that completes when the console receives a Ctrl+C.</summary>
     public static Task CancelKeyPressed => _cancelKeyPressedTcs.Task;

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
@@ -3,8 +3,8 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-// Provides helper methods to create the authentication options used by the examples.
-public static partial class Program
+/// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
+internal static partial class Program
 {
     /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
     /// specified root CA.</summary>
@@ -36,7 +36,6 @@ public static partial class Program
     /// <returns>The server authentication options.</returns>
     /// <remarks>Do not dispose the server certificate during the lifetime of the returned server authentication
     /// options.</remarks>
-    /// <seealso cref="SslStreamCertificateContext.Create(X509Certificate2, X509Certificate2[])"/>
     public static SslServerAuthenticationOptions CreateServerAuthenticationOptions(
         X509Certificate2 serverCertificate) =>
         new()

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.CancelKeyPressed.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.CancelKeyPressed.cs
@@ -1,5 +1,7 @@
-// Extends Program to provide the CancelKeyPressed property.
-public static partial class Program
+// Copyright (c) ZeroC, Inc.
+
+/// <summary>Extends Program to provide the CancelKeyPressed property.</summary>
+internal static partial class Program
 {
     /// <summary>Gets a task that completes when the console receives a Ctrl+C.</summary>
     public static Task CancelKeyPressed => _cancelKeyPressedTcs.Task;


### PR DESCRIPTION
This PR updates the build of the examples to warn (and fail) on code style violations, mainly unused using directives.