### PR TITLE
Review access modifier generation in IceRpc.Slice.Generator

### DIFF
--- a/src/IceRpc.Slice.Generator/DispatchGenerator.cs
+++ b/src/IceRpc.Slice.Generator/DispatchGenerator.cs
@@ -43,23 +43,27 @@ internal static class DispatchGenerator
 
         if (interfaceDef.Operations.Count > 0)
         {
-            builder.AddBlock(BuildServiceRequestClass(interfaceDef, scopedId, currentNamespace));
-            builder.AddBlock(BuildServiceResponseClass(interfaceDef, scopedId, currentNamespace));
+            builder.AddBlock(BuildServiceRequestClass(interfaceDef, scopedId, accessModifier, currentNamespace));
+            builder.AddBlock(BuildServiceResponseClass(interfaceDef, scopedId, accessModifier, currentNamespace));
 
             foreach (Operation op in interfaceDef.Operations)
             {
-                builder.AddBlock(BuildServiceOperationDeclaration(op, currentNamespace));
+                builder.AddBlock(BuildServiceOperationDeclaration(op, accessModifier, currentNamespace));
             }
         }
 
         return builder.Build();
     }
 
-    private static CodeBlock BuildServiceRequestClass(Interface interfaceDef, string scopedId, string currentNamespace)
+    private static CodeBlock BuildServiceRequestClass(
+        Interface interfaceDef,
+        string scopedId,
+        string accessModifier,
+        string currentNamespace)
     {
         // Use "new" keyword when the interface inherits operations from a base (to hide base's Request class)
         bool hasInheritedOps = interfaceDef.AllBases.Any(b => b.Operations.Count > 0);
-        string classModifier = hasInheritedOps ? "public static new class" : "public static class";
+        string classModifier = hasInheritedOps ? $"{accessModifier} static new class" : $"{accessModifier} static class";
         ContainerBuilder request = new ContainerBuilder(classModifier, "Request")
             .AddComment("summary", "Provides static methods that decode request payloads.")
             .AddComment(
@@ -77,7 +81,7 @@ internal static class DispatchGenerator
             {
                 // Non-streaming: expression body
                 FunctionBuilder decodeBuilder = new FunctionBuilder(
-                    "public static",
+                    $"{accessModifier} static",
                     returnType,
                     $"Decode{opName}Async",
                     FunctionType.ExpressionBody)
@@ -107,7 +111,7 @@ internal static class DispatchGenerator
             {
                 // Streaming: async block body
                 FunctionBuilder decodeBuilder = new FunctionBuilder(
-                    "public static async",
+                    $"{accessModifier} static async",
                     returnType,
                     $"Decode{opName}Async",
                     FunctionType.BlockBody)
@@ -191,10 +195,14 @@ internal static class DispatchGenerator
         return request.Build();
     }
 
-    private static CodeBlock BuildServiceResponseClass(Interface interfaceDef, string scopedId, string currentNamespace)
+    private static CodeBlock BuildServiceResponseClass(
+        Interface interfaceDef,
+        string scopedId,
+        string accessModifier,
+        string currentNamespace)
     {
         bool hasInheritedOps = interfaceDef.AllBases.Any(b => b.Operations.Count > 0);
-        string classModifier = hasInheritedOps ? "public static new class" : "public static class";
+        string classModifier = hasInheritedOps ? $"{accessModifier} static new class" : $"{accessModifier} static class";
         ContainerBuilder response = new ContainerBuilder(classModifier, "Response")
             .AddComment("summary", "Provides static methods that encode return values into response payloads.")
             .AddComment(
@@ -216,7 +224,7 @@ internal static class DispatchGenerator
 
                 response.AddBlock(
                     new FunctionBuilder(
-                        "public static",
+                        $"{accessModifier} static",
                         "global::System.IO.Pipelines.PipeReader",
                         $"Encode{opName}",
                         FunctionType.ExpressionBody)
@@ -231,7 +239,7 @@ internal static class DispatchGenerator
             else
             {
                 FunctionBuilder encodeBuilder = new FunctionBuilder(
-                    "public static",
+                    $"{accessModifier} static",
                     "global::System.IO.Pipelines.PipeReader",
                     $"Encode{opName}",
                     FunctionType.BlockBody)
@@ -264,13 +272,16 @@ internal static class DispatchGenerator
         return response.Build();
     }
 
-    private static CodeBlock BuildServiceOperationDeclaration(Operation op, string currentNamespace)
+    private static CodeBlock BuildServiceOperationDeclaration(
+        Operation op,
+        string accessModifier,
+        string currentNamespace)
     {
         string opName = op.Name;
         ImmutableList<Field> nonStreamedParams = op.NonStreamedParameters;
         string returnType = op.GetServiceReturnType(currentNamespace);
 
-        var operationBuilder = new FunctionBuilder("public", returnType, $"{opName}Async", FunctionType.Declaration)
+        var operationBuilder = new FunctionBuilder(accessModifier, returnType, $"{opName}Async", FunctionType.Declaration)
             .AddDocCommentSummary(op.Comment, currentNamespace)
             .AddDeprecatedAttribute(op.Attributes);
 

--- a/src/IceRpc.Slice.Generator/DispatchGenerator.cs
+++ b/src/IceRpc.Slice.Generator/DispatchGenerator.cs
@@ -48,7 +48,7 @@ internal static class DispatchGenerator
 
             foreach (Operation op in interfaceDef.Operations)
             {
-                builder.AddBlock(BuildServiceOperationDeclaration(op, accessModifier, currentNamespace));
+                builder.AddBlock(BuildServiceOperationDeclaration(op, currentNamespace));
             }
         }
 
@@ -258,7 +258,7 @@ internal static class DispatchGenerator
                     encodeBuilder
                         .AddParameter("SliceEncodeOptions?", "encodeOptions", "null", "The Slice encode options.")
                         .AddComment("returns", "A new response payload.")
-                        .SetBody(InterfaceGenerator.BuildPipeEncodeBody(encodeBody))
+                        .SetBody(EncodeHelper.BuildEncodeBody(encodeBody))
                         .Build());
             }
 
@@ -272,16 +272,13 @@ internal static class DispatchGenerator
         return response.Build();
     }
 
-    private static CodeBlock BuildServiceOperationDeclaration(
-        Operation op,
-        string accessModifier,
-        string currentNamespace)
+    private static CodeBlock BuildServiceOperationDeclaration(Operation op, string currentNamespace)
     {
         string opName = op.Name;
         ImmutableList<Field> nonStreamedParams = op.NonStreamedParameters;
         string returnType = op.GetServiceReturnType(currentNamespace);
 
-        var operationBuilder = new FunctionBuilder(accessModifier, returnType, $"{opName}Async", FunctionType.Declaration)
+        var operationBuilder = new FunctionBuilder(access: "", returnType, $"{opName}Async", FunctionType.Declaration)
             .AddDocCommentSummary(op.Comment, currentNamespace)
             .AddDeprecatedAttribute(op.Attributes);
 

--- a/src/IceRpc.Slice.Generator/EncodeHelper.cs
+++ b/src/IceRpc.Slice.Generator/EncodeHelper.cs
@@ -5,10 +5,10 @@ using ZeroC.CodeBuilder;
 namespace IceRpc.Slice.Generator;
 
 /// <summary>Shared helpers used by both <see cref="ProxyGenerator"/> and <see cref="DispatchGenerator"/>.</summary>
-internal static class InterfaceGenerator
+internal static class EncodeHelper
 {
     /// <summary>Wraps an encode body in the standard pipe creation/size-placeholder boilerplate.</summary>
-    internal static CodeBlock BuildPipeEncodeBody(CodeBlock encodeBody)
+    internal static CodeBlock BuildEncodeBody(CodeBlock encodeBody)
     {
         return new CodeBlock($$"""
             var pipe_ = new global::System.IO.Pipelines.Pipe(

--- a/src/IceRpc.Slice.Generator/ProxyGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ProxyGenerator.cs
@@ -133,7 +133,7 @@ internal static class ProxyGenerator
             .AddBase("ISliceProxy")
             .AddBlock(BuildProxyRequestClass(interfaceDef, scopedId, accessModifier, currentNamespace))
             .AddBlock(BuildProxyResponseClass(interfaceDef, scopedId, accessModifier, currentNamespace))
-            .AddBlock(BuildProxyProperties(scopedId, defaultServicePath));
+            .AddBlock(BuildProxyProperties(scopedId, accessModifier, defaultServicePath));
 
         // Implicit conversion operators for base interfaces
         foreach (Interface baseInterface in interfaceDef.AllBases)
@@ -579,11 +579,11 @@ internal static class ProxyGenerator
             .Build();
     }
 
-    private static CodeBlock BuildProxyProperties(string scopedId, string defaultServicePath) =>
+    private static CodeBlock BuildProxyProperties(string scopedId, string accessModifier, string defaultServicePath) =>
         $$"""
         /// <summary>Represents the default path for IceRPC services that implement Slice interface
         /// <c>{{scopedId}}</c>.</summary>
-        public const string DefaultServicePath = "{{defaultServicePath}}";
+        {{accessModifier}} const string DefaultServicePath = "{{defaultServicePath}}";
 
         /// <inheritdoc/>
         public SliceEncodeOptions? EncodeOptions { get; init; }

--- a/src/IceRpc.Slice.Generator/ProxyGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ProxyGenerator.cs
@@ -199,7 +199,7 @@ internal static class ProxyGenerator
             if (encodeBody is null)
             {
                 // Stream operations with no non-streamed params use CreateEmptySliceStructPayload
-                // (encodes an empty Slice2 struct). Truly void operations use EmptyPipeReader.Instance.
+                // (encodes an empty Slice struct). Truly void operations use EmptyPipeReader.Instance.
                 string emptyPayload = op.HasStreamedParameter ?
                     "System.IO.Pipelines.PipeReader.CreateEmptySliceStructPayload()" :
                     "IceRpc.EmptyPipeReader.Instance";
@@ -239,7 +239,7 @@ internal static class ProxyGenerator
                 request.AddBlock(
                     fn.AddParameter("SliceEncodeOptions?", "encodeOptions", "null", "The Slice encode options.")
                         .AddComment("returns", "The Slice-encoded payload.")
-                        .SetBody(InterfaceGenerator.BuildPipeEncodeBody(encodeBody))
+                        .SetBody(EncodeHelper.BuildEncodeBody(encodeBody))
                         .Build());
             }
 
@@ -645,12 +645,12 @@ internal static class ProxyGenerator
             .Build();
 
         // The parameterless struct constructor must be public (CS8958).
-        CodeBlock defaultCtor = new FunctionBuilder("public", "", proxyName, FunctionType.BlockBody)
+        CodeBlock parameterlessCtor = new FunctionBuilder("public", "", proxyName, FunctionType.BlockBody)
             .AddComment(
                 "summary",
                 @"Constructs a proxy with an icerpc service address with path <see cref=""DefaultServicePath"" />.")
             .Build();
 
-        return CodeBlock.FromBlocks([fromPath, mainCtor, uriCtor, defaultCtor]);
+        return CodeBlock.FromBlocks([fromPath, mainCtor, uriCtor, parameterlessCtor]);
     }
 }

--- a/src/IceRpc.Slice.Generator/ProxyGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ProxyGenerator.cs
@@ -131,8 +131,8 @@ internal static class ProxyGenerator
             .AddDeprecatedAttribute(interfaceDef.Attributes)
             .AddBase($"I{name}")
             .AddBase("ISliceProxy")
-            .AddBlock(BuildProxyRequestClass(interfaceDef, scopedId, currentNamespace))
-            .AddBlock(BuildProxyResponseClass(interfaceDef, scopedId, currentNamespace))
+            .AddBlock(BuildProxyRequestClass(interfaceDef, scopedId, accessModifier, currentNamespace))
+            .AddBlock(BuildProxyResponseClass(interfaceDef, scopedId, accessModifier, currentNamespace))
             .AddBlock(BuildProxyProperties(scopedId, defaultServicePath));
 
         // Implicit conversion operators for base interfaces
@@ -156,7 +156,7 @@ internal static class ProxyGenerator
                     .Build());
         }
 
-        builder.AddBlock(BuildProxyConstructors(proxyName));
+        builder.AddBlock(BuildProxyConstructors(proxyName, accessModifier));
 
         // Generate inherited operations by delegating to the base proxy
         foreach (Interface baseInterface in interfaceDef.AllBases)
@@ -176,9 +176,13 @@ internal static class ProxyGenerator
         return builder.Build();
     }
 
-    private static CodeBlock BuildProxyRequestClass(Interface interfaceDef, string scopedId, string currentNamespace)
+    private static CodeBlock BuildProxyRequestClass(
+        Interface interfaceDef,
+        string scopedId,
+        string accessModifier,
+        string currentNamespace)
     {
-        ContainerBuilder request = new ContainerBuilder("public static class", "Request")
+        ContainerBuilder request = new ContainerBuilder($"{accessModifier} static class", "Request")
             .AddComment("summary", "Provides static methods that encode operation arguments into request payloads.")
             .AddComment(
                 "remarks",
@@ -202,7 +206,7 @@ internal static class ProxyGenerator
 
                 request.AddBlock(
                     new FunctionBuilder(
-                        "public static",
+                        $"{accessModifier} static",
                         "global::System.IO.Pipelines.PipeReader",
                         $"Encode{opName}",
                         FunctionType.ExpressionBody)
@@ -217,7 +221,7 @@ internal static class ProxyGenerator
             else
             {
                 FunctionBuilder fn = new FunctionBuilder(
-                    "public static",
+                    $"{accessModifier} static",
                     "global::System.IO.Pipelines.PipeReader",
                     $"Encode{opName}",
                     FunctionType.BlockBody)
@@ -249,9 +253,13 @@ internal static class ProxyGenerator
         return request.Build();
     }
 
-    private static CodeBlock BuildProxyResponseClass(Interface interfaceDef, string scopedId, string currentNamespace)
+    private static CodeBlock BuildProxyResponseClass(
+        Interface interfaceDef,
+        string scopedId,
+        string accessModifier,
+        string currentNamespace)
     {
-        ContainerBuilder response = new ContainerBuilder("public static class", "Response")
+        ContainerBuilder response = new ContainerBuilder($"{accessModifier} static class", "Response")
             .AddComment(
                 "summary",
                 $"Provides a <see cref=\"ResponseDecodeFunc{{T}}\" /> for each operation defined in Slice interface {scopedId}.")
@@ -270,7 +278,7 @@ internal static class ProxyGenerator
             {
                 // Non-streaming: expression body
                 FunctionBuilder decodeBuilder = new FunctionBuilder(
-                    "public static",
+                    $"{accessModifier} static",
                     returnType,
                     $"Decode{opName}Async",
                     FunctionType.ExpressionBody)
@@ -308,7 +316,7 @@ internal static class ProxyGenerator
             {
                 // Streaming: async block body
                 FunctionBuilder decodeBuilder = new FunctionBuilder(
-                    "public static async",
+                    $"{accessModifier} static async",
                     returnType,
                     $"Decode{opName}Async",
                     FunctionType.BlockBody)
@@ -590,16 +598,16 @@ internal static class ProxyGenerator
             new(IceRpc.Protocol.IceRpc) { Path = DefaultServicePath };
         """;
 
-    private static CodeBlock BuildProxyConstructors(string proxyName)
+    private static CodeBlock BuildProxyConstructors(string proxyName, string accessModifier)
     {
-        CodeBlock fromPath = new FunctionBuilder("public static", proxyName, "FromPath", FunctionType.ExpressionBody)
+        CodeBlock fromPath = new FunctionBuilder($"{accessModifier} static", proxyName, "FromPath", FunctionType.ExpressionBody)
             .AddComment("summary", "Creates a relative proxy from a path.")
             .AddParameter("string", "path", docComment: "The path.")
             .AddComment("returns", "The new relative proxy.")
             .SetBody("new(IceRpc.InvalidInvoker.Instance, new IceRpc.ServiceAddress { Path = path })")
             .Build();
 
-        CodeBlock mainCtor = new FunctionBuilder("public", "", proxyName, FunctionType.BlockBody)
+        CodeBlock mainCtor = new FunctionBuilder(accessModifier, "", proxyName, FunctionType.BlockBody)
             .AddComment("summary", "Constructs a proxy from an invoker, a service address and encode options.")
             .AddParameter("IceRpc.IInvoker", "invoker", docComment: "The invocation pipeline of the proxy.")
             .AddParameter(
@@ -623,7 +631,7 @@ internal static class ProxyGenerator
                 """))
             .Build();
 
-        CodeBlock uriCtor = new FunctionBuilder("public", "", proxyName, FunctionType.BlockBody)
+        CodeBlock uriCtor = new FunctionBuilder(accessModifier, "", proxyName, FunctionType.BlockBody)
             .AddComment("summary", "Constructs a proxy from an invoker, a service address URI and encode options.")
             .AddParameter("IceRpc.IInvoker", "invoker", docComment: "The invocation pipeline of the proxy.")
             .AddParameter("System.Uri", "serviceAddressUri", docComment: "A URI that represents a service address.")
@@ -636,6 +644,7 @@ internal static class ProxyGenerator
             .AddThisParameters(["invoker", "new IceRpc.ServiceAddress(serviceAddressUri)", "encodeOptions"])
             .Build();
 
+        // The parameterless struct constructor must be public (CS8958).
         CodeBlock defaultCtor = new FunctionBuilder("public", "", proxyName, FunctionType.BlockBody)
             .AddComment(
                 "summary",


### PR DESCRIPTION
The IceRpc.Slice.Generator generates many public types that can be internal by default, and only use `public` when strictly required, or `cs::pubic` is set.