### PR TITLE
Backport #4541 to 0.5.x

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -950,6 +950,11 @@ internal class SlicConnection : IMultiplexedConnection
                         throw new InvalidDataException(
                             "The MaxStreamFrameSize connection parameter is invalid, it must be greater than 1KB.");
                     }
+                    if (maxStreamFrameSize > SlicTransportOptions.MaxStreamFrameSizeCeiling)
+                    {
+                        throw new InvalidDataException(
+                            $"The MaxStreamFrameSize connection parameter is invalid, it cannot exceed {SlicTransportOptions.MaxStreamFrameSizeCeiling} bytes.");
+                    }
                     break;
                 }
                 case ParameterKey.InitialStreamWindowSize:
@@ -1436,6 +1441,11 @@ internal class SlicConnection : IMultiplexedConnection
         else if (size == 0 && !endStream)
         {
             throw new InvalidDataException($"Received invalid {nameof(FrameType.Stream)} frame.");
+        }
+        else if (size > _maxStreamFrameSize)
+        {
+            throw new InvalidDataException(
+                $"Received stream frame with size {size} exceeding the advertised maximum of {_maxStreamFrameSize} bytes.");
         }
 
         if (!_streams.TryGetValue(streamId, out SlicStream? stream) && isRemote && IsUnknownStream(streamId))

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -22,7 +22,7 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     private readonly CancellationTokenSource _completeWritesCts = new();
     private Exception? _exception;
     private bool _isCompleted;
-    private volatile int _peerWindowSize = SlicTransportOptions.MaxWindowSize;
+    private volatile int _peerWindowSize;
     private readonly Pipe _pipe;
     // The semaphore is used when flow control is enabled to wait for additional send credit to be available.
     private readonly SemaphoreSlim _sendCreditSemaphore = new(1, 1);
@@ -211,8 +211,10 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
     {
         Debug.Assert(size > 0);
 
+        // With _peerWindowSize >= 0 and size > 0, the atomic sum is positive unless it overflows int.MaxValue
+        // (MaxWindowSize), in which case it wraps to a non-positive value.
         int newPeerWindowSize = Interlocked.Add(ref _peerWindowSize, size);
-        if (newPeerWindowSize > SlicTransportOptions.MaxWindowSize)
+        if (newPeerWindowSize <= 0)
         {
             throw new IceRpcException(
                 IceRpcError.IceRpcError,

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -31,29 +31,37 @@ public sealed record class SlicTransportOptions
             throw new ArgumentException(
                 $"The {nameof(InitialStreamWindowSize)} value cannot be less than 1 KB.",
                 nameof(value)) :
-            value > MaxWindowSize ?
-            throw new ArgumentException(
-                $"The {nameof(InitialStreamWindowSize)} value cannot be larger than {MaxWindowSize}.",
-                nameof(value)) :
             value;
     }
 
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
-    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB. Defaults to <c>32</c>
-    /// KB.</value>
+    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB or greater than
+    /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32</c> KB.</value>
     public int MaxStreamFrameSize
     {
         get => _maxStreamFrameSize;
-        set => _maxStreamFrameSize = value >= 1024 ? value :
+        set => _maxStreamFrameSize =
+            value < 1024 ?
             throw new ArgumentException(
-                $"The {nameof(MaxStreamFrameSize)} value cannot be less than 1KB.",
-                nameof(value));
+                $"The {nameof(MaxStreamFrameSize)} value cannot be less than 1 KB.",
+                nameof(value)) :
+            value > MaxStreamFrameSizeCeiling ?
+            throw new ArgumentException(
+                $"The {nameof(MaxStreamFrameSize)} value cannot be larger than {MaxStreamFrameSizeCeiling}.",
+                nameof(value)) :
+            value;
     }
+
+    // Upper bound on MaxStreamFrameSize (local and peer-advertised). Matches HTTP/2's SETTINGS_MAX_FRAME_SIZE
+    // ceiling. Larger frames worsen head-of-line blocking across multiplexed streams without improving
+    // throughput at any realistic link speed.
+    internal const int MaxStreamFrameSizeCeiling = 16_777_215;
 
     // We use the HTTP/2 maximum window size (2GB).
     internal const int MaxWindowSize = int.MaxValue;
 
     private TimeSpan _idleTimeout = TimeSpan.FromSeconds(30);
+
     // The default specified in the HTTP/2 specification.
     private int _initialStreamWindowSize = 65_536;
     private int _maxStreamFrameSize = 32_768;

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -35,8 +35,8 @@ public sealed record class SlicTransportOptions
     }
 
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
-    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB or greater than
-    /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32</c> KB.</value>
+    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1024</c> or greater than
+    /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32,768</c>.</value>
     public int MaxStreamFrameSize
     {
         get => _maxStreamFrameSize;

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -773,6 +773,183 @@ public class SlicTransportTests
     }
 
     [Test]
+    public void Setting_max_stream_frame_size_above_limit_throws()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.MaxStreamFrameSize = SlicTransportOptions.MaxStreamFrameSizeCeiling + 1, Throws.ArgumentException);
+    }
+
+    [Test]
+    public async Task Reject_peer_max_stream_frame_size_above_limit()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.ServerAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        await duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+
+        // Act - send an Initialize frame that advertises a MaxStreamFrameSize above the allowed limit.
+        await WriteFrameAsync(
+            duplexClientConnection,
+            FrameType.Initialize,
+            (ref SliceEncoder encoder) =>
+            {
+                var parameters = new Dictionary<ParameterKey, IList<byte>>();
+                byte[] oversizedMaxStreamFrameSizeBuffer = new byte[8];
+                SliceEncoder.EncodeVarUInt62(
+                    (ulong)SlicTransportOptions.MaxStreamFrameSizeCeiling + 1,
+                    oversizedMaxStreamFrameSizeBuffer);
+                parameters[ParameterKey.MaxStreamFrameSize] = oversizedMaxStreamFrameSizeBuffer;
+                byte[] initialStreamWindowSizeBuffer = new byte[4];
+                SliceEncoder.EncodeVarUInt62(32 * 1024, initialStreamWindowSizeBuffer);
+                parameters[ParameterKey.InitialStreamWindowSize] = initialStreamWindowSizeBuffer;
+
+                var initializeBody = new InitializeBody(parameters);
+                encoder.EncodeVarUInt62(1); // version
+                initializeBody.Encode(ref encoder);
+            });
+
+        // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await multiplexedServerConnection.ConnectAsync(default));
+        Assert.That(exception!.InnerException, Is.InstanceOf<InvalidDataException>());
+        Assert.That(exception.InnerException!.Message, Does.Contain("cannot exceed"));
+    }
+
+    [Test]
+    public async Task Reject_window_update_causing_overflow()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.ServerAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Advertise InitialStreamWindowSize = MaxWindowSize so the server's outgoing SlicPipeWriter starts its
+        // _peerWindowSize at int.MaxValue; any positive increment then overflows.
+        await WriteFrameAsync(
+            duplexClientConnection,
+            FrameType.Initialize,
+            (ref SliceEncoder encoder) =>
+            {
+                var parameters = new Dictionary<ParameterKey, IList<byte>>();
+                byte[] maxStreamFrameSizeBuffer = new byte[4];
+                SliceEncoder.EncodeVarUInt62(4096, maxStreamFrameSizeBuffer);
+                parameters[ParameterKey.MaxStreamFrameSize] = maxStreamFrameSizeBuffer;
+                byte[] initialStreamWindowSizeBuffer = new byte[8];
+                SliceEncoder.EncodeVarUInt62(
+                    (ulong)SlicTransportOptions.MaxWindowSize,
+                    initialStreamWindowSizeBuffer);
+                parameters[ParameterKey.InitialStreamWindowSize] = initialStreamWindowSizeBuffer;
+
+                var initializeBody = new InitializeBody(parameters);
+                encoder.EncodeVarUInt62(1); // version
+                initializeBody.Encode(ref encoder);
+            });
+        var serverConnectTask = multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader); // consume InitializeAck
+        await serverConnectTask;
+
+        // Open a bidirectional stream so the server has a SlicPipeWriter whose _peerWindowSize == MaxWindowSize.
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream acceptedStream = await multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Act - send a StreamWindowUpdate that pushes the server's cumulative window over int.MaxValue.
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.StreamWindowUpdate,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => new StreamWindowUpdateBody(1).Encode(ref encoder));
+
+        // Assert - the overflow rejection tears down the connection. Depending on whether AcceptStreamAsync
+        // observes the close state via the already-set _isClosed path or via the accept-channel completion, it
+        // may surface the close error (ConnectionAborted) or the original SlicPipeWriter exception (IceRpcError),
+        // so accept either.
+        IceRpcException exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await multiplexedServerConnection.AcceptStreamAsync(default))!;
+        Assert.That(
+            exception.IceRpcError,
+            Is.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError));
+
+        acceptedStream.Output.Complete();
+        acceptedStream.Input.Complete();
+    }
+
+    [Test]
+    public async Task Reject_stream_frame_exceeding_max_size()
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.MaxStreamFrameSize = 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.ServerAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        var serverConnectTask = multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader); // consume InitializeAck
+        await serverConnectTask;
+
+        // Act - send a stream frame whose body exceeds the server's local MaxStreamFrameSize (1024). The frame body
+        // is (streamId varint + payload), so a 2048-byte payload guarantees size > 1024.
+        const int payloadSize = 2048;
+        var writer = new MemoryBufferWriter(new byte[payloadSize + 16]);
+        {
+            var encoder = new SliceEncoder(writer, SliceEncoding.Slice2);
+            encoder.EncodeFrameType(FrameType.Stream);
+            Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
+            int startPos = encoder.EncodedByteCount;
+            encoder.EncodeVarUInt62(0ul); // streamId
+            encoder.WriteByteSpan(new byte[payloadSize]);
+            SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
+        }
+        await duplexClientConnection.WriteAsync(new ReadOnlySequence<byte>(writer.WrittenMemory), default);
+
+        // Assert - server rejects with an InvalidDataException, surfaced as IceRpcError.
+        Assert.That(
+            async () => await multiplexedServerConnection.AcceptStreamAsync(default),
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.IceRpcError));
+    }
+
+    [Test]
     public async Task Stream_peer_options_are_set_after_connect()
     {
         // Arrange


### PR DESCRIPTION
Backport of #4541 — bound Slic stream frame size and fix peer window overflow check.

## Summary
- Bounds the peer-advertised `MaxStreamFrameSize` (prevents memory exhaustion from a malicious peer advertising a huge value).
- Fixes the peer window overflow check: `Interlocked.Add` followed by `> int.MaxValue` was unreachable after wrap; now uses a pre-add check that actually detects overflow.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SlicTransportTests"` — 67/67 pass.

## Backport notes
Cherry-pick of f90a19f17 with two mechanical adaptations to the new test cases:
- `listener.TransportAddress` → `listener.ServerAddress` (0.5.x still uses `ServerAddress`).
- `new SliceEncoder(writer)` → `new SliceEncoder(writer, SliceEncoding.Slice2)` (0.5.x still has the two-encoding constructor).