### PR TITLE
Dispose ColocListener when the address is already in use

### DIFF
--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -9,7 +9,7 @@ using System.Threading.Channels;
 namespace IceRpc.Transports.Coloc.Internal;
 
 /// <summary>The listener implementation for the colocated transport.</summary>
-internal class ColocListener : IListener<IDuplexConnection>
+internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 {
     public TransportAddress TransportAddress { get; }
 
@@ -74,13 +74,13 @@ internal class ColocListener : IListener<IDuplexConnection>
         }
     }
 
-    public ValueTask DisposeAsync()
+    public void Dispose()
     {
         lock (_mutex)
         {
             if (_disposed)
             {
-                return default;
+                return;
             }
             _disposed = true;
 
@@ -100,6 +100,11 @@ internal class ColocListener : IListener<IDuplexConnection>
                 item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
             }
         }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
         return default;
     }
 

--- a/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
@@ -47,6 +47,8 @@ internal class ColocServerTransport : IDuplexServerTransport
 
         if (!_listeners.TryAdd(key, listener))
         {
+            // The listener was never published; release its resources before reporting the collision.
+            listener.DisposeAsync().AsTask().GetAwaiter().GetResult();
             throw new IceRpcException(IceRpcError.AddressInUse);
         }
         return listener;

--- a/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocServerTransport.cs
@@ -48,7 +48,7 @@ internal class ColocServerTransport : IDuplexServerTransport
         if (!_listeners.TryAdd(key, listener))
         {
             // The listener was never published; release its resources before reporting the collision.
-            listener.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            listener.Dispose();
             throw new IceRpcException(IceRpcError.AddressInUse);
         }
         return listener;


### PR DESCRIPTION
## Summary
When `ColocServerTransport.Listen` constructs a `ColocListener` but `_listeners.TryAdd` fails because the address is already taken, the newly-constructed listener becomes unreachable. Its `CancellationTokenSource` and bounded `Channel` leak (and the captured `onDispose` delegate keeps the server transport alive longer than necessary). Dispose the listener before throwing `AddressInUse`.

Flagged in code review of the backport (#4621); applying it here first so main and 0.5.x stay consistent.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ColocTransportTests"` — 14/14 pass.