### PR TITLE
Fix MaxMessageLength off-by-one in IceRpc.Protobuf

### DIFF
--- a/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
@@ -113,7 +113,7 @@ internal static class PipeReaderExtensions
         }
         int messageLength = DecodeMessageLength(readResult.Buffer.Slice(1, 4));
         reader.AdvanceTo(readResult.Buffer.GetPosition(5));
-        if (messageLength >= maxMessageLength)
+        if (messageLength > maxMessageLength)
         {
             throw new InvalidDataException("The message length exceeds the maximum value.");
         }


### PR DESCRIPTION
Closes #4436.

`PipeReaderExtensions.ReadMessageAsync` (`src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs:116`) rejects messages with `messageLength == maxMessageLength` via a `>=` comparison, even though the property is documented (`IProtobufFeature.cs:11`, `ProtobufFeature.cs:13`) as the **maximum permitted** length:

```csharp
if (messageLength >= maxMessageLength)
{
    throw new InvalidDataException("The message length exceeds the maximum value.");
}
```

Concrete consequences:

- A boundary-sized payload (e.g. exactly 1024 bytes when `MaxMessageLength` is 1024) is rejected as 'exceeds the maximum value'.
- `MaxMessageLength = 0` is silently unsatisfiable: every payload, including empty ones, is rejected.

Switch the bound check to `>` so the property's name and docs match its runtime behaviour. `dotnet build` of `src/IceRpc.Protobuf` succeeds with 0 warnings / 0 errors against current `main`.