### PR TITLE
Fix adapter-id over-escaping when decoding an Ice proxy (#4644)

### DIFF
--- a/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace IceRpc.Ice.Operations;
 
@@ -208,7 +209,8 @@ public static class IceProxyIceDecoderExtensions
         {
             if (decoder.DecodeString() is string adapterId && adapterId.Length > 0)
             {
-                serviceAddressParams = serviceAddressParams.Add("adapter-id", Uri.EscapeDataString(adapterId));
+                serviceAddressParams =
+                    serviceAddressParams.Add("adapter-id", EscapeAdapterId(adapterId));
             }
         }
         else
@@ -299,5 +301,54 @@ public static class IceProxyIceDecoderExtensions
                 "Cannot decode a server address with a port number larger than 65,535.",
                 exception);
         }
+    }
+
+    // The printable ASCII range. Characters outside this range must be percent-escaped in a service address parameter
+    // value.
+    private const char FirstValidChar = '\x21';
+    private const char LastValidChar = '\x7E';
+
+    // Same as ServiceAddress's _notValidInParamValue, plus '%' which must be escaped to make the percent-escaped
+    // value unambiguously decodable.
+    private static readonly SearchValues<char> _mustEscapeInAdapterId = SearchValues.Create("\"<>#%&\\^`{|}");
+
+    /// <summary>Percent-encodes only the characters that are invalid in a service address parameter value: characters
+    /// outside the printable ASCII range <c>\x21..\x7E</c>, characters in
+    /// <see cref="_mustEscapeInAdapterId" />, and the <c>%</c> character itself (which must be escaped to make the
+    /// result unambiguously decodable).</summary>
+    /// <param name="value">The raw adapter ID, as decoded from the wire.</param>
+    /// <returns>An escaped string suitable for use as the value of the <c>adapter-id</c> service address parameter.
+    /// </returns>
+    /// <remarks>This is intentionally narrower than <see cref="Uri.EscapeDataString(string)" />, which over-escapes
+    /// characters that are valid in service address parameter values such as <c>/</c>, <c>:</c>, and <c>@</c>.
+    /// </remarks>
+    private static string EscapeAdapterId(string value)
+    {
+        ReadOnlySpan<char> span = value.AsSpan();
+
+        // Fast path: nothing to escape. Adapter IDs are usually pure ASCII so we almost always take this path.
+        if (span.IndexOfAnyExceptInRange(FirstValidChar, LastValidChar) == -1 &&
+            span.IndexOfAny(_mustEscapeInAdapterId) == -1)
+        {
+            return value;
+        }
+
+        // Slow path. Encode the whole string to UTF-8 bytes, then percent-escape every byte that is not a valid
+        // unescaped char. UTF-8 continuation bytes (>= 0x80) naturally fall in the escape branch, so multi-byte
+        // code points are handled without any surrogate-pair logic here.
+        byte[] utf8 = Encoding.UTF8.GetBytes(value);
+        var sb = new StringBuilder(utf8.Length + 8);
+        foreach (byte b in utf8)
+        {
+            if (b >= FirstValidChar && b <= LastValidChar && !_mustEscapeInAdapterId.Contains((char)b))
+            {
+                sb.Append((char)b);
+            }
+            else
+            {
+                sb.Append('%').Append(b.ToString("X2", CultureInfo.InvariantCulture));
+            }
+        }
+        return sb.ToString();
     }
 }

--- a/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
@@ -16,6 +16,15 @@ namespace IceRpc.Ice.Operations;
 /// <summary>Provides extension methods for <see cref="IceDecoder" /> to decode proxies.</summary>
 public static class IceProxyIceDecoderExtensions
 {
+    // The printable ASCII range. Characters outside this range must be percent-escaped in a service address parameter
+    // value.
+    private const char FirstValidChar = '\x21';
+    private const char LastValidChar = '\x7E';
+
+    // Same as ServiceAddress's _notValidInParamValue, plus '%' which must be escaped to make the percent-escaped
+    // value unambiguously decodable.
+    private static readonly SearchValues<char> _mustEscapeInAdapterId = SearchValues.Create("\"<>#%&\\^`{|}");
+
     /// <summary>Decodes a proxy struct.</summary>
     /// <typeparam name="TProxy">The type of the proxy struct to decode.</typeparam>
     /// <param name="decoder">The Ice decoder.</param>
@@ -302,15 +311,6 @@ public static class IceProxyIceDecoderExtensions
                 exception);
         }
     }
-
-    // The printable ASCII range. Characters outside this range must be percent-escaped in a service address parameter
-    // value.
-    private const char FirstValidChar = '\x21';
-    private const char LastValidChar = '\x7E';
-
-    // Same as ServiceAddress's _notValidInParamValue, plus '%' which must be escaped to make the percent-escaped
-    // value unambiguously decodable.
-    private static readonly SearchValues<char> _mustEscapeInAdapterId = SearchValues.Create("\"<>#%&\\^`{|}");
 
     /// <summary>Percent-encodes only the characters that are invalid in a service address parameter value: characters
     /// outside the printable ASCII range <c>\x21..\x7E</c>, characters in

--- a/tests/IceRpc.Ice.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Ice.Tests/ProxyTests.cs
@@ -22,6 +22,15 @@ public class ProxyTests
     [TestCase("ice:/hello?adapter-id=foo%25bar", null)] // '%'
     [TestCase("ice:/hello?adapter-id=foo%20bar", null)] // ' '
     [TestCase("ice:/hello?adapter-id=foo%23bar%25baz%20qux%26quux", null)] // '#', '%', ' ', '&'
+
+    // adapter-id values that are not percent-escaped
+    [TestCase("ice:/hello?adapter-id=foo/bar", null)] // '/'
+    [TestCase("ice:/hello?adapter-id=cat:1", null)] // ':'
+    [TestCase("ice:/hello?adapter-id=user@host", null)] // '@'
+    [TestCase("ice:/hello?adapter-id=a=b,c(d)", null)] // '=', ',', '(', ')'
+
+    // no round-trip here: the URI parser keeps the `%` as is, while the decoder escapes it into `%25`.
+    [TestCase("ice:/hello?adapter-id=foo%bar", "ice:/hello?adapter-id=foo%25bar")]
     public void Encode_decode_proxy(ServiceAddress? value, ServiceAddress? expectedValue)
     {
         var buffer = new byte[256];


### PR DESCRIPTION
When decoding an Ice proxy, the adapter ID was passed through Uri.EscapeDataString before being stored as the adapter-id service address parameter value. Uri.EscapeDataString follows RFC 3986 and percent-escapes characters such as '/', ':', and '@' that are valid in a service address parameter value, breaking equality with a ServiceAddress built from the equivalent URI string.

Replace this with a narrower EscapeAdapterId helper that escapes only the characters that are actually invalid in a service address parameter value, plus '%'.

Fixes #4644