### PR TITLE
Backport #4523 + #4512 + #4518 to 0.5.x

### DIFF
--- a/src/ZeroC.Slice/SliceDecoder.cs
+++ b/src/ZeroC.Slice/SliceDecoder.cs
@@ -66,7 +66,7 @@ public ref partial struct SliceDecoder
     /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
-    /// length.</param>
+    /// length, clamped to <see cref="int.MaxValue" />.</param>
     /// <param name="activator">The activator for decoding Slice1-encoded classes and exceptions.</param>
     /// <param name="maxDepth">The maximum depth when decoding a class recursively. The default is <c>3</c>.</param>
     public SliceDecoder(
@@ -81,8 +81,8 @@ public ref partial struct SliceDecoder
         DecodingContext = decodingContext;
 
         _currentCollectionAllocation = 0;
-
-        _maxCollectionAllocation = maxCollectionAllocation == -1 ? 8 * (int)buffer.Length :
+        _maxCollectionAllocation = maxCollectionAllocation == -1 ?
+            (buffer.Length > int.MaxValue / 8 ? int.MaxValue : (int)(8L * buffer.Length)) :
             (maxCollectionAllocation >= 0 ? maxCollectionAllocation :
                 throw new ArgumentException(
                     $"The {nameof(maxCollectionAllocation)} argument must be greater than or equal to -1.",
@@ -103,7 +103,7 @@ public ref partial struct SliceDecoder
     /// <param name="decodingContext">The decoding context.</param>
     /// <param name="maxCollectionAllocation">The maximum cumulative allocation in bytes when decoding strings,
     /// sequences, and dictionaries from this buffer.<c>-1</c> (the default) is equivalent to 8 times the buffer
-    /// length.</param>
+    /// length, clamped to <see cref="int.MaxValue" />.</param>
     /// <param name="activator">The activator for decoding Slice1-encoded classes and exceptions.</param>
     /// <param name="maxDepth">The maximum depth when decoding a class recursively. The default is <c>3</c>.</param>
     public SliceDecoder(
@@ -529,6 +529,10 @@ public ref partial struct SliceDecoder
         }
 
         int size = SliceEncoder.GetBitSequenceByteCount(bitSequenceSize);
+        if (_reader.Remaining < size)
+        {
+            throw new InvalidDataException(EndOfBufferMessage);
+        }
         ReadOnlySequence<byte> bitSequence = _reader.UnreadSequence.Slice(0, size);
         _reader.Advance(size);
         Debug.Assert(bitSequence.Length == size);

--- a/src/ZeroC.Slice/SliceDecoderExtensions.cs
+++ b/src/ZeroC.Slice/SliceDecoderExtensions.cs
@@ -38,7 +38,14 @@ public static class SliceDecoderExtensions
             {
                 TKey key = keyDecodeFunc(ref decoder);
                 TValue value = valueDecodeFunc(ref decoder);
-                dictionary.Add(new KeyValuePair<TKey, TValue>(key, value));
+                try
+                {
+                    dictionary.Add(new KeyValuePair<TKey, TValue>(key, value));
+                }
+                catch (ArgumentException exception)
+                {
+                    throw new InvalidDataException($"Received dictionary with duplicate key '{key}'.", exception);
+                }
             }
             return dictionary;
         }
@@ -81,7 +88,14 @@ public static class SliceDecoderExtensions
                 bool hasValue = decoder.DecodeBool(); // simplified bit sequence
                 TKey key = keyDecodeFunc(ref decoder);
                 TValue? value = hasValue ? valueDecodeFunc(ref decoder) : default;
-                dictionary.Add(new KeyValuePair<TKey, TValue?>(key, value));
+                try
+                {
+                    dictionary.Add(new KeyValuePair<TKey, TValue?>(key, value));
+                }
+                catch (ArgumentException exception)
+                {
+                    throw new InvalidDataException($"Received dictionary with duplicate key '{key}'.", exception);
+                }
             }
             return dictionary;
         }

--- a/tests/ZeroC.Slice.Tests/DictionaryDecodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/DictionaryDecodingTests.cs
@@ -115,6 +115,35 @@ public class DictionaryDecodingTests
             Throws.Nothing);
     }
 
+    /// <summary>Verifies that an encoded dictionary containing a duplicate key is rejected with
+    /// <see cref="InvalidDataException" /> rather than surfacing the underlying <see cref="ArgumentException" />
+    /// from <see cref="Dictionary{TKey,TValue}" />.</summary>
+    [Test]
+    public void Decode_dictionary_with_duplicate_key()
+    {
+        // Arrange: encode a "dictionary" with two entries sharing the same key.
+        var buffer = new MemoryBufferWriter(new byte[64]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        encoder.EncodeSize(2);
+        encoder.EncodeInt32(42);
+        encoder.EncodeString("first");
+        encoder.EncodeInt32(42);
+        encoder.EncodeString("second");
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var sut = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2);
+                _ = sut.DecodeDictionary(
+                    count => new Dictionary<int, string>(count),
+                    (ref SliceDecoder decoder) => decoder.DecodeInt32(),
+                    (ref SliceDecoder decoder) => decoder.DecodeString());
+            },
+            Throws.InstanceOf<InvalidDataException>()
+                .With.Message.EqualTo("Received dictionary with duplicate key '42'."));
+    }
+
     /// <summary>Verifies that a crafted count near int.MaxValue / entrySize that would overflow int arithmetic
     /// is correctly rejected by the allocation check.</summary>
     [Test]

--- a/tests/ZeroC.Slice.Tests/SequenceDecodingTests.cs
+++ b/tests/ZeroC.Slice.Tests/SequenceDecodingTests.cs
@@ -136,6 +136,30 @@ public class SequenceDecodingTests
             Throws.InstanceOf<InvalidDataException>());
     }
 
+    [Test]
+    public void Decode_sequence_of_optionals_with_truncated_bit_sequence()
+    {
+        // Arrange: encode count = 8 (which requires 1 bit-sequence byte) with no bit-sequence bytes following.
+        var buffer = new MemoryBufferWriter(new byte[16]);
+        var encoder = new SliceEncoder(buffer, SliceEncoding.Slice2);
+        encoder.EncodeSize(8);
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                // The decoder only sees WrittenMemory (1 byte: the encoded size), so the default
+                // maxCollectionAllocation of 8 * buffer.Length = 8 bytes is too small and would trip the
+                // collection-allocation check before GetBitSequenceReader runs. Raise it so the truncation
+                // check is the first to fire.
+                var sut = new SliceDecoder(buffer.WrittenMemory, SliceEncoding.Slice2, maxCollectionAllocation: 1024);
+                _ = sut.DecodeSequenceOfOptionals<long?>(
+                    (ref SliceDecoder decoder) => decoder.DecodeInt64());
+            },
+            Throws.InstanceOf<InvalidDataException>()
+                .With.Message.EqualTo("Attempting to decode past the end of the Slice decoder buffer."));
+    }
+
     private enum TestEnum : short
     {
         A = 1,


### PR DESCRIPTION
Backport of three ZeroC.Slice decoder hardening fixes, bundled to one PR because they touch the same files.

## Summary
- **#4523** — Clamp default `maxCollectionAllocation` at `int.MaxValue`. The previous `8 * (int)buffer.Length` overflows to negative for buffers > 256 MiB, neutralising the allocation guard.
- **#4512** — Throw `InvalidDataException` on truncated bit sequence. `GetBitSequenceReader` was slicing the unread sequence without a remaining-bytes check; truncated payloads leaked an `ArgumentOutOfRangeException`.
- **#4518** — Throw `InvalidDataException` on duplicate dictionary key. `Dictionary.Add` raises `ArgumentException` on duplicates; the decoder now wraps it.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~DictionaryDecodingTests|FullyQualifiedName~SequenceDecodingTests"` — 22/22 pass, including the new duplicate-key test added by #4518.

## Backport notes
Cherry-picks of 07c1efb3a, 36e6fec07, f339cb987. Conflict resolution required because main split `ZeroC.Slice` and `IceRpc/Ice/Codec/` (separate `IceDecoder`/`IceDecoderExtensions`); 0.5.x keeps a single `SliceDecoder` carrying the `SliceEncoding` parameter. Adaptations:
- Dropped the parallel `IceDecoder.cs` / `IceDecoderExtensions.cs` changes (those files do not exist on 0.5.x).
- Folded the new duplicate-key test into `tests/ZeroC.Slice.Tests/DictionaryDecodingTests.cs` (no separate `Codec.Tests` dir on 0.5.x).
- Added `SliceEncoding.Slice2` to the `SliceEncoder` and `SliceDecoder` constructors in the new truncated-bit-sequence test.

Squashed to a single commit to match the bundled scope of the PR.