### PR TITLE
Update the SlicecTask to Handle the New Diagnostic Output Format

### DIFF
--- a/src/IceRpc.Slice.Tools/Diagnostic.cs
+++ b/src/IceRpc.Slice.Tools/Diagnostic.cs
@@ -9,7 +9,7 @@ public class Diagnostic
     public string Message { get; set; } = "";
     public string Severity { get; set; } = "";
 
-    public Snippet? Snippet { get; set; } = null;
+    public Snippet? Snippet { get; set; }
     public Note[] Notes { get; set; } = Array.Empty<Note>();
 
     [JsonPropertyName("error_code")]

--- a/src/IceRpc.Slice.Tools/Diagnostic.cs
+++ b/src/IceRpc.Slice.Tools/Diagnostic.cs
@@ -9,8 +9,7 @@ public class Diagnostic
     public string Message { get; set; } = "";
     public string Severity { get; set; } = "";
 
-    [JsonPropertyName("span")]
-    public SourceSpan? SourceSpan { get; set; } = null;
+    public Snippet? Snippet { get; set; } = null;
     public Note[] Notes { get; set; } = Array.Empty<Note>();
 
     [JsonPropertyName("error_code")]

--- a/src/IceRpc.Slice.Tools/Note.cs
+++ b/src/IceRpc.Slice.Tools/Note.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
-using System.Text.Json.Serialization;
-
 namespace IceRpc.Slice.Tools;
 
 public class Note
 {
     public string Message { get; set; } = "";
 
-    [JsonPropertyName("span")]
-    public SourceSpan? SourceSpan { get; set; } = null;
+    public Snippet? Snippet { get; set; } = null;
 }

--- a/src/IceRpc.Slice.Tools/Note.cs
+++ b/src/IceRpc.Slice.Tools/Note.cs
@@ -6,5 +6,5 @@ public class Note
 {
     public string Message { get; set; } = "";
 
-    public Snippet? Snippet { get; set; } = null;
+    public Snippet? Snippet { get; set; }
 }

--- a/src/IceRpc.Slice.Tools/SlicecTask.cs
+++ b/src/IceRpc.Slice.Tools/SlicecTask.cs
@@ -124,7 +124,7 @@ public class SlicecTask : ToolTask
 
             foreach (Note note in diagnostic.Notes)
             {
-                var noteSpan = note.Snippet?.SourceSpan ?? new SourceSpan();
+                var noteSpan = note.Snippet?.SourceSpan ?? diagnosticSpan;
                 Log.LogMessage(
                     "",
                     "",

--- a/src/IceRpc.Slice.Tools/SlicecTask.cs
+++ b/src/IceRpc.Slice.Tools/SlicecTask.cs
@@ -112,28 +112,28 @@ public class SlicecTask : ToolTask
                 return;
             }
 
-            diagnostic.SourceSpan ??= new SourceSpan();
+            var diagnosticSpan = diagnostic.Snippet?.SourceSpan ?? new SourceSpan();
             diagnostic.Notes ??= Array.Empty<Note>();
             LogSliceCompilerDiagnostic(
                 diagnostic.Severity,
                 diagnostic.Message,
                 diagnostic.ErrorCode,
-                diagnostic.SourceSpan.File,
-                diagnostic.SourceSpan.Start,
-                diagnostic.SourceSpan.End);
+                diagnosticSpan.File,
+                diagnosticSpan.Start,
+                diagnosticSpan.End);
 
             foreach (Note note in diagnostic.Notes)
             {
-                note.SourceSpan ??= diagnostic.SourceSpan;
+                var noteSpan = note.Snippet?.SourceSpan ?? new SourceSpan();
                 Log.LogMessage(
                     "",
                     "",
                     "",
-                    note.SourceSpan.File,
-                    note.SourceSpan.Start.Row,
-                    note.SourceSpan.Start.Column,
-                    note.SourceSpan.End.Row,
-                    note.SourceSpan.End.Column,
+                    noteSpan.File,
+                    noteSpan.Start.Row,
+                    noteSpan.Start.Column,
+                    noteSpan.End.Row,
+                    noteSpan.End.Column,
                     MessageImportance.High,
                     note.Message);
             }

--- a/src/IceRpc.Slice.Tools/Snippet.cs
+++ b/src/IceRpc.Slice.Tools/Snippet.cs
@@ -7,7 +7,7 @@ namespace IceRpc.Slice.Tools;
 public class Snippet
 {
     [JsonPropertyName("span")]
-    public SourceSpan SourceSpan { get; set; } = null;
+    public SourceSpan SourceSpan { get; set; } = new();
 
     public string Text { get; set; } = "";
 }

--- a/src/IceRpc.Slice.Tools/Snippet.cs
+++ b/src/IceRpc.Slice.Tools/Snippet.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+using System.Text.Json.Serialization;
+
 namespace IceRpc.Slice.Tools;
 
 public class Snippet

--- a/src/IceRpc.Slice.Tools/Snippet.cs
+++ b/src/IceRpc.Slice.Tools/Snippet.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace IceRpc.Slice.Tools;
+
+public class Snippet
+{
+    [JsonPropertyName("span")]
+    public SourceSpan SourceSpan { get; set; } = null;
+
+    public string Text { get; set; } = "";
+}


### PR DESCRIPTION
This PR updates the task to handle the new `snippet` field which replaced `span` on both `Diagnostic` and `Note`.
See: https://github.com/icerpc/slicec/pull/772
So now instead of `Span` being directly on these types, these types hold a `Snippet`, where:
```
Snippet {
    text: string,
    span: Span,
}
```

Right now, the task just ignores the text snippet. Would this extra information be of any use to log in the task?
Not clear to me.