### PR TITLE
Document that AddIceRpcServer requires a unique optionsName

### DIFF
--- a/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
@@ -140,7 +140,7 @@ public static class ServerServiceCollectionExtensions
     /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
     /// <paramref name="services" /> must use a distinct options name.</param>
     /// <returns>The service collection.</returns>
-    /// <remarks>You need to set a least the dispatcher in the injected options.</remarks>
+    /// <remarks>You need to set at least the dispatcher in the injected options.</remarks>
     /// <seealso cref="AddIceRpcServer(IServiceCollection, string, IDispatcher)" />
     public static IServiceCollection AddIceRpcServer(this IServiceCollection services, string optionsName) =>
         services

--- a/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
@@ -80,7 +80,7 @@ public static class ServerServiceCollectionExtensions
     /// named <paramref name="optionsName" />.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
-    /// <paramref name="services" /> must use a distinct options name.</param>
+    /// <paramref name="services" /> must use a unique options name.</param>
     /// <param name="dispatcher">The dispatch pipeline of the server.</param>
     /// <returns>The service collection.</returns>
     /// <example>
@@ -106,7 +106,7 @@ public static class ServerServiceCollectionExtensions
     /// <see cref="ServerOptions" /> named <paramref name="optionsName" />.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
-    /// <paramref name="services" /> must use a distinct options name.</param>
+    /// <paramref name="services" /> must use a unique options name.</param>
     /// <param name="configure">The action to configure the dispatch pipeline using an
     /// <see cref="IDispatcherBuilder" />.</param>
     /// <returns>The service collection.</returns>
@@ -138,7 +138,7 @@ public static class ServerServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
-    /// <paramref name="services" /> must use a distinct options name.</param>
+    /// <paramref name="services" /> must use a unique options name.</param>
     /// <returns>The service collection.</returns>
     /// <remarks>You need to set a least the dispatcher in the injected options.</remarks>
     /// <seealso cref="AddIceRpcServer(IServiceCollection, string, IDispatcher)" />

--- a/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
@@ -79,7 +79,8 @@ public static class ServerServiceCollectionExtensions
     /// specify the server's options by injecting an <see cref="IOptionsMonitor{T}" /> of <see cref="ServerOptions" />
     /// named <paramref name="optionsName" />.</summary>
     /// <param name="services">The service collection to add services to.</param>
-    /// <param name="optionsName">The name of the options instance.</param>
+    /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
+    /// <paramref name="services" /> must use a distinct options name.</param>
     /// <param name="dispatcher">The dispatch pipeline of the server.</param>
     /// <returns>The service collection.</returns>
     /// <example>
@@ -104,7 +105,8 @@ public static class ServerServiceCollectionExtensions
     /// server; you can specify the server's options by injecting an <see cref="IOptionsMonitor{T}" /> of
     /// <see cref="ServerOptions" /> named <paramref name="optionsName" />.</summary>
     /// <param name="services">The service collection to add services to.</param>
-    /// <param name="optionsName">The name of the options instance.</param>
+    /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
+    /// <paramref name="services" /> must use a distinct options name.</param>
     /// <param name="configure">The action to configure the dispatch pipeline using an
     /// <see cref="IDispatcherBuilder" />.</param>
     /// <returns>The service collection.</returns>
@@ -135,7 +137,8 @@ public static class ServerServiceCollectionExtensions
     /// an <see cref="IOptionsMonitor{T}" /> of <see cref="ServerOptions" /> named <paramref name="optionsName" />.
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
-    /// <param name="optionsName">The name of the options instance.</param>
+    /// <param name="optionsName">The name of the options instance. Each <see cref="Server" /> registered in
+    /// <paramref name="services" /> must use a distinct options name.</param>
     /// <returns>The service collection.</returns>
     /// <remarks>You need to set a least the dispatcher in the injected options.</remarks>
     /// <seealso cref="AddIceRpcServer(IServiceCollection, string, IDispatcher)" />

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/ServerServiceCollectionExtensionsTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/ServerServiceCollectionExtensionsTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Tests.Common;
+using IceRpc.Transports;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace IceRpc.Extensions.DependencyInjection.Tests;
+
+public sealed class ServerServiceCollectionExtensionsTests
+{
+    /// <summary>Verifies that two <see cref="Server" /> instances registered via DI with distinct named options each
+    /// dispatch requests to their own dispatcher.</summary>
+    [Test]
+    public async Task Two_servers_with_distinct_named_options_dispatch_to_their_own_dispatcher()
+    {
+        var firstServerAddress = new ServerAddress(new Uri("icerpc://first-host"));
+        var secondServerAddress = new ServerAddress(new Uri("icerpc://second-host"));
+
+        int firstDispatchCount = 0;
+        int secondDispatchCount = 0;
+
+        var firstDispatcher = new InlineDispatcher((request, cancellationToken) =>
+        {
+            Interlocked.Increment(ref firstDispatchCount);
+            return new(new OutgoingResponse(request));
+        });
+
+        var secondDispatcher = new InlineDispatcher((request, cancellationToken) =>
+        {
+            Interlocked.Increment(ref secondDispatchCount);
+            return new(new OutgoingResponse(request));
+        });
+
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddColocTransport()
+            .AddSlicTransport()
+            .AddIceRpcServer("first", firstDispatcher)
+            .AddIceRpcServer("second", secondDispatcher)
+            .Configure<ServerOptions>("first", options => options.ServerAddress = firstServerAddress)
+            .Configure<ServerOptions>("second", options => options.ServerAddress = secondServerAddress)
+            .BuildServiceProvider(validateScopes: true);
+
+        Server[] servers = [.. provider.GetServices<Server>()];
+        Assert.That(servers, Has.Length.EqualTo(2));
+
+        foreach (Server server in servers)
+        {
+            _ = server.Listen();
+        }
+
+        try
+        {
+            await using var firstConnection = new ClientConnection(
+                new ClientConnectionOptions { ServerAddress = firstServerAddress },
+                multiplexedClientTransport: provider.GetRequiredService<IMultiplexedClientTransport>());
+
+            await using var secondConnection = new ClientConnection(
+                new ClientConnectionOptions { ServerAddress = secondServerAddress },
+                multiplexedClientTransport: provider.GetRequiredService<IMultiplexedClientTransport>());
+
+            using var firstRequest = new OutgoingRequest(new ServiceAddress(firstServerAddress.Protocol));
+            IncomingResponse firstResponse = await firstConnection.InvokeAsync(firstRequest);
+
+            using var secondRequest = new OutgoingRequest(new ServiceAddress(secondServerAddress.Protocol));
+            IncomingResponse secondResponse = await secondConnection.InvokeAsync(secondRequest);
+
+            Assert.That(firstResponse.StatusCode, Is.EqualTo(StatusCode.Ok));
+            Assert.That(secondResponse.StatusCode, Is.EqualTo(StatusCode.Ok));
+            Assert.That(firstDispatchCount, Is.EqualTo(1));
+            Assert.That(secondDispatchCount, Is.EqualTo(1));
+        }
+        finally
+        {
+            foreach (Server server in servers)
+            {
+                await server.ShutdownAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4423.

When two `AddIceRpcServer` registrations share the same `optionsName`, both
`Server` singletons resolve the same cached `ServerOptions` from
`IOptionsMonitor<ServerOptions>`. The second registration then mutates that
shared instance (e.g. setting `ConnectionOptions.Dispatcher`), which silently
cross-wires the first server's dispatcher.

This PR (option A from the issue) makes the contract explicit in the
doc-comments of the three `optionsName`-taking overloads of `AddIceRpcServer`:
each `Server` registered in a service collection must use a distinct options
name.

The requirement is **documentation only — it is not enforced at runtime**.
Rationale:

- `Server` already copies the values it needs out of `ServerOptions` in its
  constructor, so no defensive `Clone()` is required inside `Server` itself.
- Sharing a single `ServerOptions` instance between multiple `Server`
  instances *without* DI is legitimate (e.g. when `ServerAddress.Port == 0`),
  so there is no reason to disallow it at the `ServerOptions` level.
- The DI misuse is uncommon (most apps register one or two servers) and the
  fix would otherwise require additional runtime bookkeeping that doesn't
  carry its weight.

Also adds a test that registers two servers with distinct named options and
verifies each server dispatches to its own dispatcher.
