### PR TITLE
Add Slice-encoding wire-decoding tests for invalid service-address URIs

### DIFF
--- a/tests/IceRpc.Slice.Tests/ServiceAddressTests.cs
+++ b/tests/IceRpc.Slice.Tests/ServiceAddressTests.cs
@@ -22,4 +22,61 @@ public class ServiceAddressTests
         // Act/Assert
         Assert.That(decoder.DecodeServiceAddress(), Is.EqualTo(value));
     }
+
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:")]
+    public void Decode_service_address_with_unparsable_uri_throws_invalid_data(
+        ServiceAddress value,
+        string schemePrefix)
+    {
+        var buffer = new byte[256];
+        var bufferWriter = new MemoryBufferWriter(buffer);
+        var encoder = new SliceEncoder(bufferWriter);
+        encoder.EncodeServiceAddress(value);
+        int length = bufferWriter.WrittenMemory.Length;
+
+        // Corrupt the first byte of the encoded URI scheme so that new Uri(...) throws UriFormatException.
+        // A URI scheme must start with an ALPHA; 0x01 is a control character and makes the URI unparsable.
+        int uriStart = buffer.AsSpan(0, length).IndexOf(System.Text.Encoding.UTF8.GetBytes(schemePrefix));
+        Assert.That(uriStart, Is.GreaterThanOrEqualTo(0), "scheme not found in encoded buffer");
+        buffer[uriStart] = 0x01;
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var decoder = new SliceDecoder(buffer.AsMemory(0, length));
+                _ = decoder.DecodeServiceAddress();
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
+
+    [TestCase("icerpc://hello.zeroc.com/hello", "icerpc:", "gopher:")]
+    public void Decode_service_address_with_invalid_uri_throws_invalid_data(
+        ServiceAddress value,
+        string schemePrefix,
+        string replacementScheme)
+    {
+        var buffer = new byte[256];
+        var bufferWriter = new MemoryBufferWriter(buffer);
+        var encoder = new SliceEncoder(bufferWriter);
+        encoder.EncodeServiceAddress(value);
+        int length = bufferWriter.WrittenMemory.Length;
+
+        // Replace the scheme with one that parses as a URI but is rejected by the ServiceAddress constructor,
+        // which throws ArgumentException for unsupported protocols. The replacement is chosen with the same
+        // byte length so the encoded string length prefix remains valid.
+        Assert.That(replacementScheme.Length, Is.EqualTo(schemePrefix.Length));
+        int uriStart = buffer.AsSpan(0, length).IndexOf(System.Text.Encoding.UTF8.GetBytes(schemePrefix));
+        Assert.That(uriStart, Is.GreaterThanOrEqualTo(0), "scheme not found in encoded buffer");
+        System.Text.Encoding.UTF8.GetBytes(replacementScheme).CopyTo(buffer.AsSpan(uriStart));
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var decoder = new SliceDecoder(buffer.AsMemory(0, length));
+                _ = decoder.DecodeServiceAddress();
+            },
+            Throws.InstanceOf<InvalidDataException>());
+    }
 }


### PR DESCRIPTION
## Summary
[#4548](https://github.com/icerpc/icerpc-csharp/pull/4548) added wire-decoding tests for the **Ice encoding** URI-decode path in \`tests/IceRpc.Ice.Tests/ProxyTests.cs\` but did not add equivalent tests for the **Slice encoding** path. \`DecodeServiceAddress\` in \`IceRpc.Slice\` already wraps its \`new Uri(...)\` call in a \`try\`/\`catch\` that converts \`UriFormatException\`/\`ArgumentException\` to \`InvalidDataException\`; this PR just locks in that behaviour with two tests mirroring the Ice ones:

- \`Decode_service_address_with_unparsable_uri_throws_invalid_data\` — corrupts the scheme byte so \`new Uri(...)\` throws \`UriFormatException\`.
- \`Decode_service_address_with_invalid_uri_throws_invalid_data\` — replaces the scheme with an unsupported one (\`gopher:\`) so the \`ServiceAddress\` constructor throws \`ArgumentException\`.

## Test plan
- [x] \`dotnet test tests/IceRpc.Slice.Tests --filter "FullyQualifiedName~ServiceAddressTests"\` — 3/3 pass (the existing round-trip + 2 new cases).

## Context
Surfaced by [Bernard's review](https://github.com/icerpc/icerpc-csharp/pull/4634#discussion_r3241794919) on the 0.5.x backport ([#4634](https://github.com/icerpc/icerpc-csharp/pull/4634)). Pairs with [#4645](https://github.com/icerpc/icerpc-csharp/pull/4645), which is the other half of Bernard's feedback (rename + local function refactor).

Verified \`cspell\` accepts \`unparsable\` natively (the existing \`unparseable\` entry in \`cspell.json\` was dead weight — left to [#4645](https://github.com/icerpc/icerpc-csharp/pull/4645) to clean up).