### PR TITLE
Check connection identity in ConnectionCache.RemoveFromActiveAsync

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -522,8 +522,14 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     {
         lock (_mutex)
         {
-            if (_shutdownTask is null && _activeConnections.Remove(serverAddress))
+            // Check identity before removing: a concurrent reconnect may have already replaced this connection
+            // with a new one at the same server address. Removing without the identity check would evict the
+            // healthy replacement and leak it outside the cache.
+            if (_shutdownTask is null &&
+                _activeConnections.TryGetValue(serverAddress, out IProtocolConnection? existing) &&
+                existing == connection)
             {
+                _activeConnections.Remove(serverAddress);
                 // it's now our connection.
                 _detachedConnectionCount++;
             }


### PR DESCRIPTION
## Summary
- `ConnectionCache.RemoveFromActiveAsync` removed the `_activeConnections` entry for a given server address without checking it was the same connection the caller passed in.
- Under concurrent retries, `ShutdownWhenRequestedAsync` firing after a retry loop has already reconnected can cause the stale cleanup to evict the healthy replacement connection and orphan it outside the cache.
- Added a TryGetValue + identity check before `Remove`, matching the pattern already used by `ClientConnection.RemoveFromActiveAsync`.

Closes #4415

## Test plan
- [x] `dotnet build src/IceRpc/IceRpc.csproj` (clean)
- [x] `dotnet test --filter "FullyQualifiedName~ConnectionCache"` — 8/8 passed