### PR TITLE
Make ColocListener.DisposeAsync safe under concurrent calls

### DIFF
--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -13,8 +13,12 @@ internal class ColocListener : IListener<IDuplexConnection>
 {
     public TransportAddress TransportAddress { get; }
 
+    [SuppressMessage(
+        "Usage",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Disposing this CTS races with AcceptAsync creating a linked token source from its Token; a CTS with no timer is safely reclaimed by the GC.")]
     private readonly CancellationTokenSource _disposeCts = new();
-    private Task? _disposeTask;
+    private bool _disposed;
     private readonly Action<ColocListener> _onDispose;
     private readonly Lock _mutex = new();
     private readonly EndPoint _networkAddress;
@@ -33,7 +37,7 @@ internal class ColocListener : IListener<IDuplexConnection>
         CancellationTokenSource cts;
         lock (_mutex)
         {
-            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+            ObjectDisposedException.ThrowIf(_disposed, this);
             cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
         }
         using var _ = cts;
@@ -74,12 +78,12 @@ internal class ColocListener : IListener<IDuplexConnection>
     {
         lock (_mutex)
         {
-            _disposeTask ??= PerformDisposeAsync();
-        }
-        return new(_disposeTask);
+            if (_disposed)
+            {
+                return default;
+            }
+            _disposed = true;
 
-        Task PerformDisposeAsync()
-        {
             // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
             _onDispose(this);
 
@@ -95,11 +99,8 @@ internal class ColocListener : IListener<IDuplexConnection>
             {
                 item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
             }
-
-            _disposeCts.Dispose();
-
-            return Task.CompletedTask;
         }
+        return default;
     }
 
     internal ColocListener(

--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -14,7 +14,9 @@ internal class ColocListener : IListener<IDuplexConnection>
     public TransportAddress TransportAddress { get; }
 
     private readonly CancellationTokenSource _disposeCts = new();
+    private Task? _disposeTask;
     private readonly Action<ColocListener> _onDispose;
+    private readonly Lock _mutex = new();
     private readonly EndPoint _networkAddress;
     private readonly PipeOptions _pipeOptions;
 
@@ -28,7 +30,7 @@ internal class ColocListener : IListener<IDuplexConnection>
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposeCts.IsCancellationRequested, this);
+        ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
         try
@@ -66,31 +68,34 @@ internal class ColocListener : IListener<IDuplexConnection>
 
     public ValueTask DisposeAsync()
     {
-        if (_disposeCts.IsCancellationRequested)
+        lock (_mutex)
         {
-            // Dispose already called.
-            return default;
+            _disposeTask ??= PerformDisposeAsync();
         }
+        return new(_disposeTask);
 
-        // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
-        _onDispose(this);
-
-        // Cancel pending AcceptAsync.
-        _disposeCts.Cancel();
-
-        // Ensure no more client connection establishment request is queued.
-        _channel.Writer.Complete();
-
-        // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused. Use
-        // TrySetException in case the task has been already canceled.
-        while (_channel.Reader.TryRead(out (TaskCompletionSource<PipeReader> Tcs, PipeReader) item))
+        Task PerformDisposeAsync()
         {
-            item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
+            // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
+            _onDispose(this);
+
+            // Cancel pending AcceptAsync.
+            _disposeCts.Cancel();
+
+            // Ensure no more client connection establishment request is queued.
+            _channel.Writer.Complete();
+
+            // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused.
+            // Use TrySetException in case the task has been already canceled.
+            while (_channel.Reader.TryRead(out (TaskCompletionSource<PipeReader> Tcs, PipeReader) item))
+            {
+                item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
+            }
+
+            _disposeCts.Dispose();
+
+            return Task.CompletedTask;
         }
-
-        _disposeCts.Dispose();
-
-        return default;
     }
 
     internal ColocListener(

--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -30,9 +30,13 @@ internal class ColocListener : IListener<IDuplexConnection>
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
-
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
+        CancellationTokenSource cts;
+        lock (_mutex)
+        {
+            ObjectDisposedException.ThrowIf(_disposeTask is not null, this);
+            cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
+        }
+        using var _ = cts;
         try
         {
             while (true)


### PR DESCRIPTION
## Summary

Use the `_disposeTask` + `lock` pattern so concurrent callers await the same task, which completes only after all cleanup is done.

Fixes #4483