### PR TITLE
Fail loudly on duplicate scoped identifiers in SymbolConverter

### DIFF
--- a/src/ZeroC.Slice.Symbols/SymbolConverter.cs
+++ b/src/ZeroC.Slice.Symbols/SymbolConverter.cs
@@ -54,7 +54,7 @@ internal sealed class SymbolConverter
             {
                 if (GetNamedIdentifier(symbol) is string id)
                 {
-                    // Scoped IDs are warned to be unique by the compiler, we can safely use them as dictionary keys.
+                    // Scoped IDs are guaranteed to be unique by the compiler, we can safely use them as dictionary keys.
                     _named.Add($"{moduleScope}::{id}", (file, symbol));
                 }
             }

--- a/src/ZeroC.Slice.Symbols/SymbolConverter.cs
+++ b/src/ZeroC.Slice.Symbols/SymbolConverter.cs
@@ -54,7 +54,8 @@ internal sealed class SymbolConverter
             {
                 if (GetNamedIdentifier(symbol) is string id)
                 {
-                    _named.TryAdd($"{moduleScope}::{id}", (file, symbol));
+                    // Scoped IDs are warned to be unique by the compiler, we can safely use them as dictionary keys.
+                    _named.Add($"{moduleScope}::{id}", (file, symbol));
                 }
             }
         }


### PR DESCRIPTION
Fix #4500