### PR TITLE
Add PauseWriterThreshold to bound per-stream Slic outbound buffering

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -14,7 +14,7 @@ namespace IceRpc.Transports.Slic.Internal;
 
 /// <summary>The Slic connection implements an <see cref="IMultiplexedConnection" /> on top of a <see
 /// cref="IDuplexConnection" />.</summary>
-internal class SlicConnection : IMultiplexedConnection
+internal class SlicConnection : IMultiplexedConnection, SlicDuplexConnectionWriter.ICompletionCallback
 {
     /// <summary>Gets a value indicating whether or not this is the server-side of the connection.</summary>
     internal bool IsServer { get; }
@@ -101,6 +101,10 @@ internal class SlicConnection : IMultiplexedConnection
     // followed by the shutdown of the duplex connection and if CloseAsync is called at the same time on the server
     // connection.
     private bool _writerIsShutdown;
+
+    /// <inheritdoc/>
+    void SlicDuplexConnectionWriter.ICompletionCallback.WriteCompleted(int creditBytes) =>
+        Interlocked.Decrement(ref _pendingPongReplyCount);
 
     public async ValueTask<IMultiplexedStream> AcceptStreamAsync(CancellationToken cancellationToken)
     {
@@ -763,26 +767,23 @@ internal class SlicConnection : IMultiplexedConnection
         {
             do
             {
-                // Wait for local buffering credit. This blocks if this stream already has
-                // PauseWriterThreshold bytes in-flight across Slic-owned buffers.
-                int localCredit = 0;
-                if (!source1.IsEmpty || !source2.IsEmpty)
-                {
-                    localCredit = await stream.AcquireLocalCreditAsync(writeCts.Token).ConfigureAwait(false);
-                    Debug.Assert(localCredit > 0);
-                }
-
-                // Next, ensure protocol send credit is available. If not, this will block until the receiver
-                // allows sending additional data.
                 int sendCredit = 0;
                 if (!source1.IsEmpty || !source2.IsEmpty)
                 {
-                    sendCredit = await stream.AcquireSendCreditAsync(writeCts.Token).ConfigureAwait(false);
-                    Debug.Assert(sendCredit > 0);
+                    // Wait for local buffering credit. This blocks if this stream already has PauseWriterThreshold
+                    // bytes in-flight across Slic-owned buffers.
+                    int localCredit = await stream.AcquireLocalCreditAsync(writeCts.Token).ConfigureAwait(false);
+                    Debug.Assert(localCredit > 0);
+
+                    // Wait for peer-granted send credit. This blocks if the peer's flow-control window is exhausted.
+                    int peerCredit = await stream.AcquireSendCreditAsync(writeCts.Token).ConfigureAwait(false);
+                    Debug.Assert(peerCredit > 0);
+
+                    sendCredit = Math.Min(localCredit, peerCredit);
                 }
 
-                // Gather data from source1 or source2 up to the minimum of all three limits.
-                int sendMaxSize = Math.Min(Math.Min(localCredit, sendCredit), PeerMaxStreamFrameSize);
+                // Gather data from source1 or source2 up to sendCredit bytes or the peer maximum stream frame size.
+                int sendMaxSize = Math.Min(sendCredit, PeerMaxStreamFrameSize);
                 ReadOnlySequence<byte> sendSource1;
                 ReadOnlySequence<byte> sendSource2;
                 if (!source1.IsEmpty)
@@ -832,17 +833,12 @@ internal class SlicConnection : IMultiplexedConnection
                         }
                     }
 
-                    // Consume protocol send credit. It's important to call this before sending the stream frame to
-                    // avoid race conditions where the StreamWindowUpdate frame could be received before the send
-                    // credit was updated.
+                    // Consume peer-granted and local buffering credit. It's important to consume
+                    // peer credit before sending the stream frame to avoid race conditions where the
+                    // StreamWindowUpdate frame could be received before the send credit was updated.
                     if (sendCredit > 0)
                     {
                         stream.ConsumedSendCredit(payloadSize);
-                    }
-
-                    // Consume local buffering credit.
-                    if (localCredit > 0)
-                    {
                         stream.ConsumedLocalCredit(payloadSize);
                     }
 
@@ -866,11 +862,11 @@ internal class SlicConnection : IMultiplexedConnection
                         _duplexConnectionWriter.Write(sendSource2);
                     }
 
-                    // Enqueue a completion callback to release local credit when these bytes have been written
-                    // to the duplex connection by the background writer task.
+                    // Enqueue a completion callback to release local credit when these bytes have been written to the
+                    // duplex connection by the background writer task.
                     if (payloadSize > 0)
                     {
-                        _duplexConnectionWriter.EnqueueCompletion(payloadSize, stream.ReleasedLocalCredit);
+                        _duplexConnectionWriter.EnqueueCompletion(payloadSize, stream.OutputCompletionCallback);
                     }
 
                     if (writeReadsClosedFrame)
@@ -1232,9 +1228,7 @@ internal class SlicConnection : IMultiplexedConnection
                         _closedMessage);
                 }
                 WriteFrame(FrameType.Pong, streamId: null, new PongBody(pingBody.Payload).Encode);
-                _duplexConnectionWriter.EnqueueCompletion(
-                    creditBytes: 0,
-                    releaseCredit: _ => Interlocked.Decrement(ref _pendingPongReplyCount));
+                _duplexConnectionWriter.EnqueueCompletion(creditBytes: 0, target: this);
                 _duplexConnectionWriter.Flush();
             }
         }

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -38,6 +38,9 @@ internal class SlicConnection : IMultiplexedConnection
     /// <summary>Gets the initial stream window size.</summary>
     internal int InitialStreamWindowSize { get; }
 
+    /// <summary>Gets the pause writer threshold for per-stream local buffering.</summary>
+    internal int PauseWriterThreshold { get; }
+
     /// <summary>Gets the window update threshold. When the window size is increased and this threshold reached, a <see
     /// cref="FrameType.StreamWindowUpdate" /> frame is sent.</summary>
     internal int StreamWindowUpdateThreshold => InitialStreamWindowSize / StreamWindowUpdateRatio;
@@ -46,6 +49,10 @@ internal class SlicConnection : IMultiplexedConnection
     // value is the maximum value that can be encoded as a 2-byte varuint62, which allows WriteFrame to use a 2-byte
     // size placeholder. Stream data frames are not subject to this limit; they are gated by per-stream flow control.
     private const int MaxControlFrameBodySize = 16_383;
+
+    // The maximum number of outgoing Pong replies that can be pending in the shared writer before the connection is
+    // closed. This prevents a peer from flooding Ping frames to cause unbounded control-frame buffering.
+    private const int MaxPendingPongReplies = 16;
 
     // The ratio used to compute the StreamWindowUpdateThreshold. For now, the stream window update is sent when the
     // window size grows over InitialStreamWindowSize / StreamWindowUpdateRatio.
@@ -78,6 +85,7 @@ internal class SlicConnection : IMultiplexedConnection
     private IceRpcError? _peerCloseError;
     private TimeSpan _peerIdleTimeout = Timeout.InfiniteTimeSpan;
     private int _pendingPongCount;
+    private int _pendingPongReplyCount;
     private Task? _readFramesTask;
 
     private readonly ConcurrentDictionary<ulong, SlicStream> _streams = new();
@@ -537,6 +545,7 @@ internal class SlicConnection : IMultiplexedConnection
         _maxUnidirectionalStreams = options.MaxUnidirectionalStreams;
 
         InitialStreamWindowSize = slicOptions.InitialStreamWindowSize;
+        PauseWriterThreshold = slicOptions.PauseWriterThreshold;
         _localIdleTimeout = slicOptions.IdleTimeout;
         _maxStreamFrameSize = slicOptions.MaxStreamFrameSize;
 
@@ -754,8 +763,17 @@ internal class SlicConnection : IMultiplexedConnection
         {
             do
             {
-                // Next, ensure send credit is available. If not, this will block until the receiver allows sending
-                // additional data.
+                // Wait for local buffering credit. This blocks if this stream already has
+                // PauseWriterThreshold bytes in-flight across Slic-owned buffers.
+                int localCredit = 0;
+                if (!source1.IsEmpty || !source2.IsEmpty)
+                {
+                    localCredit = await stream.AcquireLocalCreditAsync(writeCts.Token).ConfigureAwait(false);
+                    Debug.Assert(localCredit > 0);
+                }
+
+                // Next, ensure protocol send credit is available. If not, this will block until the receiver
+                // allows sending additional data.
                 int sendCredit = 0;
                 if (!source1.IsEmpty || !source2.IsEmpty)
                 {
@@ -763,8 +781,8 @@ internal class SlicConnection : IMultiplexedConnection
                     Debug.Assert(sendCredit > 0);
                 }
 
-                // Gather data from source1 or source2 up to sendCredit bytes or the peer maximum stream frame size.
-                int sendMaxSize = Math.Min(sendCredit, PeerMaxStreamFrameSize);
+                // Gather data from source1 or source2 up to the minimum of all three limits.
+                int sendMaxSize = Math.Min(Math.Min(localCredit, sendCredit), PeerMaxStreamFrameSize);
                 ReadOnlySequence<byte> sendSource1;
                 ReadOnlySequence<byte> sendSource2;
                 if (!source1.IsEmpty)
@@ -791,6 +809,7 @@ internal class SlicConnection : IMultiplexedConnection
 
                 // If there's no data left to send and endStream is true, it's the last stream frame.
                 bool lastStreamFrame = endStream && source1.IsEmpty && source2.IsEmpty;
+                int payloadSize = (int)(sendSource1.Length + sendSource2.Length);
 
                 lock (_mutex)
                 {
@@ -813,15 +832,21 @@ internal class SlicConnection : IMultiplexedConnection
                         }
                     }
 
-                    // Notify the stream that we're consuming sendSize credit. It's important to call this before
-                    // sending the stream frame to avoid race conditions where the StreamWindowUpdate frame could be
-                    // received before the send credit was updated.
+                    // Consume protocol send credit. It's important to call this before sending the stream frame to
+                    // avoid race conditions where the StreamWindowUpdate frame could be received before the send
+                    // credit was updated.
                     if (sendCredit > 0)
                     {
-                        stream.ConsumedSendCredit((int)(sendSource1.Length + sendSource2.Length));
+                        stream.ConsumedSendCredit(payloadSize);
                     }
 
-                    EncodeStreamFrameHeader(stream.Id, sendSource1.Length + sendSource2.Length, lastStreamFrame);
+                    // Consume local buffering credit.
+                    if (localCredit > 0)
+                    {
+                        stream.ConsumedLocalCredit(payloadSize);
+                    }
+
+                    EncodeStreamFrameHeader(stream.Id, payloadSize, lastStreamFrame);
 
                     if (lastStreamFrame)
                     {
@@ -839,6 +864,13 @@ internal class SlicConnection : IMultiplexedConnection
                     if (!sendSource2.IsEmpty)
                     {
                         _duplexConnectionWriter.Write(sendSource2);
+                    }
+
+                    // Enqueue a completion callback to release local credit when these bytes have been written
+                    // to the duplex connection by the background writer task.
+                    if (payloadSize > 0)
+                    {
+                        _duplexConnectionWriter.EnqueueCompletion(payloadSize, stream.ReleasedLocalCredit);
                     }
 
                     if (writeReadsClosedFrame)
@@ -1181,8 +1213,30 @@ internal class SlicConnection : IMultiplexedConnection
                 (ref SliceDecoder decoder) => new PingBody(ref decoder),
                 cancellationToken).ConfigureAwait(false);
 
-            // Return a pong frame with the ping payload.
-            WriteConnectionFrame(FrameType.Pong, new PongBody(pingBody.Payload).Encode);
+            // Check if the peer is flooding Ping frames faster than we can drain Pong replies.
+            if (Interlocked.Increment(ref _pendingPongReplyCount) > MaxPendingPongReplies)
+            {
+                throw new IceRpcException(
+                    IceRpcError.ConnectionAborted,
+                    "The peer is sending Ping frames faster than Pong replies can be drained.");
+            }
+
+            // Return a pong frame with the ping payload and enqueue a completion entry to track when
+            // the Pong is actually written to the duplex connection.
+            lock (_mutex)
+            {
+                if (_isClosed)
+                {
+                    throw new IceRpcException(
+                        _peerCloseError ?? IceRpcError.ConnectionAborted,
+                        _closedMessage);
+                }
+                WriteFrame(FrameType.Pong, streamId: null, new PongBody(pingBody.Payload).Encode);
+                _duplexConnectionWriter.EnqueueCompletion(
+                    creditBytes: 0,
+                    releaseCredit: _ => Interlocked.Decrement(ref _pendingPongReplyCount));
+                _duplexConnectionWriter.Flush();
+            }
         }
 
         async Task ReadPongFrameAsync(int size, CancellationToken cancellationToken)

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
@@ -117,11 +117,11 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
             });
     }
 
-    /// <summary>Enqueues a completion entry that releases per-stream local credit after the background writer has
-    /// written the corresponding bytes to the duplex connection.</summary>
+    /// <summary>Enqueues a completion entry that will be invoked after the background writer has written the
+    /// corresponding bytes to the duplex connection.</summary>
     /// <remarks>Must be called under SlicConnection._mutex, after writing the frame data.</remarks>
-    internal void EnqueueCompletion(int creditBytes, Action<int> releaseCredit) =>
-        _completionQueue.Enqueue(new CompletionEntry(_totalBytesEnqueued, creditBytes, releaseCredit));
+    internal void EnqueueCompletion(int creditBytes, ICompletionCallback target) =>
+        _completionQueue.Enqueue(new CompletionEntry(_totalBytesEnqueued, creditBytes, target));
 
     internal void Flush()
     {
@@ -142,12 +142,16 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
         while (_completionQueue.TryPeek(out CompletionEntry entry) && entry.PipeOffset <= bytesWrittenTotal)
         {
             _completionQueue.TryDequeue(out _);
-            entry.ReleaseCredit(entry.CreditBytes);
+            entry.Target.WriteCompleted(entry.CreditBytes);
         }
     }
 
-    private readonly record struct CompletionEntry(
-        long PipeOffset,
-        int CreditBytes,
-        Action<int> ReleaseCredit);
+    private readonly record struct CompletionEntry(long PipeOffset, int CreditBytes, ICompletionCallback Target);
+
+    /// <summary>A callback invoked when the background writer has written the corresponding bytes to the duplex
+    /// connection.</summary>
+    internal interface ICompletionCallback
+    {
+        void WriteCompleted(int creditBytes);
+    }
 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 
@@ -13,12 +14,21 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
 {
     internal Task WriterTask { get; private init; }
 
+    private readonly ConcurrentQueue<CompletionEntry> _completionQueue = new();
     private readonly IDuplexConnection _connection;
     private readonly CancellationTokenSource _disposeCts = new();
     private Task? _disposeTask;
     private readonly Pipe _pipe;
 
-    public void Advance(int bytes) => _pipe.Writer.Advance(bytes);
+    // Tracks the absolute byte position in the pipe. Incremented by Advance, which is always called under
+    // SlicConnection._mutex.
+    private long _totalBytesEnqueued;
+
+    public void Advance(int bytes)
+    {
+        _pipe.Writer.Advance(bytes);
+        _totalBytesEnqueued += bytes;
+    }
 
     /// <inheritdoc/>
     public ValueTask DisposeAsync()
@@ -54,9 +64,10 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
     {
         _connection = connection;
 
-        // We set pauseWriterThreshold to 0 because Slic implements flow-control at the stream level. So there's no need
-        // to limit the amount of data buffered by the writer pipe. The amount of data buffered is limited to
-        // (MaxBidirectionalStreams + MaxUnidirectionalStreams) * PeerPauseWriterThreshold bytes.
+        // We set pauseWriterThreshold to 0 because per-stream local buffering is bounded by PauseWriterThreshold in
+        // SlicPipeWriter, and we cannot await inside SlicConnection._mutex. The shared pipe remains an unbounded
+        // synchronous staging area. The total data buffered is bounded by
+        // PauseWriterThreshold * (MaxBidirectionalStreams + MaxUnidirectionalStreams) plus control frame overhead.
         _pipe = new Pipe(new PipeOptions(
             pool: pool,
             minimumSegmentSize: minimumSegmentSize,
@@ -66,6 +77,7 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
         WriterTask = Task.Run(
             async () =>
             {
+                long bytesWrittenTotal = 0;
                 try
                 {
                     while (true)
@@ -75,7 +87,10 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
                         if (!readResult.Buffer.IsEmpty)
                         {
                             await _connection.WriteAsync(readResult.Buffer, _disposeCts.Token).ConfigureAwait(false);
+                            bytesWrittenTotal += readResult.Buffer.Length;
                             _pipe.Reader.AdvanceTo(readResult.Buffer.End);
+
+                            DrainCompletionQueue(bytesWrittenTotal);
                         }
 
                         if (readResult.IsCompleted)
@@ -94,8 +109,19 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
                 {
                     _pipe.Reader.Complete(exception);
                 }
+                finally
+                {
+                    // Drain all remaining entries to unblock any waiting stream writers.
+                    DrainCompletionQueue(long.MaxValue);
+                }
             });
     }
+
+    /// <summary>Enqueues a completion entry that releases per-stream local credit after the background writer has
+    /// written the corresponding bytes to the duplex connection.</summary>
+    /// <remarks>Must be called under SlicConnection._mutex, after writing the frame data.</remarks>
+    internal void EnqueueCompletion(int creditBytes, Action<int> releaseCredit) =>
+        _completionQueue.Enqueue(new CompletionEntry(_totalBytesEnqueued, creditBytes, releaseCredit));
 
     internal void Flush()
     {
@@ -110,4 +136,18 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
     internal void Shutdown() =>
         // Completing the pipe writer makes the background write task complete successfully.
         _pipe.Writer.Complete();
+
+    private void DrainCompletionQueue(long bytesWrittenTotal)
+    {
+        while (_completionQueue.TryPeek(out CompletionEntry entry) && entry.PipeOffset <= bytesWrittenTotal)
+        {
+            _completionQueue.TryDequeue(out _);
+            entry.ReleaseCredit(entry.CreditBytes);
+        }
+    }
+
+    private readonly record struct CompletionEntry(
+        long PipeOffset,
+        int CreditBytes,
+        Action<int> ReleaseCredit);
 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -9,7 +9,7 @@ namespace IceRpc.Transports.Slic.Internal;
 
 // Type owns disposable field(s) '_completeWritesCts' and '_sendCreditSemaphore' but is not disposable
 #pragma warning disable CA1001
-internal class SlicPipeWriter : ReadOnlySequencePipeWriter
+internal class SlicPipeWriter : ReadOnlySequencePipeWriter, SlicDuplexConnectionWriter.ICompletionCallback
 #pragma warning restore CA1001
 {
     public override bool CanGetUnflushedBytes => true;
@@ -155,6 +155,10 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
             }
         }
     }
+
+    /// <inheritdoc/>
+    void SlicDuplexConnectionWriter.ICompletionCallback.WriteCompleted(int creditBytes) =>
+        ReleasedLocalCredit(creditBytes);
 
     internal SlicPipeWriter(SlicStream stream, SlicConnection connection)
     {

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -22,6 +22,9 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     private readonly CancellationTokenSource _completeWritesCts = new();
     private Exception? _exception;
     private bool _isCompleted;
+    private volatile int _localCredit;
+    // The semaphore is used to wait when local credit is exhausted (reaches 0).
+    private readonly SemaphoreSlim _localCreditSemaphore = new(1, 1);
     private volatile int _peerWindowSize = SlicTransportOptions.MaxWindowSize;
     private readonly Pipe _pipe;
     // The semaphore is used when flow control is enabled to wait for additional send credit to be available.
@@ -156,6 +159,7 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     internal SlicPipeWriter(SlicStream stream, SlicConnection connection)
     {
         _stream = stream;
+        _localCredit = connection.PauseWriterThreshold;
         _peerWindowSize = connection.PeerInitialStreamWindowSize;
 
         // Create a pipe that never pauses on flush or write. The SlicePipeWriter will pause the flush or write if
@@ -227,6 +231,42 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
         {
             Debug.Assert(_sendCreditSemaphore.CurrentCount == 0);
             _sendCreditSemaphore.Release();
+        }
+    }
+
+    /// <summary>Waits until local buffering credit is available and returns the current amount.</summary>
+    /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>The available local credit in bytes.</returns>
+    internal async ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken)
+    {
+        await _localCreditSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return _localCredit;
+    }
+
+    /// <summary>Decrements local credit by the actual frame payload size.</summary>
+    /// <param name="size">The payload size of the frame.</param>
+    /// <remarks>Must be called while the local credit semaphore is held.</remarks>
+    internal void ConsumedLocalCredit(int size)
+    {
+        Debug.Assert(_localCreditSemaphore.CurrentCount == 0);
+
+        int newLocalCredit = Interlocked.Add(ref _localCredit, -size);
+        if (newLocalCredit > 0)
+        {
+            _localCreditSemaphore.Release();
+        }
+    }
+
+    /// <summary>Returns local credit when the shared writer confirms bytes have been written to the duplex
+    /// connection. Called from the background WriterTask.</summary>
+    /// <param name="size">The payload size to release.</param>
+    internal void ReleasedLocalCredit(int size)
+    {
+        int newLocalCredit = Interlocked.Add(ref _localCredit, size);
+        int previousLocalCredit = newLocalCredit - size;
+        if (previousLocalCredit <= 0 && newLocalCredit > 0)
+        {
+            _localCreditSemaphore.Release();
         }
     }
 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -277,6 +277,9 @@ internal class SlicStream : IMultiplexedStream
 
     internal void ReleasedLocalCredit(int size) => _outputPipeWriter!.ReleasedLocalCredit(size);
 
+    /// <summary>Gets the output pipe writer as a completion callback for the shared writer.</summary>
+    internal SlicDuplexConnectionWriter.ICompletionCallback OutputCompletionCallback => _outputPipeWriter!;
+
     /// <summary>Fills the given writer with stream data received on the connection.</summary>
     /// <param name="bufferWriter">The destination buffer writer.</param>
     /// <param name="byteCount">The amount of stream data to read.</param>

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -103,6 +103,9 @@ internal class SlicStream : IMultiplexedStream
     /// cref="FrameType.StreamLast"/> frame to ensure enough send credit is available. If no send credit is available,
     /// it will block until send credit is available. The send credit matches the size of the peer's flow-control
     /// window.</remarks>
+    internal ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken) =>
+        _outputPipeWriter!.AcquireLocalCreditAsync(cancellationToken);
+
     internal ValueTask<int> AcquireSendCreditAsync(CancellationToken cancellationToken) =>
         _outputPipeWriter!.AcquireSendCreditAsync(cancellationToken);
 
@@ -268,7 +271,11 @@ internal class SlicStream : IMultiplexedStream
     /// <summary>Notifies the stream of the amount of data consumed by the connection to send a <see
     /// cref="FrameType.Stream" /> or <see cref="FrameType.StreamLast" /> frame.</summary>
     /// <param name="size">The size of the stream frame.</param>
+    internal void ConsumedLocalCredit(int size) => _outputPipeWriter!.ConsumedLocalCredit(size);
+
     internal void ConsumedSendCredit(int size) => _outputPipeWriter!.ConsumedSendCredit(size);
+
+    internal void ReleasedLocalCredit(int size) => _outputPipeWriter!.ReleasedLocalCredit(size);
 
     /// <summary>Fills the given writer with stream data received on the connection.</summary>
     /// <param name="bufferWriter">The destination buffer writer.</param>

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -38,6 +38,28 @@ public sealed record class SlicTransportOptions
             value;
     }
 
+    /// <summary>Gets or sets the pause writer threshold. It defines the maximum amount of outbound stream payload
+    /// data in bytes that Slic will buffer locally for a single stream before
+    /// <see cref="System.IO.Pipelines.PipeWriter.WriteAsync" /> or
+    /// <see cref="System.IO.Pipelines.PipeWriter.FlushAsync" /> starts blocking. This limit is independent of the
+    /// peer's advertised <see cref="InitialStreamWindowSize" />.</summary>
+    /// <value>The pause writer threshold in bytes. It can't be less than <c>1</c> KB. Defaults to <c>64</c> KB.
+    /// </value>
+    public int PauseWriterThreshold
+    {
+        get => _pauseWriterThreshold;
+        set
+        {
+            if (value < 1024)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(PauseWriterThreshold)} value cannot be less than 1 KB.",
+                    nameof(value));
+            }
+            _pauseWriterThreshold = value;
+        }
+    }
+
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
     /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB. Defaults to <c>32</c>
     /// KB.</value>
@@ -57,4 +79,5 @@ public sealed record class SlicTransportOptions
     // The default specified in the HTTP/2 specification.
     private int _initialStreamWindowSize = 65_536;
     private int _maxStreamFrameSize = 32_768;
+    private int _pauseWriterThreshold = 65_536;
 }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1517,22 +1517,28 @@ public class SlicTransportTests
         await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
         await writeCalledTask;
 
-        // Act: now flood 20 Ping frames. The WriterTask is blocked, so all Pong replies pile up in the
-        // shared writer. After 16+ pending Pongs, the server closes the connection.
-        for (int i = 0; i < 20; i++)
+        try
         {
-            await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
+            // Act: now flood 20 Ping frames. The WriterTask is blocked, so all Pong replies pile up in
+            // the shared writer. After 16+ pending Pongs, the server closes the connection.
+            for (int i = 0; i < 20; i++)
+            {
+                await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
+            }
+
+            // Assert: the server connection should close due to the pending Pong reply limit.
+            IceRpcException? exception =
+                Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+            Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+            Assert.That(
+                exception.Message,
+                Does.Contain("Ping frames faster than Pong replies can be drained"));
         }
-
-        // Assert: the server connection should close due to the pending Pong reply limit.
-        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
-        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
-        Assert.That(
-            exception.Message,
-            Does.Contain("Ping frames faster than Pong replies can be drained"));
-
-        // Release the held write to allow cleanup.
-        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.None;
+        finally
+        {
+            // Release the held write to allow cleanup even when the test fails early.
+            serverDuplexConnection.Operations.Hold = DuplexTransportOperations.None;
+        }
     }
 
     private static Task WriteStreamFrameAsync(

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
-using IceRpc.Transports.Coloc;
 using IceRpc.Transports.Internal;
 using IceRpc.Transports.Slic;
 using IceRpc.Transports.Slic.Internal;
@@ -1478,22 +1477,17 @@ public class SlicTransportTests
     }
 
     [Test]
-    [CancelAfter(30_000)]
     public async Task Ping_flood_closes_connection()
     {
-        // Arrange: use a low coloc PauseWriterThreshold so the shared writer's background task blocks once
-        // the coloc pipe fills up with unread Pong replies. Use a high idle timeout so it doesn't interfere.
-        IServiceCollection services = new ServiceCollection()
-            .AddMultiplexedTransportTest()
-            .AddSingleton(new ColocTransportOptions { PauseWriterThreshold = 1024, ResumeWriterThreshold = 1024 })
-            .AddColocTransport()
-            .AddSlicTransport();
-        services.AddOptions<SlicTransportOptions>("server").Configure(
-            options => options.IdleTimeout = TimeSpan.FromMinutes(10));
-
-        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        // Arrange: use the test duplex transport decorator to hold the server's writes after the
+        // Slic handshake. This deterministically blocks the WriterTask, so Pong replies pile up.
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .AddTestDuplexTransportDecorator()
+            .BuildServiceProvider(validateScopes: true);
 
         var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var serverTransportDecorator = provider.GetRequiredService<TestDuplexServerTransportDecorator>();
         var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
         var acceptTask = listener.AcceptAsync(default);
         using var duplexClientConnection = duplexClientTransport.CreateConnection(
@@ -1501,8 +1495,8 @@ public class SlicTransportTests
             new DuplexConnectionOptions(),
             clientAuthenticationOptions: null);
         Task connectTask = duplexClientConnection.ConnectAsync(default);
-        (var multiplexedServerConnection, var serverConnectionInfo) = await acceptTask;
-        await using var __ = multiplexedServerConnection;
+        (var multiplexedServerConnection, _) = await acceptTask;
+        await using var serverConnection = multiplexedServerConnection;
         await connectTask;
         using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
 
@@ -1511,31 +1505,34 @@ public class SlicTransportTests
         await multiplexedServerConnection.ConnectAsync(default);
         await ReadFrameAsync(reader);
 
+        // Now hold the server's writes. The WriterTask will block on the next WriteAsync, preventing
+        // completion callbacks from firing.
+        var serverDuplexConnection = serverTransportDecorator.LastAcceptedConnection;
+        Task writeCalledTask = serverDuplexConnection.Operations.GetCalledTask(DuplexTransportOperations.Write);
+        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.Write;
+
         ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
 
-        // Act: flood Ping frames in a background task without reading Pong replies. Each Pong is ~8-12
-        // bytes. The 1 KB coloc pipe fills after ~100 Pongs, the WriterTask blocks, and subsequent Pong
-        // replies pile up in the shared writer until MaxPendingPongReplies (16) is exceeded.
-        // We use a background task because the client->server coloc pipe can also fill up, blocking the
-        // client's WriteAsync. The server connection should close before we exhaust all 500 pings.
-        _ = Task.Run(async () =>
+        // Send one Ping to trigger a Pong write attempt, then wait for the write to be held.
+        await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
+        await writeCalledTask;
+
+        // Act: now flood 20 Ping frames. The WriterTask is blocked, so all Pong replies pile up in the
+        // shared writer. After 16+ pending Pongs, the server closes the connection.
+        for (int i = 0; i < 20; i++)
         {
-            try
-            {
-                for (int i = 0; i < 500; i++)
-                {
-                    await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
-                }
-            }
-            catch
-            {
-                // Expected: the connection closes while we're writing.
-            }
-        });
+            await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
+        }
 
         // Assert: the server connection should close due to the pending Pong reply limit.
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
         Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
+        Assert.That(
+            exception.Message,
+            Does.Contain("Ping frames faster than Pong replies can be drained"));
+
+        // Release the held write to allow cleanup.
+        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.None;
     }
 
     private static Task WriteStreamFrameAsync(

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Tests.Common;
 using IceRpc.Transports;
+using IceRpc.Transports.Coloc;
 using IceRpc.Transports.Internal;
 using IceRpc.Transports.Slic;
 using IceRpc.Transports.Slic.Internal;
@@ -1474,6 +1475,67 @@ public class SlicTransportTests
         // Assert: both writes complete.
         await writeTask1;
         await writeTask2;
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public async Task Ping_flood_closes_connection()
+    {
+        // Arrange: use a low coloc PauseWriterThreshold so the shared writer's background task blocks once
+        // the coloc pipe fills up with unread Pong replies. Use a high idle timeout so it doesn't interfere.
+        IServiceCollection services = new ServiceCollection()
+            .AddMultiplexedTransportTest()
+            .AddSingleton(new ColocTransportOptions { PauseWriterThreshold = 1024, ResumeWriterThreshold = 1024 })
+            .AddColocTransport()
+            .AddSlicTransport();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.IdleTimeout = TimeSpan.FromMinutes(10));
+
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var serverConnectionInfo) = await acceptTask;
+        await using var __ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Complete the Slic handshake.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Act: flood Ping frames in a background task without reading Pong replies. Each Pong is ~8-12
+        // bytes. The 1 KB coloc pipe fills after ~100 Pongs, the WriterTask blocks, and subsequent Pong
+        // replies pile up in the shared writer until MaxPendingPongReplies (16) is exceeded.
+        // We use a background task because the client->server coloc pipe can also fill up, blocking the
+        // client's WriteAsync. The server connection should close before we exhaust all 500 pings.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                for (int i = 0; i < 500; i++)
+                {
+                    await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0).Encode);
+                }
+            }
+            catch
+            {
+                // Expected: the connection closes while we're writing.
+            }
+        });
+
+        // Assert: the server connection should close due to the pending Pong reply limit.
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.ConnectionAborted));
     }
 
     private static Task WriteStreamFrameAsync(

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1343,6 +1343,139 @@ public class SlicTransportTests
         }
     }
 
+    [Test]
+    public void PauseWriterThreshold_default_value()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(options.PauseWriterThreshold, Is.EqualTo(65_536));
+    }
+
+    [Test]
+    public void PauseWriterThreshold_below_minimum_throws()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.PauseWriterThreshold = 1023, Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void PauseWriterThreshold_at_minimum_succeeds()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.PauseWriterThreshold = 1024, Throws.Nothing);
+        Assert.That(options.PauseWriterThreshold, Is.EqualTo(1024));
+    }
+
+    [Test]
+    public async Task Large_write_completes_with_small_pause_writer_threshold()
+    {
+        // Arrange: peer advertises a large window (256 KB) but local PauseWriterThreshold is small (8 KB).
+        // The write of 256 KB must be chunked through the PauseWriterThreshold without deadlocking.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 256 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 8 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: write a payload much larger than PauseWriterThreshold.
+        byte[] payload = new byte[256 * 1024];
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, default);
+
+        // The peer reads everything.
+        int totalRead = 0;
+        while (totalRead < payload.Length)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAtLeastAsync(1);
+            totalRead += (int)readResult.Buffer.Length;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+
+        // Assert: the write completes without deadlock and all bytes are received.
+        await writeTask;
+        Assert.That(totalRead, Is.EqualTo(payload.Length));
+    }
+
+    [TestCase(1024)]
+    [TestCase(4 * 1024)]
+    [TestCase(64 * 1024)]
+    public async Task Write_completes_with_various_pause_writer_thresholds(int threshold)
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = threshold);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: write a payload larger than PauseWriterThreshold.
+        byte[] payload = new byte[64 * 1024];
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, default);
+
+        int totalRead = 0;
+        while (totalRead < payload.Length)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAtLeastAsync(1);
+            totalRead += (int)readResult.Buffer.Length;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+
+        // Assert
+        await writeTask;
+        Assert.That(totalRead, Is.EqualTo(payload.Length));
+    }
+
+    [Test]
+    public async Task Concurrent_streams_with_small_pause_writer_threshold()
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 8 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams1 = await sut.CreateAndAcceptStreamAsync();
+        using var streams2 = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: both streams write concurrently.
+        byte[] payload = new byte[32 * 1024];
+
+        ValueTask<FlushResult> writeTask1 = streams1.Local.Output.WriteAsync(payload, default);
+        ValueTask<FlushResult> writeTask2 = streams2.Local.Output.WriteAsync(payload, default);
+
+        // Read from both streams concurrently.
+        async Task ReadAllAsync(PipeReader reader, int expectedBytes)
+        {
+            int totalRead = 0;
+            while (totalRead < expectedBytes)
+            {
+                ReadResult readResult = await reader.ReadAtLeastAsync(1);
+                totalRead += (int)readResult.Buffer.Length;
+                reader.AdvanceTo(readResult.Buffer.End);
+            }
+        }
+
+        await Task.WhenAll(
+            ReadAllAsync(streams1.Remote.Input, payload.Length),
+            ReadAllAsync(streams2.Remote.Input, payload.Length));
+
+        // Assert: both writes complete.
+        await writeTask1;
+        await writeTask2;
+    }
+
     private static Task WriteStreamFrameAsync(
         IDuplexConnection connection,
         FrameType frameType,

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -909,6 +909,91 @@ public class SlicTransportTests
         duplexClientConnection.Operations.Hold = DuplexTransportOperations.None;
     }
 
+    /// <summary>Verifies that a write blocked on peer-granted send credit (peer window exhausted) can be
+    /// canceled.</summary>
+    [Test]
+    public async Task Stream_write_cancellation_while_blocked_on_peer_credit()
+    {
+        // Arrange: use a small peer window so it's easy to exhaust.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 4 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Exhaust the peer's window without reading.
+        byte[] payload = new byte[4 * 1024 - 1];
+        _ = await streams.Local.Output.WriteAsync(payload, default);
+
+        using var writeCts = new CancellationTokenSource();
+
+        // Act: the next write blocks on AcquireSendCreditAsync because the peer window is exhausted.
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, writeCts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(writeTask.IsCompleted, Is.False);
+        writeCts.Cancel();
+
+        // Assert
+        Assert.That(
+            async () => await writeTask,
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    /// <summary>Verifies that a write blocked on local buffering credit (PauseWriterThreshold exhausted) can be
+    /// canceled.</summary>
+    [Test]
+    public async Task Stream_write_cancellation_while_blocked_on_local_credit()
+    {
+        // Arrange: use a small PauseWriterThreshold and hold the duplex Write so local credit is never
+        // released by the background writer.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 4 * 1024);
+        services.AddTestDuplexTransportDecorator();
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        var duplexClientConnection =
+            provider.GetRequiredService<TestDuplexClientTransportDecorator>().LastCreatedConnection;
+
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Write once to consume local credit, then hold duplex writes so the background writer can't
+        // drain and release local credit.
+        _ = await streams.Local.Output.WriteAsync(new byte[4 * 1024 - 1], default);
+        duplexClientConnection.Operations.Hold = DuplexTransportOperations.Write;
+
+        using var writeCts = new CancellationTokenSource();
+
+        try
+        {
+            // Act: the next write blocks on AcquireLocalCreditAsync because local credit is exhausted
+            // (the held duplex Write prevents completion callbacks from releasing it).
+            ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(
+                new byte[4 * 1024 - 1],
+                writeCts.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+            Assert.That(writeTask.IsCompleted, Is.False);
+            writeCts.Cancel();
+
+            // Assert
+            Assert.That(
+                async () => await writeTask,
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+        finally
+        {
+            duplexClientConnection.Operations.Hold = DuplexTransportOperations.None;
+        }
+    }
+
     [Test]
     public async Task Reject_slic_control_frame_with_oversized_body()
     {


### PR DESCRIPTION
## Summary

- Add a configurable `PauseWriterThreshold` option (default 64 KB) to `SlicTransportOptions` that limits how much outbound stream payload data Slic buffers locally per stream, independent of the peer's advertised flow control window.
- Introduce per-stream local credit tracking with completion callbacks on the shared `SlicDuplexConnectionWriter`. Local credit is only released after bytes are written to the underlying `IDuplexConnection`, not when they move between Slic-internal buffers.
- Add ping flood protection: the connection is closed if more than 16 Pong replies are pending in the shared writer, preventing a malicious peer from causing unbounded control-frame buffering.

Related: icerpc/icerpc-csharp-audit#15