### PR TITLE
Backport #4546 to 0.5.x

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -522,8 +522,14 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     {
         lock (_mutex)
         {
-            if (_shutdownTask is null && _activeConnections.Remove(serverAddress))
+            // Check identity before removing: a concurrent reconnect may have already replaced this connection
+            // with a new one at the same server address. Removing without the identity check would evict the
+            // healthy replacement and leak it outside the cache.
+            if (_shutdownTask is null &&
+                _activeConnections.TryGetValue(serverAddress, out IProtocolConnection? existing) &&
+                existing == connection)
             {
+                _activeConnections.Remove(serverAddress);
                 // it's now our connection.
                 _detachedConnectionCount++;
             }


### PR DESCRIPTION
Backport of #4546 — check connection identity in `ConnectionCache.RemoveFromActiveAsync`.

## Summary
On reconnect, a closing old connection could evict the *new* replacement connection that had already taken its slot in `_activeConnections`. The replacement was then leaked outside the cache and subsequent requests opened yet another connection. Added an identity check.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ConnectionCacheTests"` — 8/8 pass.

## Backport notes
Clean cherry-pick of 0909b4b5a; no source adaptation needed.