### PR TITLE
Make send-side compression format switch explicit

### DIFF
--- a/src/IceRpc.Compressor/CompressorInterceptor.cs
+++ b/src/IceRpc.Compressor/CompressorInterceptor.cs
@@ -3,7 +3,6 @@
 using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO.Compression;
 using System.IO.Pipelines;
 using ZeroC.Slice.Codec;
@@ -61,9 +60,8 @@ public class CompressorInterceptor : IInvoker
             {
                 request.Use(next => PipeWriter.Create(new BrotliStream(next.AsStream(), _compressionLevel)));
             }
-            else
+            else if (_compressionFormat == CompressionFormat.Deflate)
             {
-                Debug.Assert(_compressionFormat == CompressionFormat.Deflate);
                 request.Use(next => PipeWriter.Create(new DeflateStream(next.AsStream(), _compressionLevel)));
             }
 

--- a/src/IceRpc.Compressor/CompressorMiddleware.cs
+++ b/src/IceRpc.Compressor/CompressorMiddleware.cs
@@ -3,7 +3,6 @@
 using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO.Compression;
 using System.IO.Pipelines;
 using ZeroC.Slice.Codec;
@@ -84,9 +83,8 @@ public class CompressorMiddleware : IDispatcher
             {
                 response.Use(next => PipeWriter.Create(new BrotliStream(next.AsStream(), _compressionLevel)));
             }
-            else
+            else if (_compressionFormat == CompressionFormat.Deflate)
             {
-                Debug.Assert(_compressionFormat == CompressionFormat.Deflate);
                 response.Use(next => PipeWriter.Create(new DeflateStream(next.AsStream(), _compressionLevel)));
             }
 


### PR DESCRIPTION
## Summary
- Replace `else { Debug.Assert(_compressionFormat == Deflate); ... }` with `else if (_compressionFormat == Deflate) { ... }` in both `CompressorInterceptor.InvokeAsync` and `CompressorMiddleware.DispatchAsync`.
- The previous pattern silently treats any future `CompressionFormat` value as Deflate if someone updates the constructor's whitelist but forgets to update the send-side switch. The explicit `else if` makes the omission a no-op instead of a silent wrong compression.
- No behavior change — constructor still rejects unsupported formats upfront.

Noticed while reviewing #4416 (which is unrelated and closed as not planned: the receive-side pass-through is by design).

## Test plan
- [x] `dotnet build src/IceRpc.Compressor/IceRpc.Compressor.csproj` (clean)
- [x] `dotnet test tests/IceRpc.Compressor.Tests/IceRpc.Compressor.Tests.csproj` — 16/16 passed