### PR TITLE
Make AsyncStream Dispose safe against concurrent MoveNextAsync

### DIFF
--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
@@ -28,10 +28,6 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
     // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
     private bool _iterationStarted;
 
-    /// <summary>Disposes this stream.</summary>
-    /// <remarks>This method may be called concurrently with an in-flight <c>MoveNextAsync</c> on the stream's
-    /// enumerator: the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
-    /// <see cref="ObjectDisposedException" />. Calling it a second time is a no-op.</remarks>
     public void Dispose()
     {
         if (_disposed)

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
@@ -18,43 +18,43 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
     // Canceled by Dispose when iteration has started, to unblock any pending ReadAsync.
     private readonly CancellationTokenSource _disposeCts = new();
 
-    private bool _disposed;
-
     // Set when GetAsyncEnumerator is called. This enforces the single-enumerator contract even if the created
     // enumerator is never advanced.
     private bool _enumeratorCreated;
 
-    // Set when the iterator body starts executing (first MoveNextAsync/DisposeAsync on the enumerator). This lets
-    // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
-    private bool _iterationStarted;
+    // Atomic state used to safely arbitrate ownership of _reader.Complete() between Dispose and the first
+    // MoveNextAsync. The transition Idle -> Iterating is performed with Interlocked.CompareExchange and the
+    // transition to Disposed with Interlocked.Exchange so that exactly one of them wins from Idle.
+    private int _state;
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-        _disposed = true;
+        int original = Interlocked.Exchange(ref _state, (int)State.Disposed);
 
-        if (_iterationStarted)
+        switch ((State)original)
         {
-            // An enumerator exists. Cancel the dispose token to unblock any pending ReadAsync; the iterator's
-            // finally will complete the reader. We must not dispose _disposeCts here: a linked CTS inside the
-            // iterator may still hold a registration on _disposeCts.Token.
-            _disposeCts.Cancel();
-        }
-        else
-        {
-            // No iteration has started (either no enumerator was created, or one was created but never started),
-            // hence no pending read can exist. Safe to complete the reader directly from this thread.
-            _reader.Complete();
-            _disposeCts.Dispose();
+            case State.Idle:
+                // No iteration could have started (and any future MoveNextAsync will see Disposed and throw).
+                // Safe to complete the reader directly from this thread.
+                _reader.Complete();
+                _disposeCts.Dispose();
+                break;
+
+            case State.Iterating:
+                // The iterator owns the reader; its finally will complete it. We only signal cancellation here.
+                // We must not dispose _disposeCts here: a linked CTS inside the iterator may still hold a
+                // registration on _disposeCts.Token.
+                _disposeCts.Cancel();
+                break;
+
+            // case State.Disposed: no-op (Dispose called more than once).
         }
     }
 
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        // We don't check for Disposed here: if the stream was disposed, the first MoveNextAsync call on the
+        // returned enumerator throws ObjectDisposedException (see EnumerateAsync).
         if (_enumeratorCreated)
         {
             throw new InvalidOperationException($"An {nameof(IAsyncStream<T>)} can only be enumerated once.");
@@ -75,7 +75,12 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
         // Because this async method returns an IAsyncEnumerable<T>, it only starts executing when the caller starts
         // iterating (calls MoveNextAsync on the enumerator). It does not execute when EnumerateAsync is called, or
         // even when GetAsyncEnumerator is called on the returned IAsyncEnumerable<T>.
-        _iterationStarted = true;
+
+        // Atomically claim the reader (Idle -> Iterating). This races with Dispose's atomic transition to Disposed;
+        // whichever transition wins from Idle owns _reader.Complete().
+        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Idle);
+        ObjectDisposedException.ThrowIf(original == (int)State.Disposed, this);
+        Debug.Assert(original == (int)State.Idle); // _enumeratorCreated forbids a second iteration.
 
         // Link the caller-provided token with our internal dispose token so that Dispose can unblock ReadAsync.
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -98,13 +103,14 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
                 catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
                 {
                     // Re-issue the cancellation with the caller's token so the OCE that propagates carries the
-                    // token the caller passed in (not our internal linkedToken). When _disposed is the only
-                    // source, surface dispose-mid-iteration as ObjectDisposedException.
+                    // token the caller passed in (not our internal linkedToken). When dispose is the only source,
+                    // surface dispose-mid-iteration as ObjectDisposedException.
                     cancellationToken.ThrowIfCancellationRequested();
-                    // Safe to read _disposed without a barrier: Dispose writes _disposed before calling
+
+                    // Safe to read _state without a barrier: Dispose writes State.Disposed before calling
                     // _disposeCts.Cancel(), and observing the cancellation here establishes happens-before
                     // with that write.
-                    Debug.Assert(_disposed);
+                    Debug.Assert(_state == (int)State.Disposed);
                     throw new ObjectDisposedException(nameof(AsyncStream<>), "The stream was disposed while reading.");
                 }
 
@@ -119,5 +125,12 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
         {
             _reader.Complete();
         }
+    }
+
+    private enum State
+    {
+        Idle = 0,
+        Iterating = 1,
+        Disposed = 2
     }
 }

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
@@ -28,6 +28,10 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
     // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
     private bool _iterationStarted;
 
+    /// <summary>Disposes this stream.</summary>
+    /// <remarks>This method may be called concurrently with an in-flight <c>MoveNextAsync</c> on the stream's
+    /// enumerator: the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
+    /// <see cref="ObjectDisposedException" />. Calling it a second time is a no-op.</remarks>
     public void Dispose()
     {
         if (_disposed)
@@ -101,6 +105,9 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
                     // token the caller passed in (not our internal linkedToken). When _disposed is the only
                     // source, surface dispose-mid-iteration as ObjectDisposedException.
                     cancellationToken.ThrowIfCancellationRequested();
+                    // Safe to read _disposed without a barrier: Dispose writes _disposed before calling
+                    // _disposeCts.Cancel(), and observing the cancellation here establishes happens-before
+                    // with that write.
                     Debug.Assert(_disposed);
                     throw new ObjectDisposedException(nameof(AsyncStream<>), "The stream was disposed while reading.");
                 }

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
@@ -32,7 +32,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
 
         switch ((State)original)
         {
-            case State.Idle:
+            case State.Initial:
                 // No iteration could have started (and any future MoveNextAsync will see Disposed and throw).
                 // Safe to complete the reader directly from this thread.
                 _reader.Complete();
@@ -77,9 +77,9 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
 
         // Atomically claim the reader (Idle -> Iterating). This races with Dispose's atomic transition to Disposed;
         // whichever transition wins from Idle owns _reader.Complete().
-        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Idle);
+        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Initial);
         ObjectDisposedException.ThrowIf(original == (int)State.Disposed, this);
-        Debug.Assert(original == (int)State.Idle); // _enumeratorCreated forbids a second iteration.
+        Debug.Assert(original == (int)State.Initial); // _enumeratorCreated forbids a second iteration.
 
         // Link the caller-provided token with our internal dispose token so that Dispose can unblock ReadAsync.
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -128,7 +128,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
 
     private enum State
     {
-        Idle = 0,
+        Initial = 0,
         Iterating = 1,
         Disposed = 2
     }

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncStream.cs
@@ -23,8 +23,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T> where T : class, IMessage
     private bool _enumeratorCreated;
 
     // Atomic state used to safely arbitrate ownership of _reader.Complete() between Dispose and the first
-    // MoveNextAsync. The transition Idle -> Iterating is performed with Interlocked.CompareExchange and the
-    // transition to Disposed with Interlocked.Exchange so that exactly one of them wins from Idle.
+    // MoveNextAsync.
     private int _state;
 
     public void Dispose()

--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -19,43 +19,43 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
     // Canceled by Dispose when iteration has started, to unblock any pending ReadAsync.
     private readonly CancellationTokenSource _disposeCts = new();
 
-    private bool _disposed;
-
     // Set when GetAsyncEnumerator is called. This enforces the single-enumerator contract even if the created
     // enumerator is never advanced.
     private bool _enumeratorCreated;
 
-    // Set when the iterator body starts executing (first MoveNextAsync/DisposeAsync on the enumerator). This lets
-    // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
-    private bool _iterationStarted;
+    // Atomic state used to safely arbitrate ownership of _reader.Complete() between Dispose and the first
+    // MoveNextAsync. The transition Idle -> Iterating is performed with Interlocked.CompareExchange and the
+    // transition to Disposed with Interlocked.Exchange so that exactly one of them wins from Idle.
+    private int _state;
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-        _disposed = true;
+        int original = Interlocked.Exchange(ref _state, (int)State.Disposed);
 
-        if (_iterationStarted)
+        switch ((State)original)
         {
-            // An enumerator exists. Cancel the dispose token to unblock any pending ReadAsync; the iterator's
-            // finally will complete the reader. We must not dispose _disposeCts here: a linked CTS inside the
-            // iterator may still hold a registration on _disposeCts.Token.
-            _disposeCts.Cancel();
-        }
-        else
-        {
-            // No iteration has started (either no enumerator was created, or one was created but never started),
-            // hence no pending read can exist. Safe to complete the reader directly from this thread.
-            _reader.Complete();
-            _disposeCts.Dispose();
+            case State.Idle:
+                // No iteration could have started (and any future MoveNextAsync will see Disposed and throw).
+                // Safe to complete the reader directly from this thread.
+                _reader.Complete();
+                _disposeCts.Dispose();
+                break;
+
+            case State.Iterating:
+                // The iterator owns the reader; its finally will complete it. We only signal cancellation here.
+                // We must not dispose _disposeCts here: a linked CTS inside the iterator may still hold a
+                // registration on _disposeCts.Token.
+                _disposeCts.Cancel();
+                break;
+
+            // case State.Disposed: no-op (Dispose called more than once).
         }
     }
 
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        // We don't check for Disposed here: if the stream was disposed, the first MoveNextAsync call on the
+        // returned enumerator throws ObjectDisposedException (see EnumerateAsync).
         if (_enumeratorCreated)
         {
             throw new InvalidOperationException($"An {nameof(IAsyncStream<T>)} can only be enumerated once.");
@@ -79,7 +79,12 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
         // Because this async method returns an IAsyncEnumerable<T>, it only starts executing when the caller starts
         // iterating (calls MoveNextAsync on the enumerator). It does not execute when EnumerateAsync is called, or
         // even when GetAsyncEnumerator is called on the returned IAsyncEnumerable<T>.
-        _iterationStarted = true;
+
+        // Atomically claim the reader (Idle -> Iterating). This races with Dispose's atomic transition to Disposed;
+        // whichever transition wins from Idle owns _reader.Complete().
+        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Idle);
+        ObjectDisposedException.ThrowIf(original == (int)State.Disposed, this);
+        Debug.Assert(original == (int)State.Idle); // _enumeratorCreated forbids a second iteration.
 
         // Link the caller-provided token with our internal dispose token so that Dispose can unblock ReadAsync.
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -111,13 +116,14 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
                 catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
                 {
                     // Re-issue the cancellation with the caller's token so the OCE that propagates carries the
-                    // token the caller passed in (not our internal linkedToken). When _disposed is the only
-                    // source, surface dispose-mid-iteration as ObjectDisposedException.
+                    // token the caller passed in (not our internal linkedToken). When dispose is the only source,
+                    // surface dispose-mid-iteration as ObjectDisposedException.
                     cancellationToken.ThrowIfCancellationRequested();
-                    // Safe to read _disposed without a barrier: Dispose writes _disposed before calling
+
+                    // Safe to read _state without a barrier: Dispose writes State.Disposed before calling
                     // _disposeCts.Cancel(), and observing the cancellation here establishes happens-before
                     // with that write.
-                    Debug.Assert(_disposed);
+                    Debug.Assert(_state == (int)State.Disposed);
                     throw new ObjectDisposedException(nameof(AsyncStream<>), "The stream was disposed while reading.");
                 }
 
@@ -127,11 +133,12 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
                 foreach (T item in elements)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
                     // No memory barrier needed: this read is just an early-out optimization. If we miss a
-                    // concurrent write to _disposed, the next ReadAsync call observes the cancellation of
+                    // concurrent transition to Disposed, the next ReadAsync call observes the cancellation of
                     // _disposeCts (which has its own synchronization) and we surface ObjectDisposedException
                     // from the catch block above.
-                    ObjectDisposedException.ThrowIf(_disposed, this);
+                    ObjectDisposedException.ThrowIf(_state == (int)State.Disposed, this);
                     yield return item;
                 }
 
@@ -145,5 +152,12 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
         {
             _reader.Complete();
         }
+    }
+
+    private enum State
+    {
+        Idle = 0,
+        Iterating = 1,
+        Disposed = 2
     }
 }

--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -24,8 +24,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
     private bool _enumeratorCreated;
 
     // Atomic state used to safely arbitrate ownership of _reader.Complete() between Dispose and the first
-    // MoveNextAsync. The transition Idle -> Iterating is performed with Interlocked.CompareExchange and the
-    // transition to Disposed with Interlocked.Exchange so that exactly one of them wins from Idle.
+    // MoveNextAsync.
     private int _state;
 
     public void Dispose()

--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -33,7 +33,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
 
         switch ((State)original)
         {
-            case State.Idle:
+            case State.Initial:
                 // No iteration could have started (and any future MoveNextAsync will see Disposed and throw).
                 // Safe to complete the reader directly from this thread.
                 _reader.Complete();
@@ -81,9 +81,9 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
 
         // Atomically claim the reader (Idle -> Iterating). This races with Dispose's atomic transition to Disposed;
         // whichever transition wins from Idle owns _reader.Complete().
-        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Idle);
+        int original = Interlocked.CompareExchange(ref _state, (int)State.Iterating, (int)State.Initial);
         ObjectDisposedException.ThrowIf(original == (int)State.Disposed, this);
-        Debug.Assert(original == (int)State.Idle); // _enumeratorCreated forbids a second iteration.
+        Debug.Assert(original == (int)State.Initial); // _enumeratorCreated forbids a second iteration.
 
         // Link the caller-provided token with our internal dispose token so that Dispose can unblock ReadAsync.
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -155,7 +155,7 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
 
     private enum State
     {
-        Idle = 0,
+        Initial = 0,
         Iterating = 1,
         Disposed = 2
     }

--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -29,6 +29,10 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
     // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
     private bool _iterationStarted;
 
+    /// <summary>Disposes this stream.</summary>
+    /// <remarks>This method may be called concurrently with an in-flight <c>MoveNextAsync</c> on the stream's
+    /// enumerator: the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
+    /// <see cref="ObjectDisposedException" />. Calling it a second time is a no-op.</remarks>
     public void Dispose()
     {
         if (_disposed)
@@ -114,6 +118,9 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
                     // token the caller passed in (not our internal linkedToken). When _disposed is the only
                     // source, surface dispose-mid-iteration as ObjectDisposedException.
                     cancellationToken.ThrowIfCancellationRequested();
+                    // Safe to read _disposed without a barrier: Dispose writes _disposed before calling
+                    // _disposeCts.Cancel(), and observing the cancellation here establishes happens-before
+                    // with that write.
                     Debug.Assert(_disposed);
                     throw new ObjectDisposedException(nameof(AsyncStream<>), "The stream was disposed while reading.");
                 }
@@ -124,6 +131,10 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
                 foreach (T item in elements)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    // No memory barrier needed: this read is just an early-out optimization. If we miss a
+                    // concurrent write to _disposed, the next ReadAsync call observes the cancellation of
+                    // _disposeCts (which has its own synchronization) and we surface ObjectDisposedException
+                    // from the catch block above.
                     ObjectDisposedException.ThrowIf(_disposed, this);
                     yield return item;
                 }

--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -29,10 +29,6 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
     // Dispose distinguish "enumerator was created but never started" from "iteration actually started".
     private bool _iterationStarted;
 
-    /// <summary>Disposes this stream.</summary>
-    /// <remarks>This method may be called concurrently with an in-flight <c>MoveNextAsync</c> on the stream's
-    /// enumerator: the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
-    /// <see cref="ObjectDisposedException" />. Calling it a second time is a no-op.</remarks>
     public void Dispose()
     {
         if (_disposed)

--- a/src/IceRpc/IAsyncStream.cs
+++ b/src/IceRpc/IAsyncStream.cs
@@ -9,8 +9,7 @@ namespace IceRpc;
 /// to complete this reader by disposing the stream, or iterating over its elements, or doing both.
 /// <para><see cref="IAsyncStream{T}" /> is not thread-safe in general, but <see cref="IDisposable.Dispose" /> may
 /// be called concurrently with an in-progress or just-starting <c>MoveNextAsync</c>: the in-flight read is unblocked
-/// and the consumer's <c>MoveNextAsync</c> throws <see cref="ObjectDisposedException" />. Calling
-/// <see cref="IDisposable.Dispose" /> a second time is a no-op.</para></remarks>
+/// and the consumer's <c>MoveNextAsync</c> throws <see cref="ObjectDisposedException" />.</para></remarks>
 public interface IAsyncStream<out T> : IAsyncEnumerable<T>, IDisposable
 {
 }

--- a/src/IceRpc/IAsyncStream.cs
+++ b/src/IceRpc/IAsyncStream.cs
@@ -5,10 +5,12 @@ namespace IceRpc;
 /// <summary>Represents an incoming stream of elements decoded from a request or response payload.</summary>
 /// <typeparam name="T">The type of the streamed elements.</typeparam>
 /// <remarks>An <see cref="IAsyncStream{T}" /> owns the underlying transport
-/// <see cref="System.IO.Pipelines.PipeReader" /> from which elements are decoded. It is the caller's responsibility to
-/// complete this reader by disposing the stream, or iterating over its elements, or doing both. Calling
-/// <see cref="IDisposable.Dispose"/> on a stream while an async iteration is in progress is safe and cancels the
-/// ongoing iteration.</remarks>
+/// <see cref="System.IO.Pipelines.PipeReader" /> from which elements are decoded. It is the caller's responsibility
+/// to complete this reader by disposing the stream, or iterating over its elements, or doing both.
+/// <para>Calling <see cref="IDisposable.Dispose" /> on a stream while an async iteration is in progress is safe:
+/// the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
+/// <see cref="ObjectDisposedException" />. Calling <see cref="IDisposable.Dispose" /> a second time is a no-op.
+/// </para></remarks>
 public interface IAsyncStream<out T> : IAsyncEnumerable<T>, IDisposable
 {
 }

--- a/src/IceRpc/IAsyncStream.cs
+++ b/src/IceRpc/IAsyncStream.cs
@@ -7,10 +7,10 @@ namespace IceRpc;
 /// <remarks>An <see cref="IAsyncStream{T}" /> owns the underlying transport
 /// <see cref="System.IO.Pipelines.PipeReader" /> from which elements are decoded. It is the caller's responsibility
 /// to complete this reader by disposing the stream, or iterating over its elements, or doing both.
-/// <para>Calling <see cref="IDisposable.Dispose" /> on a stream while an async iteration is in progress is safe:
-/// the in-flight read is unblocked and the consumer's <c>MoveNextAsync</c> throws
-/// <see cref="ObjectDisposedException" />. Calling <see cref="IDisposable.Dispose" /> a second time is a no-op.
-/// </para></remarks>
+/// <para><see cref="IAsyncStream{T}" /> is not thread-safe in general, but <see cref="IDisposable.Dispose" /> may
+/// be called concurrently with an in-progress or just-starting <c>MoveNextAsync</c>: the in-flight read is unblocked
+/// and the consumer's <c>MoveNextAsync</c> throws <see cref="ObjectDisposedException" />. Calling
+/// <see cref="IDisposable.Dispose" /> a second time is a no-op.</para></remarks>
 public interface IAsyncStream<out T> : IAsyncEnumerable<T>, IDisposable
 {
 }

--- a/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
@@ -149,14 +149,57 @@ public class AsyncStreamTests
     }
 
     [Test]
-    public void GetAsyncEnumerator_throws_after_dispose()
+    public void Move_next_async_throws_after_dispose()
     {
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>([0])));
         IAsyncStream<StringValue> stream = trackingReader.ToAsyncStream(StringValue.Parser, maxMessageLength: 1024);
 
         stream.Dispose();
 
-        Assert.That(() => stream.GetAsyncEnumerator(), Throws.InstanceOf<ObjectDisposedException>());
+        // GetAsyncEnumerator on a disposed stream is allowed; the disposed check happens on the first MoveNextAsync.
+        IAsyncEnumerator<StringValue> enumerator = stream.GetAsyncEnumerator();
+        Assert.That(async () => await enumerator.MoveNextAsync(), Throws.InstanceOf<ObjectDisposedException>());
+    }
+
+    [Test]
+    public async Task Dispose_concurrent_with_first_move_next_completes_reader_exactly_once()
+    {
+        // Stress test for the Dispose / first MoveNextAsync race. We loop many times to maximize the chance of
+        // exercising both inter-leavings: Dispose wins (iterator throws ObjectDisposedException before touching the
+        // reader) and iterator wins (Dispose only signals cancellation; iterator's finally completes the reader).
+        // In every case _reader.Complete must be called exactly once and MoveNextAsync must either complete normally
+        // or throw ObjectDisposedException.
+
+        const int iterations = 200;
+        for (int i = 0; i < iterations; i++)
+        {
+            var pipe = new Pipe();
+            var trackingReader = new TrackingPipeReader(pipe.Reader);
+            IAsyncStream<StringValue> stream = trackingReader.ToAsyncStream(
+                StringValue.Parser,
+                maxMessageLength: 1024);
+
+            IAsyncEnumerator<StringValue> enumerator = stream.GetAsyncEnumerator();
+
+            var disposeTask = Task.Run(stream.Dispose);
+            Task<bool> moveNextTask = Task.Run(async () => await enumerator.MoveNextAsync());
+
+            await disposeTask;
+
+            try
+            {
+                await moveNextTask;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Expected when Dispose wins the race (or signals cancellation mid-read).
+            }
+
+            await enumerator.DisposeAsync();
+            pipe.Writer.Complete();
+
+            Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1), $"iteration {i}");
+        }
     }
 
     private static PipeReader EncodeStringValues(params string[] values)

--- a/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
@@ -222,8 +222,9 @@ public class AsyncStreamTests
     private sealed class TrackingPipeReader : PipeReader
     {
         private readonly PipeReader _inner;
+        private int _completeCallCount;
 
-        internal int CompleteCallCount { get; private set; }
+        internal int CompleteCallCount => Volatile.Read(ref _completeCallCount);
 
         public override void AdvanceTo(SequencePosition consumed) => _inner.AdvanceTo(consumed);
 
@@ -234,7 +235,7 @@ public class AsyncStreamTests
 
         public override void Complete(Exception? exception = null)
         {
-            CompleteCallCount++;
+            Interlocked.Increment(ref _completeCallCount);
             _inner.Complete(exception);
         }
 

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -162,7 +162,7 @@ public class AsyncStreamTests
     }
 
     [Test]
-    public void GetAsyncEnumerator_throws_after_dispose()
+    public void Move_next_async_throws_after_dispose()
     {
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>([0])));
         IAsyncStream<int> stream = trackingReader.ToAsyncStream(
@@ -171,7 +171,50 @@ public class AsyncStreamTests
 
         stream.Dispose();
 
-        Assert.That(() => stream.GetAsyncEnumerator(), Throws.InstanceOf<ObjectDisposedException>());
+        // GetAsyncEnumerator on a disposed stream is allowed; the disposed check happens on the first MoveNextAsync.
+        IAsyncEnumerator<int> enumerator = stream.GetAsyncEnumerator();
+        Assert.That(async () => await enumerator.MoveNextAsync(), Throws.InstanceOf<ObjectDisposedException>());
+    }
+
+    [Test]
+    public async Task Dispose_concurrent_with_first_move_next_completes_reader_exactly_once()
+    {
+        // Stress test for the Dispose / first MoveNextAsync race. We loop many times to maximize the chance of
+        // exercising both inter-leavings: Dispose wins (iterator throws ObjectDisposedException before touching the
+        // reader) and iterator wins (Dispose only signals cancellation; iterator's finally completes the reader).
+        // In every case _reader.Complete must be called exactly once and MoveNextAsync must either complete normally
+        // or throw ObjectDisposedException.
+
+        const int iterations = 200;
+        for (int i = 0; i < iterations; i++)
+        {
+            var pipe = new Pipe();
+            var trackingReader = new TrackingPipeReader(pipe.Reader);
+            IAsyncStream<int> stream = trackingReader.ToAsyncStream(
+                (ref SliceDecoder decoder) => decoder.DecodeInt32(),
+                elementSize: 4);
+
+            IAsyncEnumerator<int> enumerator = stream.GetAsyncEnumerator();
+
+            var disposeTask = Task.Run(stream.Dispose);
+            Task<bool> moveNextTask = Task.Run(async () => await enumerator.MoveNextAsync());
+
+            await disposeTask;
+
+            try
+            {
+                await moveNextTask;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Expected when Dispose wins the race (or signals cancellation mid-read).
+            }
+
+            await enumerator.DisposeAsync();
+            pipe.Writer.Complete();
+
+            Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1), $"iteration {i}");
+        }
     }
 
     private static byte[] EncodeInt32Values(params int[] values)

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -232,8 +232,9 @@ public class AsyncStreamTests
     private sealed class TrackingPipeReader : PipeReader
     {
         private readonly PipeReader _inner;
+        private int _completeCallCount;
 
-        internal int CompleteCallCount { get; private set; }
+        internal int CompleteCallCount => Volatile.Read(ref _completeCallCount);
 
         public override void AdvanceTo(SequencePosition consumed) => _inner.AdvanceTo(consumed);
 
@@ -244,7 +245,7 @@ public class AsyncStreamTests
 
         public override void Complete(Exception? exception = null)
         {
-            CompleteCallCount++;
+            Interlocked.Increment(ref _completeCallCount);
             _inner.Complete(exception);
         }
 


### PR DESCRIPTION
Makes the internal `AsyncStream<T>` `Dispose` method (Slice and Protobuf variants) safe against a concurrent or just-starting `MoveNextAsync`, and documents the contract on `IAsyncStream<T>`.

### The race

The original code used two unsynchronized bool flags (`_disposed` and `_iterationStarted`) to arbitrate ownership of `_reader.Complete()` between `Dispose` and the first `MoveNextAsync`. That's a Dekker-style race: both sides could observe the other's flag as still-unset and each call `_reader.Complete()`, or neither could and the reader would leak. This was raised by @pepone in review.

### The fix

Replace the two bools with a single lock-free 3-state machine: `Idle (0) / Iterating (1) / Disposed (2)`, held as a raw `int` so it can be passed to `Interlocked` directly (matching the convention already used in `SlicStream`).

- `Dispose` does `Interlocked.Exchange(ref _state, Disposed)` and switches on the prior value:
  - `Idle` → no iteration ever started; `Dispose` completes the reader.
  - `Iterating` → an iterator owns the reader; `Dispose` only signals `_disposeCts.Cancel()` and the iterator's `finally` completes the reader.
  - `Disposed` → no-op.
- The iterator starts with `Interlocked.CompareExchange(ref _state, Iterating, Idle)`. If it loses to a concurrent `Dispose`, it throws `ObjectDisposedException` without touching the reader.

Exactly one side wins the transition out of `Idle`, so `_reader.Complete()` is called exactly once.

The `_state = Disposed` write is ordered before `_disposeCts.Cancel()`, so the iterator's catch block can read `_state` with a plain field read once it has observed the cancellation (happens-before via the CTS).

### Other changes

- `IAsyncStream<T>` `<remarks>` now documents the contract: `Dispose` may be called concurrently with an in-flight or just-starting `MoveNextAsync`; the read is unblocked and the consumer's `MoveNextAsync` throws `ObjectDisposedException`.
- Disposed check moved from `GetAsyncEnumerator` to the first `MoveNextAsync` (where it actually matters).
- Added a stress test in both Slice and Protobuf test projects (`Dispose_concurrent_with_first_move_next_completes_reader_exactly_once`) that races `Dispose` against the first `MoveNextAsync` over many iterations and asserts the reader is completed exactly once.

Closes #4606.
