### PR TITLE
Backport #4531 to 0.5.x

### DIFF
--- a/src/IceRpc.Locator/Internal/LocationResolver.cs
+++ b/src/IceRpc.Locator/Internal/LocationResolver.cs
@@ -52,10 +52,10 @@ internal class CacheLessLocationResolver : ILocationResolver
             .ConfigureAwait(false);
 
         // A well-known service address resolution can return a service address with an adapter ID
-        if (serviceAddress is not null && serviceAddress.Params.TryGetValue("adapter-id", out string? adapterId))
+        if (serviceAddress is not null && serviceAddress.Params.TryGetValue("adapter-id", out string? escapedAdapterId))
         {
             (serviceAddress, _) = await ResolveAsync(
-                new Location { IsAdapterId = true, Value = adapterId },
+                new Location { IsAdapterId = true, Value = Uri.UnescapeDataString(escapedAdapterId) },
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -122,14 +122,14 @@ internal class LocationResolver : ILocationResolver
         }
 
         // A well-known service address resolution can return a service address with an adapter-id.
-        if (serviceAddress is not null && serviceAddress.Params.TryGetValue("adapter-id", out string? adapterId))
+        if (serviceAddress is not null && serviceAddress.Params.TryGetValue("adapter-id", out string? escapedAdapterId))
         {
             try
             {
                 // Resolves adapter ID recursively, by checking first the cache. If we resolved the well-known
                 // service address, we request a cache refresh for the adapter ID.
                 (serviceAddress, _) = await PerformResolveAsync(
-                    new Location { IsAdapterId = true, Value = adapterId },
+                    new Location { IsAdapterId = true, Value = Uri.UnescapeDataString(escapedAdapterId) },
                     refreshCache || resolved,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/IceRpc.Locator/LocatorInterceptor.cs
+++ b/src/IceRpc.Locator/LocatorInterceptor.cs
@@ -57,8 +57,8 @@ public class LocatorInterceptor : IInvoker
             }
             else if (serverAddressFeature.ServerAddress is null)
             {
-                location = request.ServiceAddress.Params.TryGetValue("adapter-id", out string? adapterId) ?
-                    new Location { IsAdapterId = true, Value = adapterId } :
+                location = request.ServiceAddress.Params.TryGetValue("adapter-id", out string? escapedAdapterId) ?
+                    new Location { IsAdapterId = true, Value = Uri.UnescapeDataString(escapedAdapterId) } :
                     new Location { Value = request.ServiceAddress.Path };
             }
             // else it could be a retry where the first attempt provided non-cached server address(es)

--- a/src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs
+++ b/src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs
@@ -220,7 +220,7 @@ public static class ServiceAddressSliceDecoderExtensions
         {
             if (decoder.DecodeString() is string adapterId && adapterId.Length > 0)
             {
-                serviceAddressParams = serviceAddressParams.Add("adapter-id", adapterId);
+                serviceAddressParams = serviceAddressParams.Add("adapter-id", Uri.EscapeDataString(adapterId));
             }
         }
         else

--- a/src/IceRpc.Slice/ServiceAddressSliceEncoderExtensions.cs
+++ b/src/IceRpc.Slice/ServiceAddressSliceEncoderExtensions.cs
@@ -64,14 +64,14 @@ public static class ServiceAddressSliceEncoderExtensions
             else
             {
                 encoder.EncodeSize(0); // 0 server addresses
-                int maxCount = value.Params.TryGetValue("adapter-id", out string? adapterId) ? 1 : 0;
+                int maxCount = value.Params.TryGetValue("adapter-id", out string? escapedAdapterId) ? 1 : 0;
 
                 if (value.Params.Count > maxCount)
                 {
                     throw new NotSupportedException(
                         "Cannot encode a service address with a parameter other than adapter-id using Slice1.");
                 }
-                encoder.EncodeString(adapterId ?? "");
+                encoder.EncodeString(escapedAdapterId is null ? "" : Uri.UnescapeDataString(escapedAdapterId));
             }
         }
         else

--- a/tests/IceRpc.Slice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Tests/ProxyTests.cs
@@ -72,6 +72,11 @@ public partial class ProxyTests
         SliceEncoding.Slice1)]
     [TestCase("ice:/cat/name?adapter-id=foo", null, SliceEncoding.Slice1)]
     [TestCase("ice:/cat/name", null, SliceEncoding.Slice1)]
+    // adapter-id values containing characters that must be percent-escaped in the URI representation.
+    [TestCase("ice:/hello?adapter-id=foo%23bar", null, SliceEncoding.Slice1)]                  // '#'
+    [TestCase("ice:/hello?adapter-id=foo%25bar", null, SliceEncoding.Slice1)]                  // '%'
+    [TestCase("ice:/hello?adapter-id=foo%20bar", null, SliceEncoding.Slice1)]                  // ' '
+    [TestCase("ice:/hello?adapter-id=foo%23bar%25baz%20qux%26quux", null, SliceEncoding.Slice1)] // '#', '%', ' ', '&'
     // cSpell:enable
     public void Decode_proxy(ServiceAddress value, ServiceAddress? expected, SliceEncoding encoding)
     {


### PR DESCRIPTION
Backport of #4531 — escape adapter-id value in `ServiceAddress` params.

## Summary
The `adapter-id` value decoded from a wire-format ice service address was inserted into the URI parameter string unescaped, allowing URI-component injection when the adapter-id contains `#`, `&`, `%`, or space (extra params, broken fragment, locator-resolution surprises). The fix:
- Decoder: `Uri.EscapeDataString(adapterId)` when adding to `Params`.
- Encoder: `Uri.UnescapeDataString(escapedAdapterId)` when reading back out.
- Locator consumers (`LocationResolver`, `LocatorInterceptor`): unescape on read so the `Location.Value` is the raw adapter-id string the locator sees.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ProxyTests"` (IceRpc.Slice.Tests) — 38/38 pass (4 new adapter-id round-trip cases).
- [x] `dotnet test tests/IceRpc.Locator.Tests` — 44/44 pass.

## Backport notes
Cherry-pick of 23852118c. Adaptations:
- The decoder/encoder changes target `src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs`/`IceProxyIceEncoderExtensions.cs` on main — both live under `src/IceRpc.Slice/ServiceAddressSliceDecoderExtensions.cs`/`ServiceAddressSliceEncoderExtensions.cs` on 0.5.x. Ported by hand to the two equivalent call sites.
- The Locator changes (`LocationResolver.cs`, `LocatorInterceptor.cs`) merged cleanly.
- The new test cases (4 adapter-id-with-special-chars round-trips) were originally added to `tests/IceRpc.Ice.Tests/ProxyTests.cs` (a file that doesn't exist on 0.5.x). Added them to `tests/IceRpc.Slice.Tests/ProxyTests.cs:Decode_proxy` instead, with `SliceEncoding.Slice1` to exercise the same code path.

**Sibling Tier B PR sharing this file:** [#4634](https://github.com/icerpc/icerpc-csharp/pull/4634) (backport of #4548, wrap URI decode errors) — whichever lands first, the other will need a trivial rebase.