### PR TITLE
Fix logger error-response logging (#4612)

### DIFF
--- a/src/IceRpc.Logger/LoggerInterceptor.cs
+++ b/src/IceRpc.Logger/LoggerInterceptor.cs
@@ -30,12 +30,24 @@ public class LoggerInterceptor : IInvoker
         {
             IncomingResponse response = await _next.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInvoke(
-                request.ServiceAddress,
-                request.Operation,
-                response.StatusCode,
-                response.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
-                response.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress);
+            if (response.StatusCode == StatusCode.Ok)
+            {
+                _logger.LogInvoke(
+                    request.ServiceAddress,
+                    request.Operation,
+                    response.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
+                    response.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress);
+            }
+            else
+            {
+                _logger.LogInvokeError(
+                    request.ServiceAddress,
+                    request.Operation,
+                    response.StatusCode,
+                    response.ErrorMessage!,
+                    response.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
+                    response.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress);
+            }
             return response;
         }
         catch (Exception exception)
@@ -54,12 +66,25 @@ internal static partial class LoggerInterceptorLoggerExtensions
         EventId = (int)LoggerInterceptorEventId.Invoke,
         EventName = nameof(LoggerInterceptorEventId.Invoke),
         Level = LogLevel.Information,
-        Message = "Sent request {Operation} to {ServiceAddress} over {LocalNetworkAddress}<->{RemoteNetworkAddress} and received a response with status code {StatusCode}")]
+        Message = "Sent request {Operation} to {ServiceAddress} over {LocalNetworkAddress}<->{RemoteNetworkAddress} and received a response with status code Ok")]
     internal static partial void LogInvoke(
         this ILogger logger,
         ServiceAddress serviceAddress,
         string operation,
+        EndPoint? localNetworkAddress,
+        EndPoint? remoteNetworkAddress);
+
+    [LoggerMessage(
+        EventId = (int)LoggerInterceptorEventId.InvokeError,
+        EventName = nameof(LoggerInterceptorEventId.InvokeError),
+        Level = LogLevel.Information,
+        Message = "Sent request {Operation} to {ServiceAddress} over {LocalNetworkAddress}<->{RemoteNetworkAddress} and received a response with status code {StatusCode} and error message: {ErrorMessage}")]
+    internal static partial void LogInvokeError(
+        this ILogger logger,
+        ServiceAddress serviceAddress,
+        string operation,
         StatusCode statusCode,
+        string errorMessage,
         EndPoint? localNetworkAddress,
         EndPoint? remoteNetworkAddress);
 

--- a/src/IceRpc.Logger/LoggerInterceptorEventId.cs
+++ b/src/IceRpc.Logger/LoggerInterceptorEventId.cs
@@ -5,9 +5,12 @@ namespace IceRpc.Logger;
 /// <summary>This enumeration contains event ID constants used by the logger interceptor.</summary>
 public enum LoggerInterceptorEventId
 {
-    /// <summary>The invocation returned a response. The response's <see cref="StatusCode"/> indicates whether the
-    /// dispatch of the request has completed successfully, and, if not, which error occurred.</summary>
+    /// <summary>The invocation returned a response with status code <see cref="StatusCode.Ok" />.</summary>
     Invoke,
+
+    /// <summary>The invocation returned a response with a status code other than <see cref="StatusCode.Ok" />.
+    /// </summary>
+    InvokeError,
 
     /// <summary>The invocation failed with an exception.</summary>
     InvokeException

--- a/src/IceRpc.Logger/LoggerMiddleware.cs
+++ b/src/IceRpc.Logger/LoggerMiddleware.cs
@@ -36,12 +36,24 @@ public class LoggerMiddleware : IDispatcher
             {
                 OutgoingResponse response = await _next.DispatchAsync(request, cancellationToken).ConfigureAwait(false);
 
-                _logger.LogDispatch(
-                    request.Path,
-                    request.Operation,
-                    request.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
-                    request.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress,
-                    response.StatusCode);
+                if (response.StatusCode == StatusCode.Ok)
+                {
+                    _logger.LogDispatch(
+                        request.Path,
+                        request.Operation,
+                        request.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
+                        request.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress);
+                }
+                else
+                {
+                    _logger.LogDispatchError(
+                        request.Path,
+                        request.Operation,
+                        request.ConnectionContext.TransportConnectionInformation.LocalNetworkAddress,
+                        request.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress,
+                        response.StatusCode,
+                        response.ErrorMessage!);
+                }
                 return response;
             }
             catch (Exception exception)
@@ -64,14 +76,27 @@ internal static partial class LoggerMiddlewareLoggerExtensions
         EventId = (int)LoggerMiddlewareEventId.Dispatch,
         EventName = nameof(LoggerMiddlewareEventId.Dispatch),
         Level = LogLevel.Information,
-        Message = "Dispatch of {Operation} to {Path} over {LocalNetworkAddress}<->{RemoteNetworkAddress} returned a response with status code {StatusCode}")]
+        Message = "Dispatch of {Operation} to {Path} over {LocalNetworkAddress}<->{RemoteNetworkAddress} returned a response with status code Ok")]
     internal static partial void LogDispatch(
         this ILogger logger,
         string path,
         string operation,
         EndPoint? localNetworkAddress,
+        EndPoint? remoteNetworkAddress);
+
+    [LoggerMessage(
+        EventId = (int)LoggerMiddlewareEventId.DispatchError,
+        EventName = nameof(LoggerMiddlewareEventId.DispatchError),
+        Level = LogLevel.Information,
+        Message = "Dispatch of {Operation} to {Path} over {LocalNetworkAddress}<->{RemoteNetworkAddress} returned a response with status code {StatusCode} and error message: {ErrorMessage}")]
+    internal static partial void LogDispatchError(
+        this ILogger logger,
+        string path,
+        string operation,
+        EndPoint? localNetworkAddress,
         EndPoint? remoteNetworkAddress,
-        StatusCode statusCode);
+        StatusCode statusCode,
+        string errorMessage);
 
     [LoggerMessage(
         EventId = (int)LoggerMiddlewareEventId.DispatchException,

--- a/src/IceRpc.Logger/LoggerMiddlewareEventId.cs
+++ b/src/IceRpc.Logger/LoggerMiddlewareEventId.cs
@@ -5,9 +5,12 @@ namespace IceRpc.Logger;
 /// <summary>This enumeration contains event ID constants used by the logger middleware.</summary>
 public enum LoggerMiddlewareEventId
 {
-    /// <summary>The dispatch returned a response. The response's <see cref="StatusCode"/> indicates whether the
-    /// dispatch of the request has completed successfully, and, if not, which error occurred.</summary>
+    /// <summary>The dispatch returned a response with status code <see cref="StatusCode.Ok" />.</summary>
     Dispatch,
+
+    /// <summary>The dispatch returned a response with a status code other than <see cref="StatusCode.Ok" />.
+    /// </summary>
+    DispatchError,
 
     /// <summary>The dispatch failed with an exception.</summary>
     DispatchException,

--- a/src/IceRpc/IncomingResponse.cs
+++ b/src/IceRpc/IncomingResponse.cs
@@ -10,8 +10,9 @@ namespace IceRpc;
 public sealed class IncomingResponse : IncomingFrame
 {
     /// <summary>Gets the error message of this response.</summary>
-    /// <value>The error message of this response if <see cref="StatusCode" /> is different from <see
-    /// cref="StatusCode.Ok" />; otherwise, <see langword="null"/>.</value>
+    /// <value>The error message of this response. It is guaranteed to be non-<see langword="null" /> when <see
+    /// cref="StatusCode" /> is different from <see cref="StatusCode.Ok" />, and <see langword="null" /> when <see
+    /// cref="StatusCode" /> is <see cref="StatusCode.Ok" />.</value>
     public string? ErrorMessage { get; }
 
     /// <summary>Gets the fields of this incoming response.</summary>

--- a/src/IceRpc/OutgoingResponse.cs
+++ b/src/IceRpc/OutgoingResponse.cs
@@ -8,8 +8,9 @@ namespace IceRpc;
 public sealed class OutgoingResponse : OutgoingFrame
 {
     /// <summary>Gets the error message of this response.</summary>
-    /// <value>The error message of this response if <see cref="StatusCode" /> is different from <see
-    /// cref="StatusCode.Ok" />; otherwise, <see langword="null" />.</value>
+    /// <value>The error message of this response. It is guaranteed to be non-<see langword="null" /> when <see
+    /// cref="StatusCode" /> is different from <see cref="StatusCode.Ok" />, and <see langword="null" /> when <see
+    /// cref="StatusCode" /> is <see cref="StatusCode.Ok" />.</value>
     public string? ErrorMessage { get; }
 
     /// <summary>Gets or sets the fields of this response.</summary>

--- a/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
@@ -11,6 +11,7 @@ public sealed class LoggerInterceptorTests
     [Test]
     public async Task Log_successful_request()
     {
+        // Arrange
         var invoker = new InlineInvoker(
             (request, cancellationToken) => Task.FromResult(
                 new IncomingResponse(request, FakeConnectionContext.Instance)));
@@ -19,11 +20,11 @@ public sealed class LoggerInterceptorTests
         using var request = new OutgoingRequest(serviceAddress) { Operation = "doIt" };
         var sut = new LoggerInterceptor(invoker, loggerFactory.CreateLogger<LoggerInterceptor>());
 
+        // Act
         await sut.InvokeAsync(request, default);
 
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        // Assert
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
-
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.Invoke));
         Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
         Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
@@ -38,6 +39,7 @@ public sealed class LoggerInterceptorTests
     [Test]
     public async Task Log_request_with_error_response()
     {
+        // Arrange
         var invoker = new InlineInvoker(
             (request, cancellationToken) => Task.FromResult(
                 new IncomingResponse(
@@ -50,11 +52,11 @@ public sealed class LoggerInterceptorTests
         using var request = new OutgoingRequest(serviceAddress) { Operation = "doIt" };
         var sut = new LoggerInterceptor(invoker, loggerFactory.CreateLogger<LoggerInterceptor>());
 
+        // Act
         await sut.InvokeAsync(request, default);
 
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        // Assert
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
-
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeError));
         Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
         Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
@@ -71,24 +73,25 @@ public sealed class LoggerInterceptorTests
     [Test]
     public async Task Log_failed_request()
     {
+        // Arrange
         var invoker = new InlineInvoker((request, cancellationToken) => throw new InvalidOperationException());
         using var loggerFactory = new TestLoggerFactory();
         var serviceAddress = new ServiceAddress(Protocol.IceRpc) { Path = "/path" };
         using var request = new OutgoingRequest(serviceAddress) { Operation = "doIt" };
         var sut = new LoggerInterceptor(invoker, loggerFactory.CreateLogger<LoggerInterceptor>());
 
+        // Act
         try
         {
             await sut.InvokeAsync(request, default);
+            Assert.Fail("Expected an InvalidOperationException to be thrown.");
         }
         catch (InvalidOperationException)
         {
         }
 
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
-
+        // Assert
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
-
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeException));
         Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
         Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));

--- a/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerInterceptorTests.cs
@@ -27,7 +27,39 @@ public sealed class LoggerInterceptorTests
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.Invoke));
         Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
         Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
-        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.Ok));
+        Assert.That(
+            entry.State["LocalNetworkAddress"],
+            Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.LocalNetworkAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"],
+            Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.RemoteNetworkAddress));
+    }
+
+    [Test]
+    public async Task Log_request_with_error_response()
+    {
+        var invoker = new InlineInvoker(
+            (request, cancellationToken) => Task.FromResult(
+                new IncomingResponse(
+                    request,
+                    FakeConnectionContext.Instance,
+                    StatusCode.ApplicationError,
+                    "some error")));
+        using var loggerFactory = new TestLoggerFactory();
+        var serviceAddress = new ServiceAddress(Protocol.IceRpc) { Path = "/path" };
+        using var request = new OutgoingRequest(serviceAddress) { Operation = "doIt" };
+        var sut = new LoggerInterceptor(invoker, loggerFactory.CreateLogger<LoggerInterceptor>());
+
+        await sut.InvokeAsync(request, default);
+
+        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerInterceptorEventId.InvokeError));
+        Assert.That(entry.State["ServiceAddress"], Is.EqualTo(serviceAddress));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.ApplicationError));
+        Assert.That(entry.State["ErrorMessage"], Is.EqualTo("some error"));
         Assert.That(
             entry.State["LocalNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.LocalNetworkAddress));

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -25,7 +25,6 @@ public sealed class LoggerMiddlewareTests
         await sut.DispatchAsync(request, default);
 
         // Assert
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.Dispatch));
@@ -42,6 +41,7 @@ public sealed class LoggerMiddlewareTests
     [Test]
     public async Task Log_request_with_error_response()
     {
+        // Arrange
         var dispatcher = new InlineDispatcher(
             (request, cancellationToken) => new(new OutgoingResponse(request, StatusCode.ApplicationError, "some error")));
         using var loggerFactory = new TestLoggerFactory();
@@ -53,9 +53,10 @@ public sealed class LoggerMiddlewareTests
         };
         var sut = new LoggerMiddleware(dispatcher, loggerFactory.CreateLogger<LoggerMiddleware>());
 
+        // Act
         await sut.DispatchAsync(request, default);
 
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        // Assert
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchError));
@@ -74,6 +75,7 @@ public sealed class LoggerMiddlewareTests
     [Test]
     public async Task Log_failed_request()
     {
+        // Arrange
         var dispatcher = new InlineDispatcher((request, cancellationToken) => throw new InvalidOperationException());
         using var loggerFactory = new TestLoggerFactory();
         await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
@@ -84,16 +86,17 @@ public sealed class LoggerMiddlewareTests
         };
         var sut = new LoggerMiddleware(dispatcher, loggerFactory.CreateLogger<LoggerMiddleware>());
 
+        // Act
         try
         {
             await sut.DispatchAsync(request, default);
+            Assert.Fail("Expected an InvalidOperationException to be thrown.");
         }
         catch (InvalidOperationException)
         {
         }
 
-        Assert.That(loggerFactory.Logger, Is.Not.Null);
-
+        // Assert
         TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
 
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchException));

--- a/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
+++ b/tests/IceRpc.Logger.Tests/LoggerMiddlewareTests.cs
@@ -31,7 +31,38 @@ public sealed class LoggerMiddlewareTests
         Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.Dispatch));
         Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
         Assert.That(entry.State["Path"], Is.EqualTo("/path"));
-        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.Ok));
+        Assert.That(
+            entry.State["LocalNetworkAddress"],
+            Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.LocalNetworkAddress));
+        Assert.That(
+            entry.State["RemoteNetworkAddress"],
+            Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.RemoteNetworkAddress));
+    }
+
+    [Test]
+    public async Task Log_request_with_error_response()
+    {
+        var dispatcher = new InlineDispatcher(
+            (request, cancellationToken) => new(new OutgoingResponse(request, StatusCode.ApplicationError, "some error")));
+        using var loggerFactory = new TestLoggerFactory();
+        await using var connection = new ClientConnection(new Uri("icerpc://127.0.0.1"));
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+        {
+            Path = "/path",
+            Operation = "doIt"
+        };
+        var sut = new LoggerMiddleware(dispatcher, loggerFactory.CreateLogger<LoggerMiddleware>());
+
+        await sut.DispatchAsync(request, default);
+
+        Assert.That(loggerFactory.Logger, Is.Not.Null);
+        TestLoggerEntry entry = await loggerFactory.Logger!.Entries.Reader.ReadAsync();
+
+        Assert.That(entry.EventId.Id, Is.EqualTo((int)LoggerMiddlewareEventId.DispatchError));
+        Assert.That(entry.State["Operation"], Is.EqualTo("doIt"));
+        Assert.That(entry.State["Path"], Is.EqualTo("/path"));
+        Assert.That(entry.State["StatusCode"], Is.EqualTo(StatusCode.ApplicationError));
+        Assert.That(entry.State["ErrorMessage"], Is.EqualTo("some error"));
         Assert.That(
             entry.State["LocalNetworkAddress"],
             Is.EqualTo(FakeConnectionContext.Instance.TransportConnectionInformation.LocalNetworkAddress));


### PR DESCRIPTION
Fixes #4612.

## Summary
- Split success and error response logs in logger interceptor and middleware.
- Added new event IDs and log methods for error responses that include both status code and error message.
- Kept exception logging unchanged.
- Clarified XML doc comments for IncomingResponse.ErrorMessage and OutgoingResponse.ErrorMessage to explicitly document the non-null guarantee when status code is not Ok.
- Added tests that verify interceptor and middleware emit the new error log events and include ErrorMessage.