### PR TITLE
Fix How we Reference Generic Types in Doc-Comments

### DIFF
--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -131,7 +131,7 @@ internal static class OperationExtensions
             return fn.Build();
         }
 
-        /// <summary>Returns the C# return type for an operation (Task, Task&lt;T&gt;, or Task&lt;tuple&gt;).
+        /// <summary>Returns the C# return type for an operation (Task, Task{T}, or Task{tuple}).
         /// Stream returns are included in the tuple with their stream type.</summary>
         internal string GetClientReturnType(string currentNamespace) =>
             BuildReturnType("global::System.Threading.Tasks.Task", op, currentNamespace, fieldType: false);

--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -131,8 +131,8 @@ internal static class OperationExtensions
             return fn.Build();
         }
 
-        /// <summary>Returns the C# return type for an operation (Task, Task{T}, or Task{tuple}).
-        /// Stream returns are included in the tuple with their stream type.</summary>
+        /// <summary>Returns the C# return type for an operation (<c>Task</c>, <c>Task&lt;T&gt;</c>, or
+        /// <c>Task&lt;tuple&gt;</c>). Stream returns are included in the tuple with their stream type.</summary>
         internal string GetClientReturnType(string currentNamespace) =>
             BuildReturnType("global::System.Threading.Tasks.Task", op, currentNamespace, fieldType: false);
 

--- a/src/IceRpc/Transports/DuplexConnectionOptions.cs
+++ b/src/IceRpc/Transports/DuplexConnectionOptions.cs
@@ -21,7 +21,7 @@ public record class DuplexConnectionOptions
     /// <value>A pool of memory blocks used for buffer management. Defaults to <see cref="MemoryPool{T}.Shared"
     /// />.</value>
     /// <remarks>The built-in TCP transport requires the pool to return array-backed memory blocks, because its
-    /// multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(IList{ArraySegment{byte}},
     /// System.Net.Sockets.SocketFlags)" />. The Coloc transport has no such requirement.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 

--- a/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
+++ b/src/IceRpc/Transports/MultiplexedConnectionOptions.cs
@@ -35,7 +35,7 @@ public record class MultiplexedConnectionOptions
     /// />.</value>
     /// <remarks>Some multiplexed transports require the pool to return array-backed memory blocks. Slic over TCP
     /// does, because Slic's write buffers are allocated from this pool and passed down to the TCP transport,
-    /// whose multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(System.Collections.Generic.IList{ArraySegment{byte}},
+    /// whose multi-segment write path uses <see cref="System.Net.Sockets.Socket.SendAsync(IList{ArraySegment{byte}},
     /// System.Net.Sockets.SocketFlags)" />. The QUIC transport has no such requirement.</remarks>
     public MemoryPool<byte> Pool { get; set; } = MemoryPool<byte>.Shared;
 

--- a/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
+++ b/src/ZeroC.Slice.Generator/DocCommentFormatter.cs
@@ -51,7 +51,8 @@ internal static class DocCommentFormatter
     };
 
     /// <summary>Converts a C# type string into a form that can be safely used in cref attributes. Specifically, it
-    /// converts generic type parameters into their cref-friendly forms (e.g. IList{T}, IDictionary{T0, T1}).</summary>
+    /// converts generic type parameters into their cref-friendly forms (<c>IList{T}</c>, <c>IDictionary{T0, T1}</c>).
+    /// </summary>
     private static string FormatTypeString(string typeString)
     {
         // For generic types we have to convert them to their cref-friendly forms (e.g. IList{T}, IDictionary{T0, T1}).

--- a/src/ZeroC.Slice.Generator/FieldExtensions.cs
+++ b/src/ZeroC.Slice.Generator/FieldExtensions.cs
@@ -254,7 +254,7 @@ internal static class FieldExtensions
         /// <summary>Gets a value indicating whether this field has the cs::readonly attribute.</summary>
         internal bool IsReadonly => value.Attributes.HasAttribute(CSAttributes.CSReadonly);
 
-        /// <summary>Gets a value indicating whether this field maps to <c>ReadOnlyMemory&lt;T&gt;</c> for outgoing
+        /// <summary>Gets a value indicating whether this field maps to <c>ReadOnlyMemory{T}</c> for outgoing
         /// parameters (fixed-size primitive sequences without cs::type).</summary>
         internal bool IsReadOnlyMemoryParam =>
             value.DataType.Type is SequenceType seq

--- a/src/ZeroC.Slice.Generator/FieldExtensions.cs
+++ b/src/ZeroC.Slice.Generator/FieldExtensions.cs
@@ -254,7 +254,7 @@ internal static class FieldExtensions
         /// <summary>Gets a value indicating whether this field has the cs::readonly attribute.</summary>
         internal bool IsReadonly => value.Attributes.HasAttribute(CSAttributes.CSReadonly);
 
-        /// <summary>Gets a value indicating whether this field maps to <c>ReadOnlyMemory{T}</c> for outgoing
+        /// <summary>Gets a value indicating whether this field maps to <c>ReadOnlyMemory&lt;T&gt;</c> for outgoing
         /// parameters (fixed-size primitive sequences without cs::type).</summary>
         internal bool IsReadOnlyMemoryParam =>
             value.DataType.Type is SequenceType seq

--- a/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
+++ b/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
@@ -75,7 +75,7 @@ internal static class TypeRefExtensions
 
     /// <summary>Returns the C# type string for an outgoing parameter (encode source). Sequences of fixed-size
     /// primitives map to <c>ReadOnlyMemory&lt;T&gt;</c>, other sequences to <c>IEnumerable&lt;T&gt;</c>, and
-    /// dictionaries to <c>IEnumerable&lt;KeyValuePair&lt;K,V&gt;</c>.</summary>
+    /// dictionaries to <c>IEnumerable&lt;KeyValuePair&lt;K,V&gt;&gt;</c>.</summary>
     internal static string OutgoingParameterTypeString(this TypeRef typeRef, bool isOptional, string currentNamespace)
     {
         bool ignoreOptional = false;

--- a/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
+++ b/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
@@ -55,7 +55,7 @@ internal static class TypeRefExtensions
     }
 
     /// <summary>Returns the C# type string for an incoming parameter (decode target). Sequences map to arrays,
-    /// dictionaries map to Dictionary&lt;K,V&gt;. Respects cs::type attribute.</summary>
+    /// dictionaries map to Dictionary{K,V};. Respects cs::type attribute.</summary>
     internal static string IncomingParameterTypeString(this TypeRef typeRef, bool isOptional, string currentNamespace)
     {
         string baseType = typeRef.Type switch
@@ -74,8 +74,8 @@ internal static class TypeRefExtensions
     }
 
     /// <summary>Returns the C# type string for an outgoing parameter (encode source). Sequences of fixed-size
-    /// primitives map to ReadOnlyMemory&lt;T&gt;, other sequences to IEnumerable&lt;T&gt;, dictionaries to
-    /// IEnumerable&lt;KeyValuePair&lt;K,V&gt;&gt;.</summary>
+    /// primitives map to ReadOnlyMemory{T}, other sequences to IEnumerable{T}, dictionaries to
+    /// IEnumerable{KeyValuePair{K,V}}.</summary>
     internal static string OutgoingParameterTypeString(this TypeRef typeRef, bool isOptional, string currentNamespace)
     {
         bool ignoreOptional = false;

--- a/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
+++ b/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
@@ -55,7 +55,7 @@ internal static class TypeRefExtensions
     }
 
     /// <summary>Returns the C# type string for an incoming parameter (decode target). Sequences map to arrays,
-    /// dictionaries map to Dictionary{K,V};. Respects cs::type attribute.</summary>
+    /// dictionaries map to <c>Dictionary&lt;K,V&gt;</c>. Respects cs::type attribute.</summary>
     internal static string IncomingParameterTypeString(this TypeRef typeRef, bool isOptional, string currentNamespace)
     {
         string baseType = typeRef.Type switch
@@ -74,8 +74,8 @@ internal static class TypeRefExtensions
     }
 
     /// <summary>Returns the C# type string for an outgoing parameter (encode source). Sequences of fixed-size
-    /// primitives map to ReadOnlyMemory{T}, other sequences to IEnumerable{T}, dictionaries to
-    /// IEnumerable{KeyValuePair{K,V}}.</summary>
+    /// primitives map to <c>ReadOnlyMemory&lt;T&gt;</c>, other sequences to <c>IEnumerable&lt;T&gt;</c>, and
+    /// dictionaries to <c>IEnumerable&lt;KeyValuePair&lt;K,V&gt;</c>.</summary>
     internal static string OutgoingParameterTypeString(this TypeRef typeRef, bool isOptional, string currentNamespace)
     {
         bool ignoreOptional = false;


### PR DESCRIPTION
We should use code-formatting for the places which are actually code, instead of leaving them in plain-text formatting.






#### Old, and no longer relevant:

The correct syntax is to use '{' and '}' instead of '<' and '>', even if they're XML escaped to '&gt;' or '&lt;'.
As we figured out after some research on #4566.