### PR TITLE
Minor Internal Cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,5 @@
 {
-  "dotnet.defaultSolution": "IceRpc.sln",
-  "rust-analyzer.linkedProjects": [
-    "tools/slicec-cs/Cargo.toml"
-  ],
-  "rust-analyzer.rustfmt.extraArgs": [
-    "+nightly"
-  ],
+  "dotnet.defaultSolution": "IceRpc.slnx",
   "prettier.documentSelectors": [
     "**/*.{props,csproj,targets}"
   ],
@@ -15,78 +9,89 @@
       "paths": ["slice"],
       "addWellKnownTypes": false
     },
-    // Tools
+    // Telemetry
     {
-      "paths": ["src/IceRpc.Protobuf.BuildTelemetry/slice"]
+      "paths": ["src/IceRpc.Slice.BuildTelemetry/slice"]
     },
     // Slice Tests
     {
       "paths": [
         "tests/ZeroC.Slice.Generator.Tests",
         "tests/IceRpc.Slice.Generator.Tests",
-        "tests/IceRpc.Compressor.Tests"
+        "tests/IceRpc.Compressor.Tests",
+        "tests/IceRpc.ServiceGenerator.Tests"
       ]
+    },
+    // Templates
+    {
+      "paths": ["src/IceRpc.Templates/Templates/IceRpc-Slice-Client"]
+    },
+    {
+      "paths": ["src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client"]
+    },
+    {
+      "paths": ["src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server"]
+    },
+    {
+      "paths": ["src/IceRpc.Templates/Templates/IceRpc-Slice-Server"]
     },
     // Examples
     {
-      "paths": ["examples/slice/Compress"]
+      "paths": ["docfx/examples"]
     },
     {
-      "paths": ["examples/slice/CustomError"]
+      "paths": ["examples/slice/Compress/slice"]
     },
     {
-      "paths": ["examples/slice/Deadline"]
+      "paths": ["examples/slice/CustomError/slice"]
     },
     {
-      "paths": ["examples/slice/DiscriminatedUnion"]
+      "paths": ["examples/slice/Deadline/slice"]
     },
     {
-      "paths": ["examples/slice/Download"]
+      "paths": ["examples/slice/DiscriminatedUnion/slice"]
     },
     {
-      "paths": ["examples/slice/GenericHost"]
+      "paths": ["examples/slice/Download/slice"]
     },
     {
-      "paths": ["examples/slice/Greeter"]
+      "paths": ["examples/slice/GenericHost/slice"]
     },
     {
-      "paths": ["examples/slice/InteropIceGrid"]
+      "paths": ["examples/slice/Greeter/slice"]
     },
     {
-      "paths": ["examples/slice/InteropMinimal"]
+      "paths": ["examples/slice/Logger/slice"]
     },
     {
-      "paths": ["examples/slice/Logger"]
+      "paths": ["examples/slice/Metrics/slice"]
     },
     {
-      "paths": ["examples/slice/Metrics"]
+      "paths": ["examples/slice/MultipleInterfaces/slice"]
     },
     {
-      "paths": ["examples/slice/MultipleInterfaces"]
+      "paths": ["examples/slice/RequestContext/slice"]
     },
     {
-      "paths": ["examples/slice/Quic"]
+      "paths": ["examples/slice/Retry/slice"]
     },
     {
-      "paths": ["examples/slice/RequestContext"]
+      "paths": ["examples/slice/Stream/slice"]
     },
     {
-      "paths": ["examples/slice/Retry"]
+      "paths": ["examples/slice/Tcp/slice"]
     },
     {
-      "paths": ["examples/slice/Secure"]
+      "paths": ["examples/slice/TcpFallback/slice"]
     },
     {
-      "paths": ["examples/slice/Stream"]
+      "paths": ["examples/slice/Telemetry/slice"]
     },
     {
-      "paths": ["examples/slice/Telemetry"]
+      "paths": ["examples/slice/Thermostat/slice"]
     },
     {
-      "paths": ["examples/slice/Thermostat"]
-    },
-    {
-      "paths": ["examples/slice/Upload"]
+      "paths": ["examples/slice/Upload/slice"]
     }
   ]
 }

--- a/build/sync-slice.py
+++ b/build/sync-slice.py
@@ -4,13 +4,13 @@
 """Synchronize vendored Slice files (*.ice, *.slice) based on slice.toml.
 
 Usage:
-    python tools/sync-slice.py           # sync files from upstream
-    python tools/sync-slice.py --verify  # verify files match upstream (for CI)
+    python builds/sync-slice.py           # sync files from upstream
+    python builds/sync-slice.py --verify  # verify files match upstream (for CI)
 
 slice.toml format
 -----------------
 
-The file contains one or more [source.<name>] sections.  Each section describes
+The file contains one or more [source.<name>] sections. Each section describes
 an upstream git repository and the files to vendor from it.
 
     [source.<name>]
@@ -24,14 +24,14 @@ an upstream git repository and the files to vendor from it.
                                      #   relative to 'source'; supports ** for recursion
 
 When multiple sources write to the same dest, their include patterns should not
-overlap.  The script warns when the same destination path is matched by more
+overlap. The script warns when the same destination path is matched by more
 than one source.
 
 Sync mode (default) clones every source, removes stale .ice/.slice files from
 dest that are no longer in the manifest, and copies the matched files.
 
 Verify mode (--verify) clones every source and checks that the local files in
-dest are identical to upstream.  It reports missing, modified, and extra files
+dest are identical to upstream. It reports missing, modified, and extra files
 and exits with a non-zero status on any mismatch.
 """
 

--- a/build/sync-slice.py
+++ b/build/sync-slice.py
@@ -4,8 +4,8 @@
 """Synchronize vendored Slice files (*.ice, *.slice) based on slice.toml.
 
 Usage:
-    python builds/sync-slice.py           # sync files from upstream
-    python builds/sync-slice.py --verify  # verify files match upstream (for CI)
+    python build/sync-slice.py           # sync files from upstream
+    python build/sync-slice.py --verify  # verify files match upstream (for CI)
 
 slice.toml format
 -----------------

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -20,8 +20,6 @@
     <_IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('Windows'))">windows</_IceRpcOSName>
     <_IceRpcOSName Condition="$([MSBuild]::IsOSPlatform('OSX'))">macos</_IceRpcOSName>
     <_IceRpcOSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower())</_IceRpcOSArch>
-    <_SliceCExe Condition="'$(_IceRpcOSName)' == 'windows'">slicec.exe</_SliceCExe>
-    <_SliceCExe Condition="'$(_IceRpcOSName)' != 'windows'">slicec</_SliceCExe>
   </PropertyGroup>
   <ItemGroup>
     <!-- Build-order-only references; see comment on the analogous block in IceRpc.Slice.Tools.targets. -->


### PR DESCRIPTION
This PR keeps the cleanup stuff from #4723.

- Most of our `.vscode/settings.json` was bogus
- There were a couple typos in the `sync-slice` script
- There was an unused property in one of our `csproj` files.