### PR TITLE
Document scoped service / response payload limitation (#4424)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines for AI Coding Agents
+
+These conventions apply to all AI coding assistants (Copilot, Claude Code, etc.) working in this repository.
+
+## Code style
+
+- **Line width: 120 columns.** Applies to C# code, doc comments, and regular comments. Reflow accordingly.
+  This is enforced informally; see `guidelines = 120` in [.editorconfig](.editorconfig).
+  Two exceptions:
+  - A method whose return type is a long tuple keeps the tuple on the same line as the method name, even if
+    that line exceeds 120 columns.
+  - Long string literals may exceed 120 columns rather than being broken up.
+- Indentation: 4 spaces (no tabs) for C# files.
+- Trailing newline at end of file.
+
+## Comments and documentation
+
+- Prefer `#1234` over full GitHub URLs when referencing issues or PRs in this repo
+  (`icerpc/icerpc-csharp`). Use full URLs only when linking to other repositories.
+- XML doc comments use `<summary>`, `<remarks>`, `<param>`, etc. — not Markdown.
+
+## Branch conventions
+
+- `main` is the active development branch. **API-breaking changes are allowed and expected on `main`.**
+  Do not flag, warn about, or suggest `[Obsolete]` shims for source-/binary-breaking changes targeting `main`.
+- For PRs targeting release branches, treat API-breaking changes as warnings worth flagging.
+
+## Tests
+
+- Test projects live under `tests/`. Use NUnit (`[Test]`, `Assert.That(..., Is.X)`).
+- Test method names use `Snake_case_descriptions` (e.g. `Scoped_service_is_disposed_before_response_payload_is_read`).
+
+## Build / test commands
+
+- Build the whole solution: `dotnet build IceRpc.slnx`
+- Run all tests: `dotnet test`
+- Run a single test project: `dotnet test tests/<Project>/<Project>.csproj --filter "FullyQualifiedName~<TestClass>"`

--- a/src/IceRpc/Extensions/DependencyInjection/IDispatcherBuilder.cs
+++ b/src/IceRpc/Extensions/DependencyInjection/IDispatcherBuilder.cs
@@ -4,6 +4,14 @@ namespace IceRpc.Extensions.DependencyInjection;
 
 /// <summary>Provides the mechanism to configure a dispatcher when using Dependency Injection (DI). Each request is
 /// dispatched in its own scope.</summary>
+/// <remarks>The per-request DI scope is disposed as soon as the dispatcher returns its
+/// <see cref="OutgoingResponse" />. The protocol connection then reads <c>response.Payload</c> (and
+/// <c>response.PayloadContinuation</c>) to send the response on the wire — at which point the scope is already gone.
+/// As a result, a response payload that lazily pulls from a scoped service (for example a streamed reply backed by
+/// a scoped <c>HttpClient</c> or by EF Core) will encounter an <see cref="ObjectDisposedException" /> partway through
+/// transmission. To avoid this, materialize the response data inside the dispatcher (under the scope) — for example
+/// by reading it into a buffer or pipe before returning the response — rather than relying on lazy reads from a
+/// scoped dependency.</remarks>
 public interface IDispatcherBuilder
 {
     /// <summary>Gets the service provider.</summary>

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/ScopedPayloadDisposalTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/ScopedPayloadDisposalTests.cs
@@ -47,14 +47,11 @@ public sealed class ScopedPayloadDisposalTests
         var lazyPayload = (LazyScopedPipeReader)response.Payload;
         Assert.That(lazyPayload.CapturedClient.IsDisposed, Is.True);
 
-        // Assert: this is what the protocol connection does at IceRpcProtocolConnection.cs:~1101 —
-        // payloadWriter.CopyFromAsync(response.Payload, ...). Because the scope is already gone, the first ReadAsync
+        // Assert: this mimics what the protocol connection does. Because the scope is already gone, the first ReadAsync
         // surfaces ObjectDisposedException from the scoped dependency.
         Assert.That(
             async () => await response.Payload.ReadAsync(),
             Throws.InstanceOf<ObjectDisposedException>());
-
-        response.Payload.Complete();
     }
 
     public interface IScopedHttpClient

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/ScopedPayloadDisposalTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/ScopedPayloadDisposalTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Extensions.DependencyInjection.Internal;
+using IceRpc.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace IceRpc.Extensions.DependencyInjection.Tests;
+
+/// <summary>Demonstrates the issue reported in #4424: the per-request DI scope is disposed by
+/// <see cref="DispatcherBuilder" /> as soon as the dispatcher returns its <see cref="OutgoingResponse" />, but the
+/// protocol connection only reads <c>response.Payload</c> afterwards. A payload that lazily pulls from a scoped
+/// service therefore hits an <see cref="ObjectDisposedException" /> mid-transmission.</summary>
+public sealed class ScopedPayloadDisposalTests
+{
+    /// <summary>This test documents the limitation: a response payload that lazily pulls from a scoped service will
+    /// fail because the per-request DI scope is already disposed by the time the protocol connection reads the
+    /// payload. Application code must materialize such data inside the dispatcher (under the scope) instead of
+    /// relying on lazy reads.</summary>
+    [Test]
+    public async Task Scoped_service_is_disposed_before_response_payload_is_read()
+    {
+        // Arrange: a scoped service standing in for "scoped HttpClient" / "EF Core DbContext" — i.e. a disposable
+        // dependency resolved from the per-request scope.
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IScopedHttpClient, ScopedHttpClient>()
+            .AddScoped<StreamingService>()
+            .BuildServiceProvider(validateScopes: true);
+
+        var builder = new DispatcherBuilder(provider);
+        builder.Map<StreamingService>("/test");
+        IDispatcher dispatcher = builder.Build();
+
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+        {
+            Path = "/test"
+        };
+
+        // Act: dispatch the request. The dispatcher's await using over the AsyncServiceScope disposes the scope as
+        // soon as DispatchAsync returns the OutgoingResponse — *before* anyone reads the payload.
+        OutgoingResponse response = await dispatcher.DispatchAsync(request);
+
+        // Sanity: the scoped service captured by the lazy payload was indeed disposed by the dispatcher's scope
+        // teardown.
+        var lazyPayload = (LazyScopedPipeReader)response.Payload;
+        Assert.That(lazyPayload.CapturedClient.IsDisposed, Is.True);
+
+        // Assert: this is what the protocol connection does at IceRpcProtocolConnection.cs:~1101 —
+        // payloadWriter.CopyFromAsync(response.Payload, ...). Because the scope is already gone, the first ReadAsync
+        // surfaces ObjectDisposedException from the scoped dependency.
+        Assert.That(
+            async () => await response.Payload.ReadAsync(),
+            Throws.InstanceOf<ObjectDisposedException>());
+
+        response.Payload.Complete();
+    }
+
+    public interface IScopedHttpClient
+    {
+        bool IsDisposed { get; }
+
+        // Returns the next "chunk" of the streamed response.
+        ValueTask<ReadOnlyMemory<byte>> ReadChunkAsync();
+    }
+
+    public sealed class ScopedHttpClient : IScopedHttpClient, IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadChunkAsync()
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+            return new ValueTask<ReadOnlyMemory<byte>>(new byte[] { 1, 2, 3, 4 });
+        }
+    }
+
+    /// <summary>An <see cref="IDispatcher" /> mapped at <c>/test</c>. It captures the request's scoped
+    /// <see cref="IScopedHttpClient" /> and returns a response whose payload reads from it lazily — exactly the
+    /// pattern the audit calls out.</summary>
+    public sealed class StreamingService : IDispatcher
+    {
+        public ValueTask<OutgoingResponse> DispatchAsync(IncomingRequest request, CancellationToken cancellationToken)
+        {
+            IServiceProvider scopedProvider = request.Features.Get<IServiceProviderFeature>()!.ServiceProvider;
+            var scopedClient = scopedProvider.GetRequiredService<IScopedHttpClient>();
+
+            return new ValueTask<OutgoingResponse>(
+                new OutgoingResponse(request)
+                {
+                    Payload = new LazyScopedPipeReader(scopedClient)
+                });
+        }
+    }
+
+    /// <summary>A minimal PipeReader whose data is produced lazily by a scoped dependency. This mirrors a streamed
+    /// reply backed by a scoped HttpClient or DbContext.</summary>
+    private sealed class LazyScopedPipeReader : PipeReader
+    {
+        public IScopedHttpClient CapturedClient { get; }
+
+        public LazyScopedPipeReader(IScopedHttpClient client) => CapturedClient = client;
+
+        public override void AdvanceTo(SequencePosition consumed)
+        {
+        }
+
+        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+        {
+        }
+
+        public override void CancelPendingRead()
+        {
+        }
+
+        public override void Complete(Exception? exception = null)
+        {
+        }
+
+        public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            ReadOnlyMemory<byte> chunk = await CapturedClient.ReadChunkAsync().ConfigureAwait(false);
+            return new ReadResult(new ReadOnlySequence<byte>(chunk), isCanceled: false, isCompleted: true);
+        }
+
+        public override bool TryRead(out ReadResult result)
+        {
+            result = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4424.

Rather than fixing the underlying scope-vs-payload lifetime issue (which has knotty corners around `PayloadContinuation`, sync `PipeReader.Complete`, and error paths — see @pepone's analysis on the issue), this PR documents the limitation and adds a regression test that pins down the current behavior.

## Changes

- **`tests/IceRpc.Extensions.DependencyInjection.Tests/ScopedPayloadDisposalTests.cs`** — new test `Scoped_service_is_disposed_before_response_payload_is_read`. A dispatcher returns a response whose `Payload` lazily pulls from a scoped `IScopedHttpClient` (stand-in for the "scoped `HttpClient` / EF Core `DbContext`" pattern from the audit). The test asserts that:
  - the scoped service is already `Disposed` immediately after `DispatchAsync` returns; and
  - the first `response.Payload.ReadAsync()` (which the protocol connection performs at `IceRpcProtocolConnection.cs:~1101`) surfaces `ObjectDisposedException` from the scoped dependency.

- **`src/IceRpc/Extensions/DependencyInjection/IDispatcherBuilder.cs`** — added a `<remarks>` block documenting the limitation: the per-request DI scope is disposed when the dispatcher returns its `OutgoingResponse`, so a response payload that lazily pulls from a scoped service will hit `ObjectDisposedException` mid-transmission. Recommendation: materialize the response data inside the dispatcher (under the scope) rather than relying on lazy reads.

- **`AGENTS.md`** — new file at the repo root capturing repository conventions for AI coding assistants (line width, issue references, branch policy on API breaks, test naming, build/test commands).
