### PR TITLE
Backport #4517 + #4547 + #4668 to 0.5.x

### DIFF
--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -25,6 +25,10 @@ namespace IceRpc.Deadline;
 /// <seealso cref="DeadlineInvokerBuilderExtensions"/>
 public class DeadlineInterceptor : IInvoker
 {
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan _maxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
+
     private readonly bool _alwaysEnforceDeadline;
     private readonly IInvoker _next;
     private readonly TimeSpan _defaultTimeout;
@@ -32,17 +36,28 @@ public class DeadlineInterceptor : IInvoker
 
     /// <summary>Constructs a Deadline interceptor.</summary>
     /// <param name="next">The next invoker in the invocation pipeline.</param>
-    /// <param name="defaultTimeout">The default timeout. When not infinite, the interceptor adds a deadline to requests
-    /// without a deadline.</param>
-    /// <param name="timeProvider">The optional time provider used to obtain the current time. If <see langword="null"/>, it uses
-    /// <see cref="TimeProvider.System"/>.</param>
+    /// <param name="defaultTimeout">The default timeout applied to requests without a deadline. Must be a positive
+    /// value not exceeding ~24.8 days, or <see cref="Timeout.InfiniteTimeSpan" /> to disable the default timeout
+    /// entirely.</param>
+    /// <param name="timeProvider">The optional time provider used to obtain the current time. If
+    /// <see langword="null"/>, it uses <see cref="TimeProvider.System"/>.</param>
     /// <param name="alwaysEnforceDeadline">When <see langword="true" /> and the request carries a deadline, the
     /// interceptor always creates a cancellation token source to enforce this deadline. When <see langword="false" />
     /// and the request carries a deadline, the interceptor creates a cancellation token source to enforce this deadline
     /// only when the invocation's cancellation token cannot be canceled. The default value is <see langword="false" />.
     /// </param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="defaultTimeout" /> is neither
+    /// <see cref="Timeout.InfiniteTimeSpan" /> nor a positive value within the supported range.</exception>
     public DeadlineInterceptor(IInvoker next, TimeSpan defaultTimeout, bool alwaysEnforceDeadline, TimeProvider? timeProvider = null)
     {
+        if (defaultTimeout != Timeout.InfiniteTimeSpan &&
+            (defaultTimeout <= TimeSpan.Zero || defaultTimeout > _maxSupportedTimeout))
+        {
+            throw new ArgumentException(
+                $"The {nameof(defaultTimeout)} value must be Timeout.InfiniteTimeSpan or a positive value not exceeding {_maxSupportedTimeout}.",
+                nameof(defaultTimeout));
+        }
+
         _next = next;
         _alwaysEnforceDeadline = alwaysEnforceDeadline;
         _defaultTimeout = defaultTimeout;
@@ -58,7 +73,9 @@ public class DeadlineInterceptor : IInvoker
         DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
         if (request.Features.Get<IDeadlineFeature>() is IDeadlineFeature deadlineFeature)
         {
-            deadline = deadlineFeature.Value;
+            // Normalize to UTC.
+            deadline = deadlineFeature.Value == DateTime.MaxValue ?
+                DateTime.MaxValue : deadlineFeature.Value.ToUniversalTime();
             if (deadline != DateTime.MaxValue && (_alwaysEnforceDeadline || !cancellationToken.CanBeCanceled))
             {
                 timeout = deadline - now;
@@ -87,6 +104,15 @@ public class DeadlineInterceptor : IInvoker
 
         async Task<IncomingResponse> PerformInvokeAsync(TimeSpan timeout)
         {
+            // Reject a caller-provided IDeadlineFeature whose remaining timeout exceeds what this interceptor
+            // can enforce. Such deadlines are nonsensical in practice (~24.8 days), and silently clamping the
+            // value the caller asked for is worse than failing cleanly.
+            if (timeout > _maxSupportedTimeout)
+            {
+                throw new NotSupportedException(
+                    $"The request deadline exceeds the maximum timeout supported by this interceptor: {_maxSupportedTimeout}.");
+            }
+
             using var timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutTokenSource.CancelAfter(timeout);
 

--- a/src/IceRpc.Deadline/DeadlineMiddleware.cs
+++ b/src/IceRpc.Deadline/DeadlineMiddleware.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
+using System.Buffers;
 using ZeroC.Slice;
 
 namespace IceRpc.Deadline;
@@ -9,10 +10,16 @@ namespace IceRpc.Deadline;
 /// <summary>Represents a middleware that decodes deadline fields into deadline features. When the decoded deadline
 /// expires, this middleware cancels the dispatch and returns an <see cref="OutgoingResponse" /> with status code
 /// <see cref="StatusCode.DeadlineExceeded" />.</summary>
+/// <remarks>If the peer-encoded deadline is too far in the future for this middleware to enforce (more than
+/// ~24.8 days from now), the request is rejected with <see cref="StatusCode.NotSupported" /> instead.</remarks>
 /// <seealso cref="DeadlineRouterExtensions"/>
 /// <seealso cref="DeadlineDispatcherBuilderExtensions"/>
 public class DeadlineMiddleware : IDispatcher
 {
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan _maxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
+
     private readonly IDispatcher _next;
     private readonly TimeProvider _timeProvider;
 
@@ -31,16 +38,12 @@ public class DeadlineMiddleware : IDispatcher
         IncomingRequest request,
         CancellationToken cancellationToken = default)
     {
-        TimeSpan? timeout = null;
-
-        // not found returns default == DateTime.MinValue.
-        DateTime deadline = request.Fields.DecodeValue(
-            RequestFieldKey.Deadline,
-            (ref SliceDecoder decoder) => decoder.DecodeTimeStamp());
-
-        if (deadline != DateTime.MinValue)
+        // Check explicit field presence rather than relying on a decoded-value sentinel.
+        if (request.Fields.TryGetValue(RequestFieldKey.Deadline, out ReadOnlySequence<byte> value))
         {
-            timeout = deadline - _timeProvider.GetUtcNow().UtcDateTime;
+            var decoder = new SliceDecoder(value, SliceEncoding.Slice2);
+            DateTime deadline = decoder.DecodeTimeStamp();
+            TimeSpan timeout = deadline - _timeProvider.GetUtcNow().UtcDateTime;
 
             if (timeout <= TimeSpan.Zero)
             {
@@ -50,10 +53,22 @@ public class DeadlineMiddleware : IDispatcher
                     "The request deadline has expired."));
             }
 
+            // Reject a peer-encoded deadline that exceeds what this middleware can enforce. Silently clamping
+            // a deadline the client asked for to a smaller value the implementation supports is worse than
+            // failing cleanly.
+            if (timeout > _maxSupportedTimeout)
+            {
+                return new(new OutgoingResponse(
+                    request,
+                    StatusCode.NotSupported,
+                    $"The request deadline exceeds the maximum timeout supported by this server: {_maxSupportedTimeout}."));
+            }
+
             request.Features = request.Features.With<IDeadlineFeature>(new DeadlineFeature(deadline));
+            return PerformDispatchAsync(timeout);
         }
 
-        return timeout is null ? _next.DispatchAsync(request, cancellationToken) : PerformDispatchAsync(timeout.Value);
+        return _next.DispatchAsync(request, cancellationToken);
 
         async ValueTask<OutgoingResponse> PerformDispatchAsync(TimeSpan timeout)
         {

--- a/src/IceRpc/Features/DeadlineFeature.cs
+++ b/src/IceRpc/Features/DeadlineFeature.cs
@@ -5,10 +5,25 @@ namespace IceRpc.Features;
 /// <summary>Default implementation of <see cref="IDeadlineFeature" />.</summary>
 public sealed class DeadlineFeature : IDeadlineFeature
 {
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
+
     /// <summary>Creates a deadline from a timeout.</summary>
-    /// <param name="timeout">The timeout.</param>
+    /// <param name="timeout">The timeout. Must be a positive value not exceeding ~24.8 days.</param>
     /// <returns>A new deadline equal to now plus the timeout.</returns>
-    public static DeadlineFeature FromTimeout(TimeSpan timeout) => new(DateTime.UtcNow + timeout);
+    /// <exception cref="ArgumentException">Thrown if <paramref name="timeout" /> is not a positive value
+    /// within the supported range.</exception>
+    public static DeadlineFeature FromTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero || timeout > MaxSupportedTimeout)
+        {
+            throw new ArgumentException(
+                $"The {nameof(timeout)} value must be positive and not exceed {MaxSupportedTimeout}.",
+                nameof(timeout));
+        }
+        return new(DateTime.UtcNow + timeout);
+    }
 
     /// <inheritdoc/>
     public DateTime Value { get; }

--- a/src/IceRpc/Features/IDeadlineFeature.cs
+++ b/src/IceRpc/Features/IDeadlineFeature.cs
@@ -3,10 +3,10 @@
 namespace IceRpc.Features;
 
 /// <summary>Represents the expiration time of a request.</summary>
-/// <remarks>Once the deadline of a two-way request is reached, the caller
-/// is no longer interested in the response and the request should be discarded by the application code and IceRPC. For
-/// a one-way request, the processing of the request should be canceled once its deadline is reached. The value of this
-/// deadline feature is transmitted with requests using the <see cref="RequestFieldKey.Deadline" /> field.</remarks>
+/// <remarks>Once the deadline of a two-way request is reached, the caller is no longer interested in the response and
+/// the request should be discarded by the application code and IceRPC. For a one-way request, the processing of the
+/// request should be canceled once its deadline is reached. The value of this deadline feature is transmitted with
+/// requests using the <see cref="RequestFieldKey.Deadline" /> field.</remarks>
 public interface IDeadlineFeature
 {
     /// <summary>Gets the value of deadline.</summary>

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -2,10 +2,10 @@
 
 using IceRpc.Features;
 using IceRpc.Tests.Common;
+using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using System.IO.Pipelines;
 using ZeroC.Slice;
-using Microsoft.Extensions.Time.Testing;
 
 namespace IceRpc.Deadline.Tests;
 
@@ -135,6 +135,30 @@ public sealed class DeadlineInterceptorTests
         Assert.That(token!.Value, Is.EqualTo(cts.Token));
     }
 
+    /// <summary>Verifies the interceptor rejects an extreme-future IDeadlineFeature value with
+    /// <see cref="NotSupportedException" /> rather than silently clamping it.</summary>
+    [Test]
+    public void Invoke_with_extreme_future_deadline_throws_not_supported()
+    {
+        // Arrange
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        var sut = new DeadlineInterceptor(invoker, Timeout.InfiniteTimeSpan, alwaysEnforceDeadline: true);
+        // Close to DateTime.MaxValue but not equal, so the interceptor's "== DateTime.MaxValue" short-circuit
+        // does not kick in and the deadline-too-far-in-future path is exercised.
+        DateTime extreme = DateTime.SpecifyKind(DateTime.MaxValue.AddDays(-1), DateTimeKind.Utc);
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc))
+        {
+            Features = new FeatureCollection().With<IDeadlineFeature>(new DeadlineFeature(extreme))
+        };
+
+        // Act/Assert
+        Assert.That(
+            async () => await sut.InvokeAsync(request, default),
+            Throws.TypeOf<NotSupportedException>());
+    }
+
     [Test]
     public void Deadline_interceptor_can_enforce_application_deadline()
     {
@@ -160,6 +184,87 @@ public sealed class DeadlineInterceptorTests
 
         // Act/Assert
         Assert.ThrowsAsync<TimeoutException>(() => sut.InvokeAsync(request, tokenSource.Token));
+    }
+
+    /// <summary>Verifies that the interceptor encodes and enforces the same UTC instant regardless of the
+    /// deadline feature value's <see cref="DateTime.Kind" />.</summary>
+    [TestCaseSource(nameof(DeadlineFeatureIsNormalizedToUtcSource))]
+    public async Task Deadline_feature_is_normalized_to_utc(DateTime deadlineValue)
+    {
+        // Arrange
+        DateTime encodedDeadline = DateTime.MaxValue;
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+        {
+            if (request.Fields.TryGetValue(RequestFieldKey.Deadline, out OutgoingFieldValue deadlineField))
+            {
+                encodedDeadline = ReadDeadline(deadlineField);
+            }
+            return Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance));
+        });
+
+        var timeProvider = new FakeTimeProvider(
+            new DateTimeOffset(TargetUtc - TimeSpan.FromMinutes(1), TimeSpan.Zero));
+        var sut = new DeadlineInterceptor(invoker, Timeout.InfiniteTimeSpan, alwaysEnforceDeadline: false, timeProvider);
+
+        IFeatureCollection features = new FeatureCollection();
+        features.Set<IDeadlineFeature>(new DeadlineFeature(deadlineValue));
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc)) { Features = features };
+
+        // Act
+        await sut.InvokeAsync(request, default);
+
+        // Assert
+        Assert.That(encodedDeadline, Is.EqualTo(TargetUtc));
+    }
+
+    [TestCase(0)]
+    [TestCase(-5000)]
+    public void Constructor_rejects_invalid_default_timeout(int milliseconds)
+    {
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        Assert.That(
+            () => new DeadlineInterceptor(invoker, TimeSpan.FromMilliseconds(milliseconds), alwaysEnforceDeadline: false),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    /// <summary>Verifies the constructor rejects a default timeout that exceeds the maximum supported value.
+    /// <see cref="TimeSpan.MaxValue" /> would otherwise later cause <c>DateTime</c> overflow (now + timeout) or
+    /// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" /> to throw at first invoke.</summary>
+    [Test]
+    public void Constructor_rejects_default_timeout_beyond_maximum()
+    {
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        Assert.That(
+            () => new DeadlineInterceptor(invoker, TimeSpan.MaxValue, alwaysEnforceDeadline: false),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Constructor_accepts_infinite_timeout()
+    {
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+
+        Assert.That(
+            () => new DeadlineInterceptor(invoker, Timeout.InfiniteTimeSpan, alwaysEnforceDeadline: false),
+            Throws.Nothing);
+    }
+
+    private static readonly DateTime TargetUtc = new(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private static IEnumerable<TestCaseData> DeadlineFeatureIsNormalizedToUtcSource
+    {
+        get
+        {
+            yield return new TestCaseData(TargetUtc).SetName("Utc");
+            yield return new TestCaseData(TargetUtc.ToLocalTime()).SetName("Local");
+            yield return new TestCaseData(
+                DateTime.SpecifyKind(TargetUtc.ToLocalTime(), DateTimeKind.Unspecified)).SetName("Unspecified");
+        }
     }
 
     private static DateTime ReadDeadline(OutgoingFieldValue field)

--- a/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
@@ -56,6 +56,85 @@ public sealed class DeadlineMiddlewareTests
         pipeReader.Complete();
     }
 
+    /// <summary>Verifies that a request with an explicitly encoded DateTime.MinValue deadline returns
+    /// DeadlineExceeded and does not fall through to the next dispatcher. This is the decoded form of a peer-encoded
+    /// ticks=0 deadline, which must be treated as an expired deadline rather than as an absent field.</summary>
+    [Test]
+    public async Task Dispatch_fails_when_deadline_is_min_value()
+    {
+        // Arrange
+        bool nextCalled = false;
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+        {
+            nextCalled = true;
+            return new(new OutgoingResponse(request));
+        });
+
+        var sut = new DeadlineMiddleware(dispatcher);
+
+        // Encode an explicit ticks=0 deadline: the Utc kind avoids ToUniversalTime shifting it away from 0 in
+        // timezones other than UTC. Decoded server-side as DateTime.MinValue, which collides with the "field
+        // absent" sentinel the middleware used to rely on.
+        PipeReader pipeReader = WriteDeadline(new DateTime(0, DateTimeKind.Utc));
+        pipeReader.TryRead(out var readResult);
+
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+        {
+            Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>
+            {
+                [RequestFieldKey.Deadline] = readResult.Buffer
+            }
+        };
+
+        // Act
+        OutgoingResponse response = await sut.DispatchAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.DeadlineExceeded));
+        Assert.That(nextCalled, Is.False);
+
+        // Cleanup
+        pipeReader.Complete();
+    }
+
+    /// <summary>Verifies the middleware rejects an extreme-future peer-encoded deadline with
+    /// <see cref="StatusCode.NotSupported" /> rather than silently clamping it to its supported maximum.</summary>
+    [Test]
+    public async Task Dispatch_with_extreme_future_deadline_returns_not_supported()
+    {
+        // Arrange
+        bool nextCalled = false;
+        var dispatcher = new InlineDispatcher((request, cancellationToken) =>
+        {
+            nextCalled = true;
+            return new(new OutgoingResponse(request));
+        });
+
+        var sut = new DeadlineMiddleware(dispatcher);
+
+        PipeReader pipeReader = WriteDeadline(
+            DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc));
+        pipeReader.TryRead(out var readResult);
+
+        using var request = new IncomingRequest(Protocol.IceRpc, FakeConnectionContext.Instance)
+        {
+            Fields = new Dictionary<RequestFieldKey, ReadOnlySequence<byte>>
+            {
+                [RequestFieldKey.Deadline] = readResult.Buffer
+            }
+        };
+
+        // Act
+        OutgoingResponse response = await sut.DispatchAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.NotSupported));
+        Assert.That(nextCalled, Is.False);
+
+        // Cleanup
+        pipeReader.Complete();
+    }
+
     /// <summary>Verifies that the deadline decoded by the middleware has the expected value.</summary>
     [Test]
     public async Task Deadline_decoded_by_middleware_has_expected_value()

--- a/tests/IceRpc.Tests/Features/DeadlineFeatureTests.cs
+++ b/tests/IceRpc.Tests/Features/DeadlineFeatureTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ZeroC, Inc.
+
+using NUnit.Framework;
+
+namespace IceRpc.Features.Tests;
+
+[Parallelizable(scope: ParallelScope.All)]
+public class DeadlineFeatureTests
+{
+    [Test]
+    public void FromTimeout_rejects_non_positive_timeout()
+    {
+        Assert.That(() => DeadlineFeature.FromTimeout(TimeSpan.Zero), Throws.TypeOf<ArgumentException>());
+        Assert.That(() => DeadlineFeature.FromTimeout(TimeSpan.FromSeconds(-1)), Throws.TypeOf<ArgumentException>());
+    }
+
+    /// <summary>Verifies FromTimeout rejects a timeout that exceeds the maximum supported value rather than
+    /// letting <see cref="DateTime.UtcNow" /> + timeout overflow.</summary>
+    [Test]
+    public void FromTimeout_rejects_timeout_beyond_maximum()
+    {
+        Assert.That(() => DeadlineFeature.FromTimeout(TimeSpan.MaxValue), Throws.TypeOf<ArgumentException>());
+    }
+}


### PR DESCRIPTION
Bundled backport of three related deadline-handling fixes from main, squashed because [#4547](https://github.com/icerpc/icerpc-csharp/pull/4547) introduces clamping behavior that [#4668](https://github.com/icerpc/icerpc-csharp/pull/4668) then reworks to clean rejection — landing them as a single backport gives 0.5.x the final intended shape directly.

## Summary
- **[#4517](https://github.com/icerpc/icerpc-csharp/pull/4517)** — Normalize the `IDeadlineFeature` `DateTime` to UTC. A caller setting `IDeadlineFeature` with a `Local` or `Unspecified` `DateTime` currently encodes the wrong instant on the wire.
- **[#4547](https://github.com/icerpc/icerpc-csharp/pull/4547)** — Validate `defaultTimeout` / `IDeadlineFeature.FromTimeout` inputs at construction; handle near-`MaxValue` deadlines and a peer-encoded `DateTime.MinValue` (was ambiguous with the "field absent" sentinel).
- **[#4668](https://github.com/icerpc/icerpc-csharp/pull/4668)** — Reject deadlines beyond the supported maximum (~24.8 days) with `NotSupportedException` (interceptor) or `StatusCode.NotSupported` (middleware) instead of silently clamping. Also cleans up doc-comments to not reference `CancellationTokenSource.CancelAfter` implementation detail.

## Test plan
- [x] `dotnet test tests/IceRpc.Deadline.Tests` — 17/17 pass.
- [x] `dotnet test tests/IceRpc.Tests --filter "FullyQualifiedName~DeadlineFeatureTests"` — 2/2 pass.

## Backport notes
`DeadlineMiddleware` on main uses the `value.DecodeSliceBuffer(...)` extension helper from `ZeroC.Slice.Codec`; neither exists on 0.5.x. The 0.5.x port replaces both with `new SliceDecoder(value, SliceEncoding.Slice2)` and `using ZeroC.Slice`. Same adaptation applied to the test files.

Surfaced by the [2026-05-15 follow-up audit](https://github.com/icerpc/icerpc-csharp-audit/blob/main/0.5.x-backport-audit-2026-05-15.md); reworked per [Bernard's review](https://github.com/icerpc/icerpc-csharp/pull/4655#pullrequestreview-...) before merging.