### PR TITLE
Fix Test Release on 0.6.x: restore local NuGet source for examples

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -58,6 +58,13 @@ jobs:
           gh run download "$RUN_ID" --repo icerpc/icerpc-csharp --name "nuget-packages" --dir packages
         shell: pwsh
 
+      - name: Configure NuGet sources
+        run: |
+          # Add the locally built packages as a NuGet source so the examples restore the
+          # release version being tested instead of an older version from nuget.org.
+          dotnet nuget add source ${{ github.workspace }}/packages -n local-packages --configfile examples/nuget.config
+        shell: pwsh
+
       - name: Install dotnet new templates
         run: |
           $version = $env:IceRpcVersion


### PR DESCRIPTION
## What broke

The `Test NuGet Packages` workflow fails on `0.6.x` at the **🔨 Build Examples** step ([example run](https://github.com/icerpc/icerpc-csharp/actions/runs/27003823521/job/79691092842)):

```
error NU1101: Unable to find package IceRpc.Ice. No packages exist with this id in source(s): nuget.org
error NU1102: Unable to find package IceRpc.Slice with version (>= 0.6.0) — Nearest version: 0.5.2
```

## Cause

#4719 ("Remove nightlies from 0.6.x branch") deleted `examples/nuget.config` **and** removed the `Configure NuGet sources` step from `test-release.yml`. That step was the only thing pointing NuGet at the downloaded `packages/` directory, so the examples now restore from nuget.org alone — where 0.6.0 isn't published yet.

## Fix

Re-add a minimal step that registers the downloaded packages directory as a local NuGet source. Since `examples/nuget.config` no longer exists, `dotnet nuget add source --configfile` creates it with just the local source; nuget.org is still inherited from the global config, so non-IceRPC packages resolve normally. This does **not** reintroduce the nightly feed.