### PR TITLE
Fix depfile parsing for Windows paths in UpToDateCheckTask

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -18,6 +18,7 @@
     "contentfiles",
     "Datagram",
     "decoratee",
+    "depfile",
     "dependencyinjection",
     "docfx",
     "dprime",

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -94,12 +94,13 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
 
             dependContents = dependContents[(i + outputPrefix.Length)..];
 
-            // The Make depfile format uses '\' at end of line as a line continuation. Each dependency
-            // path appears on its own line (possibly after a continuation). We split on newlines, strip
-            // trailing '\' and whitespace, then treat each non-empty result as a path.
+            // The Make depfile format uses '\' at end of line as a line continuation, and escapes
+            // spaces inside paths as '\ '. Windows directory separators are emitted as literal '\'
+            // (not escaped). We split on newlines, strip the trailing continuation '\' and whitespace,
+            // then unescape '\ ' -> ' ' so paths containing spaces resolve correctly.
             foreach (string line in dependContents.Split('\n'))
             {
-                string filePath = line.TrimEnd().TrimEnd('\\').Trim();
+                string filePath = line.TrimEnd().TrimEnd('\\').Trim().Replace("\\ ", " ", StringComparison.Ordinal);
                 if (!string.IsNullOrEmpty(filePath))
                 {
                     depends.Add(Path.GetFullPath(filePath));

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -83,21 +83,29 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
         {
             var depends = new List<string>();
             string dependContents = File.ReadAllText(dependOutput);
-            // strip everything before Xxx.cs:
+
+            // Strip everything before and including "Xxx.cs:" (the output target).
             const string outputPrefix = ".cs:";
             int i = dependContents.IndexOf(outputPrefix, StringComparison.CurrentCultureIgnoreCase);
-            if (i != -1 && i + outputPrefix.Length < dependContents.Length)
+            if (i == -1 || i + outputPrefix.Length >= dependContents.Length)
             {
-                dependContents = dependContents[(i + outputPrefix.Length)..];
-                foreach (string line in dependContents.Split(['\\']))
+                return depends;
+            }
+
+            dependContents = dependContents[(i + outputPrefix.Length)..];
+
+            // The Make depfile format uses '\' at end of line as a line continuation. Each dependency
+            // path appears on its own line (possibly after a continuation). We split on newlines, strip
+            // trailing '\' and whitespace, then treat each non-empty result as a path.
+            foreach (string line in dependContents.Split('\n'))
+            {
+                string filePath = line.TrimEnd().TrimEnd('\\').Trim();
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    string filePath = line.Trim();
-                    if (!string.IsNullOrEmpty(filePath))
-                    {
-                        depends.Add(Path.GetFullPath(filePath));
-                    }
+                    depends.Add(Path.GetFullPath(filePath));
                 }
             }
+
             return depends;
         }
     }


### PR DESCRIPTION
## Summary

Fix `ProcessDependencies` to split on newlines instead of `\`, which broke Windows paths (e.g., `C:\work\src\foo.proto`). The Make depfile format only uses `\` at end of line as a continuation marker.

Fixes #4453