### PR TITLE
Accept empty payloads in Protobuf-encoded responses

### DIFF
--- a/src/IceRpc.Protobuf/RpcMethods/IncomingRequestExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/IncomingRequestExtensions.cs
@@ -35,6 +35,7 @@ public static class IncomingRequestExtensions
         TInput input = await request.Payload.DecodeProtobufMessageAsync(
             inputParser,
             protobufFeature.MaxMessageLength,
+            acceptEmptyPayload: false,
             cancellationToken).ConfigureAwait(false);
 
         TOutput output = await method(service, input, request.Features, cancellationToken).ConfigureAwait(false);
@@ -107,6 +108,7 @@ public static class IncomingRequestExtensions
         TInput input = await request.Payload.DecodeProtobufMessageAsync(
             inputParser,
             protobufFeature.MaxMessageLength,
+            acceptEmptyPayload: false,
             cancellationToken).ConfigureAwait(false);
 
         IAsyncEnumerable<TOutput> output = await method(service, input, request.Features, cancellationToken)

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
@@ -15,7 +15,7 @@ internal static class PipeReaderExtensions
     /// <param name="reader">The <see cref="PipeReader" /> containing the Protobuf length-prefixed message.</param>
     /// <param name="parser">The <see cref="MessageParser{T}" /> used to parse the message data.</param>
     /// <param name="maxMessageLength">The maximum allowed length.</param>
-    /// <param name="acceptEmptyPayload">Indicates whether to accept empty payloads.</param>
+    /// <param name="acceptEmptyPayload">Indicates whether to accept or reject empty payloads.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The decoded message object.</returns>
     /// <remarks>The envelope follows the gRPC Length-Prefixed-Message format: a 1-byte compression flag (0 for
@@ -38,13 +38,13 @@ internal static class PipeReaderExtensions
         {
             if (acceptEmptyPayload)
             {
-                // An empty payload can represent an empty message. Used for oneway requests.
+                // An empty payload represents a default-constructed message. Used for oneway requests.
                 message = parser.ParseFrom([]);
             }
             else
             {
                 throw new InvalidDataException(
-                    "The payload is empty but a length-prefixed Protobuf message was expected.");
+                    "The payload is empty; a length-prefixed Protobuf message was expected.");
             }
         }
         else

--- a/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/PipeReaderExtensions.cs
@@ -15,6 +15,7 @@ internal static class PipeReaderExtensions
     /// <param name="reader">The <see cref="PipeReader" /> containing the Protobuf length-prefixed message.</param>
     /// <param name="parser">The <see cref="MessageParser{T}" /> used to parse the message data.</param>
     /// <param name="maxMessageLength">The maximum allowed length.</param>
+    /// <param name="acceptEmptyPayload">Indicates whether to accept empty payloads.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The decoded message object.</returns>
     /// <remarks>The envelope follows the gRPC Length-Prefixed-Message format: a 1-byte compression flag (0 for
@@ -25,29 +26,45 @@ internal static class PipeReaderExtensions
         this PipeReader reader,
         MessageParser<T> parser,
         int maxMessageLength,
+        bool acceptEmptyPayload,
         CancellationToken cancellationToken) where T : class, IMessage<T>
     {
-        T message = await reader.ReadProtobufMessageAsync(
+        T? message = await reader.ReadProtobufMessageAsync(
             parser,
             maxMessageLength,
-            cancellationToken).ConfigureAwait(false) ??
-            throw new InvalidDataException("The payload is empty; expected a Protobuf message.");
+            cancellationToken).ConfigureAwait(false);
 
-        // A unary payload must contain exactly one message; any trailing bytes indicate a framing error.
-        ReadResult readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        // We never call CancelPendingRead; an interceptor or middleware can but it's not correct.
-        if (readResult.IsCanceled)
+        if (message is null)
         {
-            throw new InvalidOperationException("Unexpected call to CancelPendingRead.");
+            if (acceptEmptyPayload)
+            {
+                // An empty payload can represent an empty message. Used for oneway requests.
+                message = parser.ParseFrom([]);
+            }
+            else
+            {
+                throw new InvalidDataException(
+                    "The payload is empty but a length-prefixed Protobuf message was expected.");
+            }
         }
-        bool hasTrailingBytes = !readResult.Buffer.IsEmpty;
-        reader.AdvanceTo(readResult.Buffer.End);
-        if (hasTrailingBytes)
+        else
         {
-            throw new InvalidDataException(
-                "The payload contains unexpected trailing bytes after the Protobuf message.");
+            // A unary payload must contain exactly one message; any trailing bytes indicate a framing error.
+            ReadResult readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            // We never call CancelPendingRead; an interceptor or middleware can but it's not correct.
+            if (readResult.IsCanceled)
+            {
+                throw new InvalidOperationException("Unexpected call to CancelPendingRead.");
+            }
+            bool hasTrailingBytes = !readResult.Buffer.IsEmpty;
+            reader.AdvanceTo(readResult.Buffer.End);
+            if (hasTrailingBytes)
+            {
+                throw new InvalidDataException(
+                    "The payload contains unexpected trailing bytes after the Protobuf message.");
+            }
+            Debug.Assert(readResult.IsCompleted);
         }
-        Debug.Assert(readResult.IsCompleted);
 
         return message;
     }

--- a/src/IceRpc.Protobuf/RpcMethods/InvokerExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/InvokerExtensions.cs
@@ -230,6 +230,7 @@ public static class InvokerExtensions
                 return await response.Payload.DecodeProtobufMessageAsync(
                     messageParser,
                     protobufFeature.MaxMessageLength,
+                    acceptEmptyPayload: true,
                     cancellationToken).ConfigureAwait(false);
             }
             else

--- a/src/IceRpc.Protobuf/RpcMethods/InvokerExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/InvokerExtensions.cs
@@ -230,7 +230,9 @@ public static class InvokerExtensions
                 return await response.Payload.DecodeProtobufMessageAsync(
                     messageParser,
                     protobufFeature.MaxMessageLength,
-                    acceptEmptyPayload: true,
+                    // The payload of the response to a oneway request is empty and we decode it as a
+                    // default-constructed response message.
+                    acceptEmptyPayload: request.IsOneway,
                     cancellationToken).ConfigureAwait(false);
             }
             else

--- a/tests/IceRpc.Protobuf.Tests/OperationTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/OperationTests.cs
@@ -36,6 +36,46 @@ public partial class OperationTests
         Assert.That(response.P2, Is.EqualTo(message.P2));
     }
 
+    /// <summary>Verifies that a unary RPC works when an interceptor sets the request to oneway. The
+    /// response payload is empty in this case, and the generated client must decode this empty payload
+    /// successfully.</summary>
+    [Test]
+    public async Task Unary_rpc_with_oneway_request()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddClientServerColocTest(dispatcher: new MyOperationsService())
+            .BuildServiceProvider(validateScopes: true);
+        provider.GetRequiredService<Server>().Listen();
+        ClientConnection clientConnection = provider.GetRequiredService<ClientConnection>();
+
+        var pipeline = new Pipeline();
+        pipeline
+            .Use(next => new InlineInvoker(
+                (request, cancellationToken) =>
+                {
+                    request.IsOneway = true;
+                    return next.InvokeAsync(request, cancellationToken);
+                }))
+            .Into(clientConnection);
+
+        var client = new MyOperationsClient(pipeline);
+
+        var message = new InputMessage()
+        {
+            P1 = "P1",
+            P2 = 2,
+        };
+
+        // Act
+        var response = await client.UnaryOpAsync(message);
+
+        // Assert
+        // The response is decoded from an empty payload, so it's a default-constructed OutputMessage.
+        Assert.That(response.P1, Is.EqualTo(""));
+        Assert.That(response.P2, Is.EqualTo(0));
+    }
+
     [Test]
     public void Client_streaming_rpc()
     {

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -25,6 +25,7 @@ public partial class PipeReaderExtensionsTests
         StringValue decoded = await pipeReader.DecodeProtobufMessageAsync(
             StringValue.Parser,
             maxMessageLength: 1027,
+            acceptEmptyPayload: false,
             CancellationToken.None);
 
         // Assert
@@ -45,6 +46,7 @@ public partial class PipeReaderExtensionsTests
             await pipeReader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1026,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipeReader.Complete();
     }
@@ -63,6 +65,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipe.Reader.Complete();
     }
@@ -81,6 +84,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipe.Reader.Complete();
     }
@@ -101,6 +105,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipe.Reader.Complete();
     }
@@ -122,6 +127,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipe.Reader.Complete();
     }
@@ -142,6 +148,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         pipe.Reader.Complete();
     }
@@ -171,6 +178,7 @@ public partial class PipeReaderExtensionsTests
             await pipe.Reader.DecodeProtobufMessageAsync(
                 StringValue.Parser,
                 maxMessageLength: 1024,
+                acceptEmptyPayload: false,
                 CancellationToken.None));
         Assert.That(exception!.InnerException, Is.InstanceOf<InvalidProtocolBufferException>());
         pipe.Reader.Complete();


### PR DESCRIPTION
This is a follow-up to #4675.

When IceRpc.Protobuf receives a non-streaming IncomingResponse, it expects the response's payload to contain a length-prefixed Protobuf message.

Prior to this PR, if the response payload is empty - which is what happens with a oneway request - the decoding fails.

This PR updates the logic to accept an empty payload in this situation (non-streaming response): empty is treated like an empty (zero byte) Protobuf message. 

Such a Protobuf message is decoded as default-initialized message. This works for google.protobuf.empty and any other messages. You just get a default initialized message.