### PR TITLE
Aggregate Protobuf build telemetry into a single per-build report

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
@@ -15,6 +15,18 @@
     <IceRpcBuildTelemetry Condition="'$(IceRpcBuildTelemetry)' == ''">true</IceRpcBuildTelemetry>
   </PropertyGroup>
   <Choose>
+    <When Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+      <PropertyGroup>
+        <_ProtocPluginScriptExtension>.bat</_ProtocPluginScriptExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <_ProtocPluginScriptExtension>.sh</_ProtocPluginScriptExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Choose>
     <When Condition="Exists('$(MSBuildThisFileDirectory)../IceRpc.Protobuf.Generator')">
       <!--
         Use the protoc compiler from Google.Protobuf.Tools dependency, and the IceRpc.Protobuf.Generator assembly from the

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -63,11 +63,6 @@
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
     </UpToDateCheckTask>
 
-    <PropertyGroup>
-      <_ProtocPluginScriptExtension Condition="$([MSBuild]::IsOSPlatform('Windows'))">.bat</_ProtocPluginScriptExtension>
-      <_ProtocPluginScriptExtension Condition="!$([MSBuild]::IsOSPlatform('Windows'))">.sh</_ProtocPluginScriptExtension>
-    </PropertyGroup>
-
     <ItemGroup>
       <!-- Code-generating plug-ins; protoc runs once per ProtoFile to produce a dependency file per file. -->
       <_ProtocCodegenPlugin Include="csharp" />

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -26,12 +26,6 @@
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
-  <UsingTask
-    TaskName="IceRpc.Protobuf.Tools.BuildTelemetryTask"
-    TaskFactory="$(IceRpcProtobufToolsTaskFactory)"
-    AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
-    Runtime="NET"
-  />
   <ItemGroup Condition="'$(IceRpcProtobufToolsSourceBuild)' == 'true'">
     <!-- Add a reference to the Tools project to ensure it's built before we use its tasks -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)IceRpc.Protobuf.Tools.csproj" ReferenceOutputAssembly="false" />
@@ -69,6 +63,24 @@
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
     </UpToDateCheckTask>
 
+    <PropertyGroup>
+      <_ProtocPluginScriptExtension Condition="$([MSBuild]::IsOSPlatform('Windows'))">.bat</_ProtocPluginScriptExtension>
+      <_ProtocPluginScriptExtension Condition="!$([MSBuild]::IsOSPlatform('Windows'))">.sh</_ProtocPluginScriptExtension>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Code-generating plug-ins; protoc runs once per ProtoFile to produce a dependency file per file. -->
+      <_ProtocCodegenPlugin Include="csharp" />
+      <_ProtocCodegenPlugin Include="icerpc-csharp">
+        <Path>$(IceRpcProtocGenPath)protoc-gen-icerpc-csharp$(_ProtocPluginScriptExtension)</Path>
+      </_ProtocCodegenPlugin>
+
+      <!-- Telemetry plug-in; runs once over all ProtoFile items so the upload reports the whole build. -->
+      <_ProtocTelemetryPlugin Include="icerpc-build-telemetry">
+        <Path>$(IceRpcProtocBuildTelemetryPath)protoc-gen-icerpc-build-telemetry$(_ProtocPluginScriptExtension)</Path>
+      </_ProtocTelemetryPlugin>
+    </ItemGroup>
+
     <!-- Compile the Proto files
       The search path determines where protoc compiler locates import files, we add:
       - $(IceRpcProtocPath) to import google well-known files from IceRpc.Protobuf.Tools.
@@ -81,11 +93,24 @@
       OutputDir="@(_ProtoFile->'%(OutputDir)')"
       SearchPath="@(ProtoSearchPath->'%(FullPath)');$(IceRpcProtocPath);$(MSBuildProjectDirectory)"
       ToolsPath="$(IceRpcProtocPath)$(IceRpcProtocPrefix)"
-      GenPath="$(IceRpcProtocGenPath)"
-      BuildTelemetryPath="$(IceRpcProtocBuildTelemetryPath)"
-      RunBuildTelemetry="$(IceRpcBuildTelemetry)"
+      Plugins="@(_ProtocCodegenPlugin)"
+      AdditionalOptions="--dependency_out=%(_ProtoFile.OutputDir)/%(_ProtoFile.OutputFileName).d"
       Sources="%(_ProtoFile.Identity)"
       Condition="'%(_ProtoFile.UpToDate)' != 'true'"
+    />
+
+    <!--
+      Run the build-telemetry plug-in once over all ProtoFile items so it can compute a single per-build
+      compilation hash and file count from the descriptors, regardless of which files were up-to-date.
+    -->
+    <ProtocTask
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      OutputDir="$(IntermediateOutputPath)"
+      SearchPath="@(ProtoSearchPath->'%(FullPath)');$(IceRpcProtocPath);$(MSBuildProjectDirectory)"
+      ToolsPath="$(IceRpcProtocPath)$(IceRpcProtocPrefix)"
+      Plugins="@(_ProtocTelemetryPlugin)"
+      Sources="@(_ProtoFile)"
+      Condition="'$(IceRpcBuildTelemetry)' == 'true'"
     />
 
     <!--

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -89,7 +89,7 @@
       SearchPath="@(ProtoSearchPath->'%(FullPath)');$(IceRpcProtocPath);$(MSBuildProjectDirectory)"
       ToolsPath="$(IceRpcProtocPath)$(IceRpcProtocPrefix)"
       Plugins="@(_ProtocCodegenPlugin)"
-      AdditionalOptions="--dependency_out=%(_ProtoFile.OutputDir)/%(_ProtoFile.OutputFileName).d"
+      AdditionalOptions="--dependency_out=&quot;%(_ProtoFile.OutputDir)/%(_ProtoFile.OutputFileName).d&quot;"
       Sources="%(_ProtoFile.Identity)"
       Condition="'%(_ProtoFile.UpToDate)' != 'true'"
     />

--- a/src/IceRpc.Protobuf.Tools/ProtocTask.cs
+++ b/src/IceRpc.Protobuf.Tools/ProtocTask.cs
@@ -75,11 +75,10 @@ public class ProtocTask : ToolTask
             builder.AppendFileNameIfNotNull(OutputDir);
         }
 
-        // Append each option as a single argv token. AppendSwitchIfNotNull with an empty switch name quotes
-        // values containing whitespace so a path with spaces in --dependency_out=... stays one token.
         foreach (string option in AdditionalOptions)
         {
-            builder.AppendSwitchIfNotNull(string.Empty, option);
+            builder.AppendTextUnquoted(" ");
+            builder.AppendTextUnquoted(option);
         }
 
         var searchPath = new List<string>(SearchPath);

--- a/src/IceRpc.Protobuf.Tools/ProtocTask.cs
+++ b/src/IceRpc.Protobuf.Tools/ProtocTask.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceRpc.CaseConverter.Internal;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Diagnostics;
@@ -12,14 +11,23 @@ namespace IceRpc.Protobuf.Tools;
 // Properties should not return arrays, disabled as this is standard for MSBuild tasks.
 #pragma warning disable CA1819
 
-/// <summary>A MSBuild task to generate code from Protobuf files using <c>protoc</c> C# built-in generator and
-/// <c>protoc-gen-icerpc-csharp</c> generator.</summary>
+/// <summary>An MSBuild task that runs <c>protoc</c> with a configurable set of plug-ins.</summary>
 public class ProtocTask : ToolTask
 {
-    /// <summary>Gets or sets the output directory for the generated code; corresponds to the
-    /// <c>--icerpc-csharp_out=</c> option of the <c>protoc</c> compiler.</summary>
+    /// <summary>Gets or sets additional options to pass verbatim to <c>protoc</c>.</summary>
+    public string[] AdditionalOptions { get; set; } = [];
+
+    /// <summary>Gets or sets the output directory shared by all configured plug-ins; corresponds to the
+    /// <c>--&lt;name&gt;_out=</c> option of the <c>protoc</c> compiler.</summary>
     [Required]
     public string OutputDir { get; set; } = "";
+
+    /// <summary>Gets or sets the protoc plug-ins to run. Each item's <c>Identity</c> is the plug-in name (for example
+    /// <c>csharp</c>, <c>icerpc-csharp</c>, <c>icerpc-build-telemetry</c>). The <c>Path</c> metadata, when not empty,
+    /// is the full path to the plug-in script and is passed via <c>--plugin protoc-gen-&lt;name&gt;=&lt;path&gt;</c>;
+    /// an empty <c>Path</c> indicates a protoc built-in such as <c>csharp</c>.</summary>
+    [Required]
+    public ITaskItem[] Plugins { get; set; } = [];
 
     /// <summary>Gets or sets the directories in which to search for imports, corresponds to <c>-I</c> protoc compiler
     /// option.</summary>
@@ -33,18 +41,6 @@ public class ProtocTask : ToolTask
     /// <summary>Gets or sets the directory containing the protoc compiler.</summary>
     [Required]
     public string ToolsPath { get; set; } = "";
-
-    /// <summary>Gets or sets the directory containing the protoc-gen-icerpc-csharp scripts.</summary>
-    [Required]
-    public string GenPath { get; set; } = "";
-
-    /// <summary>Gets or sets the directory containing the protoc-gen-icerpc-build-telemetry scripts.</summary>
-    [Required]
-    public string BuildTelemetryPath { get; set; } = "";
-
-    /// <summary>Gets or sets a value indicating whether to run the build telemetry plug-in.</summary>
-    [Required]
-    public bool RunBuildTelemetry { get; set; }
 
     /// <summary>Gets or sets the working directory for executing the protoc compiler from.</summary>
     [Required]
@@ -63,44 +59,31 @@ public class ProtocTask : ToolTask
     {
         var builder = new CommandLineBuilder(false);
 
-        // Specify the full path to the protoc-gen-icerpc-csharp script.
-
-        string genScriptName =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                "protoc-gen-icerpc-csharp.bat" : "protoc-gen-icerpc-csharp.sh";
-        builder.AppendSwitch("--plugin");
-        builder.AppendFileNameIfNotNull($"protoc-gen-icerpc-csharp={Path.Combine(GenPath, genScriptName)}");
-
-        // Add --csharp_out to generate Protobuf C# code
-        builder.AppendSwitch("--csharp_out");
-        builder.AppendFileNameIfNotNull(OutputDir);
-
-        // Add --icerpc-csharp_out to generate IceRPC + Protobuf integration code
-        builder.AppendSwitch("--icerpc-csharp_out");
-        builder.AppendFileNameIfNotNull(OutputDir);
-
-        if (RunBuildTelemetry)
+        // Register and enable each plug-in.
+        foreach (ITaskItem plugin in Plugins)
         {
-            // Enable build telemetry
-            string buildTelemetryScriptName =
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    "protoc-gen-icerpc-build-telemetry.bat" : "protoc-gen-icerpc-build-telemetry.sh";
+            string name = plugin.ItemSpec;
+            string pluginPath = plugin.GetMetadata("Path");
 
-            // Specify the full path to the protoc-gen-icerpc-build-telemetry script.
-            builder.AppendSwitch("--plugin");
-            builder.AppendFileNameIfNotNull(
-                $"protoc-gen-icerpc-build-telemetry={Path.Combine(BuildTelemetryPath, buildTelemetryScriptName)}");
+            if (!string.IsNullOrEmpty(pluginPath))
+            {
+                builder.AppendSwitch("--plugin");
+                builder.AppendFileNameIfNotNull($"protoc-gen-{name}={pluginPath}");
+            }
 
-            // Add --icerpc-build-telemetry_out to enable build telemetry, even though the build telemetry plug-in
-            // doesn't need to generate any output files.
-            builder.AppendSwitch("--icerpc-build-telemetry_out");
+            builder.AppendSwitch($"--{name}_out");
             builder.AppendFileNameIfNotNull(OutputDir);
+        }
+
+        foreach (string option in AdditionalOptions)
+        {
+            builder.AppendTextUnquoted(" ");
+            builder.AppendTextUnquoted(option);
         }
 
         var searchPath = new List<string>(SearchPath);
 
-        // Add the sources directories to the import search path
-        var computedSources = new List<ITaskItem>();
+        // Add the sources directories to the import search path.
         foreach (ITaskItem source in Sources)
         {
             string fullPath = source.GetMetadata("FullPath");
@@ -109,14 +92,8 @@ public class ProtocTask : ToolTask
             {
                 searchPath.Add(directory);
             }
-
-            // Add dependency_out to generate dependency files
-            builder.AppendSwitch("--dependency_out");
-            builder.AppendFileNameIfNotNull(
-                Path.Combine(OutputDir, $"{source.GetMetadata("FileName").ToPascalCase()}.d"));
         }
 
-        // Add protoc searchPath paths
         foreach (string path in searchPath)
         {
             builder.AppendSwitch("-I");

--- a/src/IceRpc.Protobuf.Tools/ProtocTask.cs
+++ b/src/IceRpc.Protobuf.Tools/ProtocTask.cs
@@ -75,10 +75,11 @@ public class ProtocTask : ToolTask
             builder.AppendFileNameIfNotNull(OutputDir);
         }
 
+        // Append each option as a single argv token. AppendSwitchIfNotNull with an empty switch name quotes
+        // values containing whitespace so a path with spaces in --dependency_out=... stays one token.
         foreach (string option in AdditionalOptions)
         {
-            builder.AppendTextUnquoted(" ");
-            builder.AppendTextUnquoted(option);
+            builder.AppendSwitchIfNotNull(string.Empty, option);
         }
 
         var searchPath = new List<string>(SearchPath);

--- a/src/IceRpc.Slice.Tools/SlicecTask.cs
+++ b/src/IceRpc.Slice.Tools/SlicecTask.cs
@@ -72,12 +72,10 @@ public class SlicecTask : ToolTask
             builder.AppendSwitchIfNotNull("-R", reference);
         }
 
-        // Append each option as a single argv token. AppendSwitchIfNotNull with an empty switch name quotes
-        // values containing whitespace so a user-supplied --switch=... with a path containing spaces stays
-        // one token.
         foreach (string option in AdditionalOptions)
         {
-            builder.AppendSwitchIfNotNull(string.Empty, option);
+            builder.AppendTextUnquoted(" ");
+            builder.AppendTextUnquoted(option);
         }
         builder.AppendSwitch("--diagnostic-format=json");
         builder.AppendFileNamesIfNotNull(

--- a/src/IceRpc.Slice.Tools/SlicecTask.cs
+++ b/src/IceRpc.Slice.Tools/SlicecTask.cs
@@ -72,10 +72,12 @@ public class SlicecTask : ToolTask
             builder.AppendSwitchIfNotNull("-R", reference);
         }
 
+        // Append each option as a single argv token. AppendSwitchIfNotNull with an empty switch name quotes
+        // values containing whitespace so a user-supplied --switch=... with a path containing spaces stays
+        // one token.
         foreach (string option in AdditionalOptions)
         {
-            builder.AppendTextUnquoted(" ");
-            builder.AppendTextUnquoted(option);
+            builder.AppendSwitchIfNotNull(string.Empty, option);
         }
         builder.AppendSwitch("--diagnostic-format=json");
         builder.AppendFileNamesIfNotNull(


### PR DESCRIPTION
Fixes #4443.

## Summary

The build-telemetry plug-in was running inside each per-file `protoc` invocation, so a project with N `.proto` files produced N uploads (each with `FileCount=1` and a per-file hash) instead of one upload describing the whole compilation. The 3-second per-upload timeout also amplified the offline-build slowdown — N × 3 seconds when the telemetry server was unreachable.

The fix keeps the per-file fanout (which is required to produce per-file `.d` dependency files for incremental builds) and runs the telemetry plug-in in a separate batched `protoc` invocation that sees every `ProtoFile` in one go. The plug-in then naturally computes a single aggregate compilation hash and the correct file count, and uploads once per build.

## Changes

- Generalize `ProtocTask` to take a `Plugins` item list (each item: `Identity` = plug-in name, `Path` metadata = script path or empty for protoc built-ins) and an `AdditionalOptions` string array — same shape as `SlicecTask.Generators` / `AdditionalOptions`.
- `IceRpc.Protobuf.Tools.targets` now invokes `ProtocTask` twice:
  - Once per `ProtoFile` (driven by `Sources=\"%(_ProtoFile.Identity)\"`) with the `csharp` and `icerpc-csharp` plug-ins, and `AdditionalOptions=\"--dependency_out=…\"` to keep per-file `.d` files.
  - Once over all `ProtoFile` items with the `icerpc-build-telemetry` plug-in only, gated on `IceRpcBuildTelemetry=true`. Telemetry runs on every build (including incremental no-op builds) for analytics consistency.
- Drop the orphaned `BuildTelemetryTask` `UsingTask` declaration left behind by #4249.

## Test plan

- [x] Clean build with `-p:IceRpcBuildTelemetry=true`: 4 `.cs` + 4 `.IceRpc.cs` + 4 `.d` files produced; one telemetry txt file in `obj/Debug/net10.0/`; server reports successful upload.
- [x] Clean build with `-p:IceRpcBuildTelemetry=false`: codegen unchanged, no telemetry call.
- [x] Incremental build with telemetry on (everything up-to-date): still uploads telemetry exactly once.
- [x] `IceRpc.Protobuf.Tests`: 48/48 pass.