### PR TITLE
Enforce hostname validation in template TLS helper

### DIFF
--- a/examples/common/Program.Authentication.cs
+++ b/examples/common/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
@@ -4,28 +4,18 @@ using System.Security.Cryptography.X509Certificates;
 /// <summary>Provides helper methods to create the authentication options used by the examples.</summary>
 internal static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 


### PR DESCRIPTION
## Summary

- Replaces the custom `RemoteCertificateValidationCallback` in all 8 `dotnet new icerpc-*` templates and `examples/common/` with `SslClientAuthenticationOptions.CertificateChainPolicy`.
- The previous callback ignored the `errors` argument, silently accepting `SslPolicyErrors.RemoteCertificateNameMismatch` — any cert chaining to the trusted root CA could impersonate any host within that trust domain.
- `CertificateChainPolicy` keeps trust scoped to the supplied root CA (via `CustomRootTrust` + `CustomTrustStore`) while letting `SslStream` perform standard SAN/CN matching against the target host.

Fixes #4549.

## Test plan

- [x] `dotnet build src/IceRpc.Templates/IceRpc.Templates.csproj` — clean
- [x] Build every example `.slnx` — all clean
- [x] End-to-end Greeter run over QUIC (`icerpc://localhost`, server cert SAN covers localhost) — client received `Hello, jose!`
- [ ] CI