### PR TITLE
Create examples/nuget.config before adding local NuGet source

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           # Add the locally built packages as a NuGet source so the examples restore the
           # release version being tested instead of an older version from nuget.org.
+          dotnet new nugetconfig -o examples
           dotnet nuget add source ${{ github.workspace }}/packages -n local-packages --configfile examples/nuget.config
         shell: pwsh
 


### PR DESCRIPTION
Follow-up to #4728. That step failed with:

```
error: File '.../examples/nuget.config' does not exist.
```

`dotnet nuget add source --configfile` requires the config file to already exist — it does not create it. Generate a default config with `dotnet new nugetconfig` first, then register the local packages source.