### PR TITLE
Backport #4533 to 0.5.x

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -263,9 +263,21 @@ internal class SlicConnection : IMultiplexedConnection
 
             // Enable the idle timeout checks after the connection establishment. The Ping frames sent by the keep alive
             // check are not expected until the Slic connection initialization completes. The idle timeout check uses
-            // the smallest idle timeout.
-            TimeSpan idleTimeout = _peerIdleTimeout == Timeout.InfiniteTimeSpan ? _localIdleTimeout :
-                (_peerIdleTimeout < _localIdleTimeout ? _peerIdleTimeout : _localIdleTimeout);
+            // the smallest idle timeout. Timeout.InfiniteTimeSpan is -1 ms so we can't compare it directly with
+            // positive timeouts.
+            TimeSpan idleTimeout;
+            if (_localIdleTimeout == Timeout.InfiniteTimeSpan)
+            {
+                idleTimeout = _peerIdleTimeout;
+            }
+            else if (_peerIdleTimeout == Timeout.InfiniteTimeSpan)
+            {
+                idleTimeout = _localIdleTimeout;
+            }
+            else
+            {
+                idleTimeout = _peerIdleTimeout < _localIdleTimeout ? _peerIdleTimeout : _localIdleTimeout;
+            }
 
             if (idleTimeout != Timeout.InfiniteTimeSpan)
             {

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -7,16 +7,24 @@ namespace IceRpc.Transports.Slic;
 public sealed record class SlicTransportOptions
 {
     /// <summary>Gets or sets the idle timeout. This timeout is used to monitor the transport connection health. If no
-    /// data is received within the idle timeout period, the transport connection is aborted.
-    /// </summary>
-    /// <value>The idle timeout. Defaults to <c>30</c> s.</value>
+    /// data is received within the idle timeout period, the transport connection is aborted. The effective idle timeout
+    /// is negotiated with the peer: use <see cref="Timeout.InfiniteTimeSpan" /> to defer to the peer's idle timeout.
+    /// Idle timeout monitoring is disabled only when both sides use <see cref="Timeout.InfiniteTimeSpan" />.</summary>
+    /// <value>The idle timeout. It must be positive or <see cref="Timeout.InfiniteTimeSpan" />.
+    /// Defaults to <c>30</c> s.</value>
     public TimeSpan IdleTimeout
     {
         get => _idleTimeout;
-        set => _idleTimeout = value != TimeSpan.Zero ? value :
-            throw new ArgumentException(
-                $"The value '0' is not a valid for {nameof(IdleTimeout)} property.",
-                nameof(value));
+        set
+        {
+            if (value != Timeout.InfiniteTimeSpan && value <= TimeSpan.Zero)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(IdleTimeout)} value must be positive or Timeout.InfiniteTimeSpan.",
+                    nameof(value));
+            }
+            _idleTimeout = value;
+        }
     }
 
     /// <summary>Gets or sets the initial stream window size. It defines the initial size of the stream receive buffer


### PR DESCRIPTION
Backport of #4533 — fix idle timeout handling for large peer values.

## Summary
The min-of-timeouts logic used a raw `<` comparison against `Timeout.InfiniteTimeSpan` (−1 ms). When the local `IdleTimeout` is `Infinite`, any positive `_peerIdleTimeout` was considered "greater", so the code picked `_localIdleTimeout` (infinite) and **disabled idle monitoring entirely** even when the peer requested one — letting a peer hold half-open / silent connections indefinitely (resource exhaustion / dead-peer detection bypass). The fix correctly treats `Infinite` as "no constraint" and picks the peer's finite value. Also tightens the `IdleTimeout` setter validation (reject negative non-`Infinite` values).

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SlicTransportTests|FullyQualifiedName~SlicConnectionTests"` — 67/67 pass.

## Backport notes
Clean cherry-pick of feddd0d47.

**Sibling Tier B PR sharing this file:** [#4544 backport](https://github.com/icerpc/icerpc-csharp/pull/4544) (Slic first-stream gap check) — whichever lands first, the other will need a trivial rebase.