### PR TITLE
Backport #4522 to 0.5.x

### DIFF
--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -14,6 +14,7 @@ internal class ColocListener : IListener<IDuplexConnection>
     public ServerAddress ServerAddress { get; }
 
     private readonly CancellationTokenSource _disposeCts = new();
+    private readonly Action<ColocListener> _onDispose;
     private readonly EndPoint _networkAddress;
     private readonly PipeOptions _pipeOptions;
 
@@ -71,6 +72,9 @@ internal class ColocListener : IListener<IDuplexConnection>
             return default;
         }
 
+        // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
+        _onDispose(this);
+
         // Cancel pending AcceptAsync.
         _disposeCts.Cancel();
 
@@ -91,11 +95,12 @@ internal class ColocListener : IListener<IDuplexConnection>
 
     internal ColocListener(
         ServerAddress serverAddress,
+        Action<ColocListener> onDispose,
         ColocTransportOptions colocTransportOptions,
         DuplexConnectionOptions duplexConnectionOptions)
     {
         ServerAddress = serverAddress;
-
+        _onDispose = onDispose;
         _networkAddress = new ColocEndPoint(serverAddress);
         _pipeOptions = new PipeOptions(
             pool: duplexConnectionOptions.Pool,

--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -9,7 +9,7 @@ using System.Threading.Channels;
 namespace IceRpc.Transports.Coloc.Internal;
 
 /// <summary>The listener implementation for the colocated transport.</summary>
-internal class ColocListener : IListener<IDuplexConnection>
+internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 {
     public ServerAddress ServerAddress { get; }
 
@@ -64,12 +64,12 @@ internal class ColocListener : IListener<IDuplexConnection>
         }
     }
 
-    public ValueTask DisposeAsync()
+    public void Dispose()
     {
         if (_disposeCts.IsCancellationRequested)
         {
             // Dispose already called.
-            return default;
+            return;
         }
 
         // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
@@ -89,7 +89,11 @@ internal class ColocListener : IListener<IDuplexConnection>
         }
 
         _disposeCts.Dispose();
+    }
 
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
         return default;
     }
 

--- a/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
@@ -35,6 +35,7 @@ internal class ColocServerTransport : IDuplexServerTransport
 
         var listener = new ColocListener(
             serverAddress with { Transport = Name },
+            onDispose: OnDispose,
             colocTransportOptions: _options,
             duplexConnectionOptions: options);
 
@@ -43,6 +44,11 @@ internal class ColocServerTransport : IDuplexServerTransport
             throw new IceRpcException(IceRpcError.AddressInUse);
         }
         return listener;
+
+        void OnDispose(ColocListener disposedListener) =>
+            _listeners.TryRemove(new KeyValuePair<ServerAddress, ColocListener>(
+                disposedListener.ServerAddress,
+                disposedListener));
     }
 
     internal ColocServerTransport(

--- a/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
@@ -41,6 +41,8 @@ internal class ColocServerTransport : IDuplexServerTransport
 
         if (!_listeners.TryAdd(listener.ServerAddress, listener))
         {
+            // The listener was never published; release its resources before reporting the collision.
+            listener.Dispose();
             throw new IceRpcException(IceRpcError.AddressInUse);
         }
         return listener;

--- a/tests/IceRpc.Tests/Transports/Coloc/ColocTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Coloc/ColocTransportTests.cs
@@ -11,6 +11,36 @@ namespace IceRpc.Tests.Transports.Coloc;
 [Parallelizable(scope: ParallelScope.All)]
 public class ColocTransportTests
 {
+    /// <summary>Verifies that after a listener is disposed, a new listener can be created at the same
+    /// transport address on the same <see cref="ColocTransport" /> (see issue #4484).</summary>
+    [Test]
+    public async Task Listen_succeeds_at_the_same_address_after_dispose()
+    {
+        // Arrange
+        var colocTransport = new ColocTransport();
+        var serverAddress = new ServerAddress(new Uri($"icerpc://{Guid.NewGuid()}"));
+
+        IListener<IDuplexConnection> firstListener = colocTransport.ServerTransport.Listen(
+            serverAddress,
+            new DuplexConnectionOptions(),
+            null);
+        await firstListener.DisposeAsync();
+
+        // Act/Assert
+        IListener<IDuplexConnection>? secondListener = null;
+        Assert.That(
+            () => secondListener = colocTransport.ServerTransport.Listen(
+                serverAddress,
+                new DuplexConnectionOptions(),
+                null),
+            Throws.Nothing);
+
+        if (secondListener is not null)
+        {
+            await secondListener.DisposeAsync();
+        }
+    }
+
     [Test]
     public async Task Coloc_transport_connection_information()
     {


### PR DESCRIPTION
Backport of #4522 — remove `ColocListener` from the shared dictionary on dispose.

## Summary
Without this fix, `ColocServerTransport._listeners` entries persist forever after the listener is disposed: re-listening at the same address throws `AddressInUse`, and the listener object is pinned in the dictionary. The fix adds an `onDispose` callback that removes the listener (identity-checked) from the shared dictionary.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ColocTransportTests"` — 14/14 pass, including the new `Listen_succeeds_at_the_same_address_after_dispose` test.

## Backport notes
Cherry-pick of a672a6789 with conflict resolution required because 0.5.x:
- Keys `_listeners` by `ServerAddress` (not `(string Host, ushort Port)`).
- Names the parameter `serverAddress` (not `transportAddress`).
- The new test uses `new TransportAddress { Host = ... }`, ported to `new ServerAddress(new Uri($"icerpc://{Guid.NewGuid()}"))` to match 0.5.x's API.

The behavior is identical to the main fix; only the dict key type and parameter names differ.