### PR TITLE
Escape cref value in generated <see> doc comments

### DIFF
--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -36,7 +36,22 @@ internal static class DocCommentFormatter
 
         foreach (CommentLink link in seeTags)
         {
-            if (link is ResolvedCommentLink r)
+            if (link is not ResolvedCommentLink r)
+            {
+                continue;
+            }
+
+            if (r.Entity is TypeAlias alias)
+            {
+                // Type aliases don't generate a C# type; map to the underlying C# type. We can't reliably
+                // produce a seealso for a generic mapped type without C# parsing, so skip those.
+                string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
+                if (!mapped.Contains('<', StringComparison.Ordinal))
+                {
+                    yield return new CommentTag("seealso", "cref", mapped, "");
+                }
+            }
+            else
             {
                 yield return new CommentTag("seealso", "cref", FormatEntityCref(r.Entity, currentNamespace), "");
             }
@@ -45,13 +60,22 @@ internal static class DocCommentFormatter
 
     private static string FormatInlineLink(CommentLink link, string currentNamespace) => link switch
     {
-        // Type aliases don't generate C# types, so output the identifier as plain text.
-        ResolvedCommentLink { Entity: TypeAlias } r => $"<c>{CommentTag.XmlEscape(r.Entity.Identifier)}</c>",
-        ResolvedCommentLink r =>
-            $"""<see cref="{CommentTag.XmlEscape(FormatEntityCref(r.Entity, currentNamespace))}" />""",
+        ResolvedCommentLink { Entity: TypeAlias alias } => FormatTypeAliasInline(alias, currentNamespace),
+        ResolvedCommentLink r => $"""<see cref="{FormatEntityCref(r.Entity, currentNamespace)}" />""",
         UnresolvedCommentLink u => $"<c>{CommentTag.XmlEscape(u.Identifier)}</c>",
         _ => ""
     };
+
+    private static string FormatTypeAliasInline(TypeAlias alias, string currentNamespace)
+    {
+        // Type aliases don't generate a C# type; link to the underlying C# type instead. For generic mapped
+        // types we emit the type name as inline code (XML-escaped) to avoid constructing cref-friendly forms
+        // like IList{T} or IDictionary{T, U}.
+        string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
+        return mapped.Contains('<', StringComparison.Ordinal)
+            ? $"<c>{CommentTag.XmlEscape(mapped)}</c>"
+            : $"""<see cref="{mapped}" />""";
+    }
 
     private static string FormatEntityCref(Entity entity, string currentNamespace)
     {

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -47,7 +47,8 @@ internal static class DocCommentFormatter
     {
         // Type aliases don't generate C# types, so output the identifier as plain text.
         ResolvedCommentLink { Entity: TypeAlias } r => $"<c>{CommentTag.XmlEscape(r.Entity.Identifier)}</c>",
-        ResolvedCommentLink r => $"""<see cref="{FormatEntityCref(r.Entity, currentNamespace)}" />""",
+        ResolvedCommentLink r =>
+            $"""<see cref="{CommentTag.XmlEscape(FormatEntityCref(r.Entity, currentNamespace))}" />""",
         UnresolvedCommentLink u => $"<c>{CommentTag.XmlEscape(u.Identifier)}</c>",
         _ => ""
     };

--- a/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
@@ -4,7 +4,35 @@ module IceRpc::Slice::Generator::Tests
 
 // This file contains Slice definitions for testing the mapping of doc comments
 
+// Typealiases used to test how doc comment links to a typealias are mapped to its underlying C# type:
+// - UserName maps to a non-generic C# type (string), so links resolve to <see cref="string" />.
+// - UserList, UserMap, UserResult map to generic C# types, so inline @link is emitted as <c>...</c>
+//   (XML-escaped) and @see is skipped.
+typealias UserName = string
 typealias UserList = Sequence<string>
+typealias UserMap = Dictionary<string, MySession>
+typealias UserResult = Result<MySession, string>
+
+/// Tests how doc comment links to typealiases are mapped to their underlying C# types.
+/// The {@link UserName} alias maps to a non-generic type while {@link UserList},
+/// {@link UserMap}, and {@link UserResult} map to generic types.
+/// @see UserName
+/// @see UserList
+/// @see UserMap
+/// @see UserResult
+interface MyTypealiasDocs {
+    /// Returns the {@link UserName} for the active user.
+    getName() -> UserName
+
+    /// Returns a {@link UserList} of active user names.
+    getNames() -> UserList
+
+    /// Returns a {@link UserMap} keyed by user name.
+    getSessions() -> UserMap
+
+    /// Returns a {@link UserResult} containing the session or an error message.
+    getResult() -> UserResult
+}
 
 /// This is the session manager interface summary. The caller must use the {@link MyAuthorizationManager::createAuthToken}
 /// operation to create an authentication token before creating a session.

--- a/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
@@ -4,7 +4,7 @@ module IceRpc::Slice::Generator::Tests
 
 // This file contains Slice definitions for testing the mapping of doc comments
 
-// Typealiases used to test how doc comment links to a typealias are mapped to its underlying C# type:
+// Type aliases used to test how doc comment links to a typealias are mapped to its underlying C# type:
 // - UserName maps to a non-generic C# type (string), so links resolve to <see cref="string" />.
 // - UserList, UserMap, UserResult map to generic C# types, so inline @link is emitted as <c>...</c>
 //   (XML-escaped) and @see is skipped.
@@ -13,7 +13,7 @@ typealias UserList = Sequence<string>
 typealias UserMap = Dictionary<string, MySession>
 typealias UserResult = Result<MySession, string>
 
-/// Tests how doc comment links to typealiases are mapped to their underlying C# types.
+/// Tests how doc comment links to type aliases are mapped to their underlying C# types.
 /// The {@link UserName} alias maps to a non-generic type while {@link UserList},
 /// {@link UserMap}, and {@link UserResult} map to generic types.
 /// @see UserName


### PR DESCRIPTION
Fix #4494