### PR TITLE
Fix MaxMessageLength off-by-one in Protobuf payload decoder (#4436)

### DIFF
--- a/src/IceRpc.Ice/AssemblyInfo.cs
+++ b/src/IceRpc.Ice/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Runtime.CompilerServices;
+
+// Make internals visible to the tests assembly, to allow writing unit tests for the internal classes.
+[assembly: InternalsVisibleTo("IceRpc.Ice.Tests")]

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
@@ -113,7 +113,7 @@ internal static class PipeReaderExtensions
         }
         int messageLength = DecodeMessageLength(readResult.Buffer.Slice(1, 4));
         reader.AdvanceTo(readResult.Buffer.GetPosition(5));
-        if (messageLength >= maxMessageLength)
+        if (messageLength > maxMessageLength)
         {
             throw new InvalidDataException("The message length exceeds the maximum value.");
         }

--- a/tests/IceRpc.Ice.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Ice.Tests/PipeReaderExtensionsTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Ice.Operations.Internal;
+using NUnit.Framework;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace IceRpc.Ice.Tests;
+
+[Parallelizable(scope: ParallelScope.All)]
+public class PipeReaderExtensionsTests
+{
+    [Test]
+    public async Task Reading_a_full_payload_with_size_equal_to_max_size_succeeds()
+    {
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }));
+
+        ReadResult readResult = await pipeReader.ReadFullPayloadAsync(maxSize: 5, default);
+
+        Assert.That(readResult.Buffer.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4, 5 }));
+        pipeReader.Complete();
+    }
+
+    [Test]
+    public void Reading_a_full_payload_larger_than_max_size_fails()
+    {
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }));
+
+        Assert.That(
+            async () => await pipeReader.ReadFullPayloadAsync(maxSize: 4, default),
+            Throws.TypeOf<InvalidDataException>());
+        pipeReader.Complete();
+    }
+
+    [Test]
+    public void Trying_to_read_a_full_payload_with_size_equal_to_max_size_succeeds()
+    {
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }));
+
+        bool success = pipeReader.TryReadFullPayload(maxSize: 5, out ReadResult readResult);
+
+        Assert.That(success, Is.True);
+        Assert.That(readResult.Buffer.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4, 5 }));
+        pipeReader.Complete();
+    }
+
+    [Test]
+    public void Trying_to_read_a_full_payload_larger_than_max_size_fails()
+    {
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }));
+
+        Assert.That(
+            () => _ = pipeReader.TryReadFullPayload(maxSize: 4, out ReadResult readResult),
+            Throws.TypeOf<InvalidDataException>());
+        pipeReader.Complete();
+    }
+}

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -11,18 +11,37 @@ namespace IceRpc.Protobuf.Tests;
 public partial class PipeReaderExtensionsTests
 {
     [Test]
+    public async Task Read_message_succeeds_when_message_length_equals_max_message_length()
+    {
+        // Arrange
+        // A StringValue with 1024 ASCII chars encodes to 1 (tag) + 2 (varint length) + 1024 (data) = 1027 bytes.
+        var stringValue = new StringValue { Value = new string('s', 1024) };
+        var pipeReader = stringValue.EncodeAsLengthPrefixedMessage(new PipeOptions(pauseWriterThreshold: 0));
+
+        // Act
+        StringValue decoded = await pipeReader.DecodeProtobufMessageAsync(
+            StringValue.Parser,
+            maxMessageLength: 1027,
+            CancellationToken.None);
+
+        // Assert
+        Assert.That(decoded.Value, Is.EqualTo(stringValue.Value));
+        pipeReader.Complete();
+    }
+
+    [Test]
     public void Read_message_throws_invalid_data_exception_when_max_message_length_is_exceeded()
     {
         // Arrange
-        var stringValue = new StringValue();
-        stringValue.Value = new string('s', 1024);
+        // A StringValue with 1024 ASCII chars encodes to 1027 bytes; 1026 is one byte short of the limit.
+        var stringValue = new StringValue { Value = new string('s', 1024) };
         var pipeReader = stringValue.EncodeAsLengthPrefixedMessage(new PipeOptions(pauseWriterThreshold: 0));
 
         // Act & Assert
         Assert.ThrowsAsync<InvalidDataException>(async () =>
             await pipeReader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
-                maxMessageLength: 1024,
+                maxMessageLength: 1026,
                 CancellationToken.None));
         pipeReader.Complete();
     }

--- a/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
+++ b/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
@@ -112,4 +112,51 @@ public class PipeReaderTests
             () => _ = pipeReader.TryReadSliceSegment(maxSize: 100, out ReadResult readResult),
             Throws.TypeOf<InvalidDataException>());
     }
+
+    [Test]
+    public async Task Reading_a_segment_with_size_equal_to_max_size_succeeds()
+    {
+        // 20 = 4 * 5 means the payload size is 5
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
+
+        ReadResult readResult = await pipeReader.ReadSliceSegmentAsync(maxSize: 5, default);
+
+        Assert.That(readResult.Buffer.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4, 5 }));
+        pipeReader.Complete();
+    }
+
+    [Test]
+    public void Reading_a_segment_larger_than_max_size_fails()
+    {
+        // 20 = 4 * 5 means the payload size is 5
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
+
+        Assert.That(
+            async () => await pipeReader.ReadSliceSegmentAsync(maxSize: 4, default),
+            Throws.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public void Trying_to_read_a_segment_with_size_equal_to_max_size_succeeds()
+    {
+        // 20 = 4 * 5 means the payload size is 5
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
+
+        bool success = pipeReader.TryReadSliceSegment(maxSize: 5, out ReadResult readResult);
+
+        Assert.That(success, Is.True);
+        Assert.That(readResult.Buffer.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4, 5 }));
+        pipeReader.Complete();
+    }
+
+    [Test]
+    public void Trying_to_read_a_segment_larger_than_max_size_fails()
+    {
+        // 20 = 4 * 5 means the payload size is 5
+        var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
+
+        Assert.That(
+            () => _ = pipeReader.TryReadSliceSegment(maxSize: 4, out ReadResult readResult),
+            Throws.TypeOf<InvalidDataException>());
+    }
 }

--- a/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
+++ b/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
@@ -56,7 +56,7 @@ public class PipeReaderTests
     [Test]
     public void Reading_a_short_segment_fails()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4 }));
 
         Assert.That(
@@ -105,7 +105,7 @@ public class PipeReaderTests
     [Test]
     public void Trying_to_read_a_short_segment_fails()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4 }));
 
         Assert.That(
@@ -116,7 +116,7 @@ public class PipeReaderTests
     [Test]
     public async Task Reading_a_segment_with_size_equal_to_max_size_succeeds()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
 
         ReadResult readResult = await pipeReader.ReadSliceSegmentAsync(maxSize: 5, default);
@@ -128,7 +128,7 @@ public class PipeReaderTests
     [Test]
     public void Reading_a_segment_larger_than_max_size_fails()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
 
         Assert.That(
@@ -139,7 +139,7 @@ public class PipeReaderTests
     [Test]
     public void Trying_to_read_a_segment_with_size_equal_to_max_size_succeeds()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
 
         bool success = pipeReader.TryReadSliceSegment(maxSize: 5, out ReadResult readResult);
@@ -152,7 +152,7 @@ public class PipeReaderTests
     [Test]
     public void Trying_to_read_a_segment_larger_than_max_size_fails()
     {
-        // 20 = 4 * 5 means the payload size is 5
+        // 20 = 5 << 2 means the payload size is 5
         var pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(new byte[] { 20, 1, 2, 3, 4, 5 }));
 
         Assert.That(


### PR DESCRIPTION
Fix #4436