### PR TITLE
Reject deadlines beyond supported max instead of silently clamping

### DIFF
--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -25,8 +25,9 @@ namespace IceRpc.Deadline;
 /// <seealso cref="DeadlineInvokerBuilderExtensions"/>
 public class DeadlineInterceptor : IInvoker
 {
-    // The maximum delay CancellationTokenSource.CancelAfter(TimeSpan) accepts.
-    private static readonly TimeSpan _maxCancelAfterDelay = TimeSpan.FromMilliseconds(int.MaxValue);
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan _maxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
     private readonly bool _alwaysEnforceDeadline;
     private readonly IInvoker _next;
@@ -35,10 +36,9 @@ public class DeadlineInterceptor : IInvoker
 
     /// <summary>Constructs a Deadline interceptor.</summary>
     /// <param name="next">The next invoker in the invocation pipeline.</param>
-    /// <param name="defaultTimeout">The default timeout applied to requests without a deadline. Must be positive and
-    /// must not exceed <see cref="int.MaxValue" /> milliseconds (~24.8 days), the maximum supported by
-    /// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" />, or <see cref="Timeout.InfiniteTimeSpan" /> to
-    /// disable this behavior.</param>
+    /// <param name="defaultTimeout">The default timeout applied to requests without a deadline. Must be a positive
+    /// value not exceeding ~24.8 days, or <see cref="Timeout.InfiniteTimeSpan" /> to disable the default timeout
+    /// entirely.</param>
     /// <param name="timeProvider">The optional time provider used to obtain the current time. If
     /// <see langword="null"/>, it uses <see cref="TimeProvider.System"/>.</param>
     /// <param name="alwaysEnforceDeadline">When <see langword="true" /> and the request carries a deadline, the
@@ -46,24 +46,15 @@ public class DeadlineInterceptor : IInvoker
     /// and the request carries a deadline, the interceptor creates a cancellation token source to enforce this deadline
     /// only when the invocation's cancellation token cannot be canceled. The default value is <see langword="false" />.
     /// </param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="defaultTimeout" /> is not
-    /// <see cref="Timeout.InfiniteTimeSpan" />, not positive, or exceeds the maximum supported value.</exception>
-    /// <remarks>A request carrying an <see cref="IDeadlineFeature" /> whose computed remaining timeout exceeds
-    /// the <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" /> maximum (~24.8 days) is silently clamped to
-    /// that maximum at invocation time.</remarks>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="defaultTimeout" /> is neither
+    /// <see cref="Timeout.InfiniteTimeSpan" /> nor a positive value within the supported range.</exception>
     public DeadlineInterceptor(IInvoker next, TimeSpan defaultTimeout, bool alwaysEnforceDeadline, TimeProvider? timeProvider = null)
     {
-        if (defaultTimeout != Timeout.InfiniteTimeSpan && defaultTimeout <= TimeSpan.Zero)
+        if (defaultTimeout != Timeout.InfiniteTimeSpan &&
+            (defaultTimeout <= TimeSpan.Zero || defaultTimeout > _maxSupportedTimeout))
         {
             throw new ArgumentException(
-                $"The {nameof(defaultTimeout)} value must be positive or Timeout.InfiniteTimeSpan.",
-                nameof(defaultTimeout));
-        }
-
-        if (defaultTimeout != Timeout.InfiniteTimeSpan && defaultTimeout > _maxCancelAfterDelay)
-        {
-            throw new ArgumentException(
-                $"The {nameof(defaultTimeout)} value must not exceed {_maxCancelAfterDelay} or be Timeout.InfiniteTimeSpan.",
+                $"The {nameof(defaultTimeout)} value must be Timeout.InfiniteTimeSpan or a positive value not exceeding {_maxSupportedTimeout}.",
                 nameof(defaultTimeout));
         }
 
@@ -113,11 +104,13 @@ public class DeadlineInterceptor : IInvoker
 
         async Task<IncomingResponse> PerformInvokeAsync(TimeSpan timeout)
         {
-            // Clamp to CancelAfter's supported maximum. A caller-provided IDeadlineFeature value near
-            // DateTime.MaxValue would otherwise cause CancelAfter to throw ArgumentOutOfRangeException.
-            if (timeout > _maxCancelAfterDelay)
+            // Reject a caller-provided IDeadlineFeature whose remaining timeout exceeds what this interceptor
+            // can enforce. Such deadlines are nonsensical in practice (~24.8 days), and silently clamping the
+            // value the caller asked for is worse than failing cleanly.
+            if (timeout > _maxSupportedTimeout)
             {
-                timeout = _maxCancelAfterDelay;
+                throw new NotSupportedException(
+                    $"The request deadline exceeds the maximum timeout supported by this interceptor: {_maxSupportedTimeout}.");
             }
 
             using var timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/IceRpc.Deadline/DeadlineMiddleware.cs
+++ b/src/IceRpc.Deadline/DeadlineMiddleware.cs
@@ -10,15 +10,15 @@ namespace IceRpc.Deadline;
 /// <summary>Represents a middleware that decodes deadline fields into deadline features. When the decoded deadline
 /// expires, this middleware cancels the dispatch and returns an <see cref="OutgoingResponse" /> with status code
 /// <see cref="StatusCode.DeadlineExceeded" />.</summary>
-/// <remarks>A peer-encoded deadline whose computed remaining timeout exceeds the
-/// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" /> maximum (~24.8 days) is silently clamped to that
-/// maximum.</remarks>
+/// <remarks>If the peer-encoded deadline is too far in the future for this middleware to enforce (more than
+/// ~24.8 days from now), the request is rejected with <see cref="StatusCode.NotSupported" /> instead.</remarks>
 /// <seealso cref="DeadlineRouterExtensions"/>
 /// <seealso cref="DeadlineDispatcherBuilderExtensions"/>
 public class DeadlineMiddleware : IDispatcher
 {
-    // The maximum delay CancellationTokenSource.CancelAfter(TimeSpan) accepts.
-    private static readonly TimeSpan _maxCancelAfterDelay = TimeSpan.FromMilliseconds(int.MaxValue);
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan _maxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
     private readonly IDispatcher _next;
     private readonly TimeProvider _timeProvider;
@@ -53,12 +53,15 @@ public class DeadlineMiddleware : IDispatcher
                     "The request deadline has expired."));
             }
 
-            // Clamp to CancelAfter's supported maximum. A peer-encoded deadline thousands of years in the future
-            // would otherwise cause CancelAfter to throw ArgumentOutOfRangeException, surfacing as a generic
-            // InternalError response.
-            if (timeout > _maxCancelAfterDelay)
+            // Reject a peer-encoded deadline that exceeds what this middleware can enforce. Silently clamping
+            // a deadline the client asked for to a smaller value the implementation supports is worse than
+            // failing cleanly.
+            if (timeout > _maxSupportedTimeout)
             {
-                timeout = _maxCancelAfterDelay;
+                return new(new OutgoingResponse(
+                    request,
+                    StatusCode.NotSupported,
+                    $"The request deadline exceeds the maximum timeout supported by this server: {_maxSupportedTimeout}."));
             }
 
             request.Features = request.Features.With<IDeadlineFeature>(new DeadlineFeature(deadline));

--- a/src/IceRpc/Features/DeadlineFeature.cs
+++ b/src/IceRpc/Features/DeadlineFeature.cs
@@ -5,28 +5,21 @@ namespace IceRpc.Features;
 /// <summary>Default implementation of <see cref="IDeadlineFeature" />.</summary>
 public sealed class DeadlineFeature : IDeadlineFeature
 {
-    // The maximum delay CancellationTokenSource.CancelAfter(TimeSpan) accepts.
-    private static readonly TimeSpan MaxCancelAfterDelay = TimeSpan.FromMilliseconds(int.MaxValue);
+    // The maximum supported timeout (int.MaxValue ms, ~24.8 days). This is the maximum delay
+    // CancellationTokenSource.CancelAfter accepts.
+    private static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
     /// <summary>Creates a deadline from a timeout.</summary>
-    /// <param name="timeout">The timeout. Must be positive and must not exceed
-    /// <see cref="int.MaxValue" /> milliseconds (~24.8 days), the maximum supported by
-    /// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" />.</param>
+    /// <param name="timeout">The timeout. Must be a positive value not exceeding ~24.8 days.</param>
     /// <returns>A new deadline equal to now plus the timeout.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="timeout" /> is not positive, or exceeds the
-    /// maximum supported value.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="timeout" /> is not a positive value
+    /// within the supported range.</exception>
     public static DeadlineFeature FromTimeout(TimeSpan timeout)
     {
-        if (timeout <= TimeSpan.Zero)
+        if (timeout <= TimeSpan.Zero || timeout > MaxSupportedTimeout)
         {
             throw new ArgumentException(
-                $"The {nameof(timeout)} value must be positive.",
-                nameof(timeout));
-        }
-        if (timeout > MaxCancelAfterDelay)
-        {
-            throw new ArgumentException(
-                $"The {nameof(timeout)} value must not exceed {MaxCancelAfterDelay}.",
+                $"The {nameof(timeout)} value must be positive and not exceed {MaxSupportedTimeout}.",
                 nameof(timeout));
         }
         return new(DateTime.UtcNow + timeout);

--- a/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineInterceptorTests.cs
@@ -135,10 +135,10 @@ public sealed class DeadlineInterceptorTests
         Assert.That(token!.Value, Is.EqualTo(cts.Token));
     }
 
-    /// <summary>Verifies the interceptor clamps an extreme-future IDeadlineFeature value instead of letting
-    /// CancelAfter throw ArgumentOutOfRangeException.</summary>
+    /// <summary>Verifies the interceptor rejects an extreme-future IDeadlineFeature value with
+    /// <see cref="NotSupportedException" /> rather than silently clamping it.</summary>
     [Test]
-    public async Task Invoke_with_extreme_future_deadline_does_not_throw()
+    public void Invoke_with_extreme_future_deadline_throws_not_supported()
     {
         // Arrange
         var invoker = new InlineInvoker((request, cancellationToken) =>
@@ -146,7 +146,7 @@ public sealed class DeadlineInterceptorTests
 
         var sut = new DeadlineInterceptor(invoker, Timeout.InfiniteTimeSpan, alwaysEnforceDeadline: true);
         // Close to DateTime.MaxValue but not equal, so the interceptor's "== DateTime.MaxValue" short-circuit
-        // does not kick in and the CancelAfter path is actually exercised.
+        // does not kick in and the deadline-too-far-in-future path is exercised.
         DateTime extreme = DateTime.SpecifyKind(DateTime.MaxValue.AddDays(-1), DateTimeKind.Utc);
         using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc))
         {
@@ -154,7 +154,9 @@ public sealed class DeadlineInterceptorTests
         };
 
         // Act/Assert
-        Assert.That(async () => await sut.InvokeAsync(request, default), Throws.Nothing);
+        Assert.That(
+            async () => await sut.InvokeAsync(request, default),
+            Throws.TypeOf<NotSupportedException>());
     }
 
     [Test]
@@ -227,11 +229,11 @@ public sealed class DeadlineInterceptorTests
             Throws.TypeOf<ArgumentException>());
     }
 
-    /// <summary>Verifies the constructor rejects a default timeout beyond CancelAfter's supported maximum.
-    /// TimeSpan.MaxValue would otherwise later cause DateTime overflow (now + timeout) or CancelAfter to throw
-    /// ArgumentOutOfRangeException at first invoke.</summary>
+    /// <summary>Verifies the constructor rejects a default timeout that exceeds the maximum supported value.
+    /// <see cref="TimeSpan.MaxValue" /> would otherwise later cause <c>DateTime</c> overflow (now + timeout) or
+    /// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)" /> to throw at first invoke.</summary>
     [Test]
-    public void Constructor_rejects_default_timeout_beyond_cancel_after_max()
+    public void Constructor_rejects_default_timeout_beyond_maximum()
     {
         var invoker = new InlineInvoker((request, cancellationToken) =>
             Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));

--- a/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
+++ b/tests/IceRpc.Deadline.Tests/DeadlineMiddlewareTests.cs
@@ -97,10 +97,10 @@ public sealed class DeadlineMiddlewareTests
         pipeReader.Complete();
     }
 
-    /// <summary>Verifies the middleware clamps an extreme-future peer-encoded deadline instead of letting
-    /// CancelAfter throw ArgumentOutOfRangeException.</summary>
+    /// <summary>Verifies the middleware rejects an extreme-future peer-encoded deadline with
+    /// <see cref="StatusCode.NotSupported" /> rather than silently clamping it to its supported maximum.</summary>
     [Test]
-    public async Task Dispatch_with_extreme_future_deadline_does_not_throw()
+    public async Task Dispatch_with_extreme_future_deadline_returns_not_supported()
     {
         // Arrange
         bool nextCalled = false;
@@ -124,9 +124,12 @@ public sealed class DeadlineMiddlewareTests
             }
         };
 
-        // Act/Assert
-        Assert.That(async () => await sut.DispatchAsync(request, CancellationToken.None), Throws.Nothing);
-        Assert.That(nextCalled, Is.True);
+        // Act
+        OutgoingResponse response = await sut.DispatchAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(StatusCode.NotSupported));
+        Assert.That(nextCalled, Is.False);
 
         // Cleanup
         pipeReader.Complete();

--- a/tests/IceRpc.Tests/Features/DeadlineFeatureTests.cs
+++ b/tests/IceRpc.Tests/Features/DeadlineFeatureTests.cs
@@ -14,10 +14,10 @@ public class DeadlineFeatureTests
         Assert.That(() => DeadlineFeature.FromTimeout(TimeSpan.FromSeconds(-1)), Throws.TypeOf<ArgumentException>());
     }
 
-    /// <summary>Verifies FromTimeout rejects a timeout beyond CancelAfter's supported maximum instead of
-    /// letting DateTime.UtcNow + timeout overflow with ArgumentOutOfRangeException.</summary>
+    /// <summary>Verifies FromTimeout rejects a timeout that exceeds the maximum supported value rather than
+    /// letting <see cref="DateTime.UtcNow" /> + timeout overflow.</summary>
     [Test]
-    public void FromTimeout_rejects_timeout_beyond_cancel_after_max()
+    public void FromTimeout_rejects_timeout_beyond_maximum()
     {
         Assert.That(() => DeadlineFeature.FromTimeout(TimeSpan.MaxValue), Throws.TypeOf<ArgumentException>());
     }


### PR DESCRIPTION
## Summary
Address [Bernard's feedback](https://github.com/icerpc/icerpc-csharp/pull/4655) on the 0.5.x backport ([#4655](https://github.com/icerpc/icerpc-csharp/pull/4655)) by reworking the silent-clamp behavior that [#4547](https://github.com/icerpc/icerpc-csharp/pull/4547) introduced.

**The problem:** [#4547](https://github.com/icerpc/icerpc-csharp/pull/4547) clamped overly-large deadlines (those exceeding \`CancellationTokenSource.CancelAfter\`'s supported max, ~24.8 days) to that maximum, both in \`DeadlineInterceptor.PerformInvokeAsync\` and in \`DeadlineMiddleware.DispatchAsync\`. As Bernard put it: silently turning "deadline 5 min in the future" into "you get 3 min" because the implementation can't enforce more doesn't make sense.

**The fix:** reject such deadlines cleanly:

- **\`DeadlineMiddleware\`** returns an \`OutgoingResponse(StatusCode.NotSupported, "...")\` when the peer-encoded deadline exceeds the supported maximum. The client gets a clean, well-typed dispatch failure rather than a clamped enforcement they didn't ask for.
- **\`DeadlineInterceptor.PerformInvokeAsync\`** throws \`NotSupportedException\` when an \`IDeadlineFeature\` exceeds the supported maximum. The invocation fails up-front rather than continuing with a clamped local timeout.

Also addresses Bernard's three doc-comment notes:
- Rephrased the \`defaultTimeout\` param doc and the \`ArgumentException\` doc on \`DeadlineInterceptor\`'s constructor for clarity.
- Removed all references to \`CancellationTokenSource.CancelAfter\` from public doc-comments — they describe a limit by its value (~24.8 days), not by the implementation detail.
- Same cleanup applied to \`DeadlineFeature.FromTimeout\`.

Minor: renamed the private \`_maxCancelAfterDelay\` / \`MaxCancelAfterDelay\` constants to \`_maxSupportedTimeout\` / \`MaxSupportedTimeout\` to match the doc; folded the interceptor constructor's two-step validation into a single condition.

## Test plan
- [x] \`dotnet test tests/IceRpc.Deadline.Tests\` — 17/17 pass.
- [x] \`dotnet test tests/IceRpc.Tests --filter "FullyQualifiedName~DeadlineFeatureTests"\` — 2/2 pass.

Updated tests:
- \`Dispatch_with_extreme_future_deadline_does_not_throw\` → \`Dispatch_with_extreme_future_deadline_returns_not_supported\` (asserts \`StatusCode.NotSupported\` and that the next dispatcher was **not** called).
- \`Invoke_with_extreme_future_deadline_does_not_throw\` → \`Invoke_with_extreme_future_deadline_throws_not_supported\` (asserts \`NotSupportedException\`).
- \`Constructor_rejects_default_timeout_beyond_cancel_after_max\` → \`Constructor_rejects_default_timeout_beyond_maximum\`.
- \`FromTimeout_rejects_timeout_beyond_cancel_after_max\` → \`FromTimeout_rejects_timeout_beyond_maximum\`.

## Follow-up
Once this lands on main, I'll re-do the 0.5.x backport ([#4655](https://github.com/icerpc/icerpc-csharp/pull/4655)) on top of this reworked shape.