### PR TITLE
Use consistent units in MaxStreamFrameSize doc-comment

### DIFF
--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -43,8 +43,8 @@ public sealed record class SlicTransportOptions
     }
 
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
-    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1</c> KB or greater than
-    /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32</c> KB.</value>
+    /// <value>The maximum stream frame size in bytes. It can't be less than <c>1024</c> or greater than
+    /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32,768</c>.</value>
     public int MaxStreamFrameSize
     {
         get => _maxStreamFrameSize;


### PR DESCRIPTION
## Summary
The doc-comment for `SlicTransportOptions.MaxStreamFrameSize` mixed KB and bytes: "It can't be less than `1` KB or greater than `16,777,215` (2^24 - 1). Defaults to `32` KB." The ceiling has no clean KB form (2^24 - 1 bytes ≈ 16 MB - 1 byte), so use bytes throughout.

Raised by @bernardnormier in code review of the backport (#4618); applying it here first so main and 0.5.x stay consistent.

## Test plan
- [x] Doc-comment only; `dotnet build src/IceRpc/IceRpc.csproj` succeeds.