### PR TITLE
Support generic service classes in ServiceGenerator

### DIFF
--- a/src/IceRpc.ServiceGenerator/Internal/ContainerDefinition.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/ContainerDefinition.cs
@@ -8,19 +8,38 @@ internal class ContainerDefinition
     /// <summary>Gets the keyword of this definition (struct, class, or record).</summary>
     internal string Keyword { get; }
 
-    /// <summary>Gets the name of this definition.</summary>
+    /// <summary>Gets the name of this definition, including the type-parameter list when generic
+    /// (e.g. <c>Foo&lt;T&gt;</c>).</summary>
     internal string Name { get; }
+
+    /// <summary>Gets the number of type parameters, or 0 when this definition is not generic.</summary>
+    internal int TypeParameterCount { get; }
 
     /// <summary>Gets the full name of this definition (does not include namespace).</summary>
     internal string FullName => Enclosing is null ? Name : $"{Enclosing.FullName}.{Name}";
+
+    /// <summary>Gets a file-name-safe form of <see cref="FullName"/>, using the metadata-style arity suffix
+    /// (e.g. <c>Outer.Foo`1</c>) instead of the angle-bracket type-parameter list.</summary>
+    internal string FullFileName => Enclosing is null ? FileName : $"{Enclosing.FullFileName}.{FileName}";
 
     /// <summary>Gets or sets the enclosing definition in which this definition is nested.</summary>
     /// <value>The enclosing definition or <c>null</c> if this definition is not nested into another definition.</value>
     internal ContainerDefinition? Enclosing { get; set; }
 
-    internal ContainerDefinition(string name, string keyword)
+    internal ContainerDefinition(string name, string keyword, int typeParameterCount = 0)
     {
         Name = name;
         Keyword = keyword;
+        TypeParameterCount = typeParameterCount;
+    }
+
+    private string FileName
+    {
+        get
+        {
+            int angleBracket = Name.IndexOf('<');
+            string identifier = angleBracket < 0 ? Name : Name.Substring(0, angleBracket);
+            return TypeParameterCount > 0 ? $"{identifier}`{TypeParameterCount}" : identifier;
+        }
     }
 }

--- a/src/IceRpc.ServiceGenerator/Internal/Emitter.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Emitter.cs
@@ -58,7 +58,7 @@ internal class Emitter
             ? "public override"
             : serviceClass.IsSealed ? "public" : "public virtual";
 
-        // In doc-comment crefs, generic type parameters use { } instead of < > (e.g. Foo{T}).
+        // In a doc-comment cref, generic type parameters use { } instead of < > (e.g. Foo{T}).
         string crefName = serviceClass.Name.Replace('<', '{').Replace('>', '}');
 
         return @$"

--- a/src/IceRpc.ServiceGenerator/Internal/Emitter.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Emitter.cs
@@ -58,8 +58,11 @@ internal class Emitter
             ? "public override"
             : serviceClass.IsSealed ? "public" : "public virtual";
 
+        // In doc-comment crefs, generic type parameters use { } instead of < > (e.g. Foo{T}).
+        string crefName = serviceClass.Name.Replace('<', '{').Replace('>', '}');
+
         return @$"
-/// <summary>Dispatches an incoming request to a method of <see cref=""{serviceClass.Name}"" /> based on
+/// <summary>Dispatches an incoming request to a method of <see cref=""{crefName}"" /> based on
 /// the operation name carried by the request.</summary>
 /// <param name=""request"">The incoming request.</param>
 /// <param name=""cancellationToken"">A cancellation token that receives the cancellation requests.</param>

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -101,10 +101,17 @@ internal sealed class Parser
                 serviceMethods = serviceMethods.Distinct();
 
                 string containingNamespace = classSymbol.ContainingNamespace.GetFullName();
+                // Capture the type-parameter list (e.g. "<T1, T2>") in the name so the emitted partial declaration
+                // matches the user's generic type. WithoutTrivia gives a clean form with no source whitespace.
+                // Constraint clauses (where T : ...) are not captured: C# only requires them on one partial
+                // declaration, so the user's own declaration carries them.
+                string typeParameterList =
+                    typeDeclaration.TypeParameterList?.WithoutTrivia().ToString() ?? string.Empty;
                 var serviceClass = new ServiceClass(
-                    classSymbol.Name,
+                    classSymbol.Name + typeParameterList,
                     containingNamespace.Length > 0 ? containingNamespace : null,
                     typeDeclaration.Keyword.ValueText,
+                    typeDeclaration.TypeParameterList?.Parameters.Count ?? 0,
                     serviceMethods.ToList(),
                     hasBaseServiceClass: baseServiceClass is not null,
                     isSealed: classSymbol.IsSealed);

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -107,8 +107,9 @@ internal sealed class Parser
                 // declaration, so the user's own declaration carries them.
                 string typeParameterList =
                     typeDeclaration.TypeParameterList?.WithoutTrivia().ToString() ?? string.Empty;
+                // Use Identifier.Text (not classSymbol.Name) so verbatim identifiers like @class keep their @.
                 var serviceClass = new ServiceClass(
-                    classSymbol.Name + typeParameterList,
+                    typeDeclaration.Identifier.Text + typeParameterList,
                     containingNamespace.Length > 0 ? containingNamespace : null,
                     typeDeclaration.Keyword.ValueText,
                     typeDeclaration.TypeParameterList?.Parameters.Count ?? 0,

--- a/src/IceRpc.ServiceGenerator/Internal/ServiceClass.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/ServiceClass.cs
@@ -24,10 +24,11 @@ internal class ServiceClass : ContainerDefinition
         string name,
         string? containingNamespace,
         string keyword,
+        int typeParameterCount,
         IReadOnlyList<ServiceMethod> serviceMethods,
         bool hasBaseServiceClass,
         bool isSealed)
-        : base(name, keyword)
+        : base(name, keyword, typeParameterCount)
     {
         ContainingNamespace = containingNamespace;
         ServiceMethods = serviceMethods;

--- a/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
+++ b/src/IceRpc.ServiceGenerator/ServiceGenerator.cs
@@ -50,8 +50,8 @@ public class ServiceGenerator : IIncrementalGenerator
         {
             string result = emitter.Emit(serviceClass, context.CancellationToken);
             string fullName = serviceClass.ContainingNamespace is null ?
-                serviceClass.FullName :
-                $"{serviceClass.ContainingNamespace}.{serviceClass.FullName}";
+                serviceClass.FullFileName :
+                $"{serviceClass.ContainingNamespace}.{serviceClass.FullFileName}";
 
             context.AddSource($"{fullName}.g.cs", SourceText.From(result, Encoding.UTF8));
         }

--- a/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
@@ -27,8 +27,36 @@ public partial class SupportedShapesTests
         Assert.That(await sliceProxy.OpSliceWithArgsAsync("Record"), Is.EqualTo("Record"));
     }
 
+    /// <summary>Verifies that the service generator accepts a generic class as a service type and dispatches
+    /// operations correctly. The generated partial class must include the type-parameter list to merge with the
+    /// user-written declaration.</summary>
+    [Test]
+    public async Task Service_can_be_a_generic_class()
+    {
+        // Arrange
+        var service = new GenericService<string>();
+        var invoker = new ColocInvoker(service);
+
+        var sliceProxy = new SliceGreeterProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await sliceProxy.OpSliceAsync(), Throws.Nothing);
+        Assert.That(await sliceProxy.OpSliceWithArgsAsync("Generic"), Is.EqualTo("Generic"));
+    }
+
     [Service]
     internal partial record class RecordService : ISliceGreeterService
+    {
+        public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+
+        public ValueTask<string> OpSliceWithArgsAsync(
+            string message,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(message);
+    }
+
+    [Service]
+    internal partial class GenericService<T> : ISliceGreeterService where T : class
     {
         public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
 


### PR DESCRIPTION
Fixes the second bug reported in #4462: applying `[Service]` to a generic class produced two partial declarations with different type-parameter lists, so they did not merge.

The parser now captures the type-parameter list (e.g. `<T>`) and includes it in the emitted partial declaration's name. The generated source file uses the metadata-style arity suffix (``Foo`1.g.cs``) because `<` and `>` are invalid in file names on Windows. Cref doc-comments use the brace form (`Foo{T}`).

Constraint clauses (`where T : ...`) are not captured: C# only requires them on one partial declaration, so the user's own declaration carries them.

A new `Service_can_be_a_generic_class` test exercises this.
