### PR TITLE
Backport #4285 to 0.5.x

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -726,7 +726,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
         ReadOnlySequence<byte> buffer,
         int requestId)
     {
-        ReplyStatus replyStatus = ((int)buffer.FirstSpan[0]).AsReplyStatus();
+        var replyStatus = (ReplyStatus)buffer.FirstSpan[0];
 
         if (replyStatus <= ReplyStatus.UserException)
         {

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -63,6 +63,60 @@ public sealed class IceProtocolConnectionTests
         }
     }
 
+    private static IEnumerable<TestCaseData> StatusCodeRoundTripSource
+    {
+        get
+        {
+            // These StatusCodes encode as RequestFailedExceptionData; the decode rebuilds the message.
+            yield return new TestCaseData(
+                StatusCode.NotFound,
+                StatusCode.NotFound,
+                "The dispatch failed with status code NotFound while dispatching 'op' on '/foo'.");
+            yield return new TestCaseData(
+                StatusCode.NotImplemented,
+                StatusCode.NotImplemented,
+                "The dispatch failed with status code NotImplemented while dispatching 'op' on '/foo'.");
+
+            // These StatusCodes encode their ErrorMessage as a string and decode it back unchanged.
+            yield return new TestCaseData(
+                StatusCode.InvalidData,
+                StatusCode.InvalidData,
+                "The dispatch failed with status code InvalidData.");
+            yield return new TestCaseData(
+                StatusCode.Unauthorized,
+                StatusCode.Unauthorized,
+                "The dispatch failed with status code Unauthorized.");
+            yield return new TestCaseData(
+                StatusCode.InternalError,
+                StatusCode.InternalError,
+                "The dispatch failed with status code InternalError.");
+
+            // Well-known status codes without a dedicated ReplyStatus encode as UnknownException
+            // with the original StatusCode preserved in the error message.
+            yield return new TestCaseData(
+                StatusCode.ApplicationError,
+                StatusCode.InternalError,
+                "The dispatch failed with status code ApplicationError. { Original StatusCode = ApplicationError }");
+            yield return new TestCaseData(
+                StatusCode.DeadlineExceeded,
+                StatusCode.InternalError,
+                "The dispatch failed with status code DeadlineExceeded. { Original StatusCode = DeadlineExceeded }");
+
+            // Custom status codes are mapped to InternalError with the original StatusCode preserved in the
+            // error message.
+            yield return new TestCaseData(
+                (StatusCode)42,
+                StatusCode.InternalError,
+                "The dispatch failed with status code 42. { Original StatusCode = 42 }");
+
+            yield return new TestCaseData(
+                (StatusCode)1000,
+                StatusCode.InternalError,
+                "The dispatch failed with status code 1000. { Original StatusCode = 1000 }");
+
+        }
+    }
+
     [Test, TestCaseSource(nameof(DispatchFailureSource))]
     public async Task Dispatcher_failure(
         InlineDispatcher dispatcher,
@@ -89,6 +143,38 @@ public sealed class IceProtocolConnectionTests
         Assert.That(response.ErrorMessage, Is.EqualTo(expectedErrorMessage));
         Assert.That(readResult.IsCompleted, Is.True);
         Assert.That(readResult.Buffer.IsEmpty, Is.True);
+    }
+
+    /// <summary>Verifies that a StatusCode dispatched by the server is encoded as a ReplyStatus and decoded back to
+    /// the expected StatusCode by the client.</summary>
+    [Test, TestCaseSource(nameof(StatusCodeRoundTripSource))]
+    public async Task Response_reply_status_maps_to_expected_status_code(
+        StatusCode dispatchStatusCode,
+        StatusCode expectedStatusCode,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+            new(new OutgoingResponse(request, dispatchStatusCode)));
+
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(Protocol.Ice, dispatcher)
+            .BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        await sut.ConnectAsync();
+
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.Ice) { Path = "/foo" })
+        {
+            Operation = "op"
+        };
+
+        // Act
+        IncomingResponse response = await sut.Client.InvokeAsync(request);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(expectedStatusCode));
+        Assert.That(response.ErrorMessage, Is.EqualTo(expectedErrorMessage));
     }
 
     /// <summary>Verifies that an abortive server connection shutdown causes an invocation failure.</summary>


### PR DESCRIPTION
Backport of [#4285](https://github.com/icerpc/icerpc-csharp/pull/4285) (fix [#4281](https://github.com/icerpc/icerpc-csharp/issues/4281)) — fix unknown reply status handling in the ice protocol.

## Summary
\`DecodeResponseHeader\` was using the generated \`((int)b).AsReplyStatus()\` to convert the wire reply-status byte to the \`ReplyStatus\` enum. The generated converter throws on values it doesn't recognise, so a peer sending an unknown reply status currently produces a misleading \`InvalidDataException\` instead of the \`UnknownReplyStatus\` value the rest of the dispatch code expects. The fix is a direct cast, matching how \`ReplyStatus\` is documented to handle forward compatibility with new server status codes. Round-trip tests added.

## Test plan
- [x] \`dotnet test tests/IceRpc.Tests --filter "FullyQualifiedName~IceProtocolConnectionTests"\` — 45/45 pass.

## Backport notes
Clean cherry-pick of 73ffb32d4. No adaptation needed.

Surfaced by the [2026-05-15 follow-up audit](https://github.com/icerpc/icerpc-csharp-audit/blob/main/0.5.x-backport-audit-2026-05-15.md).