### PR TITLE
Correctly Generate Doc-Links to Generic Types, Instead of Code-Formatting

### DIFF
--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -70,7 +70,7 @@ internal static class DocCommentFormatter
                 switch (c)
                 {
                     case ',' when nestingLevel == 1: // Only count commas within the first level of '<...>'.
-                        sanitizedTypeString = $"{commaCount}{sanitizedTypeString}, T";
+                        sanitizedTypeString = $"{sanitizedTypeString}{commaCount}, T";
                         commaCount += 1;
                         break;
                     case '<':

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -92,7 +92,8 @@ internal static class DocCommentFormatter
         if (entity is TypeAlias alias)
         {
             // Type aliases don't generate a C# type; link to the underlying C# type instead.
-            string mapped = alias.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0] ?? alias.UnderlyingType.Type.ToTypeString(currentNamespace);
+            string mapped = alias.UnderlyingType.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0]
+                ?? alias.UnderlyingType.Type.ToTypeString(currentNamespace);
             return FormatTypeString(mapped);
         }
 

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -68,13 +68,40 @@ internal static class DocCommentFormatter
 
     private static string FormatTypeAliasInline(TypeAlias alias, string currentNamespace)
     {
-        // Type aliases don't generate a C# type; link to the underlying C# type instead. For generic mapped
-        // types we emit the type name as inline code (XML-escaped) to avoid constructing cref-friendly forms
-        // like IList{T} or IDictionary{T, U}.
+        // Type aliases don't generate a C# type; link to the underlying C# type instead.
         string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
-        return mapped.Contains('<', StringComparison.Ordinal)
-            ? $"<c>{CommentTag.XmlEscape(mapped)}</c>"
-            : $"""<see cref="{mapped}" />""";
+
+        // For generic mapped we have to convert them to their cref-friendly forms (ex: IList{T0}, IDictionary{T0, T1}).
+        var start = mapped.IndexOf('<', StringComparison.Ordinal);
+        if (start != -1)
+        {
+            // Get the type-name without any generics, then append a generic parameter 'T0'. There must be at least one.
+            string sanitizedTypeString = string.Concat(mapped.AsSpan(0, start), "{T0");
+
+            // Add an extra type parameter for each top-level comma we see, skipping over any commas within nested
+            // generic types, since they don't correspond to type parameters of the outer type.
+            int commaCount = 0;
+            int nestingLevel = 0;
+            foreach(char c in mapped)
+            {
+                switch (c)
+                {
+                    case ',' when nestingLevel == 1: // Only count commas within the first level of '<...>'.
+                        commaCount += 1;
+                        sanitizedTypeString += ", T" + commaCount;
+                        break;
+                    case '<':
+                        nestingLevel += 1;
+                        break;
+                    case '>':
+                        nestingLevel -= 1;
+                        break;
+                }
+            }
+            mapped = sanitizedTypeString + "}";
+        }
+
+        return $"""<see cref="{mapped}" />""";
     }
 
     private static string FormatEntityCref(Entity entity, string currentNamespace)

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -98,6 +98,7 @@ internal static class DocCommentFormatter
 
         if (entity is CustomType custom)
         {
+            // Custom types don't generate a C# type; link to their mapped C# type instead.
             if (custom.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0] is string mapped)
             {
                 return FormatTypeString(mapped);

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -19,8 +19,8 @@ internal static class DocCommentFormatter
 
         return string.Concat(overview.Select(c => c switch
         {
-            CommentText t => CommentTag.XmlEscape(t.Value),
-            CommentInlineLink l => FormatInlineLink(l.Target, currentNamespace),
+            CommentText text => CommentTag.XmlEscape(text.Value),
+            CommentInlineLink link => FormatInlineLink(link.Target, currentNamespace),
             _ => ""
         })).TrimEnd();
     }
@@ -36,30 +36,30 @@ internal static class DocCommentFormatter
 
         foreach (CommentLink link in seeTags)
         {
-            if (link is ResolvedCommentLink r)
+            if (link is ResolvedCommentLink resolved)
             {
-                yield return new CommentTag("seealso", "cref", FormatEntityCref(r.Entity, currentNamespace), "");
+                yield return new CommentTag("seealso", "cref", FormatEntityCref(resolved.Entity, currentNamespace), "");
             }
         }
     }
 
     private static string FormatInlineLink(CommentLink link, string currentNamespace) => link switch
     {
-        ResolvedCommentLink r => $"""<see cref="{FormatEntityCref(r.Entity, currentNamespace)}" />""",
-        UnresolvedCommentLink u => $"<c>{CommentTag.XmlEscape(u.Identifier)}</c>",
+        ResolvedCommentLink resolved => $"""<see cref="{FormatEntityCref(resolved.Entity, currentNamespace)}" />""",
+        UnresolvedCommentLink unresolved => $"<c>{CommentTag.XmlEscape(unresolved.Identifier)}</c>",
         _ => ""
     };
 
     /// <summary>Converts a C# type string into a form that can be safely used in cref attributes. Specifically, it
-    /// converts generic type parameters into their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).</summary>
+    /// converts generic type parameters into their cref-friendly forms (e.g. IList{T}, IDictionary{T0, T1}).</summary>
     private static string FormatTypeString(string typeString)
     {
-        // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).
+        // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T}, IDictionary{T0, T1}).
         var start = typeString.IndexOf('<', StringComparison.Ordinal);
         if (start != -1)
         {
-            // Get the type-name without any generics, then append a generic parameter 'T0'. There must be at least one.
-            string sanitizedTypeString = string.Concat(typeString.AsSpan(0, start), "{T0");
+            // Get the type-name without any generics, then append a generic parameter 'T'. There must be at least one.
+            string sanitizedTypeString = string.Concat(typeString.AsSpan(0, start), "{T");
 
             // Add an extra type parameter for each top-level comma we see, skipping over any commas within nested
             // generic types, since they don't correspond to type parameters of the outer type.
@@ -70,8 +70,8 @@ internal static class DocCommentFormatter
                 switch (c)
                 {
                     case ',' when nestingLevel == 1: // Only count commas within the first level of '<...>'.
+                        sanitizedTypeString = $"{commaCount}{sanitizedTypeString}, T";
                         commaCount += 1;
-                        sanitizedTypeString = $"{sanitizedTypeString}, T{commaCount}";
                         break;
                     case '<':
                         nestingLevel += 1;
@@ -80,6 +80,12 @@ internal static class DocCommentFormatter
                         nestingLevel -= 1;
                         break;
                 }
+            }
+            if (commaCount > 0)
+            {
+                // If there were multiple generic parameters, we generate T0, T1, ... instead of T. But we always have
+                // a trailing 'T' with no number. Write the final number if there were multiple parameters to get 'TN'.
+                sanitizedTypeString += commaCount;
             }
             typeString = sanitizedTypeString + "}";
         }

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -50,6 +50,8 @@ internal static class DocCommentFormatter
         _ => ""
     };
 
+    /// <summary>Converts a C# type string into a form that can be safely used in cref attributes. Specifically, it
+    /// converts generic type parameters into their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).</summary>
     private static string FormatTypeString(string typeString)
     {
         // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -69,7 +69,7 @@ internal static class DocCommentFormatter
                 {
                     case ',' when nestingLevel == 1: // Only count commas within the first level of '<...>'.
                         commaCount += 1;
-                        sanitizedTypeString += ", T" + commaCount;
+                        sanitizedTypeString = $"{sanitizedTypeString}, T{commaCount}";
                         break;
                     case '<':
                         nestingLevel += 1;

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -71,7 +71,7 @@ internal static class DocCommentFormatter
         // Type aliases don't generate a C# type; link to the underlying C# type instead.
         string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
 
-        // For generic mapped we have to convert them to their cref-friendly forms (ex: IList{T0}, IDictionary{T0, T1}).
+        // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).
         var start = mapped.IndexOf('<', StringComparison.Ordinal);
         if (start != -1)
         {

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -36,22 +36,7 @@ internal static class DocCommentFormatter
 
         foreach (CommentLink link in seeTags)
         {
-            if (link is not ResolvedCommentLink r)
-            {
-                continue;
-            }
-
-            if (r.Entity is TypeAlias alias)
-            {
-                // Type aliases don't generate a C# type; map to the underlying C# type. We can't reliably
-                // produce a seealso for a generic mapped type without C# parsing, so skip those.
-                string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
-                if (!mapped.Contains('<', StringComparison.Ordinal))
-                {
-                    yield return new CommentTag("seealso", "cref", mapped, "");
-                }
-            }
-            else
+            if (link is ResolvedCommentLink r)
             {
                 yield return new CommentTag("seealso", "cref", FormatEntityCref(r.Entity, currentNamespace), "");
             }
@@ -60,29 +45,25 @@ internal static class DocCommentFormatter
 
     private static string FormatInlineLink(CommentLink link, string currentNamespace) => link switch
     {
-        ResolvedCommentLink { Entity: TypeAlias alias } => FormatTypeAliasInline(alias, currentNamespace),
         ResolvedCommentLink r => $"""<see cref="{FormatEntityCref(r.Entity, currentNamespace)}" />""",
         UnresolvedCommentLink u => $"<c>{CommentTag.XmlEscape(u.Identifier)}</c>",
         _ => ""
     };
 
-    private static string FormatTypeAliasInline(TypeAlias alias, string currentNamespace)
+    private static string FormatTypeString(string typeString)
     {
-        // Type aliases don't generate a C# type; link to the underlying C# type instead.
-        string mapped = alias.UnderlyingType.Type.ToTypeString(currentNamespace);
-
         // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T0}, IDictionary{T0, T1}).
-        var start = mapped.IndexOf('<', StringComparison.Ordinal);
+        var start = typeString.IndexOf('<', StringComparison.Ordinal);
         if (start != -1)
         {
             // Get the type-name without any generics, then append a generic parameter 'T0'. There must be at least one.
-            string sanitizedTypeString = string.Concat(mapped.AsSpan(0, start), "{T0");
+            string sanitizedTypeString = string.Concat(typeString.AsSpan(0, start), "{T0");
 
             // Add an extra type parameter for each top-level comma we see, skipping over any commas within nested
             // generic types, since they don't correspond to type parameters of the outer type.
             int commaCount = 0;
             int nestingLevel = 0;
-            foreach(char c in mapped)
+            foreach(char c in typeString)
             {
                 switch (c)
                 {
@@ -98,18 +79,32 @@ internal static class DocCommentFormatter
                         break;
                 }
             }
-            mapped = sanitizedTypeString + "}";
+            typeString = sanitizedTypeString + "}";
         }
 
-        return $"""<see cref="{mapped}" />""";
+        return typeString;
     }
 
     private static string FormatEntityCref(Entity entity, string currentNamespace)
     {
+        if (entity is TypeAlias alias)
+        {
+            // Type aliases don't generate a C# type; link to the underlying C# type instead.
+            string mapped = alias.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0] ?? alias.UnderlyingType.Type.ToTypeString(currentNamespace);
+            return FormatTypeString(mapped);
+        }
+
+        if (entity is CustomType custom)
+        {
+            if (custom.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0] is string mapped)
+            {
+                return FormatTypeString(mapped);
+            }
+        }
+
         string name = entity switch
         {
             Interface => $"I{entity.Name}",
-            CustomType ct => ct.Attributes.FindAttribute(CSAttributes.CSType)?.Args[0] ?? entity.Name,
             Operation op when op.Parent is Interface => $"I{op.Parent.Name}.{entity.Name}Async",
             Field f when f.Parent is not null => $"{f.Parent.Name}.{entity.Name}",
             VariantEnum.Variant e when e.Parent is not null => $"{e.Parent.Name}.{entity.Name}",


### PR DESCRIPTION
This PR follows in the footsteps of #4573. When we generate a link to a generic type, we just use code-formatting instead to avoid all the headaches we found in #4566.

This PR updates our behavior to always generate a valid link, by massaging generic types with a little parser.
It replaces `<` and `>` with `{` and `}`, and replaces the actual type parameters with `T0`, `T1`, etc., up to `TN` where `N` is the number of commas in the type-string. This is the expected syntax for linking to generic types with `cref` in DocFX.

----

Before:
```csharp
///  The <see cref="string" /> alias maps to a non-generic type while <c>global::System.Collections.Generic.IList&lt;string&gt;</c>,
///  <c>global::System.Collections.Generic.IDictionary&lt;string, MySession&gt;</c>, and <c>ZeroC.Slice.Result&lt;MySession, string&gt;</c> map to generic types.
```

After:
```csharp
///  The <see cref="string" /> alias maps to a non-generic type while <see cref="global::System.Collections.Generic.IList{T0}" />,
///  <see cref="global::System.Collections.Generic.IDictionary{T0, T1}" />, and <see cref="ZeroC.Slice.Result{T0, T1}" /> map to generic types.
```

These are easier to read (no XML escaping) and are clickable links.
(This snippet was generated from `tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice`)