### PR TITLE
Update api reference links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,10 +85,6 @@ TestResults
 examples/Upload/Server/uploads/*
 examples/Download/Client/downloads/*
 
-# docfx
-docfx/_site
-docfx/api
-
 nuget.config
 NuGet.config
 *.nupkg

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,13 +29,10 @@ exclude = [
     # GitHub edit/blame links (may require auth)
     "github\\.com/.*/edit/",
     "github\\.com/.*/blame/",
-    # TODO: remove once 0.6 packages and API docs are published.
+    # TODO: remove once 0.6 packages are published.
     "^https?://www\\.nuget\\.org/packages/IceRpc\\.Ice/?$",
     "^https?://www\\.nuget\\.org/packages/IceRpc\\.ServiceGenerator/?$",
     "^https?://www\\.nuget\\.org/packages/ZeroC\\.Slice\\.Codec/?$",
-    "^https?://docs\\.icerpc\\.dev/api/csharp/api/IceRpc\\.Ice\\.html$",
-    "^https?://docs\\.icerpc\\.dev/api/csharp/api/IceRpc\\.Protobuf\\.html$",
-    "^https?://docs\\.icerpc\\.dev/api/csharp/api/ZeroC\\.Slice\\.Codec\\.html$",
 ]
 
 # Accept these status codes as valid

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ to the license for the full terms and conditions.
 in-memory transport for testing). Future releases may add additional transports.
 
 [Apache License version 2.0]: LICENSE
-[API reference]: https://docs.icerpc.dev/api/csharp/api/IceRpc.html
+[API reference]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.html
 [Building from source]: BUILDING.md
 [ci-home]: https://github.com/icerpc/icerpc-csharp/actions/workflows/ci.yml
 [custom]: https://docs.icerpc.dev/slice2/language-guide/custom-types

--- a/docfx/.gitignore
+++ b/docfx/.gitignore
@@ -7,3 +7,4 @@
 /**/bin/
 /**/obj/
 _site
+reference

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -19,7 +19,7 @@
           "src": "../"
         }
       ],
-      "dest": "api",
+      "dest": "reference",
       "filter": "filterConfig.yml",
       "includePrivateMembers": false,
       "disableGitFeatures": false,
@@ -32,7 +32,7 @@
   "build": {
     "content": [
       {
-        "files": ["api/**.yml"]
+        "files": ["reference/**.yml"]
       },
       {
         "files": ["toc.yml", "*.md"]

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -27,24 +27,24 @@ layout: landing
 | [IceRpc.Transports.Tcp]                 | Provides the TCP duplex transport. It implements the duplex transport abstractions using plain TCP and TCP + SSL.                                  |
 | [ZeroC.Slice.Codec]                     | Supports encoding/decoding structured data to/from bytes in the Slice format. The Slice compiler for C# generates code that relies on these APIs.  |
 
-[IceRpc]: api/IceRpc.yml
-[IceRpc.Compressor]: api/IceRpc.Compressor.yml
-[IceRpc.Deadline]: api/IceRpc.Deadline.yml
-[IceRpc.Extensions.DependencyInjection]: api/IceRpc.Extensions.DependencyInjection.yml
-[IceRpc.Features]: api/IceRpc.Features.yml
-[IceRpc.Ice]: api/IceRpc.Ice.yml
-[IceRpc.Locator]: api/IceRpc.Locator.yml
-[IceRpc.Logger]: api/IceRpc.Logger.yml
-[IceRpc.Metrics]: api/IceRpc.Metrics.yml
-[IceRpc.Protobuf]: api/IceRpc.Protobuf.yml
-[IceRpc.RequestContext]: api/IceRpc.RequestContext.yml
-[IceRpc.Retry]: api/IceRpc.Retry.yml
-[IceRpc.Slice]: api/IceRpc.Slice.yml
-[IceRpc.Telemetry]: api/IceRpc.Telemetry.yml
-[IceRpc.Transports]: api/IceRpc.Transports.yml
-[IceRpc.Transports.Coloc]: api/IceRpc.Transports.Coloc.yml
-[IceRpc.Transports.Quic]: api/IceRpc.Transports.Quic.yml
-[IceRpc.Transports.Slic]: api/IceRpc.Transports.Slic.yml
-[IceRpc.Transports.Tcp]: api/IceRpc.Transports.Tcp.yml
+[IceRpc]: reference/IceRpc.yml
+[IceRpc.Compressor]: reference/IceRpc.Compressor.yml
+[IceRpc.Deadline]: reference/IceRpc.Deadline.yml
+[IceRpc.Extensions.DependencyInjection]: reference/IceRpc.Extensions.DependencyInjection.yml
+[IceRpc.Features]: reference/IceRpc.Features.yml
+[IceRpc.Ice]: reference/IceRpc.Ice.yml
+[IceRpc.Locator]: reference/IceRpc.Locator.yml
+[IceRpc.Logger]: reference/IceRpc.Logger.yml
+[IceRpc.Metrics]: reference/IceRpc.Metrics.yml
+[IceRpc.Protobuf]: reference/IceRpc.Protobuf.yml
+[IceRpc.RequestContext]: reference/IceRpc.RequestContext.yml
+[IceRpc.Retry]: reference/IceRpc.Retry.yml
+[IceRpc.Slice]: reference/IceRpc.Slice.yml
+[IceRpc.Telemetry]: reference/IceRpc.Telemetry.yml
+[IceRpc.Transports]: reference/IceRpc.Transports.yml
+[IceRpc.Transports.Coloc]: reference/IceRpc.Transports.Coloc.yml
+[IceRpc.Transports.Quic]: reference/IceRpc.Transports.Quic.yml
+[IceRpc.Transports.Slic]: reference/IceRpc.Transports.Slic.yml
+[IceRpc.Transports.Tcp]: reference/IceRpc.Transports.Tcp.yml
 [OpenTelemetry]: https://opentelemetry.io
-[ZeroC.Slice.Codec]: api/ZeroC.Slice.Codec.yml
+[ZeroC.Slice.Codec]: reference/ZeroC.Slice.Codec.yml

--- a/examples/protobuf/Deadline/README.md
+++ b/examples/protobuf/Deadline/README.md
@@ -24,4 +24,4 @@ cd Client
 dotnet run
 ```
 
-[IDeadlineFeature]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Features.IDeadlineFeature.html
+[IDeadlineFeature]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Features.IDeadlineFeature.html

--- a/examples/slice/Deadline/README.md
+++ b/examples/slice/Deadline/README.md
@@ -24,4 +24,4 @@ cd Client
 dotnet run
 ```
 
-[IDeadlineFeature]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Features.IDeadlineFeature.html
+[IDeadlineFeature]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Features.IDeadlineFeature.html

--- a/src/IceRpc.Compressor/README.md
+++ b/src/IceRpc.Compressor/README.md
@@ -130,7 +130,7 @@ host.Run();
 The compressor interceptor and middleware compress and decompress payloads regardless of how these payloads are encoded.
 They work well with Slice but don't require Slice.
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Compressor.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Compressor.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Compress

--- a/src/IceRpc.Deadline/README.md
+++ b/src/IceRpc.Deadline/README.md
@@ -79,7 +79,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Deadline.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Deadline.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Deadline
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Extensions.DependencyInjection/README.md
+++ b/src/IceRpc.Extensions.DependencyInjection/README.md
@@ -54,7 +54,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Extensions.DependencyInjection.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Extensions.DependencyInjection.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/GenericHost
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [ms_di]: https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection

--- a/src/IceRpc.Ice/README.md
+++ b/src/IceRpc.Ice/README.md
@@ -85,7 +85,7 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Ice.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Ice.html
 [docs]: TBD
 [ice]: https://zeroc.com/ice
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples

--- a/src/IceRpc.Locator/README.md
+++ b/src/IceRpc.Locator/README.md
@@ -44,7 +44,7 @@ var indirectProxy = new HelloProxy(
     new Uri("ice:/hello?adapter-id=HelloAdapter"));
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Locator.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Locator.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interop]: https://docs.icerpc.dev/icerpc-for-ice-users
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/ice/IceGrid

--- a/src/IceRpc.Logger/README.md
+++ b/src/IceRpc.Logger/README.md
@@ -90,7 +90,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Logger.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Logger.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Logger
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Metrics/README.md
+++ b/src/IceRpc.Metrics/README.md
@@ -74,7 +74,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Metrics.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Metrics.html
 [dotnet_counters]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Protobuf/README.md
+++ b/src/IceRpc.Protobuf/README.md
@@ -84,7 +84,7 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Protobuf.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Protobuf.html
 [docs]: https://docs.icerpc.dev/protobuf
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples

--- a/src/IceRpc.RequestContext/README.md
+++ b/src/IceRpc.RequestContext/README.md
@@ -83,7 +83,7 @@ host.Run();
 The ice protocol can send and receive request context fields. They correspond to
 [request contexts][ice_request_contexts] in Ice.
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.RequestContext.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.RequestContext.html
 [ice_request_contexts]: https://docs.zeroc.com/ice/3.8/csharp/request-contexts
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Retry/README.md
+++ b/src/IceRpc.Retry/README.md
@@ -42,7 +42,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Retry.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Retry.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Retry

--- a/src/IceRpc.Slice/README.md
+++ b/src/IceRpc.Slice/README.md
@@ -72,7 +72,7 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Slice.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Slice.html
 [docs]: https://docs.icerpc.dev/slice2
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples

--- a/src/IceRpc.Telemetry/README.md
+++ b/src/IceRpc.Telemetry/README.md
@@ -85,7 +85,7 @@ using var host = hostBuilder.Build();
 host.Run();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Telemetry.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Telemetry.html
 [example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/slice/Telemetry
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [interceptor]: https://docs.icerpc.dev/icerpc/invocation/interceptor

--- a/src/IceRpc.Transports.Coloc/README.md
+++ b/src/IceRpc.Transports.Coloc/README.md
@@ -35,7 +35,7 @@ await using var connection = new ClientConnection(
 await connection.ConnectAsync();
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.Transports.Coloc.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Transports.Coloc.html
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp
 [package]: https://www.nuget.org/packages/IceRpc.Transports.Coloc
 [product]: https://docs.icerpc.dev/icerpc

--- a/src/IceRpc/README.md
+++ b/src/IceRpc/README.md
@@ -95,7 +95,7 @@ internal class Chatbot : IDispatcher
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/IceRpc.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.html
 [docs]:https://docs.icerpc.dev
 [getting-started]: https://docs.icerpc.dev/getting-started
 [icerpc-csharp]: https://github.com/icerpc/icerpc-csharp

--- a/src/ZeroC.Slice.Codec/README.md
+++ b/src/ZeroC.Slice.Codec/README.md
@@ -66,7 +66,7 @@ public partial record struct Person
 }
 ```
 
-[api]: https://docs.icerpc.dev/api/csharp/api/ZeroC.Slice.Codec.html
+[api]: https://code.icerpc.dev/csharp/main/api/reference/ZeroC.Slice.Codec.html
 [cs-buffers]: https://learn.microsoft.com/en-us/dotnet/standard/io/buffers
 [docs]: https://docs.icerpc.dev/slice2
 [idl]: https://en.wikipedia.org/wiki/Interface_description_language


### PR DESCRIPTION
- Update DocFX output and index links to use the `reference` directory instead of `api`. So no more `/api/api` links
- Point README and example API reference URLs to `code.icerpc.dev/csharp/main/api/reference`. 

The link check job will fail until this is merged.