### PR TITLE
Update Microsoft.CodeAnalysis.CSharp dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,8 @@
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+
+    <!-- 5.0.0 to maintain compatibility with .NET SDK 10.0.10x -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 
     <!-- MSBuild SDK packages (used by IceRpc.*.Tools) -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 
     <!-- MSBuild SDK packages (used by IceRpc.*.Tools) -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.6.3" />


### PR DESCRIPTION
This PR updates (reduces) the Microsoft.CodeAnalysis.CSharp to 5.0.0 for compatibility with dotnet 10.0.10x.