### PR TITLE
Fix idle timeout handling for large peer values

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -263,9 +263,21 @@ internal class SlicConnection : IMultiplexedConnection
 
             // Enable the idle timeout checks after the connection establishment. The Ping frames sent by the keep alive
             // check are not expected until the Slic connection initialization completes. The idle timeout check uses
-            // the smallest idle timeout.
-            TimeSpan idleTimeout = _peerIdleTimeout == Timeout.InfiniteTimeSpan ? _localIdleTimeout :
-                (_peerIdleTimeout < _localIdleTimeout ? _peerIdleTimeout : _localIdleTimeout);
+            // the smallest idle timeout. Timeout.InfiniteTimeSpan is -1 ms so we can't compare it directly with
+            // positive timeouts.
+            TimeSpan idleTimeout;
+            if (_localIdleTimeout == Timeout.InfiniteTimeSpan)
+            {
+                idleTimeout = _peerIdleTimeout;
+            }
+            else if (_peerIdleTimeout == Timeout.InfiniteTimeSpan)
+            {
+                idleTimeout = _localIdleTimeout;
+            }
+            else
+            {
+                idleTimeout = _peerIdleTimeout < _localIdleTimeout ? _peerIdleTimeout : _localIdleTimeout;
+            }
 
             if (idleTimeout != Timeout.InfiniteTimeSpan)
             {

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -7,16 +7,23 @@ namespace IceRpc.Transports.Slic;
 public sealed record class SlicTransportOptions
 {
     /// <summary>Gets or sets the idle timeout. This timeout is used to monitor the transport connection health. If no
-    /// data is received within the idle timeout period, the transport connection is aborted.
-    /// </summary>
-    /// <value>The idle timeout. Defaults to <c>30</c> s.</value>
+    /// data is received within the idle timeout period, the transport connection is aborted. Use
+    /// <see cref="Timeout.InfiniteTimeSpan" /> to disable idle timeout monitoring.</summary>
+    /// <value>The idle timeout. It must be positive or <see cref="Timeout.InfiniteTimeSpan" />.
+    /// Defaults to <c>30</c> s.</value>
     public TimeSpan IdleTimeout
     {
         get => _idleTimeout;
-        set => _idleTimeout = value != TimeSpan.Zero ? value :
-            throw new ArgumentException(
-                $"The value '0' is not a valid for {nameof(IdleTimeout)} property.",
-                nameof(value));
+        set
+        {
+            if (value != Timeout.InfiniteTimeSpan && value <= TimeSpan.Zero)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(IdleTimeout)} value must be positive or Timeout.InfiniteTimeSpan.",
+                    nameof(value));
+            }
+            _idleTimeout = value;
+        }
     }
 
     /// <summary>Gets or sets the initial stream window size. It defines the initial size of the stream receive buffer

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -7,8 +7,9 @@ namespace IceRpc.Transports.Slic;
 public sealed record class SlicTransportOptions
 {
     /// <summary>Gets or sets the idle timeout. This timeout is used to monitor the transport connection health. If no
-    /// data is received within the idle timeout period, the transport connection is aborted. Use
-    /// <see cref="Timeout.InfiniteTimeSpan" /> to disable idle timeout monitoring.</summary>
+    /// data is received within the idle timeout period, the transport connection is aborted. The effective idle timeout
+    /// is negotiated with the peer: use <see cref="Timeout.InfiniteTimeSpan" /> to defer to the peer's idle timeout.
+    /// Idle timeout monitoring is disabled only when both sides use <see cref="Timeout.InfiniteTimeSpan" />.</summary>
     /// <value>The idle timeout. It must be positive or <see cref="Timeout.InfiniteTimeSpan" />.
     /// Defaults to <c>30</c> s.</value>
     public TimeSpan IdleTimeout


### PR DESCRIPTION
## Summary

- Fix the `min(local, peer)` idle timeout comparison to correctly treat `Timeout.InfiniteTimeSpan` as greater than any positive timeout. Previously, `InfiniteTimeSpan` (-1 ms) would win the `<` comparison, causing the effective timeout to be infinite when only the local side was configured as infinite and the peer advertised a valid timeout.
- Validate `IdleTimeout` setter to reject negative values other than `Timeout.InfiniteTimeSpan`.

Fixes #4409