### PR TITLE
Limit size of Slic control frame bodies during decoding

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -42,6 +42,11 @@ internal class SlicConnection : IMultiplexedConnection
     /// cref="FrameType.StreamWindowUpdate" /> frame is sent.</summary>
     internal int StreamWindowUpdateThreshold => InitialStreamWindowSize / StreamWindowUpdateRatio;
 
+    // The maximum body size for non-stream frames (Initialize, InitializeAck, Version, Close, Ping, Pong). This
+    // value is the maximum value that can be encoded as a 2-byte varuint62, which allows WriteFrame to use a 2-byte
+    // size placeholder. Stream data frames are not subject to this limit; they are gated by per-stream flow control.
+    private const int MaxControlFrameBodySize = 16_383;
+
     // The ratio used to compute the StreamWindowUpdateThreshold. For now, the stream window update is sent when the
     // window size grows over InitialStreamWindowSize / StreamWindowUpdateRatio.
     private const int StreamWindowUpdateRatio = 2;
@@ -1299,6 +1304,13 @@ internal class SlicConnection : IMultiplexedConnection
                 throw new InvalidDataException("The frame size can't be larger than int.MaxValue.", exception);
             }
 
+            // Reject oversized control frame bodies before any buffering occurs.
+            if (header.FrameType < FrameType.Stream && header.FrameSize > MaxControlFrameBodySize)
+            {
+                throw new InvalidDataException(
+                    $"The {header.FrameType} frame body size ({header.FrameSize}) exceeds the maximum allowed size ({MaxControlFrameBodySize}).");
+            }
+
             // If it's a stream frame, try to decode the stream ID
             if (header.FrameType >= FrameType.Stream)
             {
@@ -1560,7 +1572,9 @@ internal class SlicConnection : IMultiplexedConnection
     {
         var encoder = new SliceEncoder(_duplexConnectionWriter);
         encoder.EncodeFrameType(frameType);
-        Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
+        // 2 bytes is sufficient: control frame bodies are limited to MaxControlFrameBodySize (16,383) and the
+        // stream frames encoded by WriteFrame carry at most a stream ID + a small body (e.g., StreamWindowUpdate).
+        Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(2);
         int startPos = encoder.EncodedByteCount;
         if (streamId is not null)
         {

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -928,7 +928,6 @@ public class SlicTransportTests
         (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
         await using var _ = multiplexedServerConnection;
         await connectTask;
-        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
 
         // Act - Write an Initialize frame header that declares a body larger than MaxControlFrameBodySize (16,383).
         await WriteOversizedFrameAsync(duplexClientConnection, FrameType.Initialize, 16_384);
@@ -961,7 +960,6 @@ public class SlicTransportTests
         (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
         await using var _ = multiplexedServerConnection;
         await connectTask;
-        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
 
         // Act
         await WriteFrameAsync(duplexClientConnection, FrameType.Initialize, (ref SliceEncoder encoder) => { });
@@ -997,7 +995,6 @@ public class SlicTransportTests
         var connectTask = multiplexedClientConnection.ConnectAsync(default);
         (var duplexServerConnection, var transportConnectionInformation) = await acceptTask;
         using var _ = duplexServerConnection;
-        using var reader = new DuplexConnectionReader(duplexServerConnection, MemoryPool<byte>.Shared, 4096);
 
         // Act
         await WriteFrameAsync(duplexServerConnection, frameType, (ref SliceEncoder encoder) => { });

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -910,7 +910,7 @@ public class SlicTransportTests
     }
 
     [Test]
-    public async Task Write_initialize_frame_with_oversized_body()
+    public async Task Reject_slic_control_frame_with_oversized_body()
     {
         // Arrange
         await using ServiceProvider provider = new ServiceCollection()
@@ -1307,7 +1307,7 @@ public class SlicTransportTests
     /// <summary>Writes a frame with a body of the specified size. Used to test oversized frame rejection.</summary>
     private static Task WriteOversizedFrameAsync(IDuplexConnection connection, FrameType frameType, int bodySize)
     {
-        var writer = new MemoryBufferWriter(new byte[bodySize + 10]);
+        var writer = new MemoryBufferWriter(new byte[bodySize + 5]); // header takes 5 bytes
         Encode(writer);
         return connection.WriteAsync(new ReadOnlySequence<byte>(writer.WrittenMemory), default).AsTask();
 

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -910,6 +910,39 @@ public class SlicTransportTests
     }
 
     [Test]
+    public async Task Write_initialize_frame_with_oversized_body()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var _ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Act - Write an Initialize frame header that declares a body larger than MaxControlFrameBodySize (16,383).
+        await WriteOversizedFrameAsync(duplexClientConnection, FrameType.Initialize, 16_384);
+
+        // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await multiplexedServerConnection.ConnectAsync(default));
+        Assert.That(exception!.InnerException, Is.InstanceOf<InvalidDataException>());
+        Assert.That(
+            exception.InnerException!.Message,
+            Does.Contain("exceeds the maximum allowed size"));
+    }
+
+    [Test]
     public async Task Write_initialize_frame_with_empty_body()
     {
         // Arrange
@@ -1270,6 +1303,24 @@ public class SlicTransportTests
             Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
             int startPos = encoder.EncodedByteCount;
             encodeAction?.Invoke(ref encoder);
+            SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
+        }
+    }
+
+    /// <summary>Writes a frame with a body of the specified size. Used to test oversized frame rejection.</summary>
+    private static Task WriteOversizedFrameAsync(IDuplexConnection connection, FrameType frameType, int bodySize)
+    {
+        var writer = new MemoryBufferWriter(new byte[bodySize + 10]);
+        Encode(writer);
+        return connection.WriteAsync(new ReadOnlySequence<byte>(writer.WrittenMemory), default).AsTask();
+
+        void Encode(IBufferWriter<byte> writer)
+        {
+            var encoder = new SliceEncoder(writer);
+            encoder.EncodeFrameType(frameType);
+            Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
+            int startPos = encoder.EncodedByteCount;
+            encoder.WriteByteSpan(new byte[bodySize]);
             SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
         }
     }


### PR DESCRIPTION
This PR caps the size of the Slic control frame bodies to 16,383 bytes.