### PR TITLE
Backport #4553 to 0.5.x

### DIFF
--- a/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
+++ b/src/IceRpc.Protobuf/IncomingRequestExtensions.cs
@@ -26,8 +26,8 @@ public static class IncomingRequestExtensions
         MessageParser<TInput> inputParser,
         TService service,
         Func<TService, TInput, IFeatureCollection, CancellationToken, ValueTask<TOutput>> method,
-        CancellationToken cancellationToken) where TInput : IMessage<TInput>
-                                             where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken) where TInput : class, IMessage<TInput>
+                                             where TOutput : class, IMessage<TOutput>
                                              where TService : class
     {
         IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
@@ -61,8 +61,8 @@ public static class IncomingRequestExtensions
         MessageParser<TInput> inputParser,
         TService service,
         Func<TService, IAsyncEnumerable<TInput>, IFeatureCollection, CancellationToken, ValueTask<TOutput>> method,
-        CancellationToken cancellationToken) where TInput : IMessage<TInput>
-                                             where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken) where TInput : class, IMessage<TInput>
+                                             where TOutput : class, IMessage<TOutput>
                                              where TService : class
     {
         IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
@@ -96,8 +96,8 @@ public static class IncomingRequestExtensions
         MessageParser<TInput> inputParser,
         TService service,
         Func<TService, TInput, IFeatureCollection, CancellationToken, ValueTask<IAsyncEnumerable<TOutput>>> method,
-        CancellationToken cancellationToken) where TInput : IMessage<TInput>
-                                             where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken) where TInput : class, IMessage<TInput>
+                                             where TOutput : class, IMessage<TOutput>
                                              where TService : class
     {
         IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;
@@ -131,8 +131,8 @@ public static class IncomingRequestExtensions
         MessageParser<TInput> inputParser,
         TService service,
         Func<TService, IAsyncEnumerable<TInput>, IFeatureCollection, CancellationToken, ValueTask<IAsyncEnumerable<TOutput>>> method,
-        CancellationToken cancellationToken) where TInput : IMessage<TInput>
-                                             where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken) where TInput : class, IMessage<TInput>
+                                             where TOutput : class, IMessage<TOutput>
                                              where TService : class
     {
         IProtobufFeature protobufFeature = request.Features.Get<IProtobufFeature>() ?? ProtobufFeature.Default;

--- a/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/Internal/PipeReaderExtensions.cs
@@ -26,15 +26,31 @@ internal static class PipeReaderExtensions
         this PipeReader reader,
         MessageParser<T> parser,
         int maxMessageLength,
-        CancellationToken cancellationToken) where T : IMessage<T>
+        CancellationToken cancellationToken) where T : class, IMessage<T>
     {
-        T? message = await ReadMessageAsync(
+        T message = await ReadMessageAsync(
             reader,
             parser,
             maxMessageLength,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false) ??
+            throw new InvalidDataException("The payload is empty; expected a Protobuf message.");
 
-        Debug.Assert(message is not null);
+        // A unary payload must contain exactly one message; any trailing bytes indicate a framing error.
+        ReadResult readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        // We never call CancelPendingRead; an interceptor or middleware can but it's not correct.
+        if (readResult.IsCanceled)
+        {
+            throw new InvalidOperationException("Unexpected call to CancelPendingRead.");
+        }
+        bool hasTrailingBytes = !readResult.Buffer.IsEmpty;
+        reader.AdvanceTo(readResult.Buffer.End);
+        if (hasTrailingBytes)
+        {
+            throw new InvalidDataException(
+                "The payload contains unexpected trailing bytes after the Protobuf message.");
+        }
+        Debug.Assert(readResult.IsCompleted);
+
         return message;
     }
 

--- a/src/IceRpc.Protobuf/InvokerExtensions.cs
+++ b/src/IceRpc.Protobuf/InvokerExtensions.cs
@@ -39,7 +39,7 @@ public static class InvokerExtensions
         ProtobufEncodeOptions? encodeOptions = null,
         IFeatureCollection? features = null,
         bool idempotent = false,
-        CancellationToken cancellationToken = default) where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken = default) where TOutput : class, IMessage<TOutput>
     {
         var request = new OutgoingRequest(serviceAddress)
         {
@@ -89,8 +89,8 @@ public static class InvokerExtensions
         ProtobufEncodeOptions? encodeOptions = null,
         IFeatureCollection? features = null,
         bool idempotent = false,
-        CancellationToken cancellationToken = default) where TInput : IMessage<TInput>
-                                                       where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken = default) where TInput : class, IMessage<TInput>
+                                                       where TOutput : class, IMessage<TOutput>
     {
         var request = new OutgoingRequest(serviceAddress)
         {
@@ -138,7 +138,7 @@ public static class InvokerExtensions
         ProtobufEncodeOptions? encodeOptions = null,
         IFeatureCollection? features = null,
         bool idempotent = false,
-        CancellationToken cancellationToken = default) where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken = default) where TOutput : class, IMessage<TOutput>
     {
         var request = new OutgoingRequest(serviceAddress)
         {
@@ -188,8 +188,8 @@ public static class InvokerExtensions
         ProtobufEncodeOptions? encodeOptions = null,
         IFeatureCollection? features = null,
         bool idempotent = false,
-        CancellationToken cancellationToken = default) where TInput : IMessage<TInput>
-                                                       where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken = default) where TInput : class, IMessage<TInput>
+                                                       where TOutput : class, IMessage<TOutput>
 
     {
         var request = new OutgoingRequest(serviceAddress)
@@ -220,7 +220,7 @@ public static class InvokerExtensions
         MessageParser<TOutput> messageParser,
         Task<IncomingResponse> responseTask,
         OutgoingRequest request,
-        CancellationToken cancellationToken) where TOutput : IMessage<TOutput>
+        CancellationToken cancellationToken) where TOutput : class, IMessage<TOutput>
     {
         try
         {
@@ -251,7 +251,7 @@ public static class InvokerExtensions
     private static async Task<IAsyncEnumerable<TOutput>> ReceiveStreamingResponseAsync<TOutput>(
         MessageParser<TOutput> messageParser,
         Task<IncomingResponse> responseTask,
-        OutgoingRequest request) where TOutput : IMessage<TOutput>
+        OutgoingRequest request) where TOutput : class, IMessage<TOutput>
     {
         try
         {

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -121,6 +121,65 @@ public partial class PipeReaderExtensionsTests
         pipe.Reader.Complete();
     }
 
+    /// <summary>Verifies that a unary Protobuf payload with trailing bytes after the message is rejected
+    /// as <see cref="InvalidDataException" />.</summary>
+    [Test]
+    public void Decode_message_throws_invalid_data_exception_when_payload_has_trailing_bytes()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        WriteLengthPrefixedMessage(pipe.Writer, new StringValue { Value = "hello" });
+        pipe.Writer.Write(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that a unary Protobuf payload carrying two concatenated length-prefixed messages
+    /// is rejected: the unary path must read exactly one message.</summary>
+    [Test]
+    public void Decode_message_throws_invalid_data_exception_when_payload_has_concatenated_messages()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        WriteLengthPrefixedMessage(pipe.Writer, new StringValue { Value = "hello" });
+        WriteLengthPrefixedMessage(pipe.Writer, new StringValue { Value = "world" });
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that an empty unary payload is rejected with <see cref="InvalidDataException" />.
+    /// Previously this was guarded by a <c>Debug.Assert</c>, which is a no-op in Release builds and could
+    /// return <see langword="null" /> to the caller.</summary>
+    [Test]
+    public void Decode_message_throws_invalid_data_exception_on_empty_payload()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        pipe.Writer.Complete();
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await pipe.Reader.DecodeProtobufMessageAsync(
+                StringValue.Parser,
+                maxMessageLength: 1024,
+                CancellationToken.None));
+        pipe.Reader.Complete();
+    }
+
     // Writes a length-prefixed Protobuf envelope: 1 compression-flag byte + 4 big-endian uint32 length bytes
     // + optional message body. envelopeLength overrides the length field (used to construct mismatched
     // envelopes or values > int.MaxValue); when omitted, the length matches the actual encoded message size


### PR DESCRIPTION
Backport of #4553 — reject trailing bytes in unary Protobuf payloads.

## Summary
A unary Protobuf payload silently accepting bytes after the framed message is a smuggling primitive (middleware vs. dispatcher parsing divergence). `DecodeProtobufMessageAsync` now reads once more after extracting the message and rejects any remaining bytes (and any non-completed read) with `InvalidDataException`.

## Test plan
- [x] `dotnet test tests/IceRpc.Protobuf.Tests` — 53/53 pass (51 + 2 new tests).

## Backport notes
Cherry-pick of 80ff266a3 with one conflict resolution in `tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs`: the file was modified by the already-merged [#4624](https://github.com/icerpc/icerpc-csharp/pull/4624) (backport of #4593, envelope validation), which introduced a richer `WriteLengthPrefixedMessage` helper. Kept all of #4593's tests + the richer helper from 0.5.x, and appended the two new #4553 tests (`Decode_message_throws_invalid_data_exception_when_payload_has_trailing_bytes`, `Decode_message_throws_invalid_data_exception_when_payload_has_concatenated_messages`).

Now unblocked since [#4624](https://github.com/icerpc/icerpc-csharp/pull/4624) merged.