### PR TITLE
Backport #4544 to 0.5.x

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1459,7 +1459,10 @@ internal class SlicConnection : IMultiplexedConnection
 
             if (isBidirectional)
             {
-                if (streamId > _lastRemoteBidirectionalStreamId + 4)
+                ulong expectedStreamId = _lastRemoteBidirectionalStreamId is ulong lastId
+                    ? lastId + 4
+                    : (IsServer ? 0ul : 1ul);
+                if (streamId != expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }
@@ -1474,7 +1477,10 @@ internal class SlicConnection : IMultiplexedConnection
             }
             else
             {
-                if (streamId > _lastRemoteUnidirectionalStreamId + 4)
+                ulong expectedStreamId = _lastRemoteUnidirectionalStreamId is ulong lastId
+                    ? lastId + 4
+                    : (IsServer ? 2ul : 3ul);
+                if (streamId != expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -67,6 +67,26 @@ public class SlicTransportTests
                     $"Received {frameType} frame for unknown stream.");
             }
 
+            // Stream frame opening a new remote bidirectional stream with a non-initial stream ID.
+            // The first remote bidirectional stream ID the server expects from the client is 0.
+            yield return new TestCaseData(
+                (IDuplexConnection connection) => WriteStreamFrameAsync(
+                    connection,
+                    FrameType.Stream,
+                    streamId: 4ul,
+                    (ref SliceEncoder encoder) => encoder.EncodeBool(false)),
+                "Invalid stream ID.");
+
+            // Stream frame opening a new remote unidirectional stream with a non-initial stream ID.
+            // The first remote unidirectional stream ID the server expects from the client is 2.
+            yield return new TestCaseData(
+                (IDuplexConnection connection) => WriteStreamFrameAsync(
+                    connection,
+                    FrameType.Stream,
+                    streamId: 6ul,
+                    (ref SliceEncoder encoder) => encoder.EncodeBool(false)),
+                "Invalid stream ID.");
+
             // Bogus stream frame with FrameSize=0 (stream ID not encoded)
             yield return new TestCaseData((IDuplexConnection connection) =>
                 WriteFrameAsync(connection, FrameType.StreamLast, (ref SliceEncoder encoder) => { }),


### PR DESCRIPTION
Backport of #4544 — gap-check the first remote Slic stream ID.

## Summary
When `_lastRemoteBidirectionalStreamId is null` (i.e., we haven't yet seen a remote bidirectional stream), the gap check `streamId > _lastRemoteBidirectionalStreamId + 4` evaluated with `null + 4 == null`, and `streamId > null` is `false`, so **any** first stream ID (e.g. `4`, `6`, or `2^62 - 1`) was accepted. That let a peer skew the server's stream-id accounting and bypass the gap invariant. The fix initialises `_lastRemoteBidirectionalStreamId`/`_lastRemoteUnidirectionalStreamId` to a sentinel that makes the existing check work uniformly for the first stream and subsequent streams.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SlicTransportTests"` — 69/69 pass (2 new gap-check cases).

## Backport notes
Clean cherry-pick of 453157988.

**Sibling Tier B PR sharing this file:** [#4632](https://github.com/icerpc/icerpc-csharp/pull/4632) (backport of #4533, Slic idle timeout) — whichever lands first, the other will need a trivial rebase.