### PR TITLE
Make the trailing-bytes test write 4 explicit bytes

### DIFF
--- a/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
+++ b/tests/IceRpc.RequestContext.Tests/RequestContextMiddlewareTests.cs
@@ -83,9 +83,8 @@ public sealed class RequestContextMiddlewareTests
                 (ref SliceEncoder encoder, string key) => encoder.EncodeString(key),
                 (ref SliceEncoder encoder, string value) => encoder.EncodeString(value));
         }
-        // Append extra trailing bytes.
-        pipe.Writer.GetMemory(4).Span.Clear();
-        pipe.Writer.Advance(4);
+        // Append 4 trailing bytes.
+        pipe.Writer.Write(new byte[] { 0, 0, 0, 0 });
         pipe.Writer.Complete();
         pipe.Reader.TryRead(out var readResult);
 


### PR DESCRIPTION
## Summary
Tiny readability tweak in `RequestContextMiddlewareTests.Context_field_with_trailing_bytes_is_rejected`. The intent "write 4 trailing bytes" was obscured by:

\`\`\`csharp
pipe.Writer.GetMemory(4).Span.Clear();
pipe.Writer.Advance(4);
\`\`\`

Replaced with a direct \`pipe.Writer.Write(new byte[] { 0, 0, 0, 0 })\`.

## Test plan
- [x] \`dotnet test tests/IceRpc.RequestContext.Tests\` — 5/5 pass.

## Context
[Bernard pointed this out](https://github.com/icerpc/icerpc-csharp/pull/4636#discussion_r3241823931) while reviewing the 0.5.x backport of #4521 ([#4636](https://github.com/icerpc/icerpc-csharp/pull/4636)). The 0.5.x PR has been updated with the same change. I also grepped for similar \`pipe.Writer.GetMemory(N).Span.Clear()\` / \`writer.GetSpan(N).Clear()\` patterns elsewhere in the repo and found none.