### PR TITLE
Generate valid C# for .proto files with no package or csharp_namespace

### DIFF
--- a/src/IceRpc.Protobuf.Generator/MessageDescriptorExtensions.cs
+++ b/src/IceRpc.Protobuf.Generator/MessageDescriptorExtensions.cs
@@ -8,10 +8,7 @@ internal static class MessageDescriptorExtensions
 {
     internal static string GetType(this MessageDescriptor messageDescriptor, string scope, bool streaming)
     {
-        string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
-        string qualifiedName = messageDescriptor.GetQualifiedCsharpName();
-        string csharpType = scope == csharpNamespace ?
-            qualifiedName : $"global::{csharpNamespace}.{qualifiedName}";
+        string csharpType = messageDescriptor.GetQualifiedTypeName(scope);
         if (streaming)
         {
             csharpType = $"global::System.Collections.Generic.IAsyncEnumerable<{csharpType}>";
@@ -19,13 +16,18 @@ internal static class MessageDescriptorExtensions
         return csharpType;
     }
 
-    internal static string GetParserType(this MessageDescriptor messageDescriptor, string scope)
+    internal static string GetParserType(this MessageDescriptor messageDescriptor, string scope) =>
+        $"{messageDescriptor.GetQualifiedTypeName(scope)}.Parser";
+
+    private static string GetQualifiedTypeName(this MessageDescriptor messageDescriptor, string scope)
     {
         string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
         string qualifiedName = messageDescriptor.GetQualifiedCsharpName();
-        string csharpType = scope == csharpNamespace ?
-            qualifiedName : $"global::{csharpNamespace}.{qualifiedName}";
-        return $"{csharpType}.Parser";
+        return scope == csharpNamespace ?
+            qualifiedName :
+            csharpNamespace.Length == 0 ?
+                $"global::{qualifiedName}" :
+                $"global::{csharpNamespace}.{qualifiedName}";
     }
 
     // Google's C# Protobuf generator emits nested message types inside a "Types" container class on each enclosing

--- a/src/IceRpc.Protobuf.Generator/Program.cs
+++ b/src/IceRpc.Protobuf.Generator/Program.cs
@@ -49,7 +49,12 @@ using IceRpc.Protobuf;
 using IceRpc.Protobuf.RpcMethods;
 ");
 
-    codeBlock.AddBlock($"namespace {descriptor.GetCsharpNamespace()};");
+    string csharpNamespace = descriptor.GetCsharpNamespace();
+    if (csharpNamespace.Length > 0)
+    {
+        codeBlock.AddBlock($"namespace {csharpNamespace};");
+    }
+    // else generated types land in the global namespace, matching Google's protoc-gen-csharp behavior.
 
     foreach (ServiceDescriptor service in descriptor.Services)
     {

--- a/tests/IceRpc.Protobuf.Tests/NoNamespaceTests.proto
+++ b/tests/IceRpc.Protobuf.Tests/NoNamespaceTests.proto
@@ -1,0 +1,15 @@
+// Copyright (c) ZeroC, Inc.
+
+// Intentionally has no `package` and no `option csharp_namespace`. The generator must emit valid C# in
+// this case (no `namespace ;` declaration; cross-namespace references use `global::Type` rather than
+// `global::.Type`).
+
+syntax = "proto3";
+
+service NoNamespaceOperations {
+    rpc UnaryOp(NoNamespaceMessage) returns (NoNamespaceMessage);
+}
+
+message NoNamespaceMessage {
+    string value = 1;
+}


### PR DESCRIPTION
## Summary
- When a `.proto` has neither `package` nor `option csharp_namespace = ...`, `GetCsharpNamespace` returned `""` and the generator emitted `namespace ;` (CS1001 from the C# compiler) and `global::.MyMessage` for any cross-namespace reference.
- Skip the namespace declaration when the namespace is empty, and emit `global::MyMessage` instead of `global::.MyMessage` for cross-namespace references targeting a file with no namespace. Matches Google's `protoc-gen-csharp` behavior of placing top-level types in the global namespace.
- Add a `.proto` regression file with neither `package` nor `csharp_namespace`. Without the fix the test project fails to compile with `CS1001: Identifier expected` on the generated `namespace ;` line; with the fix it builds cleanly and all 48 Protobuf tests pass.

Fixes #4447