### PR TITLE
Backport #4548 to 0.5.x

### DIFF
--- a/src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs
+++ b/src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs
@@ -110,7 +110,7 @@ public static class ServiceAddressSliceDecoderExtensions
                         break;
 
                     case TransportCode.Uri:
-                        serverAddress = new ServerAddress(new Uri(decoder.DecodeString()));
+                        serverAddress = DecodeUriServerAddress(decoder.DecodeString());
                         if (serverAddress.Value.Protocol != protocol)
                         {
                             throw new InvalidDataException(
@@ -151,7 +151,7 @@ public static class ServiceAddressSliceDecoderExtensions
             else if (transportCode == TransportCode.Uri)
             {
                 // The server addresses of Slice1 encoded icerpc proxies only use TransportCode.Uri.
-                serverAddress = new ServerAddress(new Uri(decoder.DecodeString()));
+                serverAddress = DecodeUriServerAddress(decoder.DecodeString());
                 if (serverAddress.Value.Protocol != protocol)
                 {
                     throw new InvalidDataException(
@@ -177,6 +177,20 @@ public static class ServiceAddressSliceDecoderExtensions
         }
 
         return serverAddress.Value;
+
+        static ServerAddress DecodeUriServerAddress(string uriString)
+        {
+            try
+            {
+                return new ServerAddress(new Uri(uriString));
+            }
+            catch (Exception exception) when (exception is UriFormatException or ArgumentException)
+            {
+                throw new InvalidDataException(
+                    $"Received invalid server address URI '{uriString}'.",
+                    exception);
+            }
+        }
     }
 
     /// <summary>Decodes a service address encoded with Slice1.</summary>

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -89,6 +89,73 @@ public partial class ProxyTests
         Assert.That(decoded.ServiceAddress, Is.EqualTo(expected));
     }
 
+    // Using transport=quic forces TransportCode.Uri on the ice side (only tcp/ssl have dedicated codes);
+    // icerpc always uses TransportCode.Uri.
+    [TestCase("ice://hello.zeroc.com/hello?transport=quic", "ice:", SliceEncoding.Slice1)]
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:", SliceEncoding.Slice1)]
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:", SliceEncoding.Slice2)]
+    public void Decode_proxy_with_unparsable_server_address_uri_throws_invalid_data(
+        ServiceAddress value,
+        string schemePrefix,
+        SliceEncoding encoding)
+    {
+        var buffer = new byte[256];
+        var bufferWriter = new MemoryBufferWriter(buffer);
+        var encoder = new SliceEncoder(bufferWriter, encoding);
+        encoder.EncodeServiceAddress(value);
+        int length = bufferWriter.WrittenMemory.Length;
+
+        // Corrupt the first byte of the encoded URI scheme so that new Uri(...) throws UriFormatException.
+        // A URI scheme must start with an ALPHA; 0x01 is a control character and makes the URI unparsable.
+        int uriStart = buffer.AsSpan(0, length).IndexOf(System.Text.Encoding.UTF8.GetBytes(schemePrefix));
+        Assert.That(uriStart, Is.GreaterThanOrEqualTo(0), "scheme not found in encoded buffer");
+        buffer[uriStart] = 0x01;
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var decoder = new SliceDecoder(buffer.AsMemory(0, length), encoding: encoding);
+                _ = decoder.DecodePingableProxy();
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
+    // Using transport=quic forces TransportCode.Uri on the ice side (only tcp/ssl have dedicated codes);
+    // icerpc always uses TransportCode.Uri.
+    [TestCase("ice://hello.zeroc.com/hello?transport=quic", "ice:", "ftp:", SliceEncoding.Slice1)]
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:", "gopher:", SliceEncoding.Slice1)]
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:", "gopher:", SliceEncoding.Slice2)]
+    public void Decode_proxy_with_invalid_server_address_uri_throws_invalid_data(
+        ServiceAddress value,
+        string schemePrefix,
+        string replacementScheme,
+        SliceEncoding encoding)
+    {
+        var buffer = new byte[256];
+        var bufferWriter = new MemoryBufferWriter(buffer);
+        var encoder = new SliceEncoder(bufferWriter, encoding);
+        encoder.EncodeServiceAddress(value);
+        int length = bufferWriter.WrittenMemory.Length;
+
+        // Replace the scheme with one that parses as a URI but is rejected by the ServerAddress constructor,
+        // which throws ArgumentException for unsupported protocols. The replacement is chosen with the same
+        // byte length so the encapsulation size remains valid.
+        Assert.That(replacementScheme.Length, Is.EqualTo(schemePrefix.Length));
+        int uriStart = buffer.AsSpan(0, length).IndexOf(System.Text.Encoding.UTF8.GetBytes(schemePrefix));
+        Assert.That(uriStart, Is.GreaterThanOrEqualTo(0), "scheme not found in encoded buffer");
+        System.Text.Encoding.UTF8.GetBytes(replacementScheme).CopyTo(buffer.AsSpan(uriStart));
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var decoder = new SliceDecoder(buffer.AsMemory(0, length), encoding: encoding);
+                _ = decoder.DecodePingableProxy();
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
     /// <summary>Verifies that a relative proxy gets the invalid invoker by default.</summary>
     [Test]
     public void Decode_relative_proxy()


### PR DESCRIPTION
Backport of #4548 — wrap URI-based server address decoding errors as `InvalidDataException`.

## Summary
`new ServerAddress(new Uri(decoder.DecodeString()))` could throw `UriFormatException` (malformed scheme) or `ArgumentException` (unsupported protocol) on a crafted payload, which escaped as an unhandled parser exception (DoS / misclassified dispatch) rather than the documented `InvalidDataException`. The fix routes both `TransportCode.Uri` branches through a new `DecodeUriServerAddress` helper that catches those and wraps them.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ProxyTests"` — 38/38 pass (2 new tests, parameterised on ice + icerpc).

## Backport notes
Cherry-pick of 88514baad. The original lands in `src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs` (a file that exists only on main, where `IceRpc.Ice` is split out). On 0.5.x the same two `TransportCode.Uri` call sites live in `src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs`. Ported by hand:
- Replaced both `new ServerAddress(new Uri(decoder.DecodeString()))` call sites with the new `DecodeUriServerAddress` helper.
- Added the helper near the bottom of the class.
- Dropped the cherry-pick's `tests/IceRpc.Ice.Tests/ProxyTests.cs` additions and re-implemented the two new tests inside `tests/IceRpc.Slice.Tests/ProxyTests.cs` using 0.5.x's unified `SliceEncoder`/`SliceDecoder` + `PingableProxy` types and explicit `SliceEncoding.Slice1`.

**Sibling Tier B PR sharing this file:** [#4531 backport](https://github.com/icerpc/icerpc-csharp/pull/4531) (escape adapter-id) will be sent next — whichever lands first, the other will need a trivial rebase.