### PR TITLE
IceRpc.Slice.Tools: prune stale generated outputs across rebuilds

### DIFF
--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -56,19 +56,11 @@
     />
   </ItemGroup>
   <!--
-    Compute the path of the manifest tracking every output produced by the most recent Slicec run. Stored
-    under $(IntermediateOutputPath) so each configuration/TargetFramework has its own copy and parallel
-    multi-target inner builds don't race on a shared file.
-
-    This must run inside a target rather than as a top-level <PropertyGroup>, because $(IntermediateOutputPath)
-    is set by the SDK targets that get imported AFTER this file - at top-level evaluation time it is empty.
+    The manifest tracking every output produced by the most recent Slicec run is stored at
+    $(IntermediateOutputPath)slicec.outputs.txt - this gives each configuration/TargetFramework its own copy
+    so parallel multi-target inner builds don't race on a shared file. $(IntermediateOutputPath) is only
+    available after the SDK targets are imported, so we reference it inline (not via a top-level property).
   -->
-  <Target Name="_InitSlicecManifestPath">
-    <PropertyGroup>
-      <_SlicecOutputManifest>$(IntermediateOutputPath)slicec.outputs.txt</_SlicecOutputManifest>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_ComputeSliceFiles" Condition="@(SliceFile) != ''">
     <ItemGroup>
       <_SliceFile Include="@(SliceFile)" />
@@ -98,9 +90,9 @@
   -->
   <Target Name="_SlicecPruneStaleOutputs"
           BeforeTargets="Slicec;CoreCompile;SlicecClean;Clean"
-          DependsOnTargets="_InitSlicecManifestPath;_ComputeSliceFiles"
+          DependsOnTargets="_ComputeSliceFiles"
           Condition="Exists('$(IntermediateOutputPath)slicec.outputs.txt')">
-    <ReadLinesFromFile File="$(_SlicecOutputManifest)">
+    <ReadLinesFromFile File="$(IntermediateOutputPath)slicec.outputs.txt">
       <Output TaskParameter="Lines" ItemName="_PreviousSlicecOutput" />
     </ReadLinesFromFile>
     <ItemGroup>
@@ -160,7 +152,6 @@
   <!-- Record this build's outputs so the next build can prune anything we no longer produce. -->
   <Target Name="_SlicecWriteOutputManifest"
           AfterTargets="Slicec"
-          DependsOnTargets="_InitSlicecManifestPath"
           Condition="@(SliceFile) != ''">
     <ItemGroup>
       <_AllSlicecOutput Include="%(_SliceFile.GeneratedPath)" />
@@ -168,15 +159,16 @@
     </ItemGroup>
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile
-      File="$(_SlicecOutputManifest)"
+      File="$(IntermediateOutputPath)slicec.outputs.txt"
       Lines="@(_AllSlicecOutput)"
       Overwrite="true" />
   </Target>
 
-  <Target Name="SlicecClean" BeforeTargets="Clean" DependsOnTargets="_InitSlicecManifestPath;_ComputeSliceFiles">
+  <Target Name="SlicecClean" BeforeTargets="Clean" DependsOnTargets="_ComputeSliceFiles">
     <Delete Files="%(_SliceFile.GeneratedPath)" />
     <Delete Files="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
-    <Delete Files="$(_SlicecOutputManifest)" Condition="Exists('$(_SlicecOutputManifest)')" />
+    <Delete Files="$(IntermediateOutputPath)slicec.outputs.txt"
+            Condition="Exists('$(IntermediateOutputPath)slicec.outputs.txt')" />
   </Target>
 
   <!-- Package SliceFile items -->

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -55,13 +55,19 @@
       Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
     />
   </ItemGroup>
-  <PropertyGroup>
-    <!--
-      Manifest tracking every output path produced by the most recent Slicec run. Used to detect and delete
-      stale outputs when SliceFile items are removed or reconfigured (see _SlicecPruneStaleOutputs).
-    -->
-    <_SlicecOutputManifest>$(BaseIntermediateOutputPath)slicec.outputs.txt</_SlicecOutputManifest>
-  </PropertyGroup>
+  <!--
+    Compute the path of the manifest tracking every output produced by the most recent Slicec run. Stored
+    under $(IntermediateOutputPath) so each configuration/TargetFramework has its own copy and parallel
+    multi-target inner builds don't race on a shared file.
+
+    This must run inside a target rather than as a top-level <PropertyGroup>, because $(IntermediateOutputPath)
+    is set by the SDK targets that get imported AFTER this file - at top-level evaluation time it is empty.
+  -->
+  <Target Name="_InitSlicecManifestPath">
+    <PropertyGroup>
+      <_SlicecOutputManifest>$(IntermediateOutputPath)slicec.outputs.txt</_SlicecOutputManifest>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="_ComputeSliceFiles" Condition="@(SliceFile) != ''">
     <ItemGroup>
@@ -85,11 +91,15 @@
     Delete generated files recorded in the previous build's manifest that the current build no longer produces.
     Without this, a removed/renamed .slice file (or a SliceFile whose OutputDir or IceRpc metadata changed) leaves
     orphan .cs files behind that the SDK's default Compile glob keeps picking up.
+
+    BeforeTargets covers both the SliceFile-present case (Slicec/SlicecClean) and the SliceFile-empty case where
+    those targets are skipped by their conditions but stale files from a previous build still need pruning
+    (CoreCompile/Clean).
   -->
   <Target Name="_SlicecPruneStaleOutputs"
-          BeforeTargets="Slicec;SlicecClean"
-          DependsOnTargets="_ComputeSliceFiles"
-          Condition="Exists('$(_SlicecOutputManifest)')">
+          BeforeTargets="Slicec;CoreCompile;SlicecClean;Clean"
+          DependsOnTargets="_InitSlicecManifestPath;_ComputeSliceFiles"
+          Condition="Exists('$(IntermediateOutputPath)slicec.outputs.txt')">
     <ReadLinesFromFile File="$(_SlicecOutputManifest)">
       <Output TaskParameter="Lines" ItemName="_PreviousSlicecOutput" />
     </ReadLinesFromFile>
@@ -97,6 +107,22 @@
       <_CurrentSlicecOutput Include="%(_SliceFile.GeneratedPath)" />
       <_CurrentSlicecOutput Include="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
       <_StaleSlicecOutput Include="@(_PreviousSlicecOutput)" Exclude="@(_CurrentSlicecOutput)" />
+      <!--
+        The SDK's default Compile glob captured these paths during item evaluation, with project-relative
+        Identities. We materialize the relative form into its own item so that <Compile Remove> can match it
+        - inlining the MakeRelative call inside an item transform pattern doesn't evaluate the property
+        function as expected.
+      -->
+      <_StaleSlicecOutputRelative
+        Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_StaleSlicecOutput.Identity)))"
+        Condition="'%(_StaleSlicecOutput.Identity)' != ''" />
+      <!--
+        Remove now, otherwise csc still reports the stale files as inputs and fails with CS2001 once we
+        delete them on disk. We try both the absolute and relative form to cover Compile entries added by
+        either explicit ProjectReference users or the SDK glob.
+      -->
+      <Compile Remove="@(_StaleSlicecOutput)" />
+      <Compile Remove="@(_StaleSlicecOutputRelative)" />
     </ItemGroup>
     <Delete Files="@(_StaleSlicecOutput)" />
   </Target>
@@ -134,19 +160,20 @@
   <!-- Record this build's outputs so the next build can prune anything we no longer produce. -->
   <Target Name="_SlicecWriteOutputManifest"
           AfterTargets="Slicec"
+          DependsOnTargets="_InitSlicecManifestPath"
           Condition="@(SliceFile) != ''">
     <ItemGroup>
       <_AllSlicecOutput Include="%(_SliceFile.GeneratedPath)" />
       <_AllSlicecOutput Include="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
     </ItemGroup>
-    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile
       File="$(_SlicecOutputManifest)"
       Lines="@(_AllSlicecOutput)"
       Overwrite="true" />
   </Target>
 
-  <Target Name="SlicecClean" BeforeTargets="Clean" DependsOnTargets="_ComputeSliceFiles">
+  <Target Name="SlicecClean" BeforeTargets="Clean" DependsOnTargets="_InitSlicecManifestPath;_ComputeSliceFiles">
     <Delete Files="%(_SliceFile.GeneratedPath)" />
     <Delete Files="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
     <Delete Files="$(_SlicecOutputManifest)" Condition="Exists('$(_SlicecOutputManifest)')" />

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -55,6 +55,14 @@
       Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
     />
   </ItemGroup>
+  <PropertyGroup>
+    <!--
+      Manifest tracking every output path produced by the most recent Slicec run. Used to detect and delete
+      stale outputs when SliceFile items are removed or reconfigured (see _SlicecPruneStaleOutputs).
+    -->
+    <_SlicecOutputManifest>$(BaseIntermediateOutputPath)slicec.outputs.txt</_SlicecOutputManifest>
+  </PropertyGroup>
+
   <Target Name="_ComputeSliceFiles" Condition="@(SliceFile) != ''">
     <ItemGroup>
       <_SliceFile Include="@(SliceFile)" />
@@ -71,6 +79,26 @@
         <TelemetryPath>$([MSBuild]::NormalizePath('%(OutputDir)/icerpc_build_telemetry.txt'))</TelemetryPath>
       </_SliceFile>
     </ItemGroup>
+  </Target>
+
+  <!--
+    Delete generated files recorded in the previous build's manifest that the current build no longer produces.
+    Without this, a removed/renamed .slice file (or a SliceFile whose OutputDir or IceRpc metadata changed) leaves
+    orphan .cs files behind that the SDK's default Compile glob keeps picking up.
+  -->
+  <Target Name="_SlicecPruneStaleOutputs"
+          BeforeTargets="Slicec;SlicecClean"
+          DependsOnTargets="_ComputeSliceFiles"
+          Condition="Exists('$(_SlicecOutputManifest)')">
+    <ReadLinesFromFile File="$(_SlicecOutputManifest)">
+      <Output TaskParameter="Lines" ItemName="_PreviousSlicecOutput" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_CurrentSlicecOutput Include="%(_SliceFile.GeneratedPath)" />
+      <_CurrentSlicecOutput Include="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
+      <_StaleSlicecOutput Include="@(_PreviousSlicecOutput)" Exclude="@(_CurrentSlicecOutput)" />
+    </ItemGroup>
+    <Delete Files="@(_StaleSlicecOutput)" />
   </Target>
 
   <Target Name="Slicec" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeSliceFiles" Condition="@(SliceFile) != ''">
@@ -103,9 +131,25 @@
     </ItemGroup>
   </Target>
 
+  <!-- Record this build's outputs so the next build can prune anything we no longer produce. -->
+  <Target Name="_SlicecWriteOutputManifest"
+          AfterTargets="Slicec"
+          Condition="@(SliceFile) != ''">
+    <ItemGroup>
+      <_AllSlicecOutput Include="%(_SliceFile.GeneratedPath)" />
+      <_AllSlicecOutput Include="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
+    </ItemGroup>
+    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <WriteLinesToFile
+      File="$(_SlicecOutputManifest)"
+      Lines="@(_AllSlicecOutput)"
+      Overwrite="true" />
+  </Target>
+
   <Target Name="SlicecClean" BeforeTargets="Clean" DependsOnTargets="_ComputeSliceFiles">
     <Delete Files="%(_SliceFile.GeneratedPath)" />
     <Delete Files="%(_SliceFile.TelemetryPath)" Condition="'%(_SliceFile.TelemetryPath)' != ''" />
+    <Delete Files="$(_SlicecOutputManifest)" Condition="Exists('$(_SlicecOutputManifest)')" />
   </Target>
 
   <!-- Package SliceFile items -->


### PR DESCRIPTION
The build now writes a manifest (obj/slicec.outputs.txt) listing every path produced by the latest Slicec run. Before each subsequent build (and before SlicecClean), any path in the previous manifest that the current build no longer produces is deleted, so:

- removing or renaming a .slice file no longer leaves orphan .cs files matching the SDK's default Compile glob,
- changing OutputDir prunes the old folder's outputs,
- toggling IceRpc=true->false prunes the old .IceRpc.cs.

Closes #4474.