### PR TITLE
Backport #4529 to 0.5.x

### DIFF
--- a/src/IceRpc.Slice/IncomingRequestExtensions.cs
+++ b/src/IceRpc.Slice/IncomingRequestExtensions.cs
@@ -62,7 +62,11 @@ public static class IncomingRequestExtensions
 
             pipe.Writer.Complete();
 
-            return new OutgoingResponse(request, StatusCode.ApplicationError, GetErrorMessage(sliceException))
+            // By default, the generated Slice exceptions don't set a custom message and don't support setting an inner
+            // exception. However, Message can still be overridden, so the value transmitted over icerpc is whatever
+            // sliceException.Message returns.
+            // The icerpc client uses this message when it can't decode the Slice exception.
+            return new OutgoingResponse(request, StatusCode.ApplicationError, sliceException.Message)
             {
                 Payload = pipe.Reader
             };
@@ -116,11 +120,4 @@ public static class IncomingRequestExtensions
             encoding,
             request.Features.Get<ISliceFeature>() ?? SliceFeature.Default,
             cancellationToken);
-
-    // The error message includes the inner exception type and message because we don't transmit this inner exception
-    // with the response.
-    private static string GetErrorMessage(SliceException exception) =>
-        exception.InnerException is Exception innerException ?
-            $"{exception.Message} This exception was caused by an exception of type '{innerException.GetType()}' with message: {innerException.Message}" :
-            exception.Message;
 }


### PR DESCRIPTION
Backport of #4529 — stop capturing the inner exception message of Slice/Ice exceptions.

## Summary
Previously, `GetErrorMessage` appended the inner exception's type and message to the response error string sent back to the caller. This leaked server-side internals (file paths, internal type names, stack-like info) to remote callers. The response now carries only `sliceException.Message`.

## Test plan
- [x] `dotnet test tests/IceRpc.Slice.Tests` — 297/297 pass.

## Backport notes
Cherry-pick of f98fe8af7 with adaptation: main split `IceRpc.Slice` into `IceRpc.Slice` + `IceRpc.Ice`, and the fix landed in `src/IceRpc.Ice/Operations/IncomingRequestExtensions.cs`. On 0.5.x the corresponding code is in `src/IceRpc.Slice/IncomingRequestExtensions.cs` and uses the `SliceException` type (rather than `IceException`). The fix was ported by hand to the 0.5.x file:
- Replaced `GetErrorMessage(sliceException)` with `sliceException.Message` in the response constructor.
- Updated the explanatory comment to refer to "Slice exceptions" instead of "Ice exceptions".
- Removed the now-unused `GetErrorMessage` helper.