### PR TITLE
Use consistent spelling for file name (fileName/FileName)

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -119,7 +119,7 @@
 
     <Copy
       SourceFiles="@(ProtocCompiler)"
-      DestinationFiles="@(ProtocCompiler->'$(MSBuildThisFileDirectory)obj/tools/%(Prefix)/%(Filename)%(Extension)')"
+      DestinationFiles="@(ProtocCompiler->'$(MSBuildThisFileDirectory)obj/tools/%(Prefix)/%(FileName)%(Extension)')"
       SkipUnchangedFiles="true" />
 
   </Target>

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -33,7 +33,7 @@
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link
         Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))"
-      >%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
+      >%(LinkBase)%(RecursiveDir)%(FileName)%(Extension)</Link>
     </ProtoFile>
   </ItemGroup>
 

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -36,7 +36,7 @@
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link
         Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))"
-      >%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
+      >%(LinkBase)%(RecursiveDir)%(FileName)%(Extension)</Link>
     </SliceFile>
   </ItemGroup>
 
@@ -60,11 +60,11 @@
       <_SliceFile Include="@(SliceFile)" />
       <_SliceFile>
         <Generators>%(_SliceFile.Generators);$(_ZeroCSliceGeneratorPath)slicec-csharp-generator$(_SliceGeneratorScriptExtension)</Generators>
-        <GeneratedPath>%(_SliceFile.GeneratedPath);$([MSBuild]::NormalizePath('%(OutputDir)/%(Filename).cs'))</GeneratedPath>
+        <GeneratedPath>%(_SliceFile.GeneratedPath);$([MSBuild]::NormalizePath('%(OutputDir)/%(FileName).cs'))</GeneratedPath>
       </_SliceFile>
       <_SliceFile Condition="'%(IceRpc)' == 'true'">
         <Generators>%(_SliceFile.Generators);$(_IceRpcSliceGeneratorPath)slicec-icerpc-csharp-generator$(_SliceGeneratorScriptExtension)</Generators>
-        <GeneratedPath>%(_SliceFile.GeneratedPath);$([MSBuild]::NormalizePath('%(OutputDir)/%(Filename).IceRpc.cs'))</GeneratedPath>
+        <GeneratedPath>%(_SliceFile.GeneratedPath);$([MSBuild]::NormalizePath('%(OutputDir)/%(FileName).IceRpc.cs'))</GeneratedPath>
       </_SliceFile>
       <_SliceFile Condition="'$(IceRpcBuildTelemetry)' == 'true'">
         <Generators>%(_SliceFile.Generators);$(_IceRpcSliceBuildTelemetryPath)slicec-gen-icerpc-build-telemetry$(_SliceGeneratorScriptExtension)</Generators>

--- a/src/ZeroC.Slice.Generator/GeneratorDriver.cs
+++ b/src/ZeroC.Slice.Generator/GeneratorDriver.cs
@@ -61,9 +61,9 @@ internal static class GeneratorDriver
                     {
                         Level = DiagnosticLevel.Error,
                         Message =
-                            $"Multiple source files have the same filename '{fileName}': " +
+                            $"Multiple source files have the same file name '{fileName}': " +
                             $"'{previousPath}' and '{file.Path}'. " +
-                            "Generated files are written to a common directory, so source files must have unique filenames.",
+                            "Generated files are written to a common directory, so source files must have unique file names.",
                     });
                 }
                 else


### PR DESCRIPTION
This tiny PR fixes the spelling for file name in a few files. The convention in C#/MSBuild is to use two words.