### PR TITLE
Count non-OK responses in failed-requests metric

### DIFF
--- a/src/IceRpc.Metrics/MetricsInterceptor.cs
+++ b/src/IceRpc.Metrics/MetricsInterceptor.cs
@@ -30,9 +30,7 @@ public class MetricsInterceptor : IInvoker
         try
         {
             IncomingResponse response = await _next.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
-            // A non-OK status code means the server returned a failure response (for example DeadlineExceeded
-            // from DeadlineMiddleware or NotFound from NotFoundDispatcher). Count it as a failure so that
-            // failed-requests is consistent with the throw-based path.
+            // A non-OK status code means the server returned a failure response.
             if (response.StatusCode != StatusCode.Ok)
             {
                 _invocationMetrics.RequestFailure();

--- a/src/IceRpc.Metrics/MetricsInterceptor.cs
+++ b/src/IceRpc.Metrics/MetricsInterceptor.cs
@@ -29,7 +29,15 @@ public class MetricsInterceptor : IInvoker
         _invocationMetrics.RequestStart();
         try
         {
-            return await _next.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
+            IncomingResponse response = await _next.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
+            // A non-OK status code means the server returned a failure response (for example DeadlineExceeded
+            // from DeadlineMiddleware or NotFound from NotFoundDispatcher). Count it as a failure so that
+            // failed-requests is consistent with the throw-based path.
+            if (response.StatusCode != StatusCode.Ok)
+            {
+                _invocationMetrics.RequestFailure();
+            }
+            return response;
         }
         catch (OperationCanceledException)
         {

--- a/src/IceRpc.Metrics/MetricsMiddleware.cs
+++ b/src/IceRpc.Metrics/MetricsMiddleware.cs
@@ -31,7 +31,15 @@ public class MetricsMiddleware : IDispatcher
         _dispatchMetrics.RequestStart();
         try
         {
-            return await _next.DispatchAsync(request, cancellationToken).ConfigureAwait(false);
+            OutgoingResponse response = await _next.DispatchAsync(request, cancellationToken).ConfigureAwait(false);
+            // A non-OK status code means the dispatch produced a failure response (for example DeadlineExceeded
+            // from DeadlineMiddleware or NotFound from the router). Count it as a failure so that
+            // failed-requests is consistent with the throw-based path.
+            if (response.StatusCode != StatusCode.Ok)
+            {
+                _dispatchMetrics.RequestFailure();
+            }
+            return response;
         }
         catch (OperationCanceledException)
         {

--- a/src/IceRpc.Metrics/MetricsMiddleware.cs
+++ b/src/IceRpc.Metrics/MetricsMiddleware.cs
@@ -32,9 +32,7 @@ public class MetricsMiddleware : IDispatcher
         try
         {
             OutgoingResponse response = await _next.DispatchAsync(request, cancellationToken).ConfigureAwait(false);
-            // A non-OK status code means the dispatch produced a failure response (for example DeadlineExceeded
-            // from DeadlineMiddleware or NotFound from the router). Count it as a failure so that
-            // failed-requests is consistent with the throw-based path.
+            // A non-OK status code means the dispatch produced a failure response.
             if (response.StatusCode != StatusCode.Ok)
             {
                 _dispatchMetrics.RequestFailure();

--- a/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
@@ -108,6 +108,53 @@ public sealed class MetricsInterceptorTests
         Assert.That(total, Is.EqualTo(new long[] { 1 }));
     }
 
+    /// <summary>Verifies that a non-OK IncomingResponse is counted as a failure, matching the throw-based path.
+    /// </summary>
+    [Test]
+    public async Task Non_ok_response_publishes_total_current_and_failed_measurements()
+    {
+        const string meterName = "Test.NonOkResponse.IceRpc.Invocation";
+        var current = new List<long>();
+        var failed = new List<long>();
+        var total = new List<long>();
+        using var meterListener = new TestMeterListener<long>(
+            meterName,
+            (instrument, measurement, tags, state) =>
+            {
+                switch (instrument.Name)
+                {
+                    case "current-requests":
+                    {
+                        current.Add(measurement);
+                        break;
+                    }
+                    case "failed-requests":
+                    {
+                        failed.Add(measurement);
+                        break;
+                    }
+                    case "total-requests":
+                    {
+                        total.Add(measurement);
+                        break;
+                    }
+                }
+            });
+
+        using var invocationMetrics = new InvocationMetrics(meterName);
+        var invoker = new InlineInvoker((request, cancellationToken) => Task.FromResult(
+            new IncomingResponse(request, FakeConnectionContext.Instance, StatusCode.NotFound, errorMessage: "not found")));
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/path" });
+        var sut = new MetricsInterceptor(invoker, invocationMetrics);
+
+        IncomingResponse response = await sut.InvokeAsync(request, default);
+
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.NotFound));
+        Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
+        Assert.That(failed, Is.EqualTo(new long[] { 1 }));
+        Assert.That(total, Is.EqualTo(new long[] { 1 }));
+    }
+
     [Test]
     public async Task Successful_invocation_publishes_total_and_current_measurements()
     {

--- a/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
@@ -107,6 +107,53 @@ public sealed class MetricsMiddlewareTests
         Assert.That(total, Is.EqualTo(new long[] { 1 }));
     }
 
+    /// <summary>Verifies that a non-OK OutgoingResponse is counted as a failure, matching the throw-based path.
+    /// </summary>
+    [Test]
+    public async Task Non_ok_response_publishes_total_current_and_failed_measurements()
+    {
+        const string meterName = "Test.NonOkResponse.IceRpc.Dispatch";
+        var current = new List<long>();
+        var failed = new List<long>();
+        var total = new List<long>();
+        using var meterListener = new TestMeterListener<long>(
+            meterName,
+            (instrument, measurement, tags, state) =>
+            {
+                switch (instrument.Name)
+                {
+                    case "current-requests":
+                    {
+                        current.Add(measurement);
+                        break;
+                    }
+                    case "failed-requests":
+                    {
+                        failed.Add(measurement);
+                        break;
+                    }
+                    case "total-requests":
+                    {
+                        total.Add(measurement);
+                        break;
+                    }
+                }
+            });
+
+        using var dispatchMetrics = new DispatchMetrics(meterName);
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+            new(new OutgoingResponse(request, StatusCode.DeadlineExceeded, "deadline exceeded")));
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance);
+        var sut = new MetricsMiddleware(dispatcher, dispatchMetrics);
+
+        OutgoingResponse response = await sut.DispatchAsync(request, default);
+
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.DeadlineExceeded));
+        Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
+        Assert.That(failed, Is.EqualTo(new long[] { 1 }));
+        Assert.That(total, Is.EqualTo(new long[] { 1 }));
+    }
+
     [Test]
     public async Task Successful_dispatch_publishes_total_and_current_measurements()
     {


### PR DESCRIPTION
Fix #4435