### PR TITLE
Remove File-Overwriting Check (now done by `slicec`)

### DIFF
--- a/src/ZeroC.Slice.Generator/GeneratorDriver.cs
+++ b/src/ZeroC.Slice.Generator/GeneratorDriver.cs
@@ -46,24 +46,6 @@ internal static class GeneratorDriver
                 ?? assembly.GetName().Version?.ToString()
                 ?? "unknown";
 
-            // Check for duplicate file names — two files with the same name would produce the same
-            // output file, with the second silently overwriting the first.
-            var seenFileNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (SliceFile file in symbolFiles)
-            {
-                string fileName = Path.GetFileName(file.Path);
-                if (seenFileNames.TryGetValue(fileName, out string? previousPath))
-                {
-                    string message = $"Multiple source files have the same file name '{fileName}': '{previousPath}' and '{file.Path}'. " +
-                        "Generated files are written to a common directory, so source files must have unique file names.";
-                    diagnostics.Add(Diagnostic.Error(message));
-                }
-                else
-                {
-                    seenFileNames[fileName] = file.Path;
-                }
-            }
-
             // Generate code for each source file, skipping generation if there are validation errors.
             var generatedFiles = new List<GeneratedFile>();
             if (!diagnostics.Any(d => d.IsError()))

--- a/src/ZeroC.Slice.Symbols/Diagnostic.cs
+++ b/src/ZeroC.Slice.Symbols/Diagnostic.cs
@@ -14,14 +14,6 @@ public record struct Diagnostic
     /// <summary>Gets any notes that should be reported along with this diagnostic.</summary>
     internal IList<Compiler.DiagnosticNote> Notes { get; init; }
 
-    /// <summary>Creates a new diagnostic to describe a general error.</summary>
-    public static Diagnostic Error(string message, string? source = null) => new()
-    {
-        Kind = new Compiler.DiagnosticKind.Error(message),
-        Source = source,
-        Notes = [],
-    };
-
     /// <summary>Creates a new diagnostic to describe an attribute which was invalidly applied to an element.</summary>
     public static Diagnostic InvalidAttribute(string directive, string source) => new()
     {


### PR DESCRIPTION
Now that `slicec` has the logic to detect file-overwrites (see #783), this check in C# is redundant.