### PR TITLE
Backport #4511 to 0.5.x

### DIFF
--- a/src/ZeroC.Slice/SliceDecoder.cs
+++ b/src/ZeroC.Slice/SliceDecoder.cs
@@ -234,6 +234,10 @@ public ref partial struct SliceDecoder
         }
         else
         {
+            // In the worst-case scenario, each byte becomes a new character. We'll adjust this allocation increase
+            // after decoding the string.
+            IncreaseCollectionAllocation(size, Unsafe.SizeOf<char>());
+
             string result;
             if (_reader.UnreadSpan.Length >= size)
             {
@@ -271,9 +275,8 @@ public ref partial struct SliceDecoder
 
             _reader.Advance(size);
 
-            // We can only compute the new allocation _after_ decoding the string. For dictionaries and sequences,
-            // we perform this check before the allocation.
-            IncreaseCollectionAllocation(result.Length, Unsafe.SizeOf<char>());
+            // Make the adjustment. The overall increase in allocation is result.Length * SizeOf<char>().
+            DecreaseCollectionAllocation(size - result.Length, Unsafe.SizeOf<char>());
             return result;
         }
     }
@@ -556,6 +559,7 @@ public ref partial struct SliceDecoder
     /// <seealso cref="SliceDecoder(ReadOnlySequence{byte}, SliceEncoding, object?, int, IActivator?, int)" />
     public void IncreaseCollectionAllocation(int count, int elementSize)
     {
+        Debug.Assert(count >= 0, $"{nameof(count)} must be greater than or equal to 0.");
         Debug.Assert(elementSize > 0, $"{nameof(elementSize)} must be greater than 0.");
 
         // Widen count to long to avoid overflow when multiplying by elementSize.
@@ -737,6 +741,21 @@ public ref partial struct SliceDecoder
                 return true;
             }
         }
+    }
+
+    /// <summary>Decreases the number of bytes in the decoder's collection allocation.</summary>
+    /// <param name="count">The number of elements.</param>
+    /// <param name="elementSize">The size of each element in bytes.</param>
+    private void DecreaseCollectionAllocation(int count, int elementSize)
+    {
+        Debug.Assert(count >= 0, $"{nameof(count)} must be greater than or equal to 0.");
+        Debug.Assert(elementSize > 0, $"{nameof(elementSize)} must be greater than 0.");
+
+        // Widen count to long to avoid overflow when multiplying by elementSize.
+        long byteCount = (long)count * elementSize;
+
+        Debug.Assert(byteCount <= _currentCollectionAllocation, "Decreasing more than the current collection allocation.");
+        _currentCollectionAllocation -= (int)byteCount;
     }
 
     private readonly byte PeekByte() =>


### PR DESCRIPTION
See https://github.com/icerpc/icerpc-csharp/pull/4511

It's desirable to keep the allocation-checking code in sync on main and 0.5.x.