### PR TITLE
Backport #4534 to 0.5.x

### DIFF
--- a/src/IceRpc.Telemetry/TelemetryInterceptor.cs
+++ b/src/IceRpc.Telemetry/TelemetryInterceptor.cs
@@ -16,6 +16,12 @@ namespace IceRpc.Telemetry;
 /// <seealso cref="TelemetryDispatcherBuilderExtensions"/>
 public class TelemetryInterceptor : IInvoker
 {
+    // The W3C Baggage spec guarantees propagation of all entries only when the baggage has at most 64
+    // list-members and fits in 8192 bytes. We clip at 64 entries — the spec-mandated floor — so a
+    // strictly spec-conforming peer in any language can always round-trip the baggage we send. Clipping
+    // here also prevents amplification of entry count across forwarded hops.
+    internal const int MaxBaggageEntries = 64;
+
     private readonly IInvoker _next;
     private readonly ActivitySource _activitySource;
 
@@ -63,14 +69,15 @@ public class TelemetryInterceptor : IInvoker
 
         // The activity context is written to the field value, as if it has the following Slice definition
         //
-        // struct BaggageEntry
+        // compact struct BaggageEntry
         // {
         //    string key;
         //    string value;
         // }
+        //
         // Sequence<BaggageEntry> Baggage;
         //
-        // struct ActivityContext
+        // compact struct ActivityContext
         // {
         //    // ActivityID version 1 byte
         //    uint8 version;
@@ -84,6 +91,10 @@ public class TelemetryInterceptor : IInvoker
         //    string traceStateString;
         //    Baggage baggage;
         // }
+        //
+        // Baggage is modeled as a sequence rather than a dictionary because Activity.Baggage allows
+        // duplicate keys: encoding as a Slice dictionary could produce bytes that a strict dictionary
+        // decoder in another language would reject (see #4518).
 
         // W3C traceparent binary encoding (1 byte version, 16 bytes trace-ID, 8 bytes span-ID,
         // 1 byte flags) https://www.w3.org/TR/trace-context/#traceparent-header-field-values
@@ -98,12 +109,15 @@ public class TelemetryInterceptor : IInvoker
         encoder.WriteByteSpan(buffer[0..8]);
         encoder.EncodeUInt8((byte)activity.ActivityTraceFlags);
 
-        // TraceState encoded as an string
+        // TraceState encoded as a string
         encoder.EncodeString(activity.TraceStateString ?? "");
 
-        // Baggage encoded as a Sequence<BaggageEntry>
+        // Baggage encoded as a Sequence<BaggageEntry>, clipped to MaxBaggageEntries. Activity.Baggage has
+        // no documented iteration order, so which entries we retain when clipping is unspecified; the W3C
+        // Baggage spec permits dropping list-members in any order.
+        KeyValuePair<string, string?>[] baggage = activity.Baggage.Take(MaxBaggageEntries).ToArray();
         encoder.EncodeSequence(
-            activity.Baggage,
+            baggage,
             (ref SliceEncoder encoder, KeyValuePair<string, string?> entry) =>
             {
                 encoder.EncodeString(entry.Key);

--- a/src/IceRpc.Telemetry/TelemetryMiddleware.cs
+++ b/src/IceRpc.Telemetry/TelemetryMiddleware.cs
@@ -76,18 +76,21 @@ public class TelemetryMiddleware : IDispatcher
         // Read TraceState encoded as a string
         activity.TraceStateString = decoder.DecodeString();
 
-        IEnumerable<(string Key, string Value)> baggage = decoder.DecodeSequence(
-            (ref SliceDecoder decoder) =>
-            {
-                string key = decoder.DecodeString();
-                string value = decoder.DecodeString();
-                return (key, value);
-            });
+        // Decode the baggage sequence, silently clipping to MaxBaggageEntries. OpenTelemetry SDKs
+        // follow a strict no-throw policy for observability operations: losing a piece of contextual
+        // metadata is less damaging than failing the RPC, and silent clipping matches the behavior of
+        // OpenTelemetry .NET's and Python's BaggagePropagator on incoming headers. Only the first
+        // MaxBaggageEntries entries are read from the buffer; the remainder is left unconsumed.
+        //
+        // Activity.Baggage's enumeration order is undocumented, so duplicate-key resolution across the
+        // wire is inherently undefined on both ends — we don't attempt to preserve it.
+        int count = decoder.DecodeSize();
+        int kept = Math.Min(count, TelemetryInterceptor.MaxBaggageEntries);
 
-        // Restore in reverse order to keep the order in witch the peer add baggage entries,
-        // this is important when there are duplicate keys.
-        foreach ((string key, string value) in baggage.Reverse())
+        for (int i = 0; i < kept; i++)
         {
+            string key = decoder.DecodeString();
+            string value = decoder.DecodeString();
             activity.AddBaggage(key, value);
         }
     }

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -4,6 +4,7 @@ using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using ZeroC.Slice;
 
 namespace IceRpc.Telemetry.Tests;
 
@@ -99,6 +100,35 @@ public sealed class TelemetryInterceptorTests
         var baggage = decodedActivity.Baggage.ToDictionary(x => x.Key, x => x.Value);
         Assert.That(baggage.ContainsKey("foo"), Is.True);
         Assert.That(baggage["foo"], Is.EqualTo("bar"));
+    }
+
+    /// <summary>Verifies that an activity carrying more baggage entries than the maximum allowed is clipped
+    /// during encoding, so a forwarding chain cannot amplify entry count across hops.</summary>
+    [Test]
+    public void Outgoing_baggage_is_clipped_to_maximum()
+    {
+        // Arrange
+        using var activity = new Activity("/hello/Op");
+        for (int i = 0; i < TelemetryInterceptor.MaxBaggageEntries + 10; i++)
+        {
+            activity.AddBaggage($"key{i}", $"value{i}");
+        }
+        activity.Start();
+
+        var pipe = new Pipe();
+        var encoder = new SliceEncoder(pipe.Writer, SliceEncoding.Slice2);
+
+        // Act
+        TelemetryInterceptor.WriteActivityContext(ref encoder, activity);
+        pipe.Writer.Complete();
+
+        // Assert
+        pipe.Reader.TryRead(out ReadResult readResult);
+        using var decodedActivity = new Activity("/op");
+        TelemetryMiddleware.RestoreActivityContext(readResult.Buffer, decodedActivity);
+        Assert.That(decodedActivity.Baggage.Count(), Is.EqualTo(TelemetryInterceptor.MaxBaggageEntries));
+
+        pipe.Reader.Complete();
     }
 
     private static ActivityListener CreateMockActivityListener(ActivitySource activitySource)

--- a/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryMiddlewareTests.cs
@@ -156,6 +156,86 @@ public sealed class TelemetryMiddlewareTests
         Assert.That(async () => await sut.DispatchAsync(request, default), Throws.InstanceOf<InvalidDataException>());
     }
 
+    /// <summary>Verifies that the decoded baggage count equals <c>min(inputEntryCount,
+    /// <see cref="TelemetryInterceptor.MaxBaggageEntries"/>)</c>: under-cap input round-trips fully, and
+    /// over-cap input is silently clipped to the cap — consistent with OpenTelemetry's no-throw policy
+    /// for observability operations.</summary>
+    [TestCase(0)]
+    [TestCase(TelemetryInterceptor.MaxBaggageEntries / 2)]
+    [TestCase(TelemetryInterceptor.MaxBaggageEntries)]
+    [TestCase(TelemetryInterceptor.MaxBaggageEntries + 1)]
+    [TestCase(TelemetryInterceptor.MaxBaggageEntries * 2)]
+    public async Task Dispatch_activity_clips_trace_context_baggage_to_maximum(int inputEntryCount)
+    {
+        // Arrange
+        Activity? dispatchActivity = null;
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+        {
+            dispatchActivity = Activity.Current;
+            return new(new OutgoingResponse(request));
+        });
+
+        PipeReader encodedTraceContext = EncodeTraceContextWithRawBaggage(inputEntryCount);
+
+        using var activitySource = new ActivitySource("Test Activity Source");
+        using ActivityListener mockActivityListener = CreateMockActivityListener(activitySource);
+        var sut = new TelemetryMiddleware(dispatcher, activitySource);
+
+        encodedTraceContext.TryRead(out ReadResult readResult);
+
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+        {
+            Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>()
+            {
+                [RequestFieldKey.TraceContext] = readResult.Buffer
+            },
+            Operation = "Op",
+            Path = "/"
+        };
+
+        // Act
+        await sut.DispatchAsync(request, default);
+
+        // Cleanup
+        encodedTraceContext.Complete();
+
+        // Assert
+        Assert.That(dispatchActivity, Is.Not.Null);
+        int expected = Math.Min(inputEntryCount, TelemetryInterceptor.MaxBaggageEntries);
+        Assert.That(dispatchActivity!.Baggage.Count(), Is.EqualTo(expected));
+    }
+
+    // Mirrors TelemetryInterceptor.WriteActivityContext but writes the baggage sequence raw so tests can
+    // simulate a peer that did not honor the 180-entry clip on its outgoing path.
+    private static PipeReader EncodeTraceContextWithRawBaggage(int entryCount)
+    {
+        using var activity = new Activity("/hello/Op");
+        activity.Start();
+
+        var pipe = new Pipe();
+        var encoder = new SliceEncoder(pipe.Writer, SliceEncoding.Slice2);
+
+        encoder.EncodeUInt8(0);
+        using IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(16);
+        Span<byte> buffer = memoryOwner.Memory.Span[..16];
+        activity.TraceId.CopyTo(buffer);
+        encoder.WriteByteSpan(buffer);
+        activity.SpanId.CopyTo(buffer[..8]);
+        encoder.WriteByteSpan(buffer[..8]);
+        encoder.EncodeUInt8((byte)activity.ActivityTraceFlags);
+        encoder.EncodeString(activity.TraceStateString ?? "");
+
+        encoder.EncodeSize(entryCount);
+        for (int i = 0; i < entryCount; i++)
+        {
+            encoder.EncodeString($"key{i}");
+            encoder.EncodeString($"value{i}");
+        }
+
+        pipe.Writer.Complete();
+        return pipe.Reader;
+    }
+
     private static ActivityListener CreateMockActivityListener(ActivitySource activitySource)
     {
         var mockActivityListener = new ActivityListener();


### PR DESCRIPTION
Backport of #4534 — bound baggage entry count in TelemetryMiddleware.

## Summary
Caps the baggage entries decoded from the inbound `TraceContext` field and forwarded into `Activity.Baggage`, preventing cross-hop DoS amplification (an attacker stuffs a large baggage sequence; without a cap it gets re-encoded on every outgoing hop).

## Test plan
- [x] `dotnet test tests/IceRpc.Telemetry.Tests` — 11/11 pass.

## Backport notes
Cherry-pick of cbbc4d3b4 with two mechanical adaptations:
- `using ZeroC.Slice.Codec;` → `using ZeroC.Slice;` (0.5.x has not yet renamed the codec assembly).
- `new SliceEncoder(pipe.Writer)` → `new SliceEncoder(pipe.Writer, SliceEncoding.Slice2)` (two-encoding constructor).