### PR TITLE
Backport #4506 + a6f7f3c73 to 0.5.x

### DIFF
--- a/src/IceRpc.Transports.Quic/Internal/QuicMultiplexedConnection.cs
+++ b/src/IceRpc.Transports.Quic/Internal/QuicMultiplexedConnection.cs
@@ -109,14 +109,7 @@ internal abstract class QuicMultiplexedConnection : IMultiplexedConnection
 
         if (_connection is not null)
         {
-            try
-            {
-                await _connection.DisposeAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                // Workaround for https://github.com/dotnet/runtime/issues/78641.
-            }
+            await _connection.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -960,7 +960,7 @@ internal class SlicConnection : IMultiplexedConnection
                     if (maxStreamFrameSize < 1024)
                     {
                         throw new InvalidDataException(
-                            "The MaxStreamFrameSize connection parameter is invalid, it must be greater than 1KB.");
+                            "The MaxStreamFrameSize connection parameter is invalid, it must be at least 1 KB.");
                     }
                     if (maxStreamFrameSize > SlicTransportOptions.MaxStreamFrameSizeCeiling)
                     {
@@ -975,7 +975,7 @@ internal class SlicConnection : IMultiplexedConnection
                     if (peerInitialStreamWindowSize < 1024)
                     {
                         throw new InvalidDataException(
-                            "The InitialStreamWindowSize connection parameter is invalid, it must be greater than 1KB.");
+                            "The InitialStreamWindowSize connection parameter is invalid, it must be at least 1 KB.");
                     }
                     break;
                 }
@@ -1501,7 +1501,7 @@ internal class SlicConnection : IMultiplexedConnection
                 {
                     throw new IceRpcException(
                         IceRpcError.IceRpcError,
-                        $"The maximum unidirectional stream count {_maxUnidirectionalStreams} was reached");
+                        $"The maximum unidirectional stream count {_maxUnidirectionalStreams} was reached.");
                 }
                 Interlocked.Increment(ref _unidirectionalStreamCount);
             }


### PR DESCRIPTION
Two unrelated trivial cleanups bundled into one PR.

## Summary
- **[#4506](https://github.com/icerpc/icerpc-csharp/pull/4506)** — Remove the obsolete try/catch workaround around \`QuicMultiplexedConnection.DisposeAsync\`. The underlying [dotnet/runtime#78641](https://github.com/dotnet/runtime/issues/78641) was fixed in .NET 8; on 0.5.x's .NET 9/10 baseline the catch just swallows real bugs.
- **[\`a6f7f3c73\`](https://github.com/icerpc/icerpc-csharp/commit/a6f7f3c73)** — Minor \`SlicConnection\` exception-message tweaks: "1KB" → "1 KB" (×2, units consistency) and add a missing trailing period on one error.

## Test plan
- [x] Full \`dotnet build IceRpc.slnx\` — 0 warnings, 0 errors.
- [x] \`dotnet test --filter "FullyQualifiedName~SlicTransportTests"\` — 69/69 pass.

## Backport notes
Clean cherry-picks of f744237c8 + a6f7f3c73. Squashed into one commit because the two are independent trivial diffs and not worth separate review.

Surfaced by the [2026-05-15 follow-up audit](https://github.com/icerpc/icerpc-csharp-audit/blob/main/0.5.x-backport-audit-2026-05-15.md).