### PR TITLE
Polish #4548: rename unparseable → unparsable; inline DecodeUriServerAddress

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -73,7 +73,6 @@
     "uncategorized",
     "unflushed",
     "uninstantiated",
-    "unparseable",
     "unregisters",
     "varint",
     "varuint",

--- a/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
@@ -165,6 +165,20 @@ public static class IceProxyIceDecoderExtensions
         }
 
         return serverAddress.Value;
+
+        static ServerAddress DecodeUriServerAddress(string uriString)
+        {
+            try
+            {
+                return new ServerAddress(new Uri(uriString));
+            }
+            catch (Exception exception) when (exception is UriFormatException or ArgumentException)
+            {
+                throw new InvalidDataException(
+                    $"Received invalid server address URI '{uriString}'.",
+                    exception);
+            }
+        }
     }
 
     /// <summary>Decodes a service address encoded with the Ice encoding.</summary>
@@ -251,21 +265,6 @@ public static class IceProxyIceDecoderExtensions
         catch (Exception exception)
         {
             throw new InvalidDataException("Received invalid service address.", exception);
-        }
-    }
-
-    /// <summary>Decodes a server address from its URI string representation.</summary>
-    private static ServerAddress DecodeUriServerAddress(string uriString)
-    {
-        try
-        {
-            return new ServerAddress(new Uri(uriString));
-        }
-        catch (Exception exception) when (exception is UriFormatException or ArgumentException)
-        {
-            throw new InvalidDataException(
-                $"Received invalid server address URI '{uriString}'.",
-                exception);
         }
     }
 

--- a/tests/IceRpc.Ice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Ice.Tests/ProxyTests.cs
@@ -39,7 +39,7 @@ public class ProxyTests
     // icerpc always uses TransportCode.Uri.
     [TestCase("ice://hello.zeroc.com/hello?transport=quic", "ice:")]
     [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:")]
-    public void Decode_proxy_with_unparseable_server_address_uri_throws_invalid_data(
+    public void Decode_proxy_with_unparsable_server_address_uri_throws_invalid_data(
         ServiceAddress value,
         string schemePrefix)
     {
@@ -50,7 +50,7 @@ public class ProxyTests
         int length = bufferWriter.WrittenMemory.Length;
 
         // Corrupt the first byte of the encoded URI scheme so that new Uri(...) throws UriFormatException.
-        // A URI scheme must start with an ALPHA; 0x01 is a control character and makes the URI unparseable.
+        // A URI scheme must start with an ALPHA; 0x01 is a control character and makes the URI unparsable.
         int uriStart = buffer.AsSpan(0, length).IndexOf(System.Text.Encoding.UTF8.GetBytes(schemePrefix));
         Assert.That(uriStart, Is.GreaterThanOrEqualTo(0), "scheme not found in encoded buffer");
         buffer[uriStart] = 0x01;


### PR DESCRIPTION
## Summary
Two small follow-ups to [#4548](https://github.com/icerpc/icerpc-csharp/pull/4548), picked up by Bernard while reviewing the 0.5.x backport ([#4634](https://github.com/icerpc/icerpc-csharp/pull/4634)):

- Rename \`unparseable\` (extra \`e\`) → \`unparsable\` in:
  - the \`Decode_proxy_with_unparseable_server_address_uri_throws_invalid_data\` test method name
  - one source comment
- **Drop** the \`"unparseable"\` entry from \`.vscode/cspell.json\` — verified that cspell accepts both \`unparsable\` and \`unparseable\` natively, so the entry was dead weight (it predates the spellcheck dictionary that now recognises the word).
- Move \`DecodeUriServerAddress\` from a private static helper at the class level to a local \`static\` function inside \`DecodeServerAddress\` (its only caller).

## Test plan
- [x] \`dotnet test tests/IceRpc.Ice.Tests --filter "FullyQualifiedName~ProxyTests"\` — 13/13 pass.

## Context
The corresponding 0.5.x backport ([#4634](https://github.com/icerpc/icerpc-csharp/pull/4634)) has been updated with the rename + local-function changes. Pairs with [#4646](https://github.com/icerpc/icerpc-csharp/pull/4646), which adds the Slice-encoding wire-decoding tests that were missing on main.