### PR TITLE
Validate defaultTimeout in DeadlineInterceptor constructor

### DIFF
--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -43,6 +43,13 @@ public class DeadlineInterceptor : IInvoker
     /// </param>
     public DeadlineInterceptor(IInvoker next, TimeSpan defaultTimeout, bool alwaysEnforceDeadline, TimeProvider? timeProvider = null)
     {
+        if (defaultTimeout != Timeout.InfiniteTimeSpan && defaultTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"The {nameof(defaultTimeout)} value must be positive or Timeout.InfiniteTimeSpan.",
+                nameof(defaultTimeout));
+        }
+
         _next = next;
         _alwaysEnforceDeadline = alwaysEnforceDeadline;
         _defaultTimeout = defaultTimeout;

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -216,4 +216,27 @@ public sealed class DeadlineInterceptorTests
         var decoder = new SliceDecoder(readResult.Buffer);
         return decoder.DecodeTimeStamp();
     }
+
+    [TestCase(0)]
+    [TestCase(-5000)]
+    public void Constructor_rejects_invalid_default_timeout(int milliseconds)
+    {
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        Assert.That(
+            () => new DeadlineInterceptor(invoker, TimeSpan.FromMilliseconds(milliseconds), alwaysEnforceDeadline: false),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Constructor_accepts_infinite_timeout()
+    {
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        Assert.That(
+            () => new DeadlineInterceptor(invoker, Timeout.InfiniteTimeSpan, alwaysEnforceDeadline: false),
+            Throws.Nothing);
+    }
 }


### PR DESCRIPTION
## Summary

Reject zero and negative `defaultTimeout` values (except `Timeout.InfiniteTimeSpan`) at construction time rather than surfacing configuration errors per invocation.

Fixes #4418