### PR TITLE
Add 'compile-slice' Script for Slice Compiler Definitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,5 @@
 {
   "dotnet.defaultSolution": "IceRpc.sln",
-  "rust-analyzer.linkedProjects": [
-    "tools/slicec-cs/Cargo.toml"
-  ],
-  "rust-analyzer.rustfmt.extraArgs": [
-    "+nightly"
-  ],
   "prettier.documentSelectors": [
     "**/*.{props,csproj,targets}"
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "dotnet.defaultSolution": "IceRpc.sln",
+  "dotnet.defaultSolution": "IceRpc.slnx",
   "prettier.documentSelectors": [
     "**/*.{props,csproj,targets}"
   ],

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -138,9 +138,9 @@ def main() -> None:
     slice_files = find_compiler_slice_files(repo_root)
 
     # Inform the user what is being used for this compilation run.
-    print("Found valid 'slicec' at: '" + slicec_executable + "'")
-    print("Found valid code-generator at: '" + code_generator + "'")
-    print("Found valid output directory at: '" + output_dir + "'")
+    print("Found 'slicec' at: '" + slicec_executable + "'")
+    print("Found code-generator at: '" + code_generator + "'")
+    print("Found output directory at: '" + output_dir + "'")
     print("Compiling the following files: [\n    " + '\n    '.join(slice_files) + "\n]")
 
     # Actually run the compilation.

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -7,7 +7,7 @@ This script relies on the downloaded `slicec` to function. The easiest way to ma
 `dotnet build` before running this script.
 
 Usage:
-    python build/compiler-slice.py
+    python build/compile-slice.py
 """
 
 import os
@@ -23,8 +23,8 @@ IS_WINDOWS = os.name == "nt"
 
 
 def runCommand(args) -> tuple[str, str]:
-    result = subprocess.run(args, check=False, shell=IS_WINDOWS, capture_output=True)
-    return [result.stdout.decode("utf-8").strip(), result.stderr.decode("utf-8").strip()]
+    result = subprocess.run(args, check=False, capture_output=True)
+    return (result.stdout.decode("utf-8").strip(), result.stderr.decode("utf-8").strip())
 
 
 def get_slicec_name() -> tuple[str, str]:
@@ -87,7 +87,11 @@ def find_code_generator(repo_root: str) -> list[str]:
     bin_root = os.path.join(repo_root, "src", "ZeroC.Slice.Generator", "bin")
     if not os.path.isdir(bin_root):
         raise RuntimeError("'src/ZeroC.Slice.Generator/bin' is not a directory or does not exist")
+    if len(os.listdir(bin_root)) == 0:
+        raise RuntimeError("Directory '" + bin_root + "' is empty")
     bin_subdir = os.path.join(bin_root, os.listdir(bin_root)[0])
+    if len(os.listdir(bin_subdir)) == 0:
+        raise RuntimeError("Directory '" + bin_subdir + "' is empty")
     code_gen_dir = os.path.join(bin_subdir, os.listdir(bin_subdir)[0])
 
     # Determine which extension the code-generator script will have.

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) ZeroC, Inc.
+
+import os
+import platform
+import subprocess
+
+
+
+
+
+# If this is set to 'True' the script will print lots of letters to the terminal while it's running.
+DEBUGGING = False
+
+# Determine if we're running on a windows platform.
+IS_WINDOWS = os.name == "nt"
+
+
+
+
+
+def runCommand(args, checked) -> str:
+    result = subprocess.run(args, check=checked, shell=IS_WINDOWS, capture_output=True)
+    return (result.stdout.decode("utf-8").strip() + "\n" + result.stderr.decode("utf-8").strip()).strip()
+
+
+
+def get_slicec_name() -> tuple[str, str]:
+    # Lookup the name of the system we're running on.
+    system = platform.system().lower()
+    if DEBUGGING:
+        print("'get_slicec_name' found the following system name: '" + system + "'")
+    # Convert it to the name we use in 'IceRpc.Slice.Tools.csproj'.
+    match system:
+        case "linux":
+            system = "linux"
+        case "windows":
+            system = "windows"
+        case "darwin":
+            system = "macos"
+        case _:
+            raise RuntimeError("Unsupported platform detected: '" + system + "'")
+
+    # Lookup the architecture of the system we're running on.
+    architecture = platform.machine().lower()
+    if DEBUGGING:
+        print("'get_slicec_name' found the following system architecture: '" + architecture + "'")
+    # Convert it to the name we use in 'IceRpc.Slice.Tools.csproj'.
+    match architecture:
+        case "x86" | "x86_64" | "amd64":
+            architecture = "x64"
+        case "arm64" | "aarch64":
+            architecture = "arm64"
+        case _:
+            raise RuntimeError("Unsupported architecture detected: '" + architecture + "'")
+    
+    # Determine which file extension to use.
+    extension = ".exe" if IS_WINDOWS else ""
+    if DEBUGGING:
+        print("'get_slicec_name' has decided to use this extension: '" + extension + "'")
+
+    # Return the name of the executable, and what folder we expected it to be in.
+    folder = system + "-" + architecture
+    file = "slicec" + extension
+    return [folder, file]
+
+
+
+def find_slicec(repo_root: str) -> str:
+    # Determine what is the exact name of the slicec we want to run is.
+    [slicec_dir, slicec_file] = get_slicec_name()
+    if DEBUGGING:
+        print("'find_slicec' determined this is the directory where slicec should be: '" + slicec_dir + "'")
+        print("'find_slicec' determined this is the filename slicec should be using: '" + slicec_file + "'")
+
+    # Check for 'slicec' in the 'obj' directory for 'IceRpc.Slice.Tools'.
+    candidate = os.path.join(repo_root, "src", "IceRpc.Slice.Tools", "obj", "tools", slicec_dir, slicec_file)
+    if os.path.isfile(candidate):
+        return candidate
+    else:
+        raise RuntimeError("Failed to locate valid slicec")
+
+
+
+def find_code_generator(repo_root: str) -> list[str]:
+    # Check for the code generator in the 'bin' directory for 'ZeroC.Slice.Generator'.
+    bin_root = os.path.join(repo_root, "src", "ZeroC.Slice.Generator", "bin")
+    if not os.path.isdir(bin_root):
+        raise RuntimeError("'src/ZeroC.Slice.Generator/bin' is not a directory or does not exist")
+    bin_subdir = os.path.join(bin_root, os.listdir(bin_root)[0])
+    code_gen_dir = os.path.join(bin_subdir, os.listdir(bin_subdir)[0])
+
+    # Determine which extension the code-generator script will have.
+    code_gen_extension = ".bat" if IS_WINDOWS else ".sh"
+
+    # Check for the actual code generator script file.
+    code_gen_script = os.path.join(code_gen_dir, "slicec-csharp-generator" + code_gen_extension)
+    if not os.path.isfile(code_gen_script):
+        raise RuntimeError("Failed to locate code-generator at expected path: '" + code_gen_script + "'")
+    else:
+        return code_gen_script
+
+
+
+def find_compiler_slice_files(repo_root: str) -> list[str]:
+    # Get the directory where the compiler-definition Slice files should be.
+    definition_dir = os.path.join(repo_root, "slice", "Compiler")
+    if not os.path.isdir(definition_dir):
+        raise RuntimeError("'slice/Compiler' is not a directory or does not exist")
+    
+    # Return any files in this directory.
+    return [os.path.join(definition_dir, f) for f in os.listdir(definition_dir)]
+
+
+
+def find_output_directory(repo_root: str) -> str:
+    output_dir = os.path.join(repo_root, "src", "ZeroC.Slice.Symbols", "Compiler")
+    if not os.path.isdir(output_dir):
+        raise RuntimeError("'src/ZeroC.Slice.Symbols/Compiler' is not a directory or does not exist")
+    
+    # Return the output directory.
+    return output_dir
+    
+
+
+def main() -> None:
+    # Find the root of the repository we're in
+    repo_root = runCommand(["git", "rev-parse", "--show-toplevel"], checked=True)
+    if DEBUGGING:
+        print("'find_slicec' determined this is the repository root: '" + repo_root + "'")
+
+    # Find a valid 'slicec' executable.
+    slicec_executable = find_slicec(repo_root)
+    # Find the Slice code-generator.
+    code_generator = find_code_generator(repo_root)
+    # Find the output directory.
+    output_dir = find_output_directory(repo_root)
+    # Find the Slice compiler definition files.
+    slice_files = find_compiler_slice_files(repo_root)
+
+    # Inform the user what is being used for this compilation run.
+    print("Found valid 'slicec' at: '" + slicec_executable + "'")
+    print("Found valid code-generator at: '" + code_generator + "'")
+    print("Found valid output directory at: '" + output_dir + "'")
+    print("Compiling the following files: [\n    " + '\n    '.join(slice_files) + "\n]")
+
+    # Actually run the compilation.
+    command = [slicec_executable, "-G", code_generator, "--output-dir", output_dir]
+    command.extend(slice_files)
+    if DEBUGGING:
+        print("Attempting to run this command: [" + ','.join(command) + "]")
+
+    print(runCommand(command, checked=False))
+    print("Completed")
+    
+
+
+
+if __name__ == "__main__":
+    main()

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -55,7 +55,7 @@ def get_slicec_name() -> tuple[str, str]:
             architecture = "arm64"
         case _:
             raise RuntimeError("Unsupported architecture detected: '" + architecture + "'")
-    
+
     # Determine which file extension to use.
     extension = ".exe" if IS_WINDOWS else ""
     if DEBUGGING:
@@ -106,7 +106,7 @@ def find_compiler_slice_files(repo_root: str) -> list[str]:
     definition_dir = os.path.join(repo_root, "slice", "Compiler")
     if not os.path.isdir(definition_dir):
         raise RuntimeError("'slice/Compiler' is not a directory or does not exist")
-    
+
     # Return any files in this directory.
     return [os.path.join(definition_dir, f) for f in os.listdir(definition_dir)]
 
@@ -115,10 +115,10 @@ def find_output_directory(repo_root: str) -> str:
     output_dir = os.path.join(repo_root, "src", "ZeroC.Slice.Symbols", "Compiler")
     if not os.path.isdir(output_dir):
         raise RuntimeError("'src/ZeroC.Slice.Symbols/Compiler' is not a directory or does not exist")
-    
+
     # Return the output directory.
     return output_dir
-    
+
 
 def main() -> None:
     # Find the root of the repository we're in

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -1,28 +1,30 @@
 #!/usr/bin/env python3
 # Copyright (c) ZeroC, Inc.
 
+"""Compiles the Slice Compiler Definition files, and writes the generated code to the correct output directory.
+
+This script relies on the downloaded `slicec` to function. The easiest way to make sure this is present is to run
+`dotnet build` before running this script.
+
+Usage:
+    python build/compiler-slice.py
+"""
+
 import os
 import platform
 import subprocess
 
 
-
-
-
-# If this is set to 'True' the script will print lots of letters to the terminal while it's running.
+# If this is set to 'True' the script will print extra information to the terminal while it's running.
 DEBUGGING = False
 
 # Determine if we're running on a windows platform.
 IS_WINDOWS = os.name == "nt"
 
 
-
-
-
-def runCommand(args, checked) -> str:
-    result = subprocess.run(args, check=checked, shell=IS_WINDOWS, capture_output=True)
-    return (result.stdout.decode("utf-8").strip() + "\n" + result.stderr.decode("utf-8").strip()).strip()
-
+def runCommand(args) -> tuple[str, str]:
+    result = subprocess.run(args, check=False, shell=IS_WINDOWS, capture_output=True)
+    return [result.stdout.decode("utf-8").strip(), result.stderr.decode("utf-8").strip()]
 
 
 def get_slicec_name() -> tuple[str, str]:
@@ -65,7 +67,6 @@ def get_slicec_name() -> tuple[str, str]:
     return [folder, file]
 
 
-
 def find_slicec(repo_root: str) -> str:
     # Determine what is the exact name of the slicec we want to run is.
     [slicec_dir, slicec_file] = get_slicec_name()
@@ -79,7 +80,6 @@ def find_slicec(repo_root: str) -> str:
         return candidate
     else:
         raise RuntimeError("Failed to locate valid slicec")
-
 
 
 def find_code_generator(repo_root: str) -> list[str]:
@@ -101,7 +101,6 @@ def find_code_generator(repo_root: str) -> list[str]:
         return code_gen_script
 
 
-
 def find_compiler_slice_files(repo_root: str) -> list[str]:
     # Get the directory where the compiler-definition Slice files should be.
     definition_dir = os.path.join(repo_root, "slice", "Compiler")
@@ -110,7 +109,6 @@ def find_compiler_slice_files(repo_root: str) -> list[str]:
     
     # Return any files in this directory.
     return [os.path.join(definition_dir, f) for f in os.listdir(definition_dir)]
-
 
 
 def find_output_directory(repo_root: str) -> str:
@@ -122,10 +120,11 @@ def find_output_directory(repo_root: str) -> str:
     return output_dir
     
 
-
 def main() -> None:
     # Find the root of the repository we're in
-    repo_root = runCommand(["git", "rev-parse", "--show-toplevel"], checked=True)
+    [repo_root, err] = runCommand(["git", "rev-parse", "--show-toplevel"])
+    if err != "":
+        raise RuntimeError("Error encountered while trying to find the repository root:\n" + err)
     if DEBUGGING:
         print("'find_slicec' determined this is the repository root: '" + repo_root + "'")
 
@@ -150,10 +149,13 @@ def main() -> None:
     if DEBUGGING:
         print("Attempting to run this command: [" + ','.join(command) + "]")
 
-    print(runCommand(command, checked=False))
+    # Actually run the Slice compiler and remit any errors.
+    [result, err] = runCommand(command)
+    print(result)
+    if err != "":
+        print("\nErrors encountered while trying to compile Slice files:\n\n" + err)
+        exit(79)
     print("Completed")
-    
-
 
 
 if __name__ == "__main__":

--- a/build/compile-slice.py
+++ b/build/compile-slice.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) ZeroC, Inc.
 
-"""Compiles the Slice Compiler Definition files, and writes the generated code to the correct output directory.
+"""Compiles the Slice-Compiler definition files, and writes the generated code to the correct output directory.
 
 This script relies on the downloaded `slicec` to function. The easiest way to make sure this is present is to run
 `dotnet build` before running this script.

--- a/build/sync-slice.py
+++ b/build/sync-slice.py
@@ -4,13 +4,13 @@
 """Synchronize vendored Slice files (*.ice, *.slice) based on slice.toml.
 
 Usage:
-    python tools/sync-slice.py           # sync files from upstream
-    python tools/sync-slice.py --verify  # verify files match upstream (for CI)
+    python build/sync-slice.py           # sync files from upstream
+    python build/sync-slice.py --verify  # verify files match upstream (for CI)
 
 slice.toml format
 -----------------
 
-The file contains one or more [source.<name>] sections.  Each section describes
+The file contains one or more [source.<name>] sections. Each section describes
 an upstream git repository and the files to vendor from it.
 
     [source.<name>]
@@ -24,14 +24,14 @@ an upstream git repository and the files to vendor from it.
                                      #   relative to 'source'; supports ** for recursion
 
 When multiple sources write to the same dest, their include patterns should not
-overlap.  The script warns when the same destination path is matched by more
+overlap. The script warns when the same destination path is matched by more
 than one source.
 
 Sync mode (default) clones every source, removes stale .ice/.slice files from
 dest that are no longer in the manifest, and copies the matched files.
 
 Verify mode (--verify) clones every source and checks that the local files in
-dest are identical to upstream.  It reports missing, modified, and extra files
+dest are identical to upstream. It reports missing, modified, and extra files
 and exits with a non-zero status on any mismatch.
 """
 

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -20,8 +20,6 @@
     <_IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</_IceRpcOSName>
     <_IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('OSX'))">macos</_IceRpcOSName>
     <_IceRpcOSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower())</_IceRpcOSArch>
-    <_SliceCExe Condition="'$(_IceRpcOSName)' == 'windows'">slicec.exe</_SliceCExe>
-    <_SliceCExe Condition="'$(_IceRpcOSName)' != 'windows'">slicec</_SliceCExe>
   </PropertyGroup>
   <ItemGroup>
     <!-- Build-order-only references; see comment on the analogous block in IceRpc.Slice.Tools.targets. -->


### PR DESCRIPTION
This PR adds a new `build/compile-slice.py` script which will automatically regenerate the C# code in `src/ZeroC.Slice.Symbols/Compiler` based on the existing compiler definitions, and the version of `slicec` downloaded in the repository.

The script should be runnable anywhere from within the repository. It will automatically figure out the pathing.

I also made sure to have it forward any errors, not that there should ever be any.

----

Normal output:
```shell
PS icerpc-csharp> python build/compile-slice.py
Found 'slicec' at: 'D:/Code/Workspace/icerpc-csharp\src\IceRpc.Slice.Tools\obj\tools\windows-x64\slicec.exe'
Found code-generator at: 'D:/Code/Workspace/icerpc-csharp\src\ZeroC.Slice.Generator\bin\Debug\net10.0\slicec-csharp-generator.bat'
Found output directory at: 'D:/Code/Workspace/icerpc-csharp\src\ZeroC.Slice.Symbols\Compiler'
Compiling the following files: [
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\CodeGenerator.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\Diagnostics.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\DocComment.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\SyntaxElements.slice
]

Completed
```


Output if there were errors:
```shell
PS icerpc-csharp> python build/compile-slice.py
Found 'slicec' at: 'D:/Code/Workspace/icerpc-csharp\src\IceRpc.Slice.Tools\obj\tools\windows-x64\slicec.exe'
Found code-generator at: 'D:/Code/Workspace/icerpc-csharp\src\ZeroC.Slice.Generator\bin\Debug\net10.0\slicec-csharp-generator.bat'
Found output directory at: 'D:/Code/Workspace/icerpc-csharp\src\ZeroC.Slice.Symbols\Compiler'
Compiling the following files: [
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\CodeGenerator.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\Diagnostics.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\DocComment.slice
    D:/Code/Workspace/icerpc-csharp\slice\Compiler\SyntaxElements.slice
]

Errors encountered while trying to compile Slice files:

error [E033]: no element with identifier 'strin' exists
  Reported by: [slicec]
 --> D:/Code/Workspace/icerpc-csharp\slice\Compiler\CodeGenerator.slice:19:11
   |
19 |     path: strin
   |           -----
   |
```