### PR TITLE
Force W3C activity ID format in TelemetryInterceptor

### DIFF
--- a/src/IceRpc.Telemetry/TelemetryInterceptor.cs
+++ b/src/IceRpc.Telemetry/TelemetryInterceptor.cs
@@ -41,6 +41,7 @@ public class TelemetryInterceptor : IInvoker
         {
             string name = $"{request.ServiceAddress.Path}/{request.Operation}";
             using Activity activity = _activitySource.CreateActivity(name, ActivityKind.Client) ?? new Activity(name);
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.AddTag("rpc.system", "icerpc");
             activity.AddTag("rpc.service", request.ServiceAddress.Path);
             activity.AddTag("rpc.method", request.Operation);
@@ -56,11 +57,7 @@ public class TelemetryInterceptor : IInvoker
 
     internal static void WriteActivityContext(ref SliceEncoder encoder, Activity activity)
     {
-        if (activity.IdFormat != ActivityIdFormat.W3C)
-        {
-            throw new NotSupportedException(
-                $"The activity ID format '{activity.IdFormat}' is not supported, the only supported activity ID format is 'W3C'.");
-        }
+        Debug.Assert(activity.IdFormat == ActivityIdFormat.W3C);
 
         if (activity.Id is null)
         {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -132,8 +132,9 @@ public sealed class TelemetryInterceptorTests
     }
 
     /// <summary>Verifies that the interceptor forces W3C activity ID format even when the process-wide default is
-    /// Hierarchical.</summary>
+    /// Hierarchical, and that the trace context field can be encoded and decoded successfully.</summary>
     [Test]
+    [NonParallelizable]
     public async Task Invocation_uses_w3c_format_regardless_of_process_default()
     {
         // Arrange
@@ -142,9 +143,11 @@ public sealed class TelemetryInterceptorTests
         try
         {
             Activity? invocationActivity = null;
+            Activity? decodedActivity = null;
             var invoker = new InlineInvoker((request, cancellationToken) =>
             {
                 invocationActivity = Activity.Current;
+                decodedActivity = DecodeTraceContextField(request.Fields, request.Operation);
                 return Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance));
             });
 
@@ -162,8 +165,9 @@ public sealed class TelemetryInterceptorTests
 
             // Assert
             Assert.That(invocationActivity, Is.Not.Null);
-            Assert.That(invocationActivity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
-            Assert.That(request.Fields.ContainsKey(RequestFieldKey.TraceContext), Is.True);
+            Assert.That(invocationActivity!.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
+            Assert.That(decodedActivity, Is.Not.Null);
+            Assert.That(decodedActivity!.ParentId, Is.EqualTo(invocationActivity.Id));
         }
         finally
         {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -132,7 +132,7 @@ public sealed class TelemetryInterceptorTests
     }
 
     /// <summary>Verifies that the interceptor forces W3C activity ID format even when the process-wide default is
-    /// Hierarchical, and that the trace context field can be encoded and decoded successfully.</summary>
+    /// <c>Hierarchical</c>, and that the trace context field can be encoded and decoded successfully.</summary>
     /// <remarks>Marked <c>NonParallelizable</c> because it mutates <see cref="Activity.DefaultIdFormat" />, a
     /// process-wide setting; running it concurrently with other tests that create activities would make their
     /// observed ID format non-deterministic.</remarks>

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -131,6 +131,46 @@ public sealed class TelemetryInterceptorTests
         pipe.Reader.Complete();
     }
 
+    /// <summary>Verifies that the interceptor forces W3C activity ID format even when the process-wide default is
+    /// Hierarchical.</summary>
+    [Test]
+    public async Task Invocation_uses_w3c_format_regardless_of_process_default()
+    {
+        // Arrange
+        ActivityIdFormat previousDefault = Activity.DefaultIdFormat;
+        Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
+        try
+        {
+            Activity? invocationActivity = null;
+            var invoker = new InlineInvoker((request, cancellationToken) =>
+            {
+                invocationActivity = Activity.Current;
+                return Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance));
+            });
+
+            using var activitySource = new ActivitySource("Test Activity Source");
+            using ActivityListener mockActivityListener = CreateMockActivityListener(activitySource);
+
+            var sut = new TelemetryInterceptor(invoker, activitySource);
+            using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/path" })
+            {
+                Operation = "Op"
+            };
+
+            // Act
+            await sut.InvokeAsync(request, default);
+
+            // Assert
+            Assert.That(invocationActivity, Is.Not.Null);
+            Assert.That(invocationActivity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
+            Assert.That(request.Fields.ContainsKey(RequestFieldKey.TraceContext), Is.True);
+        }
+        finally
+        {
+            Activity.DefaultIdFormat = previousDefault;
+        }
+    }
+
     private static ActivityListener CreateMockActivityListener(ActivitySource activitySource)
     {
         var mockActivityListener = new ActivityListener();

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -133,6 +133,9 @@ public sealed class TelemetryInterceptorTests
 
     /// <summary>Verifies that the interceptor forces W3C activity ID format even when the process-wide default is
     /// Hierarchical, and that the trace context field can be encoded and decoded successfully.</summary>
+    /// <remarks>Marked <c>NonParallelizable</c> because it mutates <see cref="Activity.DefaultIdFormat" />, a
+    /// process-wide setting; running it concurrently with other tests that create activities would make their
+    /// observed ID format non-deterministic.</remarks>
     [Test]
     [NonParallelizable]
     public async Task Invocation_uses_w3c_format_regardless_of_process_default()


### PR DESCRIPTION
## Summary

Force `ActivityIdFormat.W3C` before `activity.Start()` so the interceptor works regardless of the process-wide `Activity.DefaultIdFormat` setting.

Fixes #4479