### PR TITLE
Backport #4551 to 0.5.x

### DIFF
--- a/examples/common/Program.Authentication.cs
+++ b/examples/common/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 // Provides helper methods to create the authentication options used by the examples.
 public static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 // Provides helper methods to create the authentication options used by the examples.
 public static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 // Provides helper methods to create the authentication options used by the examples.
 public static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 // Provides helper methods to create the authentication options used by the examples.
 public static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/Program.Authentication.cs
@@ -6,28 +6,18 @@ using System.Security.Cryptography.X509Certificates;
 // Provides helper methods to create the authentication options used by the examples.
 public static partial class Program
 {
-    /// <summary>Creates client authentication options with a custom certificate validation callback that uses the
-    /// specified root CA.</summary>
+    /// <summary>Creates client authentication options that trust only the specified root CA.</summary>
     /// <param name="rootCA">The root CA certificate.</param>
     /// <returns>The client authentication options.</returns>
     public static SslClientAuthenticationOptions CreateClientAuthenticationOptions(X509Certificate2 rootCA) =>
         new()
         {
-            RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            CertificateChainPolicy = new X509ChainPolicy
             {
-                if (certificate is X509Certificate2 peerCertificate)
-                {
-                    using var customChain = new X509Chain();
-                    customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                    customChain.ChainPolicy.DisableCertificateDownloads = true;
-                    customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                    customChain.ChainPolicy.CustomTrustStore.Add(rootCA);
-                    return customChain.Build(peerCertificate);
-                }
-                else
-                {
-                    return false;
-                }
+                RevocationMode = X509RevocationMode.NoCheck,
+                DisableCertificateDownloads = true,
+                TrustMode = X509ChainTrustMode.CustomRootTrust,
+                CustomTrustStore = { rootCA }
             }
         };
 


### PR DESCRIPTION
Backport of #4551 (which itself backported #4549 to main) onto the 0.5.x release branch.

The 0.5.x branch does not contain the DI template variants (`IceRpc-Protobuf-DI-Client`, `IceRpc-Protobuf-DI-Server`, `IceRpc-Slice-DI-Client`, `IceRpc-Slice-DI-Server`), so those four hunks from the source commit are dropped. The fix is applied to the five files that exist in 0.5.x: `examples/common/Program.Authentication.cs`, the `IceRpc-Protobuf-Client`/`-Server` templates, and the `IceRpc-Slice-Client`/`-Server` templates.