### PR TITLE
Backport #4383 to 0.5.x

### DIFF
--- a/src/IceRpc.Slice.Generators/Internal/Parser.cs
+++ b/src/IceRpc.Slice.Generators/Internal/Parser.cs
@@ -82,9 +82,10 @@ internal sealed class Parser
                     }
                 }
 
+                string containingNamespace = GetFullName(classSymbol.ContainingNamespace);
                 var serviceClass = new ServiceClass(
                     classSymbol.Name,
-                    GetFullName(classSymbol.ContainingNamespace),
+                    containingNamespace.Length > 0 ? containingNamespace : null,
                     classDeclaration.Keyword.ValueText,
                     serviceMethods,
                     hasBaseServiceClass: baseServiceClass is not null,


### PR DESCRIPTION
Backport of [#4383](https://github.com/icerpc/icerpc-csharp/pull/4383) (fix [#4291](https://github.com/icerpc/icerpc-csharp/issues/4291)) — service classes declared in the global namespace generate invalid `namespace ;` code.

## Summary
`GetFullName(classSymbol.ContainingNamespace)` returns `""` for the global namespace. That empty string was being passed as `ServiceClass.ContainingNamespace` (typed `string?`); `Emitter` then tested `is not null` and emitted `namespace ;` (invalid C#). Fix: map empty string to `null` at the construction site so `Emitter`'s null check works.

Codegen-correctness fix; **low** severity. No runtime / wire-format impact.

## Test plan
- [x] `dotnet build src/IceRpc.Slice.Generators` — 0 warnings, 0 errors.
- [x] `dotnet test tests/IceRpc.Slice.Tests` — 297/297 pass (no regressions).
- [x] `dotnet test tests/IntegrationTests` — 8/8 pass.

## Backport notes
Hand-ported, not a cherry-pick: main's #4383 lands in `src/IceRpc.ServiceGenerator/Internal/Parser.cs` (renamed/refactored from the 0.5.x layout). On 0.5.x the equivalent file is `src/IceRpc.Slice.Generators/Internal/Parser.cs`, but the surrounding `GetFullName` helper and `ServiceClass` constructor are the same; the change is identical in spirit (introduce a `containingNamespace` local and pass `Length > 0 ? containingNamespace : null`).

Matches main's #4383 exactly (no test added on either branch).