### PR TITLE
CI: stop caching ~/.cargo/bin to avoid binary mismatch on macos-26

### DIFF
--- a/.github/actions/build-compiler/action.yaml
+++ b/.github/actions/build-compiler/action.yaml
@@ -15,18 +15,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 📦 Cargo Cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          tools/slicec-cs/target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
     - name: Install Cross Tools
       if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
       run: sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu --yes
@@ -36,6 +24,20 @@ runs:
       with:
         toolchain: stable
         targets: ${{ inputs.target }}
+    # ~/.cargo/bin is intentionally NOT cached: the toolchain is provisioned on every job by
+    # dtolnay/rust-toolchain above. Caching that path led to cargo behaving as rustup-init on
+    # macos-26 (see https://github.com/icerpc/icerpc-csharp/pull/4639 for the failing log).
+    - name: 📦 Cargo Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          tools/slicec-cs/target/
+        key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-v2-
     - name: Build Slice Compiler
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -14,17 +14,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Rust Toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    # ~/.cargo/bin is intentionally NOT cached: the toolchain is provisioned on every job by
+    # dtolnay/rust-toolchain above. Caching that path led to cargo behaving as rustup-init on
+    # macos-26 (see https://github.com/icerpc/icerpc-csharp/pull/4639 for the failing log).
     - uses: actions/cache@v4
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           tools/slicec-cs/target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-
+          ${{ runner.os }}-cargo-v2-
 
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
## Summary
`build_and_test (macos-26)` jobs on 0.5.x started failing on 2026-05-14 with:

```
$ cargo build --manifest-path tools/slicec-cs/Cargo.toml
error: error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

The cargo binary on PATH at the time of the build step is behaving as rustup-init. `ubuntu-24.04` and `windows-2025` jobs are unaffected, and the same workflow ran green on macos-26 the previous day. Root cause has not been confirmed.

This change reduces the surface area regardless of root cause:

- **`.github/actions/build`** (used by `ci.yml`) — the build step relied on the runner image's preinstalled cargo. Add an explicit Rust Toolchain step (`dtolnay/rust-toolchain@stable`) so cargo is provisioned by the workflow, not by whatever the image happens to ship.
- Both **`.github/actions/build`** and **`.github/actions/build-compiler`** (used by `build-packages.yml`) drop `~/.cargo/bin/` from the cached paths. The cache now carries only download/build artifacts (registry index/cache, git db, build target) and never restores executable bin contents across runs.
- In **`build-compiler`** the Rust Toolchain step also moves before the Cargo Cache step so the toolchain is provisioned before any cache restore.
- Bump the cache key to `v2` to start with a fresh namespace.

## Test plan
- [ ] CI green on all three platforms, in particular `build_and_test (macos-26)`.

## Failing logs (before this PR)
- [#4639](https://github.com/icerpc/icerpc-csharp/pull/4639) → [job 75960176649](https://github.com/icerpc/icerpc-csharp/actions/runs/25851886291/job/75960176649)
- [#4640](https://github.com/icerpc/icerpc-csharp/pull/4640) → [job 75960737113](https://github.com/icerpc/icerpc-csharp/actions/runs/25852059792/job/75960737113)