### PR TITLE
Fix off-by-one in MaxStreamFrameSize / InitialStreamWindowSize error messages

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1064,7 +1064,7 @@ internal class SlicConnection : IMultiplexedConnection
                     if (maxStreamFrameSize < 1024)
                     {
                         throw new InvalidDataException(
-                            "The MaxStreamFrameSize connection parameter is invalid, it must be greater than 1 KB.");
+                            "The MaxStreamFrameSize connection parameter is invalid, it must be at least 1 KB.");
                     }
                     if (maxStreamFrameSize > SlicTransportOptions.MaxStreamFrameSizeCeiling)
                     {
@@ -1079,7 +1079,7 @@ internal class SlicConnection : IMultiplexedConnection
                     if (peerInitialStreamWindowSize < 1024)
                     {
                         throw new InvalidDataException(
-                            "The InitialStreamWindowSize connection parameter is invalid, it must be greater than 1 KB.");
+                            "The InitialStreamWindowSize connection parameter is invalid, it must be at least 1 KB.");
                     }
                     break;
                 }


### PR DESCRIPTION
## Summary
The Slic parameter validation rejects values strictly less than 1024 (`< 1024`), so 1024 itself is accepted. The error messages said *"must be greater than 1 KB"*, which would imply `> 1024`. Fix the wording to *"must be at least 1 KB"* to match the actual requirement (two occurrences: `MaxStreamFrameSize` and `InitialStreamWindowSize`).

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SlicTransportTests"` — 84/84 pass.

## Context
[Spotted by Copilot](https://github.com/icerpc/icerpc-csharp/pull/4658#discussion_r3247561391) on the 0.5.x backport ([#4658](https://github.com/icerpc/icerpc-csharp/pull/4658)) that touched these same messages. The 0.5.x PR has been updated with the same wording fix.