### PR TITLE
Add PauseWriterThreshold to bound per-stream Slic outbound buffering

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -38,6 +38,9 @@ internal class SlicConnection : IMultiplexedConnection
     /// <summary>Gets the initial stream window size.</summary>
     internal int InitialStreamWindowSize { get; }
 
+    /// <summary>Gets the pause writer threshold for per-stream local buffering.</summary>
+    internal int PauseWriterThreshold { get; }
+
     /// <summary>Gets the window update threshold. When the window size is increased and this threshold reached, a <see
     /// cref="FrameType.StreamWindowUpdate" /> frame is sent.</summary>
     internal int StreamWindowUpdateThreshold => InitialStreamWindowSize / StreamWindowUpdateRatio;
@@ -537,6 +540,7 @@ internal class SlicConnection : IMultiplexedConnection
         _maxUnidirectionalStreams = options.MaxUnidirectionalStreams;
 
         InitialStreamWindowSize = slicOptions.InitialStreamWindowSize;
+        PauseWriterThreshold = slicOptions.PauseWriterThreshold;
         _localIdleTimeout = slicOptions.IdleTimeout;
         _maxStreamFrameSize = slicOptions.MaxStreamFrameSize;
 
@@ -754,13 +758,19 @@ internal class SlicConnection : IMultiplexedConnection
         {
             do
             {
-                // Next, ensure send credit is available. If not, this will block until the receiver allows sending
-                // additional data.
                 int sendCredit = 0;
                 if (!source1.IsEmpty || !source2.IsEmpty)
                 {
-                    sendCredit = await stream.AcquireSendCreditAsync(writeCts.Token).ConfigureAwait(false);
-                    Debug.Assert(sendCredit > 0);
+                    // Wait for local buffering credit. This blocks if this stream already has PauseWriterThreshold
+                    // bytes in-flight across Slic-owned buffers.
+                    int localCredit = await stream.AcquireLocalCreditAsync(writeCts.Token).ConfigureAwait(false);
+                    Debug.Assert(localCredit > 0);
+
+                    // Wait for peer-granted send credit. This blocks if the peer's flow-control window is exhausted.
+                    int peerCredit = await stream.AcquireSendCreditAsync(writeCts.Token).ConfigureAwait(false);
+                    Debug.Assert(peerCredit > 0);
+
+                    sendCredit = Math.Min(localCredit, peerCredit);
                 }
 
                 // Gather data from source1 or source2 up to sendCredit bytes or the peer maximum stream frame size.
@@ -791,6 +801,7 @@ internal class SlicConnection : IMultiplexedConnection
 
                 // If there's no data left to send and endStream is true, it's the last stream frame.
                 bool lastStreamFrame = endStream && source1.IsEmpty && source2.IsEmpty;
+                int payloadSize = (int)(sendSource1.Length + sendSource2.Length);
 
                 lock (_mutex)
                 {
@@ -813,15 +824,16 @@ internal class SlicConnection : IMultiplexedConnection
                         }
                     }
 
-                    // Notify the stream that we're consuming sendSize credit. It's important to call this before
-                    // sending the stream frame to avoid race conditions where the StreamWindowUpdate frame could be
-                    // received before the send credit was updated.
+                    // Consume peer-granted and local buffering credit. It's important to consume
+                    // peer credit before sending the stream frame to avoid race conditions where the
+                    // StreamWindowUpdate frame could be received before the send credit was updated.
                     if (sendCredit > 0)
                     {
-                        stream.ConsumedSendCredit((int)(sendSource1.Length + sendSource2.Length));
+                        stream.ConsumedSendCredit(payloadSize);
+                        stream.ConsumedLocalCredit(payloadSize);
                     }
 
-                    EncodeStreamFrameHeader(stream.Id, sendSource1.Length + sendSource2.Length, lastStreamFrame);
+                    EncodeStreamFrameHeader(stream.Id, payloadSize, lastStreamFrame);
 
                     if (lastStreamFrame)
                     {
@@ -839,6 +851,13 @@ internal class SlicConnection : IMultiplexedConnection
                     if (!sendSource2.IsEmpty)
                     {
                         _duplexConnectionWriter.Write(sendSource2);
+                    }
+
+                    // Enqueue a completion callback to release local credit when these bytes have been written to the
+                    // duplex connection by the background writer task.
+                    if (payloadSize > 0)
+                    {
+                        _duplexConnectionWriter.EnqueueCompletion(payloadSize, stream.OutputCompletionCallback);
                     }
 
                     if (writeReadsClosedFrame)

--- a/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicDuplexConnectionWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 
@@ -13,12 +14,21 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
 {
     internal Task WriterTask { get; private init; }
 
+    private readonly ConcurrentQueue<CompletionEntry> _completionQueue = new();
     private readonly IDuplexConnection _connection;
     private readonly CancellationTokenSource _disposeCts = new();
     private Task? _disposeTask;
     private readonly Pipe _pipe;
 
-    public void Advance(int bytes) => _pipe.Writer.Advance(bytes);
+    // Tracks the absolute byte position in the pipe. Incremented by Advance, which is always called under
+    // SlicConnection._mutex.
+    private long _totalBytesEnqueued;
+
+    public void Advance(int bytes)
+    {
+        _pipe.Writer.Advance(bytes);
+        _totalBytesEnqueued += bytes;
+    }
 
     /// <inheritdoc/>
     public ValueTask DisposeAsync()
@@ -54,9 +64,10 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
     {
         _connection = connection;
 
-        // We set pauseWriterThreshold to 0 because Slic implements flow-control at the stream level. So there's no need
-        // to limit the amount of data buffered by the writer pipe. The amount of data buffered is limited to
-        // (MaxBidirectionalStreams + MaxUnidirectionalStreams) * PeerPauseWriterThreshold bytes.
+        // We set pauseWriterThreshold to 0 because per-stream local buffering is bounded by PauseWriterThreshold in
+        // SlicPipeWriter, and we cannot await inside SlicConnection._mutex. The shared pipe remains an unbounded
+        // synchronous staging area. The total data buffered is bounded by
+        // PauseWriterThreshold * (MaxBidirectionalStreams + MaxUnidirectionalStreams) plus control frame overhead.
         _pipe = new Pipe(new PipeOptions(
             pool: pool,
             minimumSegmentSize: minimumSegmentSize,
@@ -66,6 +77,7 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
         WriterTask = Task.Run(
             async () =>
             {
+                long bytesWrittenTotal = 0;
                 try
                 {
                     while (true)
@@ -75,7 +87,10 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
                         if (!readResult.Buffer.IsEmpty)
                         {
                             await _connection.WriteAsync(readResult.Buffer, _disposeCts.Token).ConfigureAwait(false);
+                            bytesWrittenTotal += readResult.Buffer.Length;
                             _pipe.Reader.AdvanceTo(readResult.Buffer.End);
+
+                            DrainCompletionQueue(bytesWrittenTotal);
                         }
 
                         if (readResult.IsCompleted)
@@ -94,8 +109,19 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
                 {
                     _pipe.Reader.Complete(exception);
                 }
+                finally
+                {
+                    // Drain all remaining entries to unblock any waiting stream writers.
+                    DrainCompletionQueue(long.MaxValue);
+                }
             });
     }
+
+    /// <summary>Enqueues a completion entry that will be invoked after the background writer has written the
+    /// corresponding bytes to the duplex connection.</summary>
+    /// <remarks>Must be called under SlicConnection._mutex, after writing the frame data.</remarks>
+    internal void EnqueueCompletion(int creditBytes, ICompletionCallback target) =>
+        _completionQueue.Enqueue(new CompletionEntry(_totalBytesEnqueued, creditBytes, target));
 
     internal void Flush()
     {
@@ -110,4 +136,22 @@ internal class SlicDuplexConnectionWriter : IBufferWriter<byte>, IAsyncDisposabl
     internal void Shutdown() =>
         // Completing the pipe writer makes the background write task complete successfully.
         _pipe.Writer.Complete();
+
+    private void DrainCompletionQueue(long bytesWrittenTotal)
+    {
+        while (_completionQueue.TryPeek(out CompletionEntry entry) && entry.PipeOffset <= bytesWrittenTotal)
+        {
+            _completionQueue.TryDequeue(out _);
+            entry.Target.WriteCompleted(entry.CreditBytes);
+        }
+    }
+
+    private readonly record struct CompletionEntry(long PipeOffset, int CreditBytes, ICompletionCallback Target);
+
+    /// <summary>A callback invoked when the background writer has written the corresponding bytes to the duplex
+    /// connection.</summary>
+    internal interface ICompletionCallback
+    {
+        void WriteCompleted(int creditBytes);
+    }
 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -22,10 +22,10 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter, SlicDuplexConnection
     private readonly CancellationTokenSource _completeWritesCts = new();
     private Exception? _exception;
     private bool _isCompleted;
-    private volatile int _localCredit;
+    private int _localCredit;
     // The semaphore is used to wait when local credit is exhausted (reaches 0).
     private readonly SemaphoreSlim _localCreditSemaphore = new(1, 1);
-    private volatile int _peerWindowSize = SlicTransportOptions.MaxWindowSize;
+    private int _peerWindowSize = SlicTransportOptions.MaxWindowSize;
     private readonly Pipe _pipe;
     // The semaphore is used when flow control is enabled to wait for additional send credit to be available.
     private readonly SemaphoreSlim _sendCreditSemaphore = new(1, 1);

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -9,7 +9,7 @@ namespace IceRpc.Transports.Slic.Internal;
 
 // Type owns disposable field(s) '_completeWritesCts' and '_sendCreditSemaphore' but is not disposable
 #pragma warning disable CA1001
-internal class SlicPipeWriter : ReadOnlySequencePipeWriter
+internal class SlicPipeWriter : ReadOnlySequencePipeWriter, SlicDuplexConnectionWriter.ICompletionCallback
 #pragma warning restore CA1001
 {
     public override bool CanGetUnflushedBytes => true;
@@ -22,6 +22,9 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     private readonly CancellationTokenSource _completeWritesCts = new();
     private Exception? _exception;
     private bool _isCompleted;
+    private volatile int _localCredit;
+    // The semaphore is used to wait when local credit is exhausted (reaches 0).
+    private readonly SemaphoreSlim _localCreditSemaphore = new(1, 1);
     private volatile int _peerWindowSize = SlicTransportOptions.MaxWindowSize;
     private readonly Pipe _pipe;
     // The semaphore is used when flow control is enabled to wait for additional send credit to be available.
@@ -153,9 +156,14 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
         }
     }
 
+    /// <inheritdoc/>
+    void SlicDuplexConnectionWriter.ICompletionCallback.WriteCompleted(int creditBytes) =>
+        ReleasedLocalCredit(creditBytes);
+
     internal SlicPipeWriter(SlicStream stream, SlicConnection connection)
     {
         _stream = stream;
+        _localCredit = connection.PauseWriterThreshold;
         _peerWindowSize = connection.PeerInitialStreamWindowSize;
 
         // Create a pipe that never pauses on flush or write. The SlicePipeWriter will pause the flush or write if
@@ -227,6 +235,42 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
         {
             Debug.Assert(_sendCreditSemaphore.CurrentCount == 0);
             _sendCreditSemaphore.Release();
+        }
+    }
+
+    /// <summary>Waits until local buffering credit is available and returns the current amount.</summary>
+    /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>The available local credit in bytes.</returns>
+    internal async ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken)
+    {
+        await _localCreditSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return _localCredit;
+    }
+
+    /// <summary>Decrements local credit by the actual frame payload size.</summary>
+    /// <param name="size">The payload size of the frame.</param>
+    /// <remarks>Must be called while the local credit semaphore is held.</remarks>
+    internal void ConsumedLocalCredit(int size)
+    {
+        Debug.Assert(_localCreditSemaphore.CurrentCount == 0);
+
+        int newLocalCredit = Interlocked.Add(ref _localCredit, -size);
+        if (newLocalCredit > 0)
+        {
+            _localCreditSemaphore.Release();
+        }
+    }
+
+    /// <summary>Returns local credit when the shared writer confirms bytes have been written to the duplex
+    /// connection. Called from the background WriterTask.</summary>
+    /// <param name="size">The payload size to release.</param>
+    internal void ReleasedLocalCredit(int size)
+    {
+        int newLocalCredit = Interlocked.Add(ref _localCredit, size);
+        int previousLocalCredit = newLocalCredit - size;
+        if (previousLocalCredit <= 0 && newLocalCredit > 0)
+        {
+            _localCreditSemaphore.Release();
         }
     }
 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -96,6 +96,15 @@ internal class SlicStream : IMultiplexedStream
         }
     }
 
+    /// <summary>Acquires local buffering credit.</summary>
+    /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>The available local credit in bytes.</returns>
+    /// <remarks>This method blocks if this stream already has <see cref="SlicTransportOptions.PauseWriterThreshold"/>
+    /// bytes in-flight across Slic-owned buffers. Local credit is released when the shared writer confirms the bytes
+    /// have been written to the underlying duplex connection.</remarks>
+    internal ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken) =>
+        _outputPipeWriter!.AcquireLocalCreditAsync(cancellationToken);
+
     /// <summary>Acquires send credit.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The available send credit.</returns>
@@ -103,9 +112,6 @@ internal class SlicStream : IMultiplexedStream
     /// cref="FrameType.StreamLast"/> frame to ensure enough send credit is available. If no send credit is available,
     /// it will block until send credit is available. The send credit matches the size of the peer's flow-control
     /// window.</remarks>
-    internal ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken) =>
-        _outputPipeWriter!.AcquireLocalCreditAsync(cancellationToken);
-
     internal ValueTask<int> AcquireSendCreditAsync(CancellationToken cancellationToken) =>
         _outputPipeWriter!.AcquireSendCreditAsync(cancellationToken);
 

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -103,6 +103,9 @@ internal class SlicStream : IMultiplexedStream
     /// cref="FrameType.StreamLast"/> frame to ensure enough send credit is available. If no send credit is available,
     /// it will block until send credit is available. The send credit matches the size of the peer's flow-control
     /// window.</remarks>
+    internal ValueTask<int> AcquireLocalCreditAsync(CancellationToken cancellationToken) =>
+        _outputPipeWriter!.AcquireLocalCreditAsync(cancellationToken);
+
     internal ValueTask<int> AcquireSendCreditAsync(CancellationToken cancellationToken) =>
         _outputPipeWriter!.AcquireSendCreditAsync(cancellationToken);
 
@@ -268,7 +271,14 @@ internal class SlicStream : IMultiplexedStream
     /// <summary>Notifies the stream of the amount of data consumed by the connection to send a <see
     /// cref="FrameType.Stream" /> or <see cref="FrameType.StreamLast" /> frame.</summary>
     /// <param name="size">The size of the stream frame.</param>
+    internal void ConsumedLocalCredit(int size) => _outputPipeWriter!.ConsumedLocalCredit(size);
+
     internal void ConsumedSendCredit(int size) => _outputPipeWriter!.ConsumedSendCredit(size);
+
+    internal void ReleasedLocalCredit(int size) => _outputPipeWriter!.ReleasedLocalCredit(size);
+
+    /// <summary>Gets the output pipe writer as a completion callback for the shared writer.</summary>
+    internal SlicDuplexConnectionWriter.ICompletionCallback OutputCompletionCallback => _outputPipeWriter!;
 
     /// <summary>Fills the given writer with stream data received on the connection.</summary>
     /// <param name="bufferWriter">The destination buffer writer.</param>

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -38,6 +38,28 @@ public sealed record class SlicTransportOptions
             value;
     }
 
+    /// <summary>Gets or sets the pause writer threshold. It defines the maximum amount of outbound stream payload
+    /// data in bytes that Slic will buffer locally for a single stream before
+    /// <see cref="System.IO.Pipelines.PipeWriter.WriteAsync" /> or
+    /// <see cref="System.IO.Pipelines.PipeWriter.FlushAsync" /> starts blocking. This limit is independent of the
+    /// peer's advertised <see cref="InitialStreamWindowSize" />.</summary>
+    /// <value>The pause writer threshold in bytes. It can't be less than <c>1</c> KB. Defaults to <c>64</c> KB.
+    /// </value>
+    public int PauseWriterThreshold
+    {
+        get => _pauseWriterThreshold;
+        set
+        {
+            if (value < 1024)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(PauseWriterThreshold)} value cannot be less than 1 KB.",
+                    nameof(value));
+            }
+            _pauseWriterThreshold = value;
+        }
+    }
+
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
     /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB. Defaults to <c>32</c>
     /// KB.</value>
@@ -57,4 +79,5 @@ public sealed record class SlicTransportOptions
     // The default specified in the HTTP/2 specification.
     private int _initialStreamWindowSize = 65_536;
     private int _maxStreamFrameSize = 32_768;
+    private int _pauseWriterThreshold = 65_536;
 }

--- a/tests/IceRpc.Tests.Common/TestDuplexTransportDecorator.cs
+++ b/tests/IceRpc.Tests.Common/TestDuplexTransportDecorator.cs
@@ -39,6 +39,9 @@ public record class DuplexTransportOperationsOptions : TransportOperationsOption
 {
     /// <summary>The connection read decorator.</summary>
     public Func<IDuplexConnection, Memory<byte>, CancellationToken, ValueTask<int>>? ReadDecorator { get; set; }
+
+    /// <summary>The connection write decorator.</summary>
+    public Func<IDuplexConnection, ReadOnlySequence<byte>, CancellationToken, ValueTask>? WriteDecorator { get; set; }
 }
 
 /// <summary>A <see cref="IDuplexClientTransport" /> decorator to create decorated <see cref="IDuplexConnection" />
@@ -216,6 +219,7 @@ public sealed class TestDuplexConnectionDecorator : IDuplexConnection
 
     private readonly IDuplexConnection _decoratee;
     private readonly Func<IDuplexConnection, Memory<byte>, CancellationToken, ValueTask<int>>? _readDecorator;
+    private readonly Func<IDuplexConnection, ReadOnlySequence<byte>, CancellationToken, ValueTask>? _writeDecorator;
 
     /// <inheritdoc/>
     public Task<TransportConnectionInformation> ConnectAsync(CancellationToken cancellationToken) =>
@@ -247,7 +251,9 @@ public sealed class TestDuplexConnectionDecorator : IDuplexConnection
     public ValueTask WriteAsync(ReadOnlySequence<byte> buffer, CancellationToken cancellationToken) =>
         Operations.CallAsync(
             DuplexTransportOperations.Write,
-            () => _decoratee.WriteAsync(buffer, cancellationToken),
+            () => _writeDecorator is null ?
+                _decoratee.WriteAsync(buffer, cancellationToken) :
+                _writeDecorator(_decoratee, buffer, cancellationToken),
             cancellationToken);
 
     internal TestDuplexConnectionDecorator(
@@ -256,6 +262,7 @@ public sealed class TestDuplexConnectionDecorator : IDuplexConnection
     {
         _decoratee = decoratee;
         _readDecorator = operationsOptions.ReadDecorator;
+        _writeDecorator = operationsOptions.WriteDecorator;
         Operations = new(operationsOptions);
     }
 }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1561,6 +1561,73 @@ public class SlicTransportTests
         await writeTask2;
     }
 
+    /// <summary>Verifies that at most PauseWriterThreshold payload bytes are buffered in Slic-owned memory per
+    /// stream. A write decorator on the underlying duplex connection tracks the maximum payload bytes observed in
+    /// a single write, which must not exceed PauseWriterThreshold plus frame header overhead.</summary>
+    [Test]
+    public async Task Write_does_not_buffer_more_than_pause_writer_threshold()
+    {
+        // Arrange: use a small PauseWriterThreshold with a large peer window. Track the maximum bytes
+        // observed in a single duplex WriteAsync call via a write decorator.
+        int threshold = 4 * 1024;
+        long maxBytesWrittenAtOnce = 0;
+
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = threshold);
+        services.AddTestDuplexTransportDecorator(
+            clientOperationsOptions: new()
+            {
+                WriteDecorator = async (connection, buffer, cancellationToken) =>
+                {
+                    long length = buffer.Length;
+                    // Track the max bytes seen in a single write to the duplex connection.
+                    long current;
+                    do
+                    {
+                        current = Interlocked.Read(ref maxBytesWrittenAtOnce);
+                        if (length <= current)
+                        {
+                            break;
+                        }
+                    }
+                    while (Interlocked.CompareExchange(ref maxBytesWrittenAtOnce, length, current) != current);
+                    await connection.WriteAsync(buffer, cancellationToken);
+                }
+            });
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: write a payload much larger than PauseWriterThreshold. The data is chunked through the
+        // local credit mechanism, so each duplex write should carry at most ~threshold payload bytes
+        // (plus Slic frame headers).
+        byte[] payload = new byte[128 * 1024];
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, default);
+
+        int totalRead = 0;
+        while (totalRead < payload.Length)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAtLeastAsync(1);
+            totalRead += (int)readResult.Buffer.Length;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+        await writeTask;
+
+        // Assert: the maximum bytes written to the duplex connection in a single call should not
+        // significantly exceed PauseWriterThreshold. We allow a margin for Slic frame headers
+        // (frame type + size + stream ID per frame, typically ~10 bytes each).
+        Assert.That(
+            maxBytesWrittenAtOnce,
+            Is.LessThanOrEqualTo(threshold + 1024),
+            $"Expected max bytes per duplex write to be at most {threshold + 1024} " +
+            $"(threshold {threshold} + header overhead), but was {maxBytesWrittenAtOnce}");
+    }
+
     private static Task WriteStreamFrameAsync(
         IDuplexConnection connection,
         FrameType frameType,

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -909,6 +909,91 @@ public class SlicTransportTests
         duplexClientConnection.Operations.Hold = DuplexTransportOperations.None;
     }
 
+    /// <summary>Verifies that a write blocked on peer-granted send credit (peer window exhausted) can be
+    /// canceled.</summary>
+    [Test]
+    public async Task Stream_write_cancellation_while_blocked_on_peer_credit()
+    {
+        // Arrange: use a small peer window so it's easy to exhaust.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 4 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Exhaust the peer's window without reading.
+        byte[] payload = new byte[4 * 1024 - 1];
+        _ = await streams.Local.Output.WriteAsync(payload, default);
+
+        using var writeCts = new CancellationTokenSource();
+
+        // Act: the next write blocks on AcquireSendCreditAsync because the peer window is exhausted.
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, writeCts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(writeTask.IsCompleted, Is.False);
+        writeCts.Cancel();
+
+        // Assert
+        Assert.That(
+            async () => await writeTask,
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    /// <summary>Verifies that a write blocked on local buffering credit (PauseWriterThreshold exhausted) can be
+    /// canceled.</summary>
+    [Test]
+    public async Task Stream_write_cancellation_while_blocked_on_local_credit()
+    {
+        // Arrange: use a small PauseWriterThreshold and hold the duplex Write so local credit is never
+        // released by the background writer.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 4 * 1024);
+        services.AddTestDuplexTransportDecorator();
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        var duplexClientConnection =
+            provider.GetRequiredService<TestDuplexClientTransportDecorator>().LastCreatedConnection;
+
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Write once to consume local credit, then hold duplex writes so the background writer can't
+        // drain and release local credit.
+        _ = await streams.Local.Output.WriteAsync(new byte[4 * 1024 - 1], default);
+        duplexClientConnection.Operations.Hold = DuplexTransportOperations.Write;
+
+        using var writeCts = new CancellationTokenSource();
+
+        try
+        {
+            // Act: the next write blocks on AcquireLocalCreditAsync because local credit is exhausted
+            // (the held duplex Write prevents completion callbacks from releasing it).
+            ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(
+                new byte[4 * 1024 - 1],
+                writeCts.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+            Assert.That(writeTask.IsCompleted, Is.False);
+            writeCts.Cancel();
+
+            // Assert
+            Assert.That(
+                async () => await writeTask,
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+        finally
+        {
+            duplexClientConnection.Operations.Hold = DuplexTransportOperations.None;
+        }
+    }
+
     [Test]
     public async Task Reject_slic_control_frame_with_oversized_body()
     {
@@ -1341,6 +1426,139 @@ public class SlicTransportTests
             encoder.EncodeVarUInt62(version);
             initializeBody.Encode(ref encoder);
         }
+    }
+
+    [Test]
+    public void PauseWriterThreshold_default_value()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(options.PauseWriterThreshold, Is.EqualTo(65_536));
+    }
+
+    [Test]
+    public void PauseWriterThreshold_below_minimum_throws()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.PauseWriterThreshold = 1023, Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void PauseWriterThreshold_at_minimum_succeeds()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.PauseWriterThreshold = 1024, Throws.Nothing);
+        Assert.That(options.PauseWriterThreshold, Is.EqualTo(1024));
+    }
+
+    [Test]
+    public async Task Large_write_completes_with_small_pause_writer_threshold()
+    {
+        // Arrange: peer advertises a large window (256 KB) but local PauseWriterThreshold is small (8 KB).
+        // The write of 256 KB must be chunked through the PauseWriterThreshold without deadlocking.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 256 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 8 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: write a payload much larger than PauseWriterThreshold.
+        byte[] payload = new byte[256 * 1024];
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, default);
+
+        // The peer reads everything.
+        int totalRead = 0;
+        while (totalRead < payload.Length)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAtLeastAsync(1);
+            totalRead += (int)readResult.Buffer.Length;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+
+        // Assert: the write completes without deadlock and all bytes are received.
+        await writeTask;
+        Assert.That(totalRead, Is.EqualTo(payload.Length));
+    }
+
+    [TestCase(1024)]
+    [TestCase(4 * 1024)]
+    [TestCase(64 * 1024)]
+    public async Task Write_completes_with_various_pause_writer_thresholds(int threshold)
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = threshold);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: write a payload larger than PauseWriterThreshold.
+        byte[] payload = new byte[64 * 1024];
+        ValueTask<FlushResult> writeTask = streams.Local.Output.WriteAsync(payload, default);
+
+        int totalRead = 0;
+        while (totalRead < payload.Length)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAtLeastAsync(1);
+            totalRead += (int)readResult.Buffer.Length;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+
+        // Assert
+        await writeTask;
+        Assert.That(totalRead, Is.EqualTo(payload.Length));
+    }
+
+    [Test]
+    public async Task Concurrent_streams_with_small_pause_writer_threshold()
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 8 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams1 = await sut.CreateAndAcceptStreamAsync();
+        using var streams2 = await sut.CreateAndAcceptStreamAsync();
+
+        // Act: both streams write concurrently.
+        byte[] payload = new byte[32 * 1024];
+
+        ValueTask<FlushResult> writeTask1 = streams1.Local.Output.WriteAsync(payload, default);
+        ValueTask<FlushResult> writeTask2 = streams2.Local.Output.WriteAsync(payload, default);
+
+        // Read from both streams concurrently.
+        async Task ReadAllAsync(PipeReader reader, int expectedBytes)
+        {
+            int totalRead = 0;
+            while (totalRead < expectedBytes)
+            {
+                ReadResult readResult = await reader.ReadAtLeastAsync(1);
+                totalRead += (int)readResult.Buffer.Length;
+                reader.AdvanceTo(readResult.Buffer.End);
+            }
+        }
+
+        await Task.WhenAll(
+            ReadAllAsync(streams1.Remote.Input, payload.Length),
+            ReadAllAsync(streams2.Remote.Input, payload.Length));
+
+        // Assert: both writes complete.
+        await writeTask1;
+        await writeTask2;
     }
 
     private static Task WriteStreamFrameAsync(


### PR DESCRIPTION
- Add a configurable PauseWriterThreshold option (default: 64 KB) to SlicTransportOptions. This option limits how much outbound payload data Slic buffers locally per stream, independently of the peer’s advertised flow-control window.
- Introduce per-stream local credit tracking with completion callbacks on the shared SlicDuplexConnectionWriter. Local credit is released only after bytes are written to the underlying IDuplexConnection, not when they move between Slic-internal buffers.

Replaces https://github.com/icerpc/icerpc-csharp/pull/4530. The ping-flood protection from that PR will be handled separately.

This change introduces a per-stream cap on locally buffered data, independent of the flow-control window.

The peer’s window size represents how much data the peer is willing to buffer, but it does not constrain how much data the sender may accumulate locally before it is written to the connection. Without an additional limit, a sender can buffer large amounts of data per stream, leading to excessive memory usage.

PauseWriterThreshold addresses this by bounding local buffering per stream.

See also: icerpc/icerpc-csharp-audit#15