### PR TITLE
Fix #4434: only count caller-initiated cancellations as canceled requests

### DIFF
--- a/src/IceRpc.Metrics/MetricsInterceptor.cs
+++ b/src/IceRpc.Metrics/MetricsInterceptor.cs
@@ -37,7 +37,7 @@ public class MetricsInterceptor : IInvoker
             }
             return response;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
         {
             _invocationMetrics.RequestCancel();
             throw;

--- a/src/IceRpc.Metrics/MetricsMiddleware.cs
+++ b/src/IceRpc.Metrics/MetricsMiddleware.cs
@@ -39,7 +39,7 @@ public class MetricsMiddleware : IDispatcher
             }
             return response;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
         {
             _dispatchMetrics.RequestCancel();
             throw;

--- a/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
@@ -42,7 +42,70 @@ public sealed class MetricsInterceptorTests
             });
 
         using var invocationMetrics = new InvocationMetrics(meterName);
-        var invoker = new InlineInvoker((request, cancellationToken) => throw new OperationCanceledException());
+        using var cts = new CancellationTokenSource();
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            throw new OperationCanceledException(cancellationToken));
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/" });
+        var sut = new MetricsInterceptor(invoker, invocationMetrics);
+        cts.Cancel();
+
+        try
+        {
+            await sut.InvokeAsync(request, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        Assert.That(canceled, Is.EqualTo(new long[] { 1 }));
+        Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
+        Assert.That(total, Is.EqualTo(new long[] { 1 }));
+    }
+
+    /// <summary>Verifies that an OperationCanceledException carrying a token other than the invocation token is
+    /// counted as a failure, not a cancellation.</summary>
+    [Test]
+    public async Task Operation_canceled_exception_with_unrelated_token_publishes_failed_measurement()
+    {
+        const string meterName = "Test.UnrelatedOce.IceRpc.Invocation";
+        var canceled = new List<long>();
+        var current = new List<long>();
+        var failed = new List<long>();
+        var total = new List<long>();
+        using var meterListener = new TestMeterListener<long>(
+            meterName,
+            (instrument, measurement, tags, state) =>
+            {
+                switch (instrument.Name)
+                {
+                    case "canceled-requests":
+                    {
+                        canceled.Add(measurement);
+                        break;
+                    }
+                    case "current-requests":
+                    {
+                        current.Add(measurement);
+                        break;
+                    }
+                    case "failed-requests":
+                    {
+                        failed.Add(measurement);
+                        break;
+                    }
+                    case "total-requests":
+                    {
+                        total.Add(measurement);
+                        break;
+                    }
+                }
+            });
+
+        using var invocationMetrics = new InvocationMetrics(meterName);
+        using var unrelatedCts = new CancellationTokenSource();
+        unrelatedCts.Cancel();
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            throw new OperationCanceledException(unrelatedCts.Token));
         using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/" });
         var sut = new MetricsInterceptor(invoker, invocationMetrics);
 
@@ -54,7 +117,8 @@ public sealed class MetricsInterceptorTests
         {
         }
 
-        Assert.That(canceled, Is.EqualTo(new long[] { 1 }));
+        Assert.That(canceled, Is.Empty);
+        Assert.That(failed, Is.EqualTo(new long[] { 1 }));
         Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
         Assert.That(total, Is.EqualTo(new long[] { 1 }));
     }

--- a/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsInterceptorTests.cs
@@ -109,13 +109,8 @@ public sealed class MetricsInterceptorTests
         using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/" });
         var sut = new MetricsInterceptor(invoker, invocationMetrics);
 
-        try
-        {
-            await sut.InvokeAsync(request, default);
-        }
-        catch (OperationCanceledException)
-        {
-        }
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await sut.InvokeAsync(request, default));
 
         Assert.That(canceled, Is.Empty);
         Assert.That(failed, Is.EqualTo(new long[] { 1 }));

--- a/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
@@ -108,13 +108,7 @@ public sealed class MetricsMiddlewareTests
         using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance);
         var sut = new MetricsMiddleware(dispatcher, dispatchMetrics);
 
-        try
-        {
-            await sut.DispatchAsync(request, default);
-        }
-        catch (OperationCanceledException)
-        {
-        }
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await sut.DispatchAsync(request, default));
 
         Assert.That(canceled, Is.Empty);
         Assert.That(failed, Is.EqualTo(new long[] { 1 }));
@@ -158,13 +152,7 @@ public sealed class MetricsMiddlewareTests
         using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance);
         var sut = new MetricsMiddleware(dispatcher, dispatchMetrics);
 
-        try
-        {
-            await sut.DispatchAsync(request, default);
-        }
-        catch (InvalidOperationException)
-        {
-        }
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.DispatchAsync(request, default));
 
         Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
         Assert.That(failed, Is.EqualTo(new long[] { 1 }));

--- a/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
+++ b/tests/IceRpc.Metrics.Tests/MetricsMiddlewareTests.cs
@@ -41,7 +41,70 @@ public sealed class MetricsMiddlewareTests
             });
 
         using var dispatchMetrics = new DispatchMetrics(meterName);
-        var dispatcher = new InlineDispatcher((request, cancellationToken) => throw new OperationCanceledException());
+        using var cts = new CancellationTokenSource();
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+            throw new OperationCanceledException(cancellationToken));
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance);
+        var sut = new MetricsMiddleware(dispatcher, dispatchMetrics);
+        cts.Cancel();
+
+        try
+        {
+            await sut.DispatchAsync(request, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        Assert.That(canceled, Is.EqualTo(new long[] { 1 }));
+        Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
+        Assert.That(total, Is.EqualTo(new long[] { 1 }));
+    }
+
+    /// <summary>Verifies that an OperationCanceledException carrying a token other than the dispatch token is
+    /// counted as a failure, not a cancellation.</summary>
+    [Test]
+    public async Task Operation_canceled_exception_with_unrelated_token_publishes_failed_measurement()
+    {
+        const string meterName = "Test.UnrelatedOce.IceRpc.Dispatch";
+        var canceled = new List<long>();
+        var current = new List<long>();
+        var failed = new List<long>();
+        var total = new List<long>();
+        using var meterListener = new TestMeterListener<long>(
+            meterName,
+            (instrument, measurement, tags, state) =>
+            {
+                switch (instrument.Name)
+                {
+                    case "canceled-requests":
+                    {
+                        canceled.Add(measurement);
+                        break;
+                    }
+                    case "current-requests":
+                    {
+                        current.Add(measurement);
+                        break;
+                    }
+                    case "failed-requests":
+                    {
+                        failed.Add(measurement);
+                        break;
+                    }
+                    case "total-requests":
+                    {
+                        total.Add(measurement);
+                        break;
+                    }
+                }
+            });
+
+        using var dispatchMetrics = new DispatchMetrics(meterName);
+        using var unrelatedCts = new CancellationTokenSource();
+        unrelatedCts.Cancel();
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+            throw new OperationCanceledException(unrelatedCts.Token));
         using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance);
         var sut = new MetricsMiddleware(dispatcher, dispatchMetrics);
 
@@ -53,7 +116,8 @@ public sealed class MetricsMiddlewareTests
         {
         }
 
-        Assert.That(canceled, Is.EqualTo(new long[] { 1 }));
+        Assert.That(canceled, Is.Empty);
+        Assert.That(failed, Is.EqualTo(new long[] { 1 }));
         Assert.That(current, Is.EqualTo(new long[] { 1, -1 }));
         Assert.That(total, Is.EqualTo(new long[] { 1 }));
     }


### PR DESCRIPTION
Fixes #4434.

Tighten the `OperationCanceledException` catch clauses in `MetricsInterceptor` and `MetricsMiddleware` with a `when (exception.CancellationToken == cancellationToken)` filter, so only caller-initiated cancellations are counted as `canceled-requests`. Other OCEs (deadline timeouts, transport aborts, linked sources from other interceptors, etc.) now fall through to the failure handler and are counted as `failed-requests`.

Also updated the existing canceled tests to use a real `CancellationTokenSource` (the previous tests passed by accident since both tokens were `None`), and added regression tests asserting that an OCE carrying an unrelated token increments `failed-requests`, not `canceled-requests`.