### PR TITLE
Backport #4593 to 0.5.x

### DIFF
--- a/slice/IceRpc/StatusCode.slice
+++ b/slice/IceRpc/StatusCode.slice
@@ -37,4 +37,8 @@ unchecked enum StatusCode : varuint62 {
 
     /// The caller is not authorized to access the requested resource.
     Unauthorized
+
+    /// The dispatch failed because the request requires a feature that the server or the target service does not
+    /// support.
+    NotSupported
 }

--- a/src/IceRpc.Protobuf/Internal/AsyncEnumerableExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/AsyncEnumerableExtensions.cs
@@ -163,7 +163,7 @@ internal static class AsyncEnumerableExtensions
                     _asyncEnumerator.Current.WriteTo(_pipe.Writer);
                     int length = checked((int)_pipe.Writer.UnflushedBytes - written);
                     written += length;
-                    BinaryPrimitives.WriteInt32BigEndian(lengthPlaceholder, length - 5);
+                    BinaryPrimitives.WriteUInt32BigEndian(lengthPlaceholder, (uint)(length - 5));
                     ValueTask<bool> moveNext = _asyncEnumerator.MoveNextAsync();
 
                     if (moveNext.IsCompletedSuccessfully)

--- a/src/IceRpc.Protobuf/Internal/MessageExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/MessageExtensions.cs
@@ -14,6 +14,10 @@ internal static class MessageExtensions
     /// <param name="message">The <see cref="IMessage" /> to encode.</param>
     /// <param name="pipeOptions">The options used to create the pipe.</param>
     /// <returns>A <see cref="PipeReader" /> containing the length-prefixed message.</returns>
+    /// <remarks>The envelope follows the gRPC Length-Prefixed-Message format: a 1-byte compression flag (always
+    /// 0 — IceRPC does not compress Protobuf payloads), followed by the message length as a 4-byte unsigned
+    /// big-endian integer, followed by the Protobuf-encoded message bytes. See
+    /// <see href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#data-frames" />.</remarks>
     internal static PipeReader EncodeAsLengthPrefixedMessage(this IMessage message, PipeOptions pipeOptions)
     {
         var pipe = new Pipe(pipeOptions);
@@ -22,7 +26,7 @@ internal static class MessageExtensions
         pipe.Writer.Advance(4);
         message.WriteTo(pipe.Writer);
         int length = checked((int)pipe.Writer.UnflushedBytes);
-        BinaryPrimitives.WriteInt32BigEndian(lengthPlaceholder, length - 5);
+        BinaryPrimitives.WriteUInt32BigEndian(lengthPlaceholder, (uint)(length - 5));
         pipe.Writer.Complete();
         return pipe.Reader;
     }

--- a/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
@@ -12,12 +12,16 @@ namespace IceRpc.Protobuf.Internal;
 /// <summary>Provides extension methods for <see cref="PipeReader" />.</summary>
 internal static class PipeReaderExtensions
 {
-    /// <summary>Decodes a Protobuf length prefixed message from a <see cref="PipeReader" />.</summary>
-    /// <param name="reader">The <see cref="PipeReader" /> containing the Protobuf length prefixed message.</param>
+    /// <summary>Decodes a Protobuf length-prefixed message from a <see cref="PipeReader" />.</summary>
+    /// <param name="reader">The <see cref="PipeReader" /> containing the Protobuf length-prefixed message.</param>
     /// <param name="parser">The <see cref="MessageParser{T}" /> used to parse the message data.</param>
     /// <param name="maxMessageLength">The maximum allowed length.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The decoded message object.</returns>
+    /// <remarks>The envelope follows the gRPC Length-Prefixed-Message format: a 1-byte compression flag (0 for
+    /// uncompressed; 1 indicates compressed and is rejected as not supported), followed by the message length
+    /// as a 4-byte unsigned big-endian integer, followed by the Protobuf-encoded message bytes. See
+    /// <see href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#data-frames" />.</remarks>
     internal static async ValueTask<T> DecodeProtobufMessageAsync<T>(
         this PipeReader reader,
         MessageParser<T> parser,
@@ -107,16 +111,22 @@ internal static class PipeReaderExtensions
                 $"The payload has {readResult.Buffer.Length} bytes, but 5 bytes were expected.");
         }
 
-        if (readResult.Buffer.FirstSpan[0] == 1)
+        byte compressionFlag = readResult.Buffer.FirstSpan[0];
+        switch (compressionFlag)
         {
-            throw new NotSupportedException("IceRPC does not support Protobuf compressed messages");
+            case 0:
+                break;
+            case 1:
+                // The Protobuf envelope defines flag 1 as "compressed". The message is well-formed Protobuf,
+                // but IceRPC doesn't decompress it.
+                throw new NotSupportedException("IceRPC does not support Protobuf compressed messages.");
+            default:
+                // The Protobuf envelope only defines flags 0 and 1; any other value is malformed.
+                throw new InvalidDataException(
+                    $"Invalid Protobuf compression flag {compressionFlag}; expected 0 or 1.");
         }
-        int messageLength = DecodeMessageLength(readResult.Buffer.Slice(1, 4));
+        int messageLength = DecodeMessageLength(readResult.Buffer.Slice(1, 4), maxMessageLength);
         reader.AdvanceTo(readResult.Buffer.GetPosition(5));
-        if (messageLength >= maxMessageLength)
-        {
-            throw new InvalidDataException("The message length exceeds the maximum value.");
-        }
 
         readResult = await reader.ReadAtLeastAsync(messageLength, cancellationToken).ConfigureAwait(false);
         // We never call CancelPendingRead; an interceptor or middleware can but it's not correct.
@@ -131,17 +141,35 @@ internal static class PipeReaderExtensions
                 $"The payload has {readResult.Buffer.Length} bytes, but {messageLength} bytes were expected.");
         }
 
-        // TODO: Does ParseFrom check it read all the bytes?
-        T message = messageParser.ParseFrom(readResult.Buffer.Slice(0, messageLength));
+        T message;
+        try
+        {
+            // ParseFrom reads tags until end-of-input and throws InvalidProtocolBufferException on a
+            // truncated field, so passing an exact-length slice means it either consumes every byte or
+            // throws.
+            message = messageParser.ParseFrom(readResult.Buffer.Slice(0, messageLength));
+        }
+        catch (InvalidProtocolBufferException exception)
+        {
+            throw new InvalidDataException("Failed to decode the Protobuf message.", exception);
+        }
         reader.AdvanceTo(readResult.Buffer.GetPosition(messageLength));
         return message;
 
-        static int DecodeMessageLength(ReadOnlySequence<byte> buffer)
+        static int DecodeMessageLength(ReadOnlySequence<byte> buffer, int maxMessageLength)
         {
             Debug.Assert(buffer.Length == 4);
             Span<byte> spanBuffer = stackalloc byte[4];
             buffer.CopyTo(spanBuffer);
-            return BinaryPrimitives.ReadInt32BigEndian(spanBuffer);
+            // The Protobuf envelope encodes the length as an unsigned 32-bit big-endian integer. The cast of
+            // maxMessageLength to uint is safe because it is a non-negative int, and covers both the > int.MaxValue
+            // case and the > maxMessageLength case in a single comparison.
+            uint messageLength = BinaryPrimitives.ReadUInt32BigEndian(spanBuffer);
+            if (messageLength > (uint)maxMessageLength)
+            {
+                throw new InvalidDataException("The message length exceeds the maximum value.");
+            }
+            return (int)messageLength;
         }
     }
 }

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1212,6 +1212,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
                     StatusCode statusCode = exception switch
                     {
                         InvalidDataException => StatusCode.InvalidData,
+                        NotSupportedException => StatusCode.NotSupported,
                         IceRpcException iceRpcException when iceRpcException.IceRpcError == IceRpcError.TruncatedData =>
                             StatusCode.TruncatedPayload,
                         _ => StatusCode.InternalError

--- a/tests/IceRpc.Protobuf.Tests/OperationTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/OperationTests.cs
@@ -1,9 +1,14 @@
 // Copyright (c) ZeroC, Inc.
 
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Features;
 using IceRpc.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO.Pipelines;
 
 namespace IceRpc.Protobuf.Tests;
 
@@ -168,6 +173,48 @@ public partial class OperationTests
         // Assert
         Assert.That(fields, Is.Not.Null);
         Assert.That(fields, Contains.Key(RequestFieldKey.Idempotent));
+    }
+
+    /// <summary>Verifies that when a peer sends a request with a malformed Protobuf payload (here, a
+    /// tampered envelope length that overruns the actual message), the server returns a response with
+    /// <see cref="StatusCode.InvalidData" />. This pins down the full path: the decoder wraps the
+    /// underlying <see cref="InvalidProtocolBufferException" /> as <see cref="InvalidDataException" />,
+    /// and the icerpc protocol layer maps that to <c>StatusCode.InvalidData</c>.</summary>
+    [Test]
+    public async Task Unary_rpc_with_malformed_protobuf_payload_returns_invalid_data()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddClientServerColocTest(dispatcher: new MyOperationsService())
+            .BuildServiceProvider(validateScopes: true);
+        provider.GetRequiredService<Server>().Listen();
+        ClientConnection clientConnection = provider.GetRequiredService<ClientConnection>();
+
+        // Build a tampered envelope: claim one extra byte and append a single 0xFF — a varint with the
+        // continuation bit set and no follow-up byte, which Protobuf treats as a truncated tag.
+        var validMessage = new InputMessage { P1 = "hi", P2 = 1 };
+        int actualLength = validMessage.CalculateSize();
+        var pipe = new Pipe();
+        pipe.Writer.Write(new byte[] { 0 });
+        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
+        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, actualLength + 1);
+        pipe.Writer.Advance(4);
+        validMessage.WriteTo(pipe.Writer);
+        pipe.Writer.Write(new byte[] { 0xFF });
+        pipe.Writer.Complete();
+
+        using var request = new OutgoingRequest(
+            new ServiceAddress(new Uri("icerpc:/icerpc.protobuf.tests.MyOperations")))
+        {
+            Operation = "UnaryOp",
+            Payload = pipe.Reader,
+        };
+
+        // Act
+        IncomingResponse response = await clientConnection.InvokeAsync(request);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.InvalidData));
     }
 
     [Test]

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -38,10 +38,7 @@ public partial class PipeReaderExtensionsTests
     {
         // Arrange
         var pipe = new Pipe();
-        pipe.Writer.Write(new byte[] { 1 });
-        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
-        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, 0);
-        pipe.Writer.Advance(4);
+        WriteLengthPrefixedMessage(pipe.Writer, message: null, compressionFlag: 1);
         pipe.Writer.Complete();
 
         // Act & Assert
@@ -62,10 +59,7 @@ public partial class PipeReaderExtensionsTests
     {
         // Arrange
         var pipe = new Pipe();
-        pipe.Writer.Write(new byte[] { compressionFlag });
-        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
-        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, 0);
-        pipe.Writer.Advance(4);
+        WriteLengthPrefixedMessage(pipe.Writer, message: null, compressionFlag: compressionFlag);
         pipe.Writer.Complete();
 
         // Act & Assert
@@ -85,9 +79,7 @@ public partial class PipeReaderExtensionsTests
     {
         // Arrange
         var pipe = new Pipe();
-        pipe.Writer.Write(new byte[] { 0 });
-        // 0xFFFFFFFF as big-endian — uint.MaxValue, well above int.MaxValue.
-        pipe.Writer.Write(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        WriteLengthPrefixedMessage(pipe.Writer, message: null, envelopeLength: uint.MaxValue);
         pipe.Writer.Complete();
 
         // Act & Assert
@@ -115,11 +107,7 @@ public partial class PipeReaderExtensionsTests
         int actualLength = validMessage.CalculateSize();
 
         var pipe = new Pipe();
-        pipe.Writer.Write(new byte[] { 0 });
-        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
-        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, actualLength + 1);
-        pipe.Writer.Advance(4);
-        validMessage.WriteTo(pipe.Writer);
+        WriteLengthPrefixedMessage(pipe.Writer, validMessage, envelopeLength: (uint)(actualLength + 1));
         pipe.Writer.Write(new byte[] { 0xFF });
         pipe.Writer.Complete();
 
@@ -133,12 +121,20 @@ public partial class PipeReaderExtensionsTests
         pipe.Reader.Complete();
     }
 
-    private static void WriteLengthPrefixedMessage(PipeWriter writer, IMessage message)
+    // Writes a length-prefixed Protobuf envelope: 1 compression-flag byte + 4 big-endian uint32 length bytes
+    // + optional message body. envelopeLength overrides the length field (used to construct mismatched
+    // envelopes or values > int.MaxValue); when omitted, the length matches the actual encoded message size
+    // (or 0 when no message).
+    private static void WriteLengthPrefixedMessage(
+        PipeWriter writer,
+        IMessage? message,
+        byte compressionFlag = 0,
+        uint? envelopeLength = null)
     {
-        writer.Write(new byte[] { 0 }); // Not compressed
+        writer.Write(new byte[] { compressionFlag });
         Span<byte> lengthBytes = writer.GetSpan(4);
-        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, message.CalculateSize());
+        BinaryPrimitives.WriteUInt32BigEndian(lengthBytes, envelopeLength ?? (uint)(message?.CalculateSize() ?? 0));
         writer.Advance(4);
-        message.WriteTo(writer);
+        message?.WriteTo(writer);
     }
 }

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ZeroC, Inc.
 
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Protobuf.Internal;
 using NUnit.Framework;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.IO.Pipelines;
 
 namespace IceRpc.Protobuf.Tests;
@@ -25,5 +28,117 @@ public partial class PipeReaderExtensionsTests
                 maxMessageLength: 1024,
                 CancellationToken.None));
         pipeReader.Complete();
+    }
+
+    /// <summary>Verifies that a Protobuf message with the "compressed" flag (1) is rejected as
+    /// <see cref="NotSupportedException" />. The message is well-formed Protobuf, but IceRPC doesn't
+    /// decompress it. The protocol layer maps this to <c>StatusCode.NotSupported</c>.</summary>
+    [Test]
+    public void Decode_message_throws_not_supported_exception_for_compressed_flag()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        pipe.Writer.Write(new byte[] { 1 });
+        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
+        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, 0);
+        pipe.Writer.Advance(4);
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that a Protobuf message with a reserved compression flag value (anything other than
+    /// 0 or 1) is rejected as <see cref="InvalidDataException" />. Prior to the fix, values 2..255 were
+    /// silently accepted as if uncompressed.</summary>
+    [TestCase((byte)2)]
+    [TestCase((byte)0xFF)]
+    public void Decode_message_throws_invalid_data_exception_for_reserved_compression_flag(byte compressionFlag)
+    {
+        // Arrange
+        var pipe = new Pipe();
+        pipe.Writer.Write(new byte[] { compressionFlag });
+        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
+        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, 0);
+        pipe.Writer.Advance(4);
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that a length greater than <see cref="int.MaxValue" /> (i.e. with the high bit set
+    /// in the unsigned 32-bit envelope) is rejected as <see cref="InvalidDataException" /> before reaching
+    /// <c>ReadAtLeastAsync</c>, which only accepts an int-sized length.</summary>
+    [Test]
+    public void Decode_message_throws_invalid_data_exception_for_message_length_exceeding_int32_max()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        pipe.Writer.Write(new byte[] { 0 });
+        // 0xFFFFFFFF as big-endian — uint.MaxValue, well above int.MaxValue.
+        pipe.Writer.Write(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that a tampered envelope whose length field claims more bytes than the actual
+    /// message contains is rejected as <see cref="InvalidDataException" />. We slice <c>ParseFrom</c>'s
+    /// input to exactly the envelope's claimed length, so trailing malformed bytes inside the envelope
+    /// cause <c>ParseFrom</c> to throw <see cref="InvalidProtocolBufferException" />, which we wrap as
+    /// <see cref="InvalidDataException" /> so the protocol layer maps it to <c>StatusCode.InvalidData</c>.
+    /// </summary>
+    [Test]
+    public void Decode_message_throws_invalid_data_exception_for_envelope_length_overrun()
+    {
+        // Arrange: serialize a valid StringValue, claim one extra byte in the envelope length, and append a
+        // single 0xFF — a varint with the continuation bit set and no follow-up byte, which Protobuf treats
+        // as a truncated tag.
+        var validMessage = new StringValue { Value = "hi" };
+        int actualLength = validMessage.CalculateSize();
+
+        var pipe = new Pipe();
+        pipe.Writer.Write(new byte[] { 0 });
+        Span<byte> lengthBytes = pipe.Writer.GetSpan(4);
+        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, actualLength + 1);
+        pipe.Writer.Advance(4);
+        validMessage.WriteTo(pipe.Writer);
+        pipe.Writer.Write(new byte[] { 0xFF });
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        InvalidDataException? exception = Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        Assert.That(exception!.InnerException, Is.InstanceOf<InvalidProtocolBufferException>());
+        pipe.Reader.Complete();
+    }
+
+    private static void WriteLengthPrefixedMessage(PipeWriter writer, IMessage message)
+    {
+        writer.Write(new byte[] { 0 }); // Not compressed
+        Span<byte> lengthBytes = writer.GetSpan(4);
+        BinaryPrimitives.WriteInt32BigEndian(lengthBytes, message.CalculateSize());
+        writer.Advance(4);
+        message.WriteTo(writer);
     }
 }


### PR DESCRIPTION
Backport of #4593 — Protobuf envelope validation.

## Summary
- Decoder treats the envelope length as **unsigned** big-endian; previously a value with the high bit set was interpreted as a negative `int`, slipping past the `> maxMessageLength` check and propagating into `ReadAtLeastAsync` / buffer slicing (classic parser-DoS primitive).
- The compression flag is now strictly validated: `0` = uncompressed, `1` = compressed (rejected as `NotSupportedException`), any other byte rejected as `InvalidDataException`. Previously flags `2..0xFF` were silently accepted as uncompressed.
- `ParseFrom` exceptions (`InvalidProtocolBufferException`) are now wrapped as `InvalidDataException` so the protocol layer surfaces them as `StatusCode.InvalidData` rather than `InternalError`.
- Adds `StatusCode.NotSupported` and maps `NotSupportedException` at the icerpc protocol layer so the compressed-flag rejection above is reported correctly.

## Test plan
- [x] `dotnet test tests/IceRpc.Protobuf.Tests` — 51/51 pass, covering the 5 new envelope-validation tests.

## Backport notes
Cherry-pick of 5d8c146cb with these adaptations:
- Source path differs: 0.5.x uses `src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs` (not `…/RpcMethods/Internal/…`).
- Removed the now-redundant post-`DecodeMessageLength` "exceeds maximum value" check (the new `DecodeMessageLength` does it before returning).
- Resolved the test-file conflict by keeping only the 5 new tests added by #4593. Two trailing-bytes / concatenated-messages tests that travelled along the diff context belong to #4553 (unary trailing-byte rejection) and will be added when #4553 is backported.
- Dropped the incidental `slice.toml` rev bump and the `slice/IceRpc/Ice/Object.ice` docstring drift (not part of the security fix; would pull in unrelated upstream slice changes). These files are not tracked on 0.5.x anyway.

Includes the additions to `StatusCode.slice` (`NotSupported`) and the matching mapping in `IceRpcProtocolConnection.cs`, which together preserve the protocol behavior the new compression-flag path expects.