### PR TITLE
Backport #4521 to 0.5.x

### DIFF
--- a/src/IceRpc.RequestContext/RequestContextMiddleware.cs
+++ b/src/IceRpc.RequestContext/RequestContextMiddleware.cs
@@ -32,6 +32,14 @@ public class RequestContextMiddleware : IDispatcher
                 size => new Dictionary<string, string>(size),
                 keyDecodeFunc: (ref SliceDecoder decoder) => decoder.DecodeString(),
                 valueDecodeFunc: (ref SliceDecoder decoder) => decoder.DecodeString());
+
+            // The context field's buffer must be fully consumed; reject trailing bytes after the dictionary.
+            if (decoder.Remaining != 0)
+            {
+                throw new InvalidDataException(
+                    $"Unexpected trailing {decoder.Remaining} byte(s) in request context field.");
+            }
+
             if (context.Count > 0)
             {
                 request.Features = request.Features.With<IRequestContextFeature>(new RequestContextFeature(context));

--- a/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
+++ b/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
@@ -57,4 +57,43 @@ public sealed class RequestContextMiddlewareTests
             return pipe.Reader;
         }
     }
+
+    /// <summary>Verifies that a context field with trailing bytes is rejected with
+    /// <see cref="InvalidDataException" />.</summary>
+    [TestCase("icerpc")]
+    [TestCase("ice")]
+    public void Context_field_with_trailing_bytes_is_rejected(string protocolName)
+    {
+        Protocol protocol = Protocol.Parse(protocolName);
+        var pipe = new Pipe();
+        var encoder = new SliceEncoder(
+            pipe.Writer,
+            protocol == Protocol.Ice ? SliceEncoding.Slice1 : SliceEncoding.Slice2);
+        encoder.EncodeDictionary(
+            new Dictionary<string, string> { ["Foo"] = "Bar" },
+            (ref SliceEncoder encoder, string key) => encoder.EncodeString(key),
+            (ref SliceEncoder encoder, string value) => encoder.EncodeString(value));
+        // Append 4 trailing bytes.
+        pipe.Writer.Write(new byte[] { 0, 0, 0, 0 });
+        pipe.Writer.Complete();
+        pipe.Reader.TryRead(out var readResult);
+
+        using var request = new IncomingRequest(protocol, FakeConnectionContext.Instance)
+        {
+            Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>
+            {
+                [RequestFieldKey.Context] = readResult.Buffer
+            }
+        };
+
+        var sut = new RequestContextMiddleware(
+            new InlineDispatcher((request, cancellationToken) =>
+                new(new OutgoingResponse(request))));
+
+        Assert.That(
+            async () => await sut.DispatchAsync(request, default),
+            Throws.InstanceOf<InvalidDataException>());
+
+        pipe.Reader.Complete();
+    }
 }


### PR DESCRIPTION
Backport of #4521 (fix [#4456](https://github.com/icerpc/icerpc-csharp/issues/4456)) — reject trailing bytes in the request context field.

## Summary
`RequestContextMiddleware` decoded the `RequestFieldKey.Context` dictionary and silently ignored any trailing bytes. That's a smuggling primitive across middleware boundaries (the middleware sees one dictionary, a downstream component re-decoding the same field could observe extra bytes). The middleware now throws `InvalidDataException` when the decoder hasn't drained the buffer after decoding the dictionary.

## Test plan
- [x] `dotnet test tests/IceRpc.RequestContext.Tests` — 5/5 pass (3 original + 2 new trailing-bytes cases for ice and icerpc).

## Backport notes
Cherry-pick of dd980a1d1. Adaptations:
- Main's fix uses the post-split `IceDecoder` / `SliceDecoder` types and the `DecodeIceBuffer`/`DecodeSliceBuffer` extension helpers (which internally check for trailing bytes). 0.5.x keeps a unified `SliceDecoder` carrying the `SliceEncoding` parameter. Implemented the check directly with `if (decoder.Remaining != 0) throw new InvalidDataException(...)` after `DecodeDictionary`.
- The new test used the main-only `IceEncoder` (and `IceRpc.Ice.Codec` namespace). Rewrote it on top of 0.5.x's unified `SliceEncoder` constructed with `SliceEncoding.Slice1` (for ice) or `SliceEncoding.Slice2` (for icerpc); the rest of the test is unchanged.