### PR TITLE
Backport #4536 + #4535 to 0.5.x

### DIFF
--- a/src/IceRpc.Telemetry/TelemetryInterceptor.cs
+++ b/src/IceRpc.Telemetry/TelemetryInterceptor.cs
@@ -40,7 +40,8 @@ public class TelemetryInterceptor : IInvoker
         if (request.Protocol.HasFields)
         {
             string name = $"{request.ServiceAddress.Path}/{request.Operation}";
-            using Activity activity = _activitySource?.CreateActivity(name, ActivityKind.Client) ?? new Activity(name);
+            using Activity activity = _activitySource.CreateActivity(name, ActivityKind.Client) ?? new Activity(name);
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.AddTag("rpc.system", "icerpc");
             activity.AddTag("rpc.service", request.ServiceAddress.Path);
             activity.AddTag("rpc.method", request.Operation);
@@ -56,11 +57,7 @@ public class TelemetryInterceptor : IInvoker
 
     internal static void WriteActivityContext(ref SliceEncoder encoder, Activity activity)
     {
-        if (activity.IdFormat != ActivityIdFormat.W3C)
-        {
-            throw new NotSupportedException(
-                $"The activity ID format '{activity.IdFormat}' is not supported, the only supported activity ID format is 'W3C'.");
-        }
+        Debug.Assert(activity.IdFormat == ActivityIdFormat.W3C);
 
         if (activity.Id is null)
         {

--- a/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
+++ b/tests/IceRpc.Telemetry.Tests/TelemetryInterceptorTests.cs
@@ -131,6 +131,53 @@ public sealed class TelemetryInterceptorTests
         pipe.Reader.Complete();
     }
 
+    /// <summary>Verifies that the interceptor forces W3C activity ID format even when the process-wide default is
+    /// <c>Hierarchical</c>, and that the trace context field can be encoded and decoded successfully.</summary>
+    /// <remarks>Marked <c>NonParallelizable</c> because it mutates <see cref="Activity.DefaultIdFormat" />, a
+    /// process-wide setting; running it concurrently with other tests that create activities would make their
+    /// observed ID format non-deterministic.</remarks>
+    [Test]
+    [NonParallelizable]
+    public async Task Invocation_uses_w3c_format_regardless_of_process_default()
+    {
+        // Arrange
+        ActivityIdFormat previousDefault = Activity.DefaultIdFormat;
+        Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
+        try
+        {
+            Activity? invocationActivity = null;
+            Activity? decodedActivity = null;
+            var invoker = new InlineInvoker((request, cancellationToken) =>
+            {
+                invocationActivity = Activity.Current;
+                decodedActivity = DecodeTraceContextField(request.Fields, request.Operation);
+                return Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance));
+            });
+
+            using var activitySource = new ActivitySource("Test Activity Source");
+            using ActivityListener mockActivityListener = CreateMockActivityListener(activitySource);
+
+            var sut = new TelemetryInterceptor(invoker, activitySource);
+            using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc) { Path = "/path" })
+            {
+                Operation = "Op"
+            };
+
+            // Act
+            await sut.InvokeAsync(request, default);
+
+            // Assert
+            Assert.That(invocationActivity, Is.Not.Null);
+            Assert.That(invocationActivity!.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
+            Assert.That(decodedActivity, Is.Not.Null);
+            Assert.That(decodedActivity!.ParentId, Is.EqualTo(invocationActivity.Id));
+        }
+        finally
+        {
+            Activity.DefaultIdFormat = previousDefault;
+        }
+    }
+
     private static ActivityListener CreateMockActivityListener(ActivitySource activitySource)
     {
         var mockActivityListener = new ActivityListener();


### PR DESCRIPTION
Bundled backport of two related \`TelemetryInterceptor\` fixes.

## Summary
- **[#4536](https://github.com/icerpc/icerpc-csharp/pull/4536)** — Force W3C activity ID format in \`TelemetryInterceptor\`. A host process that sets \`Activity.DefaultIdFormat = Hierarchical\` currently causes \`WriteActivityContext\` to throw \`NotSupportedException\` mid-invocation. The fix sets the W3C format on the activity explicitly so the interceptor works regardless of the host's default. Adds tests.
- **[#4535](https://github.com/icerpc/icerpc-csharp/pull/4535)** — Remove the bogus null-conditional on the non-nullable \`_activitySource\` field. Bundled here because #4536 touches the same line and the cleanup is the natural conflict resolution.

## Test plan
- [x] \`dotnet test tests/IceRpc.Telemetry.Tests\` — 12/12 pass.

## Backport notes
Cherry-pick of 5c2fd4e23. The conflict in \`TelemetryInterceptor.cs\` came from #4535 not yet being on 0.5.x; resolved by taking the post-#4535 shape (drop the \`?.\`) along with #4536's \`SetIdFormat\` call.

Surfaced by the [2026-05-15 follow-up audit](https://github.com/icerpc/icerpc-csharp-audit/blob/main/0.5.x-backport-audit-2026-05-15.md).