### PR TITLE
Support service classes nested more than one level deep

### DIFF
--- a/src/IceRpc.ServiceGenerator/Internal/ContainerDefinition.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/ContainerDefinition.cs
@@ -26,7 +26,7 @@ internal class ContainerDefinition
     /// <value>The enclosing definition or <c>null</c> if this definition is not nested into another definition.</value>
     internal ContainerDefinition? Enclosing { get; set; }
 
-    internal ContainerDefinition(string name, string keyword, int typeParameterCount = 0)
+    internal ContainerDefinition(string name, string keyword, int typeParameterCount)
     {
         Name = name;
         Keyword = keyword;

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -111,31 +111,36 @@ internal sealed class Parser
                 var serviceClass = new ServiceClass(
                     typeDeclaration.Identifier.Text + typeParameterList,
                     containingNamespace.Length > 0 ? containingNamespace : null,
-                    typeDeclaration.Keyword.ValueText,
+                    GetKeyword(typeDeclaration),
                     typeDeclaration.TypeParameterList?.Parameters.Count ?? 0,
                     serviceMethods.ToList(),
                     hasBaseServiceClass: baseServiceClass is not null,
                     isSealed: classSymbol.IsSealed);
                 serviceDefinitions.Add(serviceClass);
 
-                static bool IsAllowedKind(SyntaxKind kind) =>
-                    kind == SyntaxKind.ClassDeclaration ||
-                    kind == SyntaxKind.StructDeclaration ||
-                    kind == SyntaxKind.RecordDeclaration;
-
+                // Walk the chain of enclosing type declarations (class, struct, record, record struct, interface) so
+                // the emitted partial declaration is nested inside the same chain as the user's source.
                 SyntaxNode? parentNode = typeDeclaration.Parent;
                 ContainerDefinition container = serviceClass;
-                while (parentNode is TypeDeclarationSyntax parentType && IsAllowedKind(parentType.Kind()))
+                while (parentNode is TypeDeclarationSyntax parentType)
                 {
                     string parentTypeParameterList =
                         parentType.TypeParameterList?.WithoutTrivia().ToString() ?? string.Empty;
                     container.Enclosing = new ContainerDefinition(
                         parentType.Identifier.Text + parentTypeParameterList,
-                        parentType.Keyword.ValueText,
+                        GetKeyword(parentType),
                         parentType.TypeParameterList?.Parameters.Count ?? 0);
                     container = container.Enclosing;
                     parentNode = parentNode.Parent;
                 }
+
+                // A record struct is a RecordDeclarationSyntax with ClassOrStructKeyword == "struct"; its Keyword
+                // alone ("record") is not enough to disambiguate from a record class. Other type declarations are
+                // fully described by their Keyword.
+                static string GetKeyword(TypeDeclarationSyntax decl) =>
+                    decl is RecordDeclarationSyntax record && record.ClassOrStructKeyword.ValueText == "struct" ?
+                        "record struct" :
+                        decl.Keyword.ValueText;
             }
         }
         return serviceDefinitions;

--- a/src/IceRpc.ServiceGenerator/Internal/Parser.cs
+++ b/src/IceRpc.ServiceGenerator/Internal/Parser.cs
@@ -124,12 +124,15 @@ internal sealed class Parser
                     kind == SyntaxKind.RecordDeclaration;
 
                 SyntaxNode? parentNode = typeDeclaration.Parent;
-                ContainerDefinition? container = serviceClass;
-                if (parentNode is TypeDeclarationSyntax parentType && IsAllowedKind(parentType.Kind()))
+                ContainerDefinition container = serviceClass;
+                while (parentNode is TypeDeclarationSyntax parentType && IsAllowedKind(parentType.Kind()))
                 {
+                    string parentTypeParameterList =
+                        parentType.TypeParameterList?.WithoutTrivia().ToString() ?? string.Empty;
                     container.Enclosing = new ContainerDefinition(
-                        parentType.Identifier.ToString(),
-                        parentType.Keyword.ValueText);
+                        parentType.Identifier.Text + parentTypeParameterList,
+                        parentType.Keyword.ValueText,
+                        parentType.TypeParameterList?.Parameters.Count ?? 0);
                     container = container.Enclosing;
                     parentNode = parentNode.Parent;
                 }

--- a/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
@@ -44,6 +44,22 @@ public partial class SupportedShapesTests
         Assert.That(await sliceProxy.OpSliceWithArgsAsync("Generic"), Is.EqualTo("Generic"));
     }
 
+    /// <summary>Verifies that the service generator correctly emits all enclosing types when the service is nested
+    /// more than one level deep, including when an enclosing type is generic.</summary>
+    [Test]
+    public async Task Service_can_be_nested_multiple_levels_deep()
+    {
+        // Arrange
+        var service = new MultiLevelOuter<int>.MultiLevelMiddle.MultiLevelLeaf();
+        var invoker = new ColocInvoker(service);
+
+        var sliceProxy = new SliceGreeterProxy(invoker);
+
+        // Act/Assert
+        Assert.That(async () => await sliceProxy.OpSliceAsync(), Throws.Nothing);
+        Assert.That(await sliceProxy.OpSliceWithArgsAsync("Nested"), Is.EqualTo("Nested"));
+    }
+
     [Service]
     internal partial record class RecordService : ISliceGreeterService
     {
@@ -64,5 +80,23 @@ public partial class SupportedShapesTests
             string message,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new(message);
+    }
+
+    internal partial class MultiLevelOuter<TOuter>
+    {
+        internal partial class MultiLevelMiddle
+        {
+            [Service]
+            internal partial class MultiLevelLeaf : ISliceGreeterService
+            {
+                public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) =>
+                    default;
+
+                public ValueTask<string> OpSliceWithArgsAsync(
+                    string message,
+                    IFeatureCollection features,
+                    CancellationToken cancellationToken) => new(message);
+            }
+        }
     }
 }

--- a/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
+++ b/tests/IceRpc.ServiceGenerator.Tests/SupportedShapesTests.cs
@@ -60,6 +60,34 @@ public partial class SupportedShapesTests
         Assert.That(await sliceProxy.OpSliceWithArgsAsync("Nested"), Is.EqualTo("Nested"));
     }
 
+    /// <summary>Verifies that the service generator correctly emits the enclosing type when the service is nested
+    /// inside a record struct.</summary>
+    [Test]
+    public async Task Service_can_be_nested_in_a_record_struct()
+    {
+        var service = new RecordStructOuter.RecordStructLeaf();
+        var invoker = new ColocInvoker(service);
+
+        var sliceProxy = new SliceGreeterProxy(invoker);
+
+        Assert.That(async () => await sliceProxy.OpSliceAsync(), Throws.Nothing);
+        Assert.That(await sliceProxy.OpSliceWithArgsAsync("RecordStruct"), Is.EqualTo("RecordStruct"));
+    }
+
+    /// <summary>Verifies that the service generator correctly emits the enclosing type when the service is nested
+    /// inside an interface.</summary>
+    [Test]
+    public async Task Service_can_be_nested_in_an_interface()
+    {
+        var service = new IInterfaceOuter.InterfaceLeaf();
+        var invoker = new ColocInvoker(service);
+
+        var sliceProxy = new SliceGreeterProxy(invoker);
+
+        Assert.That(async () => await sliceProxy.OpSliceAsync(), Throws.Nothing);
+        Assert.That(await sliceProxy.OpSliceWithArgsAsync("Interface"), Is.EqualTo("Interface"));
+    }
+
     [Service]
     internal partial record class RecordService : ISliceGreeterService
     {
@@ -97,6 +125,34 @@ public partial class SupportedShapesTests
                     IFeatureCollection features,
                     CancellationToken cancellationToken) => new(message);
             }
+        }
+    }
+
+    internal partial record struct RecordStructOuter
+    {
+        [Service]
+        internal partial class RecordStructLeaf : ISliceGreeterService
+        {
+            public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+
+            public ValueTask<string> OpSliceWithArgsAsync(
+                string message,
+                IFeatureCollection features,
+                CancellationToken cancellationToken) => new(message);
+        }
+    }
+
+    internal partial interface IInterfaceOuter
+    {
+        [Service]
+        internal partial class InterfaceLeaf : ISliceGreeterService
+        {
+            public ValueTask OpSliceAsync(IFeatureCollection features, CancellationToken cancellationToken) => default;
+
+            public ValueTask<string> OpSliceWithArgsAsync(
+                string message,
+                IFeatureCollection features,
+                CancellationToken cancellationToken) => new(message);
         }
     }
 }


### PR DESCRIPTION
Closes #4462.

Fixes the third bug reported in #4462: a `[Service]` class nested two or more levels deep emitted a partial declaration that included only the innermost enclosing type, so the C# compiler rejected the generated source. The same code site also dropped the type-parameter list of an enclosing generic type.

The parser now walks the full chain of enclosing `TypeDeclarationSyntax` nodes and captures each enclosing type's name, keyword, and type-parameter arity (mirroring what was done for the service class itself in #4598). The emitter already loops over the `Enclosing` chain, so no change there.

A new `Service_can_be_nested_multiple_levels_deep` test exercises both fixes by declaring a service nested inside a non-generic class which is itself nested inside a generic class (`SupportedShapesTests > MultiLevelOuter<TOuter> > MultiLevelMiddle > [Service] MultiLevelLeaf`).
