### PR TITLE
Polish #4544: tighten Slic first-stream check; drop verbose comment

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1579,14 +1579,10 @@ internal class SlicConnection : IMultiplexedConnection
 
             if (isBidirectional)
             {
-                // The next expected remote bidirectional stream ID is the last one plus 4, or the initial remote
-                // bidirectional stream ID (0 for the server, 1 for the client) if no remote bidirectional stream has
-                // been opened yet. This check also rejects a bogus first stream ID, which would otherwise slip
-                // through because `null + 4` evaluates to null.
                 ulong expectedStreamId = _lastRemoteBidirectionalStreamId is ulong lastId
                     ? lastId + 4
                     : (IsServer ? 0ul : 1ul);
-                if (streamId > expectedStreamId)
+                if (streamId != expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }
@@ -1601,14 +1597,10 @@ internal class SlicConnection : IMultiplexedConnection
             }
             else
             {
-                // The next expected remote unidirectional stream ID is the last one plus 4, or the initial remote
-                // unidirectional stream ID (2 for the server, 3 for the client) if no remote unidirectional stream
-                // has been opened yet. This check also rejects a bogus first stream ID, which would otherwise slip
-                // through because `null + 4` evaluates to null.
                 ulong expectedStreamId = _lastRemoteUnidirectionalStreamId is ulong lastId
                     ? lastId + 4
                     : (IsServer ? 2ul : 3ul);
-                if (streamId > expectedStreamId)
+                if (streamId != expectedStreamId)
                 {
                     throw new InvalidDataException("Invalid stream ID.");
                 }


### PR DESCRIPTION
## Summary
Two follow-ups to [#4544](https://github.com/icerpc/icerpc-csharp/pull/4544), picked up by Bernard while reviewing the 0.5.x backport ([#4633](https://github.com/icerpc/icerpc-csharp/pull/4633)):

- **Change \`streamId > expectedStreamId\` → \`streamId != expectedStreamId\`** in both the bidirectional and unidirectional branches. Slic opens remote streams in strict ID order (the immediately-next ID modulo type/direction), so \`!=\` matches the protocol invariant. The \`>\` was a leftover from the pre-#4544 \`streamId > _lastRemoteBidirectionalStreamId + 4\` shape; once we compute \`expectedStreamId\` explicitly there's no need to tolerate lower-than-expected IDs.
- **Remove the two 4-line comments** above each check. With the explicit \`expectedStreamId\` variable and the \`!=\` check, the code reads on its own.

## Test plan
- [x] \`dotnet test tests/IceRpc.Tests --filter "FullyQualifiedName~SlicTransportTests"\` — 84/84 pass.
- [x] \`dotnet test tests/IceRpc.Tests\` — 974/974 pass (34 skipped).

## Context
The corresponding 0.5.x backport ([#4633](https://github.com/icerpc/icerpc-csharp/pull/4633)) has been updated with the same two changes.