### PR TITLE
Improve the Diagnostic Reporting API

### DIFF
--- a/src/ZeroC.Slice.Symbols/Diagnostic.cs
+++ b/src/ZeroC.Slice.Symbols/Diagnostic.cs
@@ -47,7 +47,7 @@ public readonly record struct Diagnostic
 
     /// <summary>Creates a new diagnostic to describe an attribute with an incorrect number of arguments.</summary>
     /// <param name="directive">The directive of the attribute that had an incorrect number of arguments.</param>
-    /// <param name="expected">The correct number of arguments that should of been supplied to this attribute.</param>
+    /// <param name="expected">The correct number of arguments that should have been supplied to this attribute.</param>
     /// <param name="actual">The actual number of arguments that were supplied to this attribute.</param>
     /// <param name="source">The source location of the attribute which with an incorrect number of arguments.</param>
     /// <returns>A new diagnostic.</returns>

--- a/src/ZeroC.Slice.Symbols/Diagnostic.cs
+++ b/src/ZeroC.Slice.Symbols/Diagnostic.cs
@@ -49,7 +49,7 @@ public readonly record struct Diagnostic
     /// <param name="directive">The directive of the attribute that had an incorrect number of arguments.</param>
     /// <param name="expected">The correct number of arguments that should have been supplied to this attribute.</param>
     /// <param name="actual">The actual number of arguments that were supplied to this attribute.</param>
-    /// <param name="source">The source location of the attribute which with an incorrect number of arguments.</param>
+    /// <param name="source">The source location of the attribute with an incorrect number of arguments.</param>
     /// <returns>A new diagnostic.</returns>
     public static Diagnostic IncorrectAttributeArgumentCount(string directive, int expected, int actual, string source)
     {

--- a/src/ZeroC.Slice.Symbols/Diagnostic.cs
+++ b/src/ZeroC.Slice.Symbols/Diagnostic.cs
@@ -6,41 +6,51 @@ namespace ZeroC.Slice.Symbols;
 public readonly record struct Diagnostic
 {
     /// <summary>Returns whether this diagnostic represents an error.</summary>
-    public bool IsError => Kind is not Compiler.DiagnosticKind.Info and not Compiler.DiagnosticKind.Warning;
+    public bool IsError => _kind is not Compiler.DiagnosticKind.Info and not Compiler.DiagnosticKind.Warning;
 
-    /// <summary>Gets the exact kind of diagnostic.</summary>
-    private Compiler.DiagnosticKind Kind { get; }
+    /// <summary>The exact kind of diagnostic.</summary>
+    private readonly Compiler.DiagnosticKind _kind;
 
-    /// <summary>Gets the source location associated with this diagnostic, if any.</summary>
-    private string? Source { get; }
+    /// <summary>The source location associated with this diagnostic, if any.</summary>
+    private readonly string? _source;
 
-    /// <summary>Gets any notes that should be reported along with this diagnostic.</summary>
-    private IList<Compiler.DiagnosticNote> Notes { get; }
-
-    private Diagnostic(Compiler.DiagnosticKind kind, string? source)
-    {
-        Kind = kind;
-        Source = source;
-        Notes = [];
-    }
+    /// <summary>Notes that should be reported along with this diagnostic.</summary>
+    private readonly IList<Compiler.DiagnosticNote> _notes;
 
     /// <summary>Creates a new diagnostic to describe a general error.</summary>
+    /// <param name="message">A message describing the error.</param>
+    /// <param name="source">The source location associated with this diagnostic, if any.</param>
+    /// <returns>A new diagnostic.</returns>
     public static Diagnostic Error(string message, string? source = null) =>
         new(new Compiler.DiagnosticKind.Error(message), source);
 
     /// <summary>Creates a new diagnostic to describe an attribute which was invalidly applied to an element.</summary>
+    /// <param name="directive">The directive of the attribute that was invalid.</param>
+    /// <param name="source">The source location of the invalid attribute.</param>
+    /// <returns>A new diagnostic.</returns>
     public static Diagnostic InvalidAttribute(string directive, string source) =>
         new(new Compiler.DiagnosticKind.InvalidAttribute(directive), source);
 
     /// <summary>Creates a new diagnostic to describe an unknown attribute.</summary>
+    /// <param name="directive">The directive of the attribute that was unknown.</param>
+    /// <param name="source">The source location of the unknown attribute.</param>
+    /// <returns>A new diagnostic.</returns>
     public static Diagnostic UnknownAttribute(string directive, string source) =>
         new(new Compiler.DiagnosticKind.UnknownAttribute(directive), source);
 
     /// <summary>Creates a new diagnostic to describe a required attribute which was not present.</summary>
+    /// <param name="expectedAttribute">An example of the attribute that was required but missing.</param>
+    /// <param name="source">The source location of the Slice construct that was missing the required attribute.</param>
+    /// <returns>A new diagnostic.</returns>
     public static Diagnostic MissingRequiredAttribute(string expectedAttribute, string source) =>
         new(new Compiler.DiagnosticKind.MissingRequiredAttribute(expectedAttribute), source);
 
     /// <summary>Creates a new diagnostic to describe an attribute with an incorrect number of arguments.</summary>
+    /// <param name="directive">The directive of the attribute that had an incorrect number of arguments.</param>
+    /// <param name="expected">The correct number of arguments that should of been supplied to this attribute.</param>
+    /// <param name="actual">The actual number of arguments that were supplied to this attribute.</param>
+    /// <param name="source">The source location of the attribute which with an incorrect number of arguments.</param>
+    /// <returns>A new diagnostic.</returns>
     public static Diagnostic IncorrectAttributeArgumentCount(string directive, int expected, int actual, string source)
     {
         byte exp = expected > byte.MaxValue ? byte.MaxValue : (byte)expected;
@@ -49,9 +59,18 @@ public readonly record struct Diagnostic
     }
 
     /// <summary>Adds the provided message to this diagnostic as a note.</summary>
+    /// <param name="message">The message to add as a note.</param>
+    /// <param name="source">The source location associated with this note, if any.</param>
     public void AddNote(string message, string? source = null) =>
-        Notes.Add(new Compiler.DiagnosticNote(message, source));
+        _notes.Add(new Compiler.DiagnosticNote(message, source));
 
     /// <summary>Converts this diagnostic into a form that can be transmitted to the Slice compiler.</summary>
-    internal Compiler.Diagnostic ToCompilerDiagnostic() => new Compiler.Diagnostic(Kind, Source, Notes);
+    internal Compiler.Diagnostic ToCompilerDiagnostic() => new Compiler.Diagnostic(_kind, _source, _notes);
+
+    private Diagnostic(Compiler.DiagnosticKind kind, string? source)
+    {
+        _kind = kind;
+        _source = source;
+        _notes = [];
+    }
 }

--- a/src/ZeroC.Slice.Symbols/Diagnostic.cs
+++ b/src/ZeroC.Slice.Symbols/Diagnostic.cs
@@ -3,67 +3,55 @@
 namespace ZeroC.Slice.Symbols;
 
 /// <summary>Represents a diagnostic message produced during code generation.</summary>
-public record struct Diagnostic
+public readonly record struct Diagnostic
 {
+    /// <summary>Returns whether this diagnostic represents an error.</summary>
+    public bool IsError => Kind is not Compiler.DiagnosticKind.Info and not Compiler.DiagnosticKind.Warning;
+
     /// <summary>Gets the exact kind of diagnostic.</summary>
-    internal readonly Compiler.DiagnosticKind Kind { get; init; }
+    private Compiler.DiagnosticKind Kind { get; }
 
     /// <summary>Gets the source location associated with this diagnostic, if any.</summary>
-    internal readonly string? Source { get; init; }
+    private string? Source { get; }
 
     /// <summary>Gets any notes that should be reported along with this diagnostic.</summary>
-    internal IList<Compiler.DiagnosticNote> Notes { get; init; }
+    private IList<Compiler.DiagnosticNote> Notes { get; }
 
-    /// <summary>Returns whether this diagnostic represents an error.</summary>
-    public bool IsError =>
-        Kind is not Compiler.DiagnosticKind.Info and not Compiler.DiagnosticKind.Warning;
+    private Diagnostic(Compiler.DiagnosticKind kind, string? source)
+    {
+        Kind = kind;
+        Source = source;
+        Notes = [];
+    }
 
     /// <summary>Creates a new diagnostic to describe a general error.</summary>
-    public static Diagnostic Error(string message, string? source = null) => new()
-    {
-        Kind = new Compiler.DiagnosticKind.Error(message),
-        Source = source,
-        Notes = [],
-    };
+    public static Diagnostic Error(string message, string? source = null) =>
+        new(new Compiler.DiagnosticKind.Error(message), source);
 
     /// <summary>Creates a new diagnostic to describe an attribute which was invalidly applied to an element.</summary>
-    public static Diagnostic InvalidAttribute(string directive, string source) => new()
-    {
-        Kind = new Compiler.DiagnosticKind.InvalidAttribute(directive),
-        Source = source,
-        Notes = [],
-    };
+    public static Diagnostic InvalidAttribute(string directive, string source) =>
+        new(new Compiler.DiagnosticKind.InvalidAttribute(directive), source);
 
     /// <summary>Creates a new diagnostic to describe an unknown attribute.</summary>
-    public static Diagnostic UnknownAttribute(string directive, string source) => new()
-    {
-        Kind = new Compiler.DiagnosticKind.UnknownAttribute(directive),
-        Source = source,
-        Notes = [],
-    };
+    public static Diagnostic UnknownAttribute(string directive, string source) =>
+        new(new Compiler.DiagnosticKind.UnknownAttribute(directive), source);
 
     /// <summary>Creates a new diagnostic to describe a required attribute which was not present.</summary>
-    public static Diagnostic MissingRequiredAttribute(string expectedAttribute, string source) => new()
-    {
-        Kind = new Compiler.DiagnosticKind.MissingRequiredAttribute(expectedAttribute),
-        Source = source,
-        Notes = [],
-    };
+    public static Diagnostic MissingRequiredAttribute(string expectedAttribute, string source) =>
+        new(new Compiler.DiagnosticKind.MissingRequiredAttribute(expectedAttribute), source);
 
     /// <summary>Creates a new diagnostic to describe an attribute with an incorrect number of arguments.</summary>
     public static Diagnostic IncorrectAttributeArgumentCount(string directive, int expected, int actual, string source)
     {
         byte exp = expected > byte.MaxValue ? byte.MaxValue : (byte)expected;
         byte act = actual > byte.MaxValue ? byte.MaxValue : (byte)actual;
-        return new()
-        {
-            Kind = new Compiler.DiagnosticKind.IncorrectAttributeArgumentCount(directive, exp, exp, act),
-            Source = source,
-            Notes = [],
-        };
+        return new(new Compiler.DiagnosticKind.IncorrectAttributeArgumentCount(directive, exp, exp, act), source);
     }
 
     /// <summary>Adds the provided message to this diagnostic as a note.</summary>
-    public void AddNote(string message, string? source = null)
-        => Notes.Add(new Compiler.DiagnosticNote(message, source));
+    public void AddNote(string message, string? source = null) =>
+        Notes.Add(new Compiler.DiagnosticNote(message, source));
+
+    /// <summary>Converts this diagnostic into a form that can be transmitted to the Slice compiler.</summary>
+    internal Compiler.Diagnostic ToCompilerDiagnostic() => new Compiler.Diagnostic(Kind, Source, Notes);
 }

--- a/src/ZeroC.Slice.Symbols/Generator.cs
+++ b/src/ZeroC.Slice.Symbols/Generator.cs
@@ -66,8 +66,7 @@ public static class Generator
                 new Compiler.GeneratedFile(file.Path, file.Contents).Encode(ref encoder));
         encoder.EncodeSequence(
             response.Diagnostics,
-            (ref encoder, diagnostic) =>
-                new Compiler.Diagnostic(diagnostic.Kind, diagnostic.Source, diagnostic.Notes).Encode(ref encoder));
+            (ref encoder, diagnostic) => diagnostic.ToCompilerDiagnostic().Encode(ref encoder));
         await output.FlushAsync().ConfigureAwait(false);
         output.Complete();
     }


### PR DESCRIPTION
Makes `Diagnostic` a `readonly record struct`, adds a private constructor to reduce verbosity, and a new `ToCompilerDiagnostic` method, which lets us make all the fields `private` and `readonly`.