### PR TITLE
Backport #4537 to 0.5.x

### DIFF
--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -13,8 +13,14 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 {
     public ServerAddress ServerAddress { get; }
 
+    [SuppressMessage(
+        "Usage",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Disposing this CTS races with AcceptAsync creating a linked token source from its Token; a CTS with no timer is safely reclaimed by the GC.")]
     private readonly CancellationTokenSource _disposeCts = new();
+    private bool _disposed;
     private readonly Action<ColocListener> _onDispose;
+    private readonly Lock _mutex = new();
     private readonly EndPoint _networkAddress;
     private readonly PipeOptions _pipeOptions;
 
@@ -28,9 +34,13 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposeCts.IsCancellationRequested, this);
-
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
+        CancellationTokenSource cts;
+        lock (_mutex)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
+        }
+        using var _ = cts;
         try
         {
             while (true)
@@ -66,29 +76,30 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
     public void Dispose()
     {
-        if (_disposeCts.IsCancellationRequested)
+        lock (_mutex)
         {
-            // Dispose already called.
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+
+            // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
+            _onDispose(this);
+
+            // Cancel pending AcceptAsync.
+            _disposeCts.Cancel();
+
+            // Ensure no more client connection establishment request is queued.
+            _channel.Writer.Complete();
+
+            // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused.
+            // Use TrySetException in case the task has been already canceled.
+            while (_channel.Reader.TryRead(out (TaskCompletionSource<PipeReader> Tcs, PipeReader) item))
+            {
+                item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
+            }
         }
-
-        // Notify the owner (e.g. the server transport) so it can release its reference to this listener.
-        _onDispose(this);
-
-        // Cancel pending AcceptAsync.
-        _disposeCts.Cancel();
-
-        // Ensure no more client connection establishment request is queued.
-        _channel.Writer.Complete();
-
-        // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused. Use
-        // TrySetException in case the task has been already canceled.
-        while (_channel.Reader.TryRead(out (TaskCompletionSource<PipeReader> Tcs, PipeReader) item))
-        {
-            item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
-        }
-
-        _disposeCts.Dispose();
     }
 
     public ValueTask DisposeAsync()


### PR DESCRIPTION
Backport of #4537 — make `ColocListener.DisposeAsync` safe under concurrent calls.

## Summary
Before this fix, `_disposeCts.IsCancellationRequested` was used as the disposed flag with no lock, and `AcceptAsync` could build a linked `CancellationTokenSource` from a token whose source was being disposed by a concurrent `Dispose()` call. The fix introduces a `Lock _mutex` plus a dedicated `_disposed` bool, and serialises both the linked-CTS creation in `AcceptAsync` and the dispose body under the mutex. The `_disposeCts` is no longer disposed explicitly (suppressed via `[SuppressMessage]` with an explanatory justification — a timer-less CTS is safely reclaimed by the GC).

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ColocTransportTests"` — 14/14 pass.

## Backport notes
Cherry-pick of 307e8a2e6 with conflict resolution in the dispose body: main has only `DisposeAsync`, 0.5.x has both `Dispose()` (from `IDisposable`) and `DisposeAsync` (which delegates to `Dispose`). Applied the `_disposed` / `_mutex` pattern to the existing `Dispose()` method on 0.5.x while keeping the `DisposeAsync` → `Dispose` delegation.

Now unblocked since [#4621](https://github.com/icerpc/icerpc-csharp/pull/4621) merged.