### PR TITLE
Remove URI path from build telemetry transcript/error

### DIFF
--- a/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Protobuf.BuildTelemetry/Program.cs
@@ -92,7 +92,7 @@ catch (FormatException exception)
 
 if (fileName is not null && response.Error.Length == 0)
 {
-    string uri = "icerpc://build-telemetry.icerpc.dev";
+    const string uri = "icerpc://build-telemetry.icerpc.dev";
 
     try
     {
@@ -115,9 +115,6 @@ if (fileName is not null && response.Error.Length == 0)
 
         // Create a proxy with this invoker.
         var buildObserver = new BuildObserverClient(invoker);
-
-        // Add path to URI.
-        uri += buildObserver.ServiceAddress.Path;
 
         // Upload the telemetry to the server.
         await buildObserver.ReportProtobufBuildAsync(telemetryData, cancellationToken: cts.Token);

--- a/src/IceRpc.Slice.BuildTelemetry/Program.cs
+++ b/src/IceRpc.Slice.BuildTelemetry/Program.cs
@@ -129,7 +129,7 @@ static async Task<GeneratorResponse> BuildResponseAsync(
         (uint)operationCount,
         (uint)typeCount);
 
-    string uri = "icerpc://build-telemetry.icerpc.dev";
+    const string uri = "icerpc://build-telemetry.icerpc.dev";
     string? failure = null;
 
     try
@@ -151,8 +151,6 @@ static async Task<GeneratorResponse> BuildResponseAsync(
         });
 
         var buildObserver = new BuildObserverProxy(invoker);
-
-        uri += buildObserver.ServiceAddress.Path;
 
         await buildObserver.ReportSliceBuildAsync(telemetryData, cancellationToken: cts.Token);
         await connection.ShutdownAsync(cts.Token);


### PR DESCRIPTION
Including the default path in the transcript/error is not that useful.