### PR TITLE
Fix #4462: support [Service] on record class

### DIFF
--- a/src/IceRpc.ServiceGenerator/Internal/DiagnosticDescriptors.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/DiagnosticDescriptors.cs
@@ -14,13 +14,4 @@ internal static class DiagnosticDescriptors
             category: "ServiceGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
-
-    internal static DiagnosticDescriptor InvalidServiceTypeShape { get; } =
-        new DiagnosticDescriptor(
-            id: "IRSG0002", // cspell:disable-line
-            title: "The Service attribute can only be applied to a class or record class",
-            messageFormat: "The Service attribute cannot be applied to {0} '{1}'",
-            category: "ServiceGenerator",
-            DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
 }

--- a/src/IceRpc.ServiceGenerator/Internal/DiagnosticDescriptors.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/DiagnosticDescriptors.cs
@@ -14,4 +14,13 @@ internal static class DiagnosticDescriptors
             category: "ServiceGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+    internal static DiagnosticDescriptor InvalidServiceTypeShape { get; } =
+        new DiagnosticDescriptor(
+            id: "IRSG0002", // cspell:disable-line
+            title: "The Service attribute can only be applied to a class or record class",
+            messageFormat: "The Service attribute cannot be applied to {0} '{1}'",
+            category: "ServiceGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
 }

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -34,7 +34,7 @@ internal sealed class Parser
         ];
     }
 
-    internal IReadOnlyList<ServiceClass> GetServiceDefinitions(IEnumerable<ClassDeclarationSyntax> classes)
+    internal IReadOnlyList<ServiceClass> GetServiceDefinitions(IEnumerable<TypeDeclarationSyntax> typeDeclarations)
     {
         if (_serviceAttribute is null)
         {
@@ -44,15 +44,36 @@ internal sealed class Parser
 
         var serviceDefinitions = new List<ServiceClass>();
         // we enumerate by syntax tree, to minimize the need to instantiate semantic models (since they're expensive)
-        foreach (IGrouping<SyntaxTree, ClassDeclarationSyntax> group in classes.GroupBy(x => x.SyntaxTree))
+        foreach (IGrouping<SyntaxTree, TypeDeclarationSyntax> group in typeDeclarations.GroupBy(x => x.SyntaxTree))
         {
-            foreach (ClassDeclarationSyntax classDeclaration in group)
+            foreach (TypeDeclarationSyntax typeDeclaration in group)
             {
                 // stop if we're asked to
                 _cancellationToken.ThrowIfCancellationRequested();
 
-                SemanticModel semanticModel = _compilation.GetSemanticModel(classDeclaration.SyntaxTree);
-                INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration, _cancellationToken);
+                // The Service attribute is only valid on a class or a record class. Report a diagnostic and skip
+                // anything else (struct, record struct, interface).
+                SyntaxKind kind = typeDeclaration.Kind();
+                if (kind is not SyntaxKind.ClassDeclaration and not SyntaxKind.RecordDeclaration)
+                {
+                    string kindName = kind switch
+                    {
+                        SyntaxKind.StructDeclaration => "struct",
+                        SyntaxKind.RecordStructDeclaration => "record struct",
+                        SyntaxKind.InterfaceDeclaration => "interface",
+                        _ => typeDeclaration.Keyword.ValueText,
+                    };
+                    _reportDiagnostic(
+                        Diagnostic.Create(
+                            DiagnosticDescriptors.InvalidServiceTypeShape,
+                            typeDeclaration.Identifier.GetLocation(),
+                            kindName,
+                            typeDeclaration.Identifier.Text));
+                    continue;
+                }
+
+                SemanticModel semanticModel = _compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
+                INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, _cancellationToken);
                 if (classSymbol is null)
                 {
                     continue;
@@ -91,9 +112,9 @@ internal sealed class Parser
                         _reportDiagnostic(
                             Diagnostic.Create(
                                 DiagnosticDescriptors.DuplicateOperationNames,
-                                classDeclaration.GetLocation(),
+                                typeDeclaration.GetLocation(),
                                 method.OperationName,
-                                classDeclaration.Identifier.Text));
+                                typeDeclaration.Identifier.Text));
                     }
                 }
 
@@ -104,7 +125,7 @@ internal sealed class Parser
                 var serviceClass = new ServiceClass(
                     classSymbol.Name,
                     containingNamespace.Length > 0 ? containingNamespace : null,
-                    classDeclaration.Keyword.ValueText,
+                    typeDeclaration.Keyword.ValueText,
                     serviceMethods.ToList(),
                     hasBaseServiceClass: baseServiceClass is not null,
                     isSealed: classSymbol.IsSealed);
@@ -115,7 +136,7 @@ internal sealed class Parser
                     kind == SyntaxKind.StructDeclaration ||
                     kind == SyntaxKind.RecordDeclaration;
 
-                SyntaxNode? parentNode = classDeclaration.Parent;
+                SyntaxNode? parentNode = typeDeclaration.Parent;
                 ContainerDefinition? container = serviceClass;
                 if (parentNode is TypeDeclarationSyntax parentType && IsAllowedKind(parentType.Kind()))
                 {

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -51,27 +51,6 @@ internal sealed class Parser
                 // stop if we're asked to
                 _cancellationToken.ThrowIfCancellationRequested();
 
-                // The Service attribute is only valid on a class or a record class. Report a diagnostic and skip
-                // anything else (struct, record struct, interface).
-                SyntaxKind kind = typeDeclaration.Kind();
-                if (kind is not SyntaxKind.ClassDeclaration and not SyntaxKind.RecordDeclaration)
-                {
-                    string kindName = kind switch
-                    {
-                        SyntaxKind.StructDeclaration => "struct",
-                        SyntaxKind.RecordStructDeclaration => "record struct",
-                        SyntaxKind.InterfaceDeclaration => "interface",
-                        _ => typeDeclaration.Keyword.ValueText,
-                    };
-                    _reportDiagnostic(
-                        Diagnostic.Create(
-                            DiagnosticDescriptors.InvalidServiceTypeShape,
-                            typeDeclaration.Identifier.GetLocation(),
-                            kindName,
-                            typeDeclaration.Identifier.Text));
-                    continue;
-                }
-
                 SemanticModel semanticModel = _compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
                 INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, _cancellationToken);
                 if (classSymbol is null)

--- a/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
+++ b/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
@@ -17,34 +17,37 @@ public class ServiceGenerator : IIncrementalGenerator
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        IncrementalValuesProvider<ClassDeclarationSyntax> classDeclarations =
+        // We accept any TypeDeclarationSyntax (class, record class, struct, record struct, interface) so that the
+        // parser can report a diagnostic for unsupported shapes (e.g. struct, record struct, interface) instead of
+        // silently ignoring them.
+        IncrementalValuesProvider<TypeDeclarationSyntax> typeDeclarations =
             context.SyntaxProvider
                 .ForAttributeWithMetadataName(
                     Parser.ServiceAttribute,
-                    (node, _) => node is ClassDeclarationSyntax,
-                    (context, _) => (ClassDeclarationSyntax)context.TargetNode);
+                    (node, _) => node is TypeDeclarationSyntax,
+                    (context, _) => (TypeDeclarationSyntax)context.TargetNode);
 
-        IncrementalValueProvider<(Compilation Compilation, ImmutableArray<ClassDeclarationSyntax> ClassDeclarations)> compilationAndClasses =
-            context.CompilationProvider.Combine(classDeclarations.Collect());
+        IncrementalValueProvider<(Compilation Compilation, ImmutableArray<TypeDeclarationSyntax> TypeDeclarations)> compilationAndTypes =
+            context.CompilationProvider.Combine(typeDeclarations.Collect());
 
         context.RegisterSourceOutput(
-            compilationAndClasses,
-            static (context, source) => Execute(context, source.Compilation, source.ClassDeclarations));
+            compilationAndTypes,
+            static (context, source) => Execute(context, source.Compilation, source.TypeDeclarations));
     }
 
     private static void Execute(
         SourceProductionContext context,
         Compilation compilation,
-        ImmutableArray<ClassDeclarationSyntax> classes)
+        ImmutableArray<TypeDeclarationSyntax> types)
     {
-        if (classes.IsDefaultOrEmpty)
+        if (types.IsDefaultOrEmpty)
         {
             return;
         }
 
         var parser = new Parser(compilation, context.ReportDiagnostic, context.CancellationToken);
         var emitter = new Emitter();
-        foreach (ServiceClass serviceClass in parser.GetServiceDefinitions(classes.Distinct()))
+        foreach (ServiceClass serviceClass in parser.GetServiceDefinitions(types.Distinct()))
         {
             string result = emitter.Emit(serviceClass, context.CancellationToken);
             string fullName = serviceClass.ContainingNamespace is null ?

--- a/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
+++ b/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
@@ -17,9 +17,8 @@ public class ServiceGenerator : IIncrementalGenerator
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // We accept any TypeDeclarationSyntax (class, record class, struct, record struct, interface) so that the
-        // parser can report a diagnostic for unsupported shapes (e.g. struct, record struct, interface) instead of
-        // silently ignoring them.
+        // We accept any TypeDeclarationSyntax (in practice, a class or record class, since ServiceAttribute's
+        // AttributeUsage restricts it to classes) so that record classes are picked up alongside plain classes.
         IncrementalValuesProvider<TypeDeclarationSyntax> typeDeclarations =
             context.SyntaxProvider
                 .ForAttributeWithMetadataName(

--- a/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/MixedServiceTests.cs
@@ -1,14 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-// cspell:ignore IRSG
-
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Features;
 using IceRpc.Tests.Common;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
-using System.Collections.Immutable;
 
 namespace IceRpc.ServiceGenerator.Tests;
 
@@ -65,80 +60,5 @@ public partial class MixedServiceTests
             ProtoMessage message,
             IFeatureCollection? features,
             CancellationToken cancellationToken) => new(message);
-    }
-
-    /// <summary>Verifies that the service generator reports IRSG0001 when a derived service class adds an operation
-    /// whose name collides with an operation declared by its base service class (via a different interface).</summary>
-    [Test]
-    public void Derived_service_with_operation_name_colliding_with_base_reports_diagnostic()
-    {
-        // Arrange
-        const string source = """
-            using IceRpc;
-            using IceRpc.Features;
-            using IceRpc.Protobuf.RpcMethods;
-            using System.Threading;
-            using System.Threading.Tasks;
-
-            namespace TestNs;
-
-            public interface IBaseTestService
-            {
-                [RpcMethod("ping")]
-                ValueTask<string> BasePingAsync(
-                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
-            }
-
-            public interface IDerivedTestService
-            {
-                [RpcMethod("ping")]
-                ValueTask<string> DerivedPingAsync(
-                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
-            }
-
-            [Service]
-            public partial class BaseTestService : IBaseTestService
-            {
-                public ValueTask<string> BasePingAsync(
-                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
-                    new(input);
-            }
-
-            [Service]
-            public partial class DerivedTestService : BaseTestService, IDerivedTestService
-            {
-                public ValueTask<string> DerivedPingAsync(
-                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
-                    new(input);
-            }
-            """;
-
-        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
-
-        // Reference all assemblies currently loaded so the test source can resolve IceRpc types and BCL types.
-        ImmutableArray<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
-            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
-            .ToImmutableArray();
-
-        var compilation = CSharpCompilation.Create(
-            assemblyName: "DuplicateOpTest",
-            syntaxTrees: [syntaxTree],
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        // Act
-        _ = CSharpGeneratorDriver
-            .Create(new IceRpc.ServiceGenerator.ServiceGenerator())
-            .RunGeneratorsAndUpdateCompilation(compilation, out _, out ImmutableArray<Diagnostic> diagnostics);
-
-        // Assert
-        Assert.That(
-            diagnostics.Any(d =>
-                d.Id == "IRSG0001" &&
-                d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)
-                    .Contains("ping", StringComparison.Ordinal)),
-            Is.True,
-            $"Expected IRSG0001 for operation 'ping'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
     }
 }

--- a/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Features;
+using IceRpc.Tests.Common;
+using NUnit.Framework;
+
+namespace IceRpc.ServiceGenerator.Tests;
+
+/// <summary>Tests that verify the service generator accepts the various supported C# type shapes for a service
+/// declaration.</summary>
+[Parallelizable(ParallelScope.All)]
+public partial class SupportedShapesTests
+{
+    /// <summary>Verifies that the service generator accepts a record class as a service type and dispatches
+    /// operations correctly.</summary>
+    [Test]
+    public async Task Service_can_be_a_record_class()
+    {
+        // Arrange
+        var service = new RecordService();
+        var invoker = new ColocInvoker(service);
+
+        var sliceProxy = new SliceGreeterProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await sliceProxy.OpSliceAsync(), Throws.Nothing);
+        Assert.That(await sliceProxy.OpSliceWithArgsAsync("Record"), Is.EqualTo("Record"));
+    }
+
+    [Service]
+    internal partial record class RecordService : ISliceGreeterService
+    {
+        public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+
+        public ValueTask<string> OpSliceWithArgsAsync(
+            string message,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(message);
+    }
+}

--- a/tests/IceRpc.ServiceGenerator.Tests/ValidationTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/ValidationTests.cs
@@ -73,38 +73,6 @@ public class ValidationTests
             $"Expected IRSG0001 for operation 'ping'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
     }
 
-    /// <summary>Verifies that the service generator reports IRSG0002 when the Service attribute is applied to
-    /// a struct, a record struct, or an interface.</summary>
-    [TestCase("struct")]
-    [TestCase("record struct")]
-    [TestCase("interface")]
-    public void Service_attribute_on_unsupported_type_reports_diagnostic(string typeKeyword)
-    {
-        // Arrange
-        string source = $$"""
-            using IceRpc;
-
-            namespace TestNs;
-
-            [Service]
-            public partial {{typeKeyword}} BadService
-            {
-            }
-            """;
-
-        // Act
-        ImmutableArray<Diagnostic> diagnostics = RunGenerator(source, "InvalidShapeTest");
-
-        // Assert
-        Assert.That(
-            diagnostics.Any(d =>
-                d.Id == "IRSG0002" &&
-                d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)
-                    .Contains(typeKeyword, StringComparison.Ordinal)),
-            Is.True,
-            $"Expected IRSG0002 mentioning '{typeKeyword}'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
-    }
-
     private static ImmutableArray<Diagnostic> RunGenerator(string source, string assemblyName)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);

--- a/tests/IceRpc.ServiceGenerator.Tests/ValidationTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/ValidationTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ZeroC, Inc.
+
+// cspell:ignore IRSG
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+using System.Collections.Immutable;
+
+namespace IceRpc.ServiceGenerator.Tests;
+
+/// <summary>Tests that verify the diagnostics reported by the service generator for invalid service
+/// declarations.</summary>
+[Parallelizable(ParallelScope.All)]
+public class ValidationTests
+{
+    /// <summary>Verifies that the service generator reports IRSG0001 when a derived service class adds an operation
+    /// whose name collides with an operation declared by its base service class (via a different interface).</summary>
+    [Test]
+    public void Derived_service_with_operation_name_colliding_with_base_reports_diagnostic()
+    {
+        // Arrange
+        const string source = """
+            using IceRpc;
+            using IceRpc.Features;
+            using IceRpc.Protobuf.RpcMethods;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestNs;
+
+            public interface IBaseTestService
+            {
+                [RpcMethod("ping")]
+                ValueTask<string> BasePingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
+            }
+
+            public interface IDerivedTestService
+            {
+                [RpcMethod("ping")]
+                ValueTask<string> DerivedPingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken);
+            }
+
+            [Service]
+            public partial class BaseTestService : IBaseTestService
+            {
+                public ValueTask<string> BasePingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
+                    new(input);
+            }
+
+            [Service]
+            public partial class DerivedTestService : BaseTestService, IDerivedTestService
+            {
+                public ValueTask<string> DerivedPingAsync(
+                    string input, IFeatureCollection? features, CancellationToken cancellationToken) =>
+                    new(input);
+            }
+            """;
+
+        // Act
+        ImmutableArray<Diagnostic> diagnostics = RunGenerator(source, "DuplicateOpTest");
+
+        // Assert
+        Assert.That(
+            diagnostics.Any(d =>
+                d.Id == "IRSG0001" &&
+                d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("ping", StringComparison.Ordinal)),
+            Is.True,
+            $"Expected IRSG0001 for operation 'ping'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
+    }
+
+    /// <summary>Verifies that the service generator reports IRSG0002 when the Service attribute is applied to
+    /// a struct, a record struct, or an interface.</summary>
+    [TestCase("struct")]
+    [TestCase("record struct")]
+    [TestCase("interface")]
+    public void Service_attribute_on_unsupported_type_reports_diagnostic(string typeKeyword)
+    {
+        // Arrange
+        string source = $$"""
+            using IceRpc;
+
+            namespace TestNs;
+
+            [Service]
+            public partial {{typeKeyword}} BadService
+            {
+            }
+            """;
+
+        // Act
+        ImmutableArray<Diagnostic> diagnostics = RunGenerator(source, "InvalidShapeTest");
+
+        // Assert
+        Assert.That(
+            diagnostics.Any(d =>
+                d.Id == "IRSG0002" &&
+                d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains(typeKeyword, StringComparison.Ordinal)),
+            Is.True,
+            $"Expected IRSG0002 mentioning '{typeKeyword}'. Got: {string.Join(", ", diagnostics.Select(d => d.ToString()))}");
+    }
+
+    private static ImmutableArray<Diagnostic> RunGenerator(string source, string assemblyName)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        // Reference all assemblies currently loaded so the test source can resolve IceRpc types and BCL types.
+        ImmutableArray<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToImmutableArray();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        _ = CSharpGeneratorDriver
+            .Create(new IceRpc.ServiceGenerator.ServiceGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out _, out ImmutableArray<Diagnostic> diagnostics);
+
+        return diagnostics;
+    }
+}


### PR DESCRIPTION
Closes #4462 (partial: phase 1).

This PR addresses the first of the three sub-issues identified in #4462:

- **Record classes are now accepted.** The generator's syntax predicate was `node is ClassDeclarationSyntax`, which silently ignored `[Service]` on a `record class`. It is now `node is TypeDeclarationSyntax`, so record classes are picked up. The emitter already produces a valid `partial record Name : IceRpc.IDispatcher` header.

### Out of scope (deferred to follow-up)
- Generic service types (`[Service] partial class Foo<T>`) — generated header still uses bare name.
- Multi-level enclosing-type nesting — only one level is currently captured.

Both will be addressed in a separate PR.

### Tests

- Diagnostic tests moved out of `MixedServiceTests` (which is about multi-IDL services, not validation) into a new `ValidationTests` file, with a shared `RunGenerator` helper.
- New `SupportedShapesTests` file with `Service_can_be_a_record_class` exercising dispatch through a `partial record class` service.