### PR TITLE
Turn on build telemetry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Disable IceRpc build telemetry
-  IceRpcBuildTelemetry: false
+  # Debug and dry-run for build telemetry. Keep IceRpcBuildTelemetry as is.
+  IceRpcBuildTelemetryDebug: true
+  IceRpcBuildTelemetryDryRun: true
 
 jobs:
   build_and_test:

--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -96,7 +96,7 @@ if (fileName is not null && response.Error.Length == 0)
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(debug ? 6 : 3));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise we use Slic over
         // TCP.

--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -109,7 +109,7 @@ if (fileName is not null && response.Error.Length == 0)
         // Use a one-way invocation unless we're in debug mode.
         var invoker = new InlineInvoker((request, cancellationToken) =>
         {
-            request.IsOneway = true; // TODO: use !debug once the server is implemented
+            request.IsOneway = !debug;
             return connection.InvokeAsync(request, cancellationToken);
         });
 

--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -96,7 +96,7 @@ if (fileName is not null && response.Error.Length == 0)
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise we use Slic over
         // TCP.

--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -96,7 +96,7 @@ if (fileName is not null && response.Error.Length == 0)
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(debug ? 6 : 3));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise we use Slic over
         // TCP.

--- a/src/IceRpc.Protobuf.Tools/ProtocTask.cs
+++ b/src/IceRpc.Protobuf.Tools/ProtocTask.cs
@@ -133,11 +133,46 @@ public partial class ProtocTask : ToolTask
         @"^(?<file>.+?)\((?<line>\d+)\)\s*:\s*(?<severity>error|warning) in column=(?<column>\d+):\s*(?<message>.*)$")]
     private static partial Regex DiagnosticRegex();
 
+    // Matches protoc plug-in failure lines of the form "--<plugin>_out: <message>", which protoc writes to stderr
+    // when a code generator plug-in fails. These lines have no file/line/column info, so we surface them as MSBuild
+    // errors with the plug-in name as the subcategory.
+    [GeneratedRegex(@"^--(?<plugin>[A-Za-z0-9_\-]+)_out:\s*(?<message>.*)$")]
+    private static partial Regex PluginErrorRegex();
+
     /// <inheritdoc/>
-    protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance) =>
-        base.LogEventsFromTextOutput(
-            DiagnosticRegex().Replace(singleLine, "${file}(${line},${column}): ${severity}: ${message}"),
-            messageImportance);
+    protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+    {
+        Match diagnosticMatch = DiagnosticRegex().Match(singleLine);
+        if (diagnosticMatch.Success)
+        {
+            // Hand off to the base implementation in canonical MSBuild format so its CanonicalError parser picks up
+            // the file, line, column, severity and message.
+            base.LogEventsFromTextOutput(
+                $"{diagnosticMatch.Groups["file"].Value}({diagnosticMatch.Groups["line"].Value},{diagnosticMatch.Groups["column"].Value}): {diagnosticMatch.Groups["severity"].Value}: {diagnosticMatch.Groups["message"].Value}",
+                messageImportance);
+            return;
+        }
+
+        Match pluginMatch = PluginErrorRegex().Match(singleLine);
+        if (pluginMatch.Success)
+        {
+            Log.LogError(
+                subcategory: pluginMatch.Groups["plugin"].Value,
+                errorCode: null,
+                helpKeyword: null,
+                file: null,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: pluginMatch.Groups["message"].Value);
+            return;
+        }
+
+        // Fallback: any other protoc output (informational messages, unrecognized diagnostics) is passed through as a
+        // high importance log message so it remains visible without being misclassified as an error or warning.
+        Log.LogMessage(MessageImportance.High, singleLine);
+    }
 
     /// <inheritdoc/>
     protected override void LogToolCommand(string message) => Log.LogMessage(MessageImportance.Normal, message);

--- a/src/IceRpc.Slice.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Slice.BuildTelemetry/Program.cs
@@ -146,12 +146,13 @@ static async Task<GeneratorResponse> BuildResponseAsync(
         // Use a one-way invocation unless we're in debug mode.
         var invoker = new InlineInvoker((request, cancellationToken) =>
         {
-            request.IsOneway = true; // TODO: use !debug once the server is implemented
+            request.IsOneway = !debug;
             return connection.InvokeAsync(request, cancellationToken);
         });
 
         var buildObserver = new BuildObserverProxy(invoker);
 
+        // Add path to URI.
         uri += buildObserver.ServiceAddress.Path;
 
         await buildObserver.ReportSliceBuildAsync(telemetryData, cancellationToken: cts.Token);

--- a/src/IceRpc.Slice.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Slice.BuildTelemetry/Program.cs
@@ -134,7 +134,7 @@ static async Task<GeneratorResponse> BuildResponseAsync(
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(debug ? 6 : 3));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise Slic over TCP.
         await using var connection = new ClientConnection(

--- a/src/IceRpc.Slice.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Slice.BuildTelemetry/Program.cs
@@ -134,7 +134,7 @@ static async Task<GeneratorResponse> BuildResponseAsync(
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(debug ? 6 : 3));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise Slic over TCP.
         await using var connection = new ClientConnection(

--- a/src/IceRpc.Slice.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Slice.BuildTelemetry/Program.cs
@@ -134,7 +134,7 @@ static async Task<GeneratorResponse> BuildResponseAsync(
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
 
         // Create a client connection to the telemetry server. We use QUIC when supported, otherwise Slic over TCP.
         await using var connection = new ClientConnection(


### PR DESCRIPTION
This PR enables the two-way build telemetry reporting in debug mode, and enable build telemetry in CI (debug and dry run).

Closes #4614.