### PR TITLE
Document array-backed pool requirement on connection options

### DIFF
--- a/src/IceRpc/Transports/DuplexConnectionOptions.cs
+++ b/src/IceRpc/Transports/DuplexConnectionOptions.cs
@@ -20,6 +20,9 @@ public record class DuplexConnectionOptions
     /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
     /// <value>A pool of memory blocks used for buffer management. Defaults to <see cref="MemoryPool{T}.Shared"
     /// />.</value>
+    /// <remarks>The pool must return array-backed memory blocks. This is a requirement of the TCP transport, which
+    /// uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// System.Net.Sockets.SocketFlags)" /> for multi-segment writes.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
     private int _minSegmentSize = 4096;

--- a/src/IceRpc/Transports/DuplexConnectionOptions.cs
+++ b/src/IceRpc/Transports/DuplexConnectionOptions.cs
@@ -20,9 +20,9 @@ public record class DuplexConnectionOptions
     /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
     /// <value>A pool of memory blocks used for buffer management. Defaults to <see cref="MemoryPool{T}.Shared"
     /// />.</value>
-    /// <remarks>The pool must return array-backed memory blocks. This is a requirement of the TCP transport, which
-    /// uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
-    /// System.Net.Sockets.SocketFlags)" /> for multi-segment writes.</remarks>
+    /// <remarks>The built-in TCP transport requires the pool to return array-backed memory blocks, because its
+    /// multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// System.Net.Sockets.SocketFlags)" />. The Coloc transport has no such requirement.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
     private int _minSegmentSize = 4096;

--- a/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
+++ b/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
@@ -33,6 +33,9 @@ public record class MultiplexedConnectionOptions
     /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
     /// <value>A pool of memory blocks used for buffer management. Defaults to <see cref="MemoryPool{T}.Shared"
     /// />.</value>
+    /// <remarks>The pool must return array-backed memory blocks. This is a requirement of the underlying TCP
+    /// transport, which uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// System.Net.Sockets.SocketFlags)" /> for multi-segment writes.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
     internal const int DefaultMaxBidirectionalStreams = 100;

--- a/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
+++ b/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
@@ -33,9 +33,10 @@ public record class MultiplexedConnectionOptions
     /// <summary>Gets or sets the <see cref="MemoryPool{T}" /> object used for buffer management.</summary>
     /// <value>A pool of memory blocks used for buffer management. Defaults to <see cref="MemoryPool{T}.Shared"
     /// />.</value>
-    /// <remarks>The pool must return array-backed memory blocks. This is a requirement of the underlying TCP
-    /// transport, which uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
-    /// System.Net.Sockets.SocketFlags)" /> for multi-segment writes.</remarks>
+    /// <remarks>Some multiplexed transports require the pool to return array-backed memory blocks. Slic over TCP
+    /// does, because Slic's write buffers are allocated from this pool and passed down to the TCP transport,
+    /// whose multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// System.Net.Sockets.SocketFlags)" />. The QUIC transport has no such requirement.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 
     internal const int DefaultMaxBidirectionalStreams = 100;


### PR DESCRIPTION
## Summary
- The TCP transport's multi-segment write path relies on `Socket.SendAsync(IList<ArraySegment<byte>>, SocketFlags)`, which requires array-backed memory. This contract wasn't surfaced on `DuplexConnectionOptions.Pool` / `MultiplexedConnectionOptions.Pool`, so a user configuring a native-memory pool would only find out at write time.
- Added `<remarks>` on both `Pool` properties stating the requirement and pointing at the TCP constraint. No code change — in practice every pool we ship is array-backed, and the encoder/placeholder path is agnostic to the backing.

Closes #4411

## Test plan
- [x] `dotnet build src/IceRpc/IceRpc.csproj` (clean, 0 warnings)