### PR TITLE
Backport #4254 to 0.5.x

### DIFF
--- a/tests/IceRpc.Conformance.Tests/Transports/MultiplexedStreamConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/MultiplexedStreamConformanceTests.cs
@@ -218,22 +218,11 @@ public abstract class MultiplexedStreamConformanceTests
 
         // Act
         sut.Remote.Input.Complete(new ArgumentException()); // can be any exception
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
 
         // Assert
-        Assert.That(
-            async () =>
-            {
-                while (true)
-                {
-                    FlushResult result = await sut.Local.Output.WriteAsync(new byte[1024]);
-                    if (result.IsCompleted)
-                    {
-                        return;
-                    }
-                    await Task.Delay(TimeSpan.FromMilliseconds(20));
-                }
-            },
-            Throws.Nothing);
+        FlushResult result = await sut.Local.Output.WriteAsync(new byte[1024]);
+        Assert.That(result.IsCompleted, Is.True);
     }
 
     [Test]


### PR DESCRIPTION
Backport of [#4254](https://github.com/icerpc/icerpc-csharp/pull/4254) — remove "while true" from \`Stream_abort_read\` conformance test.

## Summary
Replaces the busy-wait \`while(true) { WriteAsync(...); await Task.Delay(1); }\` loop in \`MultiplexedStreamConformanceTests.Stream_abort_read\` with a single \`Task.Delay(50ms) + WriteAsync\`. The busy-wait pattern made the test slow and prone to flaking under CI load. Test-only.

## Test plan
- [x] \`dotnet test --filter "FullyQualifiedName~SlicStreamConformanceTests"\` — 63/63 pass.

## Backport notes
Clean cherry-pick of 29bc12def. No adaptation needed.

Surfaced by the [2026-05-15 follow-up audit](https://github.com/icerpc/icerpc-csharp-audit/blob/main/0.5.x-backport-audit-2026-05-15.md).