### PR TITLE
Backport #4562 to 0.5.x

### DIFF
--- a/tests/IceRpc.Protobuf.Tests/NoNamespaceTests.proto
+++ b/tests/IceRpc.Protobuf.Tests/NoNamespaceTests.proto
@@ -1,0 +1,15 @@
+// Copyright (c) ZeroC, Inc.
+
+// Intentionally has no `package` and no `option csharp_namespace`. The generator must emit valid C# in
+// this case (no `namespace ;` declaration; cross-namespace references use `global::Type` rather than
+// `global::.Type`).
+
+syntax = "proto3";
+
+service NoNamespaceOperations {
+    rpc UnaryOp(NoNamespaceMessage) returns (NoNamespaceMessage);
+}
+
+message NoNamespaceMessage {
+    string value = 1;
+}

--- a/tools/IceRpc.ProtocGen/MessageDescriptorExtensions.cs
+++ b/tools/IceRpc.ProtocGen/MessageDescriptorExtensions.cs
@@ -8,9 +8,7 @@ internal static class MessageDescriptorExtensions
 {
     internal static string GetType(this MessageDescriptor messageDescriptor, string scope, bool streaming)
     {
-        string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
-        string csharpType = scope == csharpNamespace ?
-            messageDescriptor.Name : $"global::{csharpNamespace}.{messageDescriptor.Name}";
+        string csharpType = messageDescriptor.GetQualifiedTypeName(scope);
         if (streaming)
         {
             csharpType = $"global::System.Collections.Generic.IAsyncEnumerable<{csharpType}>";
@@ -18,11 +16,16 @@ internal static class MessageDescriptorExtensions
         return csharpType;
     }
 
-    internal static string GetParserType(this MessageDescriptor messageDescriptor, string scope)
+    internal static string GetParserType(this MessageDescriptor messageDescriptor, string scope) =>
+        $"{messageDescriptor.GetQualifiedTypeName(scope)}.Parser";
+
+    private static string GetQualifiedTypeName(this MessageDescriptor messageDescriptor, string scope)
     {
         string csharpNamespace = messageDescriptor.File.GetCsharpNamespace();
-        string csharpType = scope == csharpNamespace ?
-            messageDescriptor.Name : $"global::{csharpNamespace}.{messageDescriptor.Name}";
-        return $"{csharpType}.Parser";
+        return scope == csharpNamespace ?
+            messageDescriptor.Name :
+            csharpNamespace.Length == 0 ?
+                $"global::{messageDescriptor.Name}" :
+                $"global::{csharpNamespace}.{messageDescriptor.Name}";
     }
 }

--- a/tools/IceRpc.ProtocGen/Program.cs
+++ b/tools/IceRpc.ProtocGen/Program.cs
@@ -46,10 +46,15 @@ foreach (FileDescriptor descriptor in descriptors)
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0619 // Type or member is obsolete
 
-using IceRpc.Protobuf;
-
-namespace {descriptor.GetCsharpNamespace()};".Trim();
+using IceRpc.Protobuf;".Trim();
     builder.AppendLine(preamble);
+    string csharpNamespace = descriptor.GetCsharpNamespace();
+    if (csharpNamespace.Length > 0)
+    {
+        builder.AppendLine();
+        builder.AppendLine($"namespace {csharpNamespace};");
+    }
+    // else generated types land in the global namespace, matching Google's protoc-gen-csharp behavior.
 
     foreach (ServiceDescriptor service in descriptor.Services)
     {


### PR DESCRIPTION
Backport of [#4562](https://github.com/icerpc/icerpc-csharp/pull/4562) — generate valid C# for `.proto` files with no `package` and no `option csharp_namespace`.

## Summary
Two codegen-correctness fixes for the case where `descriptor.GetCsharpNamespace()` returns `""`:

1. `Program.cs` was emitting `namespace ;` (invalid C#) unconditionally. Now the namespace declaration is only emitted when the C# namespace is non-empty; otherwise generated types land in the global namespace, matching Google's `protoc-gen-csharp` behavior.
2. `MessageDescriptorExtensions.cs` was producing `global::.Name` for cross-namespace references. Now it emits `global::Name` (without the dot) when the C# namespace is empty. Refactored the duplicate logic in `GetType` / `GetParserType` into a shared `GetQualifiedTypeName` private helper, mirroring main's #4562.

Codegen-correctness fix; **low** severity. No runtime / wire-format impact.

## Test plan
- [x] Added `tests/IceRpc.Protobuf.Tests/NoNamespaceTests.proto` (no `package`, no `option csharp_namespace`).
- [x] `dotnet build tests/IceRpc.Protobuf.Tests` — 0 warnings, 0 errors. Verified the generated `NoNamespaceTests.IceRpc.cs` contains no `namespace ;` line and references `NoNamespaceMessage` correctly.
- [x] `dotnet test tests/IceRpc.Protobuf.Tests` — 54/54 pass (no regressions).

## Backport notes
Hand-ported, not a cherry-pick: main's fix lives in `src/IceRpc.Protobuf.Generator/` (the C# source generator that's only on main) and uses `GetQualifiedCsharpName()` for nested-type support. On 0.5.x the equivalent files are `tools/IceRpc.ProtocGen/Program.cs` and `tools/IceRpc.ProtocGen/MessageDescriptorExtensions.cs`, which use `messageDescriptor.Name` directly (no nested-type qualification — that's a separate concern outside #4562's scope). The structural change is the same: introduce a `GetQualifiedTypeName` private helper, branch on empty namespace.

The test `.proto` is identical to main's.