### PR TITLE
Make OutgoingRequest.IsOneway get-set

### DIFF
--- a/src/IceRpc/OutgoingRequest.cs
+++ b/src/IceRpc/OutgoingRequest.cs
@@ -18,10 +18,10 @@ public sealed class OutgoingRequest : OutgoingFrame, IDisposable
     public IDictionary<RequestFieldKey, OutgoingFieldValue> Fields { get; set; } =
         ImmutableDictionary<RequestFieldKey, OutgoingFieldValue>.Empty;
 
-    /// <summary>Gets a value indicating whether this request is one-way or two-way.</summary>
+    /// <summary>Gets or sets a value indicating whether this request is one-way or two-way.</summary>
     /// <value><see langword="true" /> for one-way requests; otherwise, <see langword="false" />. The default is
     /// <see langword="false" />.</value>
-    public bool IsOneway { get; init; }
+    public bool IsOneway { get; set; }
 
     /// <summary>Gets or initializes the name of the operation to call on the target service.</summary>
     /// <value>The name of the operation. The default is the empty string.</value>

--- a/tests/IceRpc.Tests/ProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/ProtocolConnectionTests.cs
@@ -559,6 +559,38 @@ public sealed class ProtocolConnectionTests
         Assert.That(tokenCanceled, Is.False);
     }
 
+    /// <summary>Verifies that an interceptor can change <see cref="OutgoingRequest.IsOneway" /> from false to true,
+    /// and that the change is observed on the server side.</summary>
+    [Test]
+    public async Task Interceptor_can_set_request_to_oneway([Values("ice", "icerpc")] string protocolString)
+    {
+        // Arrange
+        var protocol = Protocol.Parse(protocolString);
+        using var dispatcher = new TestDispatcher();
+
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(protocol, dispatcher)
+            .BuildServiceProvider(validateScopes: true);
+
+        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        await sut.ConnectAsync();
+
+        IInvoker invoker = new InlineInvoker((request, cancellationToken) =>
+        {
+            request.IsOneway = true;
+            return sut.Client.InvokeAsync(request, cancellationToken);
+        });
+
+        using var request = new OutgoingRequest(new ServiceAddress(protocol)); // IsOneway defaults to false
+
+        // Act
+        _ = await invoker.InvokeAsync(request);
+
+        // Assert
+        IncomingRequest incomingRequest = await dispatcher.DispatchStart;
+        Assert.That(incomingRequest.IsOneway, Is.True);
+    }
+
     [Test]
     [TestCaseSource(nameof(Protocols))]
     public async Task Dispatch_returns_response_not_matching_request_response(Protocol protocol)


### PR DESCRIPTION
This PR changes the OutgoingRequest.IsOneway property from get-init to get-set.

This allows an interceptor so set IsOneway to true (or false).
