### PR TITLE
Qualify nested Protobuf message types in generated code

### DIFF
--- a/src/IceRpc.Protobuf.Generator/MessageDescriptorExtensions.cs
+++ b/src/IceRpc.Protobuf.Generator/MessageDescriptorExtensions.cs
@@ -9,8 +9,9 @@ internal static class MessageDescriptorExtensions
     internal static string GetType(this MessageDescriptor messageDescriptor, string scope, bool streaming)
     {
         string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
+        string qualifiedName = messageDescriptor.GetQualifiedCsharpName();
         string csharpType = scope == csharpNamespace ?
-            messageDescriptor.Name : $"global::{csharpNamespace}.{messageDescriptor.Name}";
+            qualifiedName : $"global::{csharpNamespace}.{qualifiedName}";
         if (streaming)
         {
             csharpType = $"global::System.Collections.Generic.IAsyncEnumerable<{csharpType}>";
@@ -21,8 +22,21 @@ internal static class MessageDescriptorExtensions
     internal static string GetParserType(this MessageDescriptor messageDescriptor, string scope)
     {
         string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
+        string qualifiedName = messageDescriptor.GetQualifiedCsharpName();
         string csharpType = scope == csharpNamespace ?
-            messageDescriptor.Name : $"global::{csharpNamespace}.{messageDescriptor.Name}";
+            qualifiedName : $"global::{csharpNamespace}.{qualifiedName}";
         return $"{csharpType}.Parser";
+    }
+
+    // Google's C# Protobuf generator emits nested message types inside a "Types" container class on each enclosing
+    // message (e.g. message Outer { message Inner {} } becomes Outer.Types.Inner).
+    private static string GetQualifiedCsharpName(this MessageDescriptor messageDescriptor)
+    {
+        string name = messageDescriptor.Name;
+        for (MessageDescriptor? parent = messageDescriptor.ContainingType; parent is not null; parent = parent.ContainingType)
+        {
+            name = $"{parent.Name}.Types.{name}";
+        }
+        return name;
     }
 }

--- a/tests/IceRpc.Protobuf.Tests/NestedMessageTests.proto
+++ b/tests/IceRpc.Protobuf.Tests/NestedMessageTests.proto
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+syntax = "proto3";
+option csharp_namespace = "IceRpc.Protobuf.Tests";
+
+package icerpc.protobuf.tests;
+
+service NestedMessageOperations {
+    rpc UnaryOp(Outer.Inner) returns (Outer.Inner);
+    rpc DeeplyNestedOp(Outer.Middle.Leaf) returns (Outer.Middle.Leaf);
+}
+
+message Outer {
+    message Inner {
+        string value = 1;
+    }
+
+    message Middle {
+        message Leaf {
+            int32 value = 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `MessageDescriptor.Name` is the leaf type name, so generated code referenced nested messages as `Inner` instead of Google's `Outer.Types.Inner` layout, which failed to compile.
- `GetType`/`GetParserType` now walk `ContainingType` and insert `.Types.` at each level.
- Adds `NestedMessageTests.proto` (single- and double-level nesting); before the fix it fails to compile, after the fix it builds cleanly.

Fixes #4448