### PR TITLE
Add support for Protobuf editions

### DIFF
--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -10,7 +10,7 @@ you can use proto2, proto3, or editions (e.g. `edition = "2024"`) in your own pr
 | [Deadline](./Deadline/)                | Shows how to use the deadline interceptor to set the invocation deadline.                                                           |
 | [GenericHost](./GenericHost/)          | Shows how to create client and server applications using Microsoft's Dependency Injection container.                                |
 | [Greeter](./Greeter/)                  | Shows how to call and implement a canonical Greeter service using the IceRPC + Protobuf integration.                                |
-| [Logger](./Loggger/)                   | Shows how to enable logging.                                                                                                        |
+| [Logger](./Logger/)                    | Shows how to enable logging.                                                                                                        |
 | [Metrics](./Metrics/)                  | Shows how to use the metrics interceptor and middleware.                                                                            |
 | [MultipleServices](./MultipleServices) | Shows how a service can implement multiple Protobuf services.                                                                       |
 | [RequestContext](./RequestContext/)    | Shows how to attach information to an invocation and retrieve this information from the dispatch in the server.                     |

--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -2,6 +2,9 @@
 
 This folder contains example applications that showcase the IceRPC + Protobuf integration.
 
+The `.proto` files in these examples use `syntax = "proto3"`, but the IceRPC + Protobuf integration is syntax-agnostic:
+you can use proto2, proto3, or editions (e.g. `edition = "2024"`) in your own projects.
+
 |                                        |                                                                                                                                     |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | [Deadline](./Deadline/)                | Shows how to use the deadline interceptor to set the invocation deadline.                                                           |

--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -14,6 +14,8 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
+using static Google.Protobuf.Compiler.CodeGeneratorResponse.Types;
+
 // The protoc compiler executes this program and writes the Protobuf serialized CodeGeneratorRequest to standard input.
 
 // Read the input and deserialize it using the Protobuf CodeGeneratorRequest object.
@@ -48,7 +50,12 @@ foreach (FileDescriptor descriptor in descriptors)
 
 byte[] hashBytes = fileCount == 0 ? [] : fileHashes.GetHashAndReset();
 
-var response = new CodeGeneratorResponse();
+var response = new CodeGeneratorResponse
+{
+    // We support all since we only generate code for services.
+    SupportedFeatures = (ulong)(Feature.Proto3Optional | Feature.SupportsEditions),
+    MaximumEdition = (int)Edition.Max
+};
 
 if (fileCount > 0)
 {

--- a/src/IceRpc.Protobuf.Generator/Program.cs
+++ b/src/IceRpc.Protobuf.Generator/Program.cs
@@ -7,6 +7,8 @@ using IceRpc.CaseConverter.Internal;
 using IceRpc.Protobuf.Generator;
 using ZeroC.CodeBuilder;
 
+using static Google.Protobuf.Compiler.CodeGeneratorResponse.Types;
+
 // The protoc compiler executes this program and writes the Protobuf serialized CodeGeneratorRequest to standard input.
 
 // Read the input and deserialize it using the Protobuf CodeGeneratorRequest object.
@@ -23,7 +25,13 @@ foreach (FileDescriptorProto? proto in request.ProtoFile)
 // Build the FileDescriptor objects from the collected encoded data.
 IReadOnlyList<FileDescriptor> descriptors = FileDescriptor.BuildFromByteStrings(sources);
 
-var response = new CodeGeneratorResponse();
+var response = new CodeGeneratorResponse
+{
+    // We support all since we only generate code for services.
+    SupportedFeatures = (ulong)(Feature.Proto3Optional | Feature.SupportsEditions),
+    MaximumEdition = (int)Edition.Max
+};
+
 foreach (FileDescriptor descriptor in descriptors)
 {
     if (!request.FileToGenerate.Contains(descriptor.Name))

--- a/tests/IceRpc.Protobuf.Tests/OperationTests.proto
+++ b/tests/IceRpc.Protobuf.Tests/OperationTests.proto
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-syntax = "proto3";
+edition = "2024";
 option csharp_namespace = "IceRpc.Protobuf.Tests";
 
 import "google/protobuf/empty.proto";


### PR DESCRIPTION
Fixes #4677 

I also asked Claude if we should update the examples to use edition:

My take: **keep `syntax = "proto3"` in the examples**, at least for now.

Reasons:

1. **Examples are teaching material, not a showcase.** People landing on the Protobuf examples are almost certainly coming from a proto3 background — that's still what every tutorial, every existing `.proto` file in the wild, and every Google doc uses. Greeting them with `edition = "2024"` adds a "wait, what's this?" speed bump before they even get to the IceRPC-specific parts, which is what the examples are actually meant to demonstrate.

2. **Editions are still very new.** Edition 2023 only shipped in late 2023 and 2024 only recently. Tooling support outside of `protoc` itself (IDEs, linters, third-party generators, docs) is uneven. Examples that "just work" when copy-pasted are more valuable than examples that look modern.

3. **Signaling matters.** Using `edition = "2024"` in *all* examples implicitly suggests "this is what IceRPC recommends / requires." Since you explicitly don't want to require any version, the conservative default sends the right message: *bring your own proto dialect, we don't care*.

4. **The interesting bit doesn't change.** Editions don't unlock anything that makes the Greeter example more illustrative. The .proto file is essentially the same shape either way — you'd just be swapping a header line.

When I *would* reconsider:

- If/when you add a feature example that genuinely benefits from an edition-only feature (e.g. `features.field_presence`, the new enum defaults, the open/closed enum distinction), put **that one** example on `edition = "2024"`. That doubles as documentation: "here's why editions exist."
- Once edition 2024 has been the protoc default for a year or two and proto3 starts feeling legacy, flip the default.

A middle ground worth considering: leave the examples on proto3, but add a short note in README.md (one or two sentences) saying "IceRPC's Protobuf integration supports proto2, proto3, and editions — pick whichever your project uses." That gets you the "we support modern Protobuf" signal without making every example look unusual.