### PR TITLE
Escape AttributeValue in CommentTag.ToString

### DIFF
--- a/src/ZeroC.CodeBuilder/CommentTag.cs
+++ b/src/ZeroC.CodeBuilder/CommentTag.cs
@@ -7,6 +7,18 @@ namespace ZeroC.CodeBuilder;
 /// <summary>Represents an XML documentation comment tag.</summary>
 public sealed class CommentTag
 {
+    /// <summary>Escapes XML-special characters (<c>&amp;</c>, <c>&lt;</c>, <c>&gt;</c>, <c>"</c>) in the given text
+    /// so it can be safely spliced into an XML doc comment.</summary>
+    /// <param name="text">The text to escape.</param>
+    /// <returns>The escaped text.</returns>
+#pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
+    public static string XmlEscape(string text) =>
+        text.Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
+#pragma warning restore CA1307
+
     /// <summary>Gets the tag name (e.g., "summary", "param", "returns").</summary>
     public string Tag { get; }
 
@@ -48,7 +60,7 @@ public sealed class CommentTag
         var sb = new StringBuilder();
 
         string attribute = AttributeName is not null
-            ? $" {AttributeName}=\"{EscapeAttributeValue(AttributeValue)}\""
+            ? $" {AttributeName}=\"{XmlEscape(AttributeValue ?? string.Empty)}\""
             : string.Empty;
 
 #pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
@@ -72,13 +84,4 @@ public sealed class CommentTag
 
         return sb.ToString();
     }
-
-#pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
-    private static string EscapeAttributeValue(string? value) =>
-        value is null ? string.Empty :
-            value.Replace("&", "&amp;")
-                 .Replace("<", "&lt;")
-                 .Replace(">", "&gt;")
-                 .Replace("\"", "&quot;");
-#pragma warning restore CA1307
 }

--- a/src/ZeroC.CodeBuilder/CommentTag.cs
+++ b/src/ZeroC.CodeBuilder/CommentTag.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using System.Security;
 using System.Text;
 
 namespace ZeroC.CodeBuilder;
@@ -7,17 +8,11 @@ namespace ZeroC.CodeBuilder;
 /// <summary>Represents an XML documentation comment tag.</summary>
 public sealed class CommentTag
 {
-    /// <summary>Escapes XML-special characters (<c>&amp;</c>, <c>&lt;</c>, <c>&gt;</c>, <c>"</c>) in the given text
-    /// so it can be safely spliced into an XML doc comment.</summary>
+    /// <summary>Escapes XML-special characters in the given text so it can be safely spliced into an XML
+    /// doc comment.</summary>
     /// <param name="text">The text to escape.</param>
     /// <returns>The escaped text.</returns>
-#pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
-    public static string XmlEscape(string text) =>
-        text.Replace("&", "&amp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\"", "&quot;");
-#pragma warning restore CA1307
+    public static string XmlEscape(string text) => SecurityElement.Escape(text);
 
     /// <summary>Gets the tag name (e.g., "summary", "param", "returns").</summary>
     public string Tag { get; }

--- a/src/ZeroC.CodeBuilder/CommentTag.cs
+++ b/src/ZeroC.CodeBuilder/CommentTag.cs
@@ -16,7 +16,8 @@ public sealed class CommentTag
     /// <summary>Gets the optional attribute value.</summary>
     public string? AttributeValue { get; }
 
-    /// <summary>Gets the tag content.</summary>
+    /// <summary>Gets the tag content. This is treated as raw XML; callers are responsible for escaping
+    /// interpolated text.</summary>
     public string Content { get; }
 
     /// <summary>Initializes a new instance of the <see cref="CommentTag"/> class.</summary>
@@ -47,7 +48,7 @@ public sealed class CommentTag
         var sb = new StringBuilder();
 
         string attribute = AttributeName is not null
-            ? $" {AttributeName}=\"{AttributeValue}\""
+            ? $" {AttributeName}=\"{EscapeAttributeValue(AttributeValue)}\""
             : string.Empty;
 
 #pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
@@ -71,4 +72,13 @@ public sealed class CommentTag
 
         return sb.ToString();
     }
+
+#pragma warning disable CA1307 // Specify StringComparison - not compatible with netstandard2.0
+    private static string EscapeAttributeValue(string? value) =>
+        value is null ? string.Empty :
+            value.Replace("&", "&amp;")
+                 .Replace("<", "&lt;")
+                 .Replace(">", "&gt;")
+                 .Replace("\"", "&quot;");
+#pragma warning restore CA1307
 }

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -19,7 +19,7 @@ internal static class DocCommentFormatter
 
         return string.Concat(overview.Select(c => c switch
         {
-            CommentText t => XmlEscape(t.Value),
+            CommentText t => CommentTag.XmlEscape(t.Value),
             CommentInlineLink l => FormatInlineLink(l.Target, currentNamespace),
             _ => ""
         })).TrimEnd();
@@ -46,9 +46,9 @@ internal static class DocCommentFormatter
     private static string FormatInlineLink(CommentLink link, string currentNamespace) => link switch
     {
         // Type aliases don't generate C# types, so output the identifier as plain text.
-        ResolvedCommentLink { Entity: TypeAlias } r => $"<c>{XmlEscape(r.Entity.Identifier)}</c>",
+        ResolvedCommentLink { Entity: TypeAlias } r => $"<c>{CommentTag.XmlEscape(r.Entity.Identifier)}</c>",
         ResolvedCommentLink r => $"""<see cref="{FormatEntityCref(r.Entity, currentNamespace)}" />""",
-        UnresolvedCommentLink u => $"<c>{XmlEscape(u.Identifier)}</c>",
+        UnresolvedCommentLink u => $"<c>{CommentTag.XmlEscape(u.Identifier)}</c>",
         _ => ""
     };
 
@@ -78,9 +78,4 @@ internal static class DocCommentFormatter
         return $"global::{entityNamespace}.{name}";
     }
 
-    private static string XmlEscape(string text) =>
-        text.Replace("&", "&amp;", StringComparison.Ordinal)
-            .Replace("<", "&lt;", StringComparison.Ordinal)
-            .Replace(">", "&gt;", StringComparison.Ordinal)
-            .Replace("\"", "&quot;", StringComparison.Ordinal);
 }


### PR DESCRIPTION
Fixes #4489. See issue comment for analysis.