### PR TITLE
Gap-check the first remote Slic stream ID

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1455,7 +1455,14 @@ internal class SlicConnection : IMultiplexedConnection
 
             if (isBidirectional)
             {
-                if (streamId > _lastRemoteBidirectionalStreamId + 4)
+                // The next expected remote bidirectional stream ID is the last one plus 4, or the initial remote
+                // bidirectional stream ID (0 for the server, 1 for the client) if no remote bidirectional stream has
+                // been opened yet. This check also rejects a bogus first stream ID, which would otherwise slip
+                // through because `null + 4` evaluates to null.
+                ulong expectedStreamId = _lastRemoteBidirectionalStreamId is ulong lastId
+                    ? lastId + 4
+                    : (IsServer ? 0ul : 1ul);
+                if (streamId > expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }
@@ -1470,7 +1477,13 @@ internal class SlicConnection : IMultiplexedConnection
             }
             else
             {
-                if (streamId > _lastRemoteUnidirectionalStreamId + 4)
+                // The next expected remote unidirectional stream ID is the last one plus 4, or the initial remote
+                // unidirectional stream ID (2 for the server, 3 for the client) if no remote unidirectional stream
+                // has been opened yet.
+                ulong expectedStreamId = _lastRemoteUnidirectionalStreamId is ulong lastId
+                    ? lastId + 4
+                    : (IsServer ? 2ul : 3ul);
+                if (streamId > expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1479,7 +1479,8 @@ internal class SlicConnection : IMultiplexedConnection
             {
                 // The next expected remote unidirectional stream ID is the last one plus 4, or the initial remote
                 // unidirectional stream ID (2 for the server, 3 for the client) if no remote unidirectional stream
-                // has been opened yet.
+                // has been opened yet. This check also rejects a bogus first stream ID, which would otherwise slip
+                // through because `null + 4` evaluates to null.
                 ulong expectedStreamId = _lastRemoteUnidirectionalStreamId is ulong lastId
                     ? lastId + 4
                     : (IsServer ? 2ul : 3ul);

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -67,6 +67,26 @@ public class SlicTransportTests
                     $"Received {frameType} frame for unknown stream.");
             }
 
+            // Stream frame opening a new remote bidirectional stream with a non-initial stream ID.
+            // The first remote bidirectional stream ID the server expects from the client is 0.
+            yield return new TestCaseData(
+                (IDuplexConnection connection) => WriteStreamFrameAsync(
+                    connection,
+                    FrameType.Stream,
+                    streamId: 4ul,
+                    (ref SliceEncoder encoder) => encoder.EncodeBool(false)),
+                "Invalid stream ID.");
+
+            // Stream frame opening a new remote unidirectional stream with a non-initial stream ID.
+            // The first remote unidirectional stream ID the server expects from the client is 2.
+            yield return new TestCaseData(
+                (IDuplexConnection connection) => WriteStreamFrameAsync(
+                    connection,
+                    FrameType.Stream,
+                    streamId: 6ul,
+                    (ref SliceEncoder encoder) => encoder.EncodeBool(false)),
+                "Invalid stream ID.");
+
             // Bogus stream frame with FrameSize=0 (stream ID not encoded)
             yield return new TestCaseData((IDuplexConnection connection) =>
                 WriteFrameAsync(connection, FrameType.StreamLast, (ref SliceEncoder encoder) => { }),


### PR DESCRIPTION
## Summary
- The gap check in `ReadStreamDataFrameAsync` used `streamId > _lastRemote...StreamId + 4`, which is a no-op when `_lastRemote...` is null (first remote stream). A peer could open its first bidi stream at any ID, e.g. `0x4000000`, and subsequent frames addressed to never-opened lower IDs were silently ignored or read-and-discarded.
- Replaced the check with an explicit expected next stream ID: `last + 4`, or the initial ID for the role/direction (0/1 for bidi, 2/3 for uni) when no remote stream has opened yet.
- Added two regression cases to `ConnectionProtocolErrors` covering bogus initial bidirectional (`streamId=4`) and unidirectional (`streamId=6`) stream IDs.

Closes #4412

## Test plan
- [x] `dotnet build tests/IceRpc.Tests/IceRpc.Tests.csproj` (clean)
- [x] `dotnet test --filter "FullyQualifiedName~Connection_protocol_errors"` - 11/11 passed (9 pre-existing + 2 new)
- [x] `dotnet test --filter "FullyQualifiedName~Slic"` - 186/186 passed