### PR TITLE
Backport link-check workflow to 0.5.x

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,36 @@
+name: Check Links
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["0.5.x"]
+    paths:
+      - "**.md"
+      - "**.html"
+      - ".lychee.toml"
+      - ".github/workflows/links.yml"
+  pull_request:
+    branches: ["0.5.x"]
+    paths:
+      - "**.md"
+      - "**.html"
+      - ".lychee.toml"
+      - ".github/workflows/links.yml"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .lychee.toml
+            --verbose
+            --no-progress
+            '**/*.md'
+            '**/*.html'
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,38 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/
+
+# Maximum number of concurrent requests
+max_concurrency = 32
+
+# Minimum interval between requests to the same host
+host_request_interval = "50ms"
+
+# Timeout for each request in seconds
+timeout = 30
+
+# Number of retries for failed requests
+max_retries = 3
+
+# User agent string
+user_agent = "Mozilla/5.0 (compatible; lychee/0.15; +https://github.com/lycheeverse/lychee)"
+
+# Exclude patterns
+exclude = [
+    # Localhost and local files
+    "^file://",
+    "^https?://localhost",
+    "^https?://127\\.0\\.0\\.1",
+    # Example domains
+    "^https?://example\\.com",
+    # Mail links
+    "^mailto:",
+    # GitHub edit/blame links (may require auth)
+    "github\\.com/.*/edit/",
+    "github\\.com/.*/blame/",
+]
+
+# Accept these status codes as valid
+accept = [200, 204, 206, 301, 308]
+
+# Include fragments (anchors) in checks
+include_fragments = true


### PR DESCRIPTION
## Summary
- Backport of the link-check workflow added to `main` in #4660.
- Uses the same `.lychee.toml` config minus the 0.6-specific exclusions; 0.5.x has different broken-link patterns that we'll address in follow-up commits on this branch once the first run reports.

## Test plan
- [x] First CI run on this PR surfaces the current set of broken links on 0.5.x — review and address.