### PR TITLE
Backport #4298 to 0.5.x

### DIFF
--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -50,13 +50,12 @@ public sealed class DeadlineInterceptorTests
     public async Task Deadline_feature_value_prevails_over_default_timeout()
     {
         // Arrange
-        var invocationTimeout = TimeSpan.FromSeconds(30);
+        DateTime expectedDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
 
         IFeatureCollection features = new FeatureCollection();
-        features.Set<IDeadlineFeature>(DeadlineFeature.FromTimeout(invocationTimeout));
+        features.Set<IDeadlineFeature>(new DeadlineFeature(expectedDeadline));
 
         DateTime deadline = DateTime.MaxValue;
-        DateTime expectedDeadline = DateTime.UtcNow + invocationTimeout;
         var sut = new DeadlineInterceptor(
             new InlineInvoker((request, cancellationToken) =>
             {
@@ -78,7 +77,7 @@ public sealed class DeadlineInterceptorTests
         await sut.InvokeAsync(request, default);
 
         // Assert
-        Assert.That(Math.Abs((deadline - expectedDeadline).TotalMilliseconds), Is.LessThan(10));
+        Assert.That(deadline, Is.EqualTo(expectedDeadline));
     }
 
     /// <summary>Verifies that the deadline interceptor encodes the expected deadline value.</summary>


### PR DESCRIPTION
Backport of [#4298](https://github.com/icerpc/icerpc-csharp/pull/4298) — fix `Deadline_feature_value_prevails_over_default_timeout` to be deterministic.

## Summary
The 0.5.x test reads the clock twice — once inside `DeadlineFeature.FromTimeout(invocationTimeout)` and again when capturing `expectedDeadline = DateTime.UtcNow + invocationTimeout` — and asserts the two derived deadlines agree within 10 ms. Under load (e.g. on a busy macos-26 runner) the wall-clock drift between the two reads can exceed the tolerance; observed failure log shows 13.29 ms drift.

The main fix (March 2026, [cdbae0628](https://github.com/icerpc/icerpc-csharp/commit/cdbae0628)) makes the test deterministic by computing `expectedDeadline` once as an absolute `DateTime`, passing it via `new DeadlineFeature(expectedDeadline)` (not the `FromTimeout` factory), and asserting exact equality.

Test-only change; no library code touched.

## Test plan
- [x] `dotnet test tests/IceRpc.Deadline.Tests` — 7/7 pass.

## Backport notes
Clean cherry-pick of cdbae0628. No adaptation needed — `DeadlineFeature(DateTime)` constructor and `IDeadlineFeature` shape are identical on 0.5.x and main.

Surfaced by a CI flake on Bernard's [#4638](https://github.com/icerpc/icerpc-csharp/pull/4638) ([job](https://github.com/icerpc/icerpc-csharp/actions/runs/25830693919/job/75894691593)); the failure is unrelated to that PR's contents.