### PR TITLE
Backport #4576 to 0.5.x

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1229,6 +1229,17 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
         {
             var decoder = new SliceDecoder(buffer, SliceEncoding.Slice2);
             var header = new IceRpcRequestHeader(ref decoder);
+
+            // Ensure that the encoded path is a valid service address path.
+            try
+            {
+                ServiceAddress.CheckPath(header.Path);
+            }
+            catch (FormatException exception)
+            {
+                throw new InvalidDataException(exception.Message, exception);
+            }
+
             (IDictionary<RequestFieldKey, ReadOnlySequence<byte>> fields, PipeReader? pipeReader) =
                 DecodeFieldDictionary(
                     ref decoder,

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -445,6 +445,51 @@ public sealed class IceRpcProtocolConnectionTests
             Throws.Nothing);
     }
 
+    /// <summary>Verifies that a request whose path violates the constraints enforced by
+    /// <see cref="ServiceAddress" /> is rejected at decode time, before it reaches the dispatcher.</summary>
+    [TestCase("/foo\r\nINJECTED")]   // CR/LF in path
+    [TestCase("/foo\0")]             // NUL in path
+    [TestCase("foo")]                // path without leading '/'
+    public async Task Request_with_invalid_path_is_rejected(string path)
+    {
+        // Arrange
+        var taskExceptionObserver = new TestTaskExceptionObserver();
+
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(Protocol.IceRpc)
+            .AddTestMultiplexedTransportDecorator()
+            .AddSingleton<ITaskExceptionObserver>(taskExceptionObserver)
+            .BuildServiceProvider(validateScopes: true);
+
+        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        await sut.ConnectAsync();
+
+        var clientTransport = provider.GetRequiredService<TestMultiplexedClientTransportDecorator>();
+        IMultiplexedConnection clientTransportConnection = clientTransport.LastCreatedConnection;
+        IMultiplexedStream stream = await clientTransportConnection.CreateStreamAsync(bidirectional: true, default);
+
+        var writer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(writer, SliceEncoding.Slice2);
+        Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
+        int startPos = encoder.EncodedByteCount;
+        encoder.EncodeString(path);
+        encoder.EncodeString("op");
+        encoder.EncodeVarUInt62(0); // empty field dictionary
+        SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
+
+        // Act
+        stream.Output.Write(writer.WrittenMemory.Span);
+        await stream.Output.FlushAsync();
+        stream.Output.CompleteOutput(success: true);
+
+        // Assert
+        Assert.That(
+            async () => await taskExceptionObserver.DispatchRefusedException,
+            Is.InstanceOf<IceRpcException>()
+                .With.Property("IceRpcError").EqualTo(IceRpcError.IceRpcError)
+                .And.InnerException.InstanceOf<InvalidDataException>());
+    }
+
     /// <summary>Verifies that a request with a field count large enough that count * 2 would overflow int arithmetic
     /// is correctly rejected.</summary>
     [Test]


### PR DESCRIPTION
Backport of #4576 — validate the path on icerpc requests at decode time.

## Summary
- Rejects icerpc requests whose path violates `ServiceAddress.CheckPath` (CR/LF, NUL, missing leading `/`) at decode time, before they reach the dispatcher, by wrapping the resulting `FormatException` as `InvalidDataException`.
- Adds a parameterized test exercising three invalid paths.

## Test plan
- [x] `dotnet test tests/IceRpc.Tests/IceRpc.Tests.csproj --filter "FullyQualifiedName~Request_with_invalid_path_is_rejected"` — 3/3 pass.
- [x] Full `IceRpcProtocolConnectionTests` class — 94/94 pass.

## Backport notes
Clean cherry-pick of 206c23b06; the only adaptation was passing `SliceEncoding.Slice2` to the test's `SliceEncoder` constructor (0.5.x still has the two-encoding constructor).