### PR TITLE
Update links on 0.5.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ to the license for the full terms and conditions.
 in-memory transport for testing). Future releases may add additional transports.
 
 [Apache License version 2.0]: LICENSE
-[API reference]: https://docs.icerpc.dev/api/csharp/api/IceRpc.html
+[API reference]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.html
 [Building from source]: BUILDING.md
 [ci-home]: https://github.com/icerpc/icerpc-csharp/actions/workflows/ci.yml
 [custom]: https://docs.icerpc.dev/slice2/language-guide/custom-types

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ in-memory transport for testing). Future releases may add additional transports.
 [icerpc-protocol]: https://docs.icerpc.dev/icerpc/icerpc-protocol/mapping-rpcs-to-streams
 [icerpc-with-di]: https://docs.icerpc.dev/icerpc/dependency-injection/di-and-icerpc-for-csharp
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
-[license]: https://github.com/icerpc/icerpc-csharp/blob/main/LICENSE
+[license]: https://github.com/icerpc/icerpc-csharp/blob/0.5.x/LICENSE
 [NuGet packages]: https://www.nuget.org/profiles/IceRPC
 [Protobuf]: https://en.wikipedia.org/wiki/Protocol_Buffers
 [QUIC]: https://en.wikipedia.org/wiki/QUIC

--- a/examples/protobuf/Deadline/README.md
+++ b/examples/protobuf/Deadline/README.md
@@ -24,4 +24,4 @@ cd Client
 dotnet run
 ```
 
-[IDeadlineFeature]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Features.IDeadlineFeature.html
+[IDeadlineFeature]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Features.IDeadlineFeature.html

--- a/examples/slice/Deadline/README.md
+++ b/examples/slice/Deadline/README.md
@@ -24,4 +24,4 @@ cd Client
 dotnet run
 ```
 
-[IDeadlineFeature]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Features.IDeadlineFeature.html
+[IDeadlineFeature]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Features.IDeadlineFeature.html

--- a/src/IceRpc.Compressor/CompressorPipelineExtensions.cs
+++ b/src/IceRpc.Compressor/CompressorPipelineExtensions.cs
@@ -17,7 +17,7 @@ public static class CompressorPipelineExtensions
     /// The following code adds the compressor interceptor to the invocation pipeline.
     /// <code source="../../docfx/examples/IceRpc.Compressor.Examples/CompressorInterceptorExamples.cs" region="UseCompressor" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Compress"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Compress"/>
     public static Pipeline UseCompressor(
         this Pipeline pipeline,
         CompressionFormat compressionFormat,

--- a/src/IceRpc.Compressor/CompressorRouterExtensions.cs
+++ b/src/IceRpc.Compressor/CompressorRouterExtensions.cs
@@ -17,7 +17,7 @@ public static class CompressorRouterExtensions
     /// The following code adds the compressor middleware to the dispatch pipeline.
     /// <code source="../../docfx/examples/IceRpc.Compressor.Examples/CompressorMiddlewareExamples.cs" region="UseCompressor" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Compress"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Compress"/>
     public static Router UseCompressor(
         this Router router,
         CompressionFormat compressionFormat,

--- a/src/IceRpc.Compressor/README.md
+++ b/src/IceRpc.Compressor/README.md
@@ -134,7 +134,7 @@ They work well with Slice but don't require Slice.
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Compressor.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Compress
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Compress
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.Compressor
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Compressor
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Compressor

--- a/src/IceRpc.Compressor/README.md
+++ b/src/IceRpc.Compressor/README.md
@@ -131,7 +131,7 @@ host.Run();
 The compressor interceptor and middleware compress and decompress payloads regardless of how these payloads are encoded.
 They work well with Slice but don't require Slice.
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Compressor.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Compressor.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Compress

--- a/src/IceRpc.Deadline/README.md
+++ b/src/IceRpc.Deadline/README.md
@@ -79,7 +79,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Deadline.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Deadline.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Deadline
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Deadline/README.md
+++ b/src/IceRpc.Deadline/README.md
@@ -80,9 +80,9 @@ host.Run();
 ```
 
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Deadline.html
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Deadline
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Deadline
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.Deadline
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Deadline
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Deadline

--- a/src/IceRpc.Extensions.DependencyInjection/README.md
+++ b/src/IceRpc.Extensions.DependencyInjection/README.md
@@ -54,7 +54,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Extensions.DependencyInjection.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Extensions.DependencyInjection.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/GenericHost
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [ms_di]: https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection

--- a/src/IceRpc.Extensions.DependencyInjection/README.md
+++ b/src/IceRpc.Extensions.DependencyInjection/README.md
@@ -55,9 +55,9 @@ host.Run();
 ```
 
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Extensions.DependencyInjection.html
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/GenericHost
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/GenericHost
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [ms_di]: https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection
 [package]: https://www.nuget.org/packages/IceRpc.Extensions.DependencyInjection
 [product]: https://docs.icerpc.dev/icerpc/dependency-injection/di-and-icerpc-for-csharp
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Extensions.DependencyInjection
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Extensions.DependencyInjection

--- a/src/IceRpc.Locator/README.md
+++ b/src/IceRpc.Locator/README.md
@@ -46,7 +46,7 @@ var indirectProxy = new HelloProxy(
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Locator.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interop]: https://docs.icerpc.dev/icerpc-for-ice-users
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/ice/IceGrid
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/InteropIceGrid
 [locator]: https://docs.zeroc.com/ice/3.8/csharp/locators
 [package]: https://www.nuget.org/packages/IceRpc.Locator
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Locator
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Locator

--- a/src/IceRpc.Locator/README.md
+++ b/src/IceRpc.Locator/README.md
@@ -43,7 +43,7 @@ var indirectProxy = new HelloProxy(
     new Uri("ice:/hello?adapter-id=HelloAdapter"));
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Locator.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Locator.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interop]: https://docs.icerpc.dev/icerpc-for-ice-users
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/InteropIceGrid

--- a/src/IceRpc.Logger/LoggerPipelineExtensions.cs
+++ b/src/IceRpc.Logger/LoggerPipelineExtensions.cs
@@ -17,7 +17,7 @@ public static class LoggerPipelineExtensions
     /// The following code adds the logger interceptor to the invocation pipeline.
     /// <code source="../../docfx/examples/IceRpc.Logger.Examples/LoggerInterceptorExamples.cs" region="UseLogger" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Logger"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Logger"/>
     public static Pipeline UseLogger(this Pipeline pipeline, ILoggerFactory loggerFactory) =>
         pipeline.Use(next => new LoggerInterceptor(next, loggerFactory.CreateLogger<LoggerInterceptor>()));
 }

--- a/src/IceRpc.Logger/LoggerRouterExtensions.cs
+++ b/src/IceRpc.Logger/LoggerRouterExtensions.cs
@@ -17,7 +17,7 @@ public static class LoggerRouterExtensions
     /// The following code adds the logger middleware to the dispatch pipeline.
     /// <code source="../../docfx/examples/IceRpc.Logger.Examples/LoggerMiddlewareExamples.cs" region="UseLogger" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Logger"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Logger"/>
     public static Router UseLogger(this Router router, ILoggerFactory loggerFactory) =>
        router.Use(next => new LoggerMiddleware(next, loggerFactory.CreateLogger<LoggerMiddleware>()));
 }

--- a/src/IceRpc.Logger/README.md
+++ b/src/IceRpc.Logger/README.md
@@ -90,7 +90,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Logger.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Logger.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Logger
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Logger/README.md
+++ b/src/IceRpc.Logger/README.md
@@ -91,9 +91,9 @@ host.Run();
 ```
 
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Logger.html
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Logger
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Logger
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.Logger
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Logger
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Logger

--- a/src/IceRpc.Metrics/MetricsPipelineExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsPipelineExtensions.cs
@@ -14,7 +14,7 @@ public static class MetricsPipelineExtensions
     /// The following code adds the metrics interceptor to the invocation pipeline.
     /// <code source="../../docfx/examples/IceRpc.Metrics.Examples/MetricsInterceptorExamples.cs" region="UseMetrics" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Metrics"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Metrics"/>
     public static Pipeline UseMetrics(this Pipeline pipeline) =>
         pipeline.Use(next => new MetricsInterceptor(next));
 }

--- a/src/IceRpc.Metrics/MetricsRouterExtensions.cs
+++ b/src/IceRpc.Metrics/MetricsRouterExtensions.cs
@@ -14,7 +14,7 @@ public static class MetricsRouterExtensions
     /// The following code adds the metrics middleware to the dispatch pipeline.
     /// <code source="../../docfx/examples/IceRpc.Metrics.Examples/MetricsMiddlewareExamples.cs" region="UseMetrics" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Metrics"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Metrics"/>
     public static Router UseMetrics(this Router router) =>
         router.Use(next => new MetricsMiddleware(next));
 }

--- a/src/IceRpc.Metrics/README.md
+++ b/src/IceRpc.Metrics/README.md
@@ -74,7 +74,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Metrics.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Metrics.html
 [dotnet_counters]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Metrics/README.md
+++ b/src/IceRpc.Metrics/README.md
@@ -78,8 +78,8 @@ host.Run();
 [dotnet_counters]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Metrics
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Metrics
 [meter]: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.meter
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.Metrics
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Metrics
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Metrics

--- a/src/IceRpc.Protobuf/README.md
+++ b/src/IceRpc.Protobuf/README.md
@@ -90,8 +90,8 @@ internal partial class Chatbot : IGreeterService
 [api]: https://docs.testing.zeroc.com/api/csharp/api/IceRpc.Protobuf.html
 [docs]: https://docs.icerpc.dev/protobuf
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
-[examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples
+[examples]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples
 [package]: https://www.nuget.org/packages/IceRpc.Protobuf
 [protobuf-tools]: https://www.nuget.org/packages/IceRpc.Protobuf.Tools
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Protobuf
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Protobuf
 [source generator]: https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview

--- a/src/IceRpc.Protobuf/README.md
+++ b/src/IceRpc.Protobuf/README.md
@@ -87,7 +87,7 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
-[api]: https://docs.testing.zeroc.com/api/csharp/api/IceRpc.Protobuf.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Protobuf.html
 [docs]: https://docs.icerpc.dev/protobuf
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples

--- a/src/IceRpc.RequestContext/README.md
+++ b/src/IceRpc.RequestContext/README.md
@@ -87,7 +87,7 @@ The ice protocol can send and receive request context fields. They correspond to
 [ice_request_contexts]: https://docs.zeroc.com/ice/3.8/csharp/request-contexts
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/RequestContext
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/RequestContext
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.RequestContext
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.RequestContext
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.RequestContext

--- a/src/IceRpc.RequestContext/README.md
+++ b/src/IceRpc.RequestContext/README.md
@@ -83,7 +83,7 @@ host.Run();
 The ice protocol can send and receive request context fields. They correspond to
 [request contexts][ice_request_contexts] in Ice.
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.RequestContext.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.RequestContext.html
 [ice_request_contexts]: https://docs.zeroc.com/ice/3.8/csharp/request-contexts
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.RequestContext/RequestContextPipelineExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextPipelineExtensions.cs
@@ -18,7 +18,7 @@ public static class RequestContextPipelineExtensions
     /// The following code shows how to set the request context feature with a Protobuf client.
     /// <code source="../../docfx/examples/IceRpc.RequestContext.Examples/RequestContextInterceptorExamples.cs" region="UseRequestContextWithProtobufClient" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/RequestContext"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/RequestContext"/>
     public static Pipeline UseRequestContext(this Pipeline pipeline) =>
         pipeline.Use(next => new RequestContextInterceptor(next));
 }

--- a/src/IceRpc.RequestContext/RequestContextRouterExtensions.cs
+++ b/src/IceRpc.RequestContext/RequestContextRouterExtensions.cs
@@ -17,7 +17,7 @@ public static class RequestContextRouterExtensions
     /// code.
     /// <code source="../../docfx/examples/IceRpc.RequestContext.Examples/Chatbot.cs" region="RequestContextFeature" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/RequestContext"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/RequestContext"/>
     public static Router UseRequestContext(this Router router) =>
         router.Use(next => new RequestContextMiddleware(next));
 }

--- a/src/IceRpc.Retry/README.md
+++ b/src/IceRpc.Retry/README.md
@@ -45,6 +45,6 @@ host.Run();
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Retry.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Retry
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Retry
 [package]: https://www.nuget.org/packages/IceRpc.Retry
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Retry
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Retry

--- a/src/IceRpc.Retry/README.md
+++ b/src/IceRpc.Retry/README.md
@@ -42,7 +42,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Retry.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Retry.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Retry

--- a/src/IceRpc.Retry/RetryPipelineExtensions.cs
+++ b/src/IceRpc.Retry/RetryPipelineExtensions.cs
@@ -18,7 +18,7 @@ public static class RetryPipelineExtensions
     /// pipeline.
     /// <code source="../../docfx/examples/IceRpc.Retry.Examples/RetryInterceptorExamples.cs" region="UseRetry" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Retry"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Retry"/>
     public static Pipeline UseRetry(this Pipeline pipeline) =>
         pipeline.UseRetry(new RetryOptions());
 
@@ -31,7 +31,7 @@ public static class RetryPipelineExtensions
     /// pipeline.
     /// <code source="../../docfx/examples/IceRpc.Retry.Examples/RetryInterceptorExamples.cs" region="UseRetryWithOptions" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Retry"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Retry"/>
     public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options) =>
         pipeline.UseRetry(options, NullLoggerFactory.Instance);
 
@@ -46,7 +46,7 @@ public static class RetryPipelineExtensions
     /// <see cref="RetryOptions"/> to the invocation pipeline.
     /// <code source="../../docfx/examples/IceRpc.Retry.Examples/RetryInterceptorExamples.cs" region="UseRetryWithLoggerFactory" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Retry"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Retry"/>
     public static Pipeline UseRetry(this Pipeline pipeline, RetryOptions options, ILoggerFactory loggerFactory) =>
         pipeline.Use(next => new RetryInterceptor(next, options, loggerFactory.CreateLogger<RetryInterceptor>()));
 }

--- a/src/IceRpc.Slice/README.md
+++ b/src/IceRpc.Slice/README.md
@@ -80,8 +80,8 @@ internal partial class Chatbot : IGreeterService
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Slice.html
 [docs]: https://docs.icerpc.dev/slice2
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
-[examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples
+[examples]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples
 [package]: https://www.nuget.org/packages/IceRpc.Slice
 [slice-tools]: https://www.nuget.org/packages/IceRpc.Slice.Tools
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Slice
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Slice
 [source generator]: https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview

--- a/src/IceRpc.Slice/README.md
+++ b/src/IceRpc.Slice/README.md
@@ -77,7 +77,7 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Slice.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Slice.html
 [docs]: https://docs.icerpc.dev/slice2
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples

--- a/src/IceRpc.Telemetry/README.md
+++ b/src/IceRpc.Telemetry/README.md
@@ -86,10 +86,10 @@ host.Run();
 ```
 
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Telemetry.html
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Telemetry
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Telemetry
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [middleware]: https://docs.icerpc.dev/icerpc/dispatch/middleware
 [package]: https://www.nuget.org/packages/IceRpc.Telemetry
 [open-telemetry]: https://opentelemetry.io/
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Telemetry
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Telemetry

--- a/src/IceRpc.Telemetry/README.md
+++ b/src/IceRpc.Telemetry/README.md
@@ -85,7 +85,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Telemetry.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Telemetry.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Telemetry
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Telemetry/TelemetryPipelineExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryPipelineExtensions.cs
@@ -17,7 +17,7 @@ public static class TelemetryPipelineExtensions
     /// The following code adds the telemetry interceptor to the invocation pipeline.
     /// <code source="../../docfx/examples/IceRpc.Telemetry.Examples/TelemetryInterceptorExamples.cs" region="UseTelemetry" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Telemetry"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Telemetry"/>
     public static Pipeline UseTelemetry(this Pipeline pipeline, ActivitySource activitySource) =>
         pipeline.Use(next => new TelemetryInterceptor(next, activitySource));
 }

--- a/src/IceRpc.Telemetry/TelemetryRouterExtensions.cs
+++ b/src/IceRpc.Telemetry/TelemetryRouterExtensions.cs
@@ -16,7 +16,7 @@ public static class TelemetryRouterExtensions
     /// The following code adds the telemetry middleware to the dispatch pipeline.
     /// <code source="../../docfx/examples/IceRpc.Telemetry.Examples/TelemetryMiddlewareExamples.cs" region="UseTelemetry" lang="csharp" />
     /// </example>
-    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Telemetry"/>
+    /// <seealso href="https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Telemetry"/>
     public static Router UseTelemetry(this Router router, ActivitySource activitySource) =>
         router.Use(next => new TelemetryMiddleware(next, activitySource));
 }

--- a/src/IceRpc.Templates/README.md
+++ b/src/IceRpc.Templates/README.md
@@ -43,4 +43,4 @@ dotnet run
 
 [icerpc]: https://www.nuget.org/packages/IceRpc
 [package]: https://www.nuget.org/packages/IceRpc.Templates
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Templates
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Templates

--- a/src/IceRpc.Transports.Coloc/README.md
+++ b/src/IceRpc.Transports.Coloc/README.md
@@ -39,4 +39,4 @@ await connection.ConnectAsync();
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [package]: https://www.nuget.org/packages/IceRpc.Transports.Coloc
 [product]: https://docs.icerpc.dev/icerpc
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Transports.Coloc
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Transports.Coloc

--- a/src/IceRpc.Transports.Coloc/README.md
+++ b/src/IceRpc.Transports.Coloc/README.md
@@ -35,7 +35,7 @@ await using var connection = new ClientConnection(
 await connection.ConnectAsync();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Transports.Coloc.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Transports.Coloc.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [package]: https://www.nuget.org/packages/IceRpc.Transports.Coloc
 [product]: https://docs.icerpc.dev/icerpc

--- a/src/IceRpc.Transports.Quic/README.md
+++ b/src/IceRpc.Transports.Quic/README.md
@@ -45,10 +45,10 @@ IceRpc.Transports.Quic has the same platform requirements as `System.Net.Quic`. 
 as the [HTTP/3 platform dependencies][platform].
 
 [api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Transports.Quic.html
-[example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/GreeterQuic
+[example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Quic
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [quic]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview
 [package]: https://www.nuget.org/packages/IceRpc.Transports.Quic
 [platform]: https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-http3#platform-dependencies
 [product]: https://docs.icerpc.dev/icerpc
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.Transports.Quic
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc.Transports.Quic

--- a/src/IceRpc.Transports.Quic/README.md
+++ b/src/IceRpc.Transports.Quic/README.md
@@ -44,7 +44,7 @@ server.Listen();
 IceRpc.Transports.Quic has the same platform requirements as `System.Net.Quic`. Microsoft documents these requirements
 as the [HTTP/3 platform dependencies][platform].
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Transports.Quic.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.Transports.Quic.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples/slice/Quic
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [quic]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview

--- a/src/IceRpc/README.md
+++ b/src/IceRpc/README.md
@@ -92,6 +92,6 @@ internal class Chatbot : IDispatcher
 [docs]:https://docs.icerpc.dev
 [getting-started]: https://docs.icerpc.dev/getting-started
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
-[examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples
+[examples]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/examples
 [package]: https://www.nuget.org/packages/IceRpc
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/IceRpc

--- a/src/IceRpc/README.md
+++ b/src/IceRpc/README.md
@@ -88,7 +88,7 @@ internal class Chatbot : IDispatcher
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/IceRpc.html
 [docs]:https://docs.icerpc.dev
 [getting-started]: https://docs.icerpc.dev/getting-started
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp

--- a/src/ZeroC.Slice/README.md
+++ b/src/ZeroC.Slice/README.md
@@ -65,7 +65,7 @@ public partial record struct Person
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/ZeroC.Slice.html
+[api]: https://code.icerpc.dev/csharp/0.5.x/api/api/ZeroC.Slice.html
 [cs-buffers]: https://learn.microsoft.com/en-us/dotnet/standard/io/buffers
 [docs]: https://docs.icerpc.dev/slice2
 [idl]: https://en.wikipedia.org/wiki/Interface_description_language

--- a/src/ZeroC.Slice/README.md
+++ b/src/ZeroC.Slice/README.md
@@ -71,5 +71,5 @@ public partial record struct Person
 [idl]: https://en.wikipedia.org/wiki/Interface_description_language
 [package]: https://www.nuget.org/packages/ZeroC.Slice
 [pipelines]: https://learn.microsoft.com/en-us/dotnet/standard/io/pipelines
-[slicec-cs]: https://github.com/icerpc/icerpc-csharp/tree/main/tools/IceRpc.Slice.Tools
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/ZeroC.Slice
+[slicec-cs]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/tools/IceRpc.Slice.Tools
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/src/ZeroC.Slice

--- a/tools/IceRpc.Protobuf.Tools/README.md
+++ b/tools/IceRpc.Protobuf.Tools/README.md
@@ -118,7 +118,7 @@ Setting this property to `false` completely disables the computation and collect
 [default-items]: https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enabledefaultitems
 [icerpc]: https://www.nuget.org/packages/IceRpc
 [package]: https://www.nuget.org/packages/IceRpc.Protobuf.Tools
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/tools/IceRpc.Protobuf.Tools
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/tools/IceRpc.Protobuf.Tools
 [system-io-pipelines]: https://www.nuget.org/packages/System.IO.Pipelines
 [google-protobuf]: https://www.nuget.org/packages/Google.Protobuf
 [google-protobuf-tools]: https://www.nuget.org/packages/Google.Protobuf.Tools

--- a/tools/IceRpc.Slice.Tools/README.md
+++ b/tools/IceRpc.Slice.Tools/README.md
@@ -141,6 +141,6 @@ Setting this property to `false` completely disables the computation and collect
 [zeroc-slice]: https://www.nuget.org/packages/ZeroC.Slice
 [package]: https://www.nuget.org/packages/IceRpc.Slice.Tools
 [slice]: https://docs.icerpc.dev/slice2
-[slicec-cs]: https://github.com/icerpc/icerpc-csharp/tree/main/tools/slicec-cs
-[source]: https://github.com/icerpc/icerpc-csharp/tree/main/tools/IceRpc.Slice.Tools
+[slicec-cs]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/tools/slicec-cs
+[source]: https://github.com/icerpc/icerpc-csharp/tree/0.5.x/tools/IceRpc.Slice.Tools
 [system-io-pipelines]: https://www.nuget.org/packages/System.IO.Pipelines


### PR DESCRIPTION
This PR fixes #4404 on the 0.5.x branch. It also updates the links to the API reference to use versioned URLs on code.icerpc.dev.

Note that still have un-versioned links to docs.icerpc.dev. We currently don't version this site; we should consider doing so.
