### PR TITLE
Fix IceRpc.ServiceGenerator silently dropping derived operations that collide with base operations (#4461)

### DIFF
--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -58,22 +58,36 @@ internal sealed class Parser
                     continue;
                 }
 
+                ImmutableArray<INamedTypeSymbol> baseInterfaces = [];
                 IReadOnlyList<ServiceMethod> baseServiceMethods = [];
+
                 INamedTypeSymbol? baseServiceClass = GetBaseServiceClass(classSymbol);
+
                 if (baseServiceClass is not null)
                 {
-                    baseServiceMethods = GetServiceMethods(baseServiceClass.AllInterfaces);
+                    baseInterfaces = baseServiceClass.AllInterfaces;
+                    baseServiceMethods = GetServiceMethods(baseInterfaces);
                 }
 
-                IEnumerable<ServiceMethod> serviceMethods =
-                    GetServiceMethods(classSymbol.AllInterfaces).Except(baseServiceMethods);
+                // Partition the interfaces into those inherited from the base service class and those new in this
+                // class. Methods from inherited interfaces are already dispatched by the base; methods from new
+                // interfaces are what this class adds.
+                var newInterfaces = classSymbol.AllInterfaces
+                    // The explicit type argument is required because SymbolEqualityComparer.Default is typed as
+                    // IEqualityComparer<ISymbol>, which would otherwise infer Except's element type as ISymbol.
+                    .Except<INamedTypeSymbol>(baseInterfaces, SymbolEqualityComparer.Default)
+                    .ToImmutableArray();
 
-                // We check for duplicates only once per class.
-                var operationNames = new HashSet<string>();
+                IEnumerable<ServiceMethod> serviceMethods = GetServiceMethods(newInterfaces);
+
+                // We check for duplicates only once per class. Seed the set with the base service operation names so
+                // we also report collisions between an operation added by this class and a base operation.
+                var operationNames = new HashSet<string>(baseServiceMethods.Select(m => m.OperationName));
                 foreach (ServiceMethod method in serviceMethods)
                 {
                     if (!operationNames.Add(method.OperationName))
                     {
+                        // The diagnostic report is not fatal: we keep going.
                         _reportDiagnostic(
                             Diagnostic.Create(
                                 DiagnosticDescriptors.DuplicateOperationNames,
@@ -83,7 +97,7 @@ internal sealed class Parser
                     }
                 }
 
-                // Suppress duplicates, if any.
+                // Suppress duplicates, if any. Any such duplicate was reported above as an error.
                 serviceMethods = serviceMethods.Distinct();
 
                 string containingNamespace = classSymbol.ContainingNamespace.GetFullName();

--- a/tests/IceRpc.ServiceGenerator.Tests/IceRpc.ServiceGenerator.Tests.csproj
+++ b/tests/IceRpc.ServiceGenerator.Tests/IceRpc.ServiceGenerator.Tests.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
@@ -25,7 +26,7 @@
     <ProjectReference Include="../../src/IceRpc.Ice/IceRpc.Ice.csproj" />
     <ProjectReference Include="../../src/IceRpc.Slice/IceRpc.Slice.csproj" />
     <ProjectReference Include="../../src/IceRpc.Protobuf/IceRpc.Protobuf.csproj" />
-    <ProjectReference Include="../../src/IceRpc.ServiceGenerator/IceRpc.ServiceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../src/IceRpc.ServiceGenerator/IceRpc.ServiceGenerator.csproj" OutputItemType="Analyzer" />
     <ProjectReference Include="../IceRpc.Tests.Common/IceRpc.Tests.Common.csproj" />
     <!-- Reference the built-in Slice files -->
     <SliceDirectory Include="../../slice" />

--- a/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
@@ -67,9 +67,8 @@ public partial class MixedServiceTests
             CancellationToken cancellationToken) => new(message);
     }
 
-    /// <summary>Verifies that the service generator reports IRSG0001 when a derived service class adds an
-    /// operation whose name collides with an operation declared by its base service class (via a different
-    /// interface). Without the fix, the colliding derived operation would be silently dropped.</summary>
+    /// <summary>Verifies that the service generator reports IRSG0001 when a derived service class adds an operation
+    /// whose name collides with an operation declared by its base service class (via a different interface).</summary>
     [Test]
     public void Derived_service_with_operation_name_colliding_with_base_reports_diagnostic()
     {
@@ -130,7 +129,7 @@ public partial class MixedServiceTests
 
         // Act
         _ = CSharpGeneratorDriver
-            .Create(new global::IceRpc.ServiceGenerator.ServiceGenerator())
+            .Create(new IceRpc.ServiceGenerator.ServiceGenerator())
             .RunGeneratorsAndUpdateCompilation(compilation, out _, out ImmutableArray<Diagnostic> diagnostics);
 
         // Assert

--- a/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
@@ -129,10 +129,9 @@ public partial class MixedServiceTests
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         // Act
-        GeneratorDriver driver = CSharpGeneratorDriver
+        _ = CSharpGeneratorDriver
             .Create(new global::IceRpc.ServiceGenerator.ServiceGenerator())
             .RunGeneratorsAndUpdateCompilation(compilation, out _, out ImmutableArray<Diagnostic> diagnostics);
-        _ = driver;
 
         // Assert
         Assert.That(

--- a/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+// cspell:ignore IRSG
+
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Features;
 using IceRpc.Tests.Common;

--- a/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
@@ -3,7 +3,10 @@
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Features;
 using IceRpc.Tests.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
+using System.Collections.Immutable;
 
 namespace IceRpc.ServiceGenerator.Tests;
 
@@ -60,5 +63,82 @@ public partial class MixedServiceTests
             ProtoMessage message,
             IFeatureCollection? features,
             CancellationToken cancellationToken) => new(message);
+    }
+
+    /// <summary>Verifies that the service generator reports IRSG0001 when a derived service class adds an
+    /// operation whose name collides with an operation declared by its base service class (via a different
+    /// interface). Without the fix, the colliding derived operation would be silently dropped.</summary>
+    [Test]
+    public void Derived_service_with_operation_name_colliding_with_base_reports_diagnostic()
+    {
+        // Arrange
+        const string source = """
+            using IceRpc;
+            using IceRpc.Features;
+            using IceRpc.Protobuf.RpcMethods;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestNs;
+
+            public interface IBaseTestService
+            {
+                [RpcMethod("ping")]
+                ValueTask<string> BasePingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
+            }
+
+            public interface IDerivedTestService
+            {
+                [RpcMethod("ping")]
+                ValueTask<string> DerivedPingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
+            }
+
+            [Service]
+            public partial class BaseTestService : IBaseTestService
+            {
+                public ValueTask<string> BasePingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
+                    new(input);
+            }
+
+            [Service]
+            public partial class DerivedTestService : BaseTestService, IDerivedTestService
+            {
+                public ValueTask<string> DerivedPingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
+                    new(input);
+            }
+            """;
+
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        // Reference all assemblies currently loaded so the test source can resolve IceRpc types and BCL types.
+        ImmutableArray<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToImmutableArray();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "DuplicateOpTest",
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Act
+        GeneratorDriver driver = CSharpGeneratorDriver
+            .Create(new global::IceRpc.ServiceGenerator.ServiceGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out _, out ImmutableArray<Diagnostic> diagnostics);
+        _ = driver;
+
+        // Assert
+        Assert.That(
+            diagnostics.Any(d =>
+                d.Id == "IRSG0001" &&
+                d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("ping", StringComparison.Ordinal)),
+            Is.True,
+            $"Expected IRSG0001 for operation 'ping'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
     }
 }


### PR DESCRIPTION
Fixes #4461.

### Problem

When a derived `[Service]` class declares an operation whose IDL name collides with an operation already declared by its base service class (via a different interface), the generator silently drops the derived operation. Incoming requests for that operation name then dispatch to the base implementation, diverging from the declared service contract — and no diagnostic is emitted.

Root cause: in `Parser.GetServiceDefinitions`, the duplicate-name check ran on the result of `derivedServiceMethods.Except(baseServiceMethods)`. Because `ServiceMethod` equality is by `OperationName`, `Except` filtered out the derived method first, so the collision never reached the diagnostic loop.

### Note on the audit recommendation

The audit suggested making `ServiceMethod.Equals` consider the full method identity (subtype + interface + signature) so both methods would be kept. That isn't right for this generator: the dispatcher routes by operation-name string, so two methods sharing an op name in one dispatcher are fundamentally undispatchable regardless of C# signature. The correct outcome is a diagnostic, not preserving both. So `Equals`/`GetHashCode` keyed on `OperationName` is left as-is.

### Fix

In `Parser.GetServiceDefinitions`:

- Partition `classSymbol.AllInterfaces` into interfaces inherited from the base service class vs. interfaces new in this class (using `SymbolEqualityComparer.Default`). Only the new interfaces contribute operations to dispatch from this class.
- Seed the duplicate-name `HashSet` with the base service's operation names, so collisions between an operation added by this class and a base operation are now reported as `IRSG0001` instead of silently dropped.

This also addresses the broader concern in the issue that two methods with different names mapping to the same operation name in the same dispatcher should be reported as a diagnostic, not silently merged.

### Tests

Added `MixedServiceTests.Derived_service_with_operation_name_colliding_with_base_reports_diagnostic`, which uses `CSharpGeneratorDriver` to run `ServiceGenerator` against a small in-memory source where a derived `[Service]` class declares an operation (`"ping"`) whose name collides with a base operation declared via a different interface, and asserts that `IRSG0001` is reported.

Verified that reverting only the `Parser.cs` change makes the new test fail, and that the existing `IceRpc.Ice.Generator.Tests` (which exercise legitimate inheritance via shared interfaces) still pass — they were the original signal that the first cut of the fix was over-eager.

### Files changed

- `src/IceRpc.ServiceGenerator/Internal/Parser.cs` — partition interfaces and seed the duplicate-name set.
- `tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs` — new collision test.
- `tests/IceRpc.ServiceGenerator.Tests/IceRpc.ServiceGenerator.Tests.csproj` — add `Microsoft.CodeAnalysis.CSharp` reference and drop `ReferenceOutputAssembly="false"` on the generator project ref so the test can instantiate `ServiceGenerator` directly while still wiring it as an analyzer.
