### PR TITLE
Stop using floating versions for Microsoft.Extensions packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,6 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Allow floating versions (e.g. 10.0.*) in <PackageVersion>. NuGet rejects floating versions in central package
-         lists by default. -->
-    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     <!-- Pin transitive dependencies to the versions listed below (when listed). Lets us force-upgrade a vulnerable
          transitive package (e.g. a CVE in System.Text.Json) by adding one <PackageVersion> entry here, with no
          spurious direct <PackageReference> in any project. Recommended baseline for new CPM repos. -->
@@ -31,11 +28,11 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
 
     <!-- Microsoft.Extensions.* -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.*" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
 
     <!-- For Slice variant enums  -->

--- a/docfx/examples/Directory.Packages.props
+++ b/docfx/examples/Directory.Packages.props
@@ -2,9 +2,6 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Allow floating versions (e.g. 10.0.*) in <PackageVersion>. NuGet rejects floating versions in central package
-         lists by default. -->
-    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     <!-- Pin transitive dependencies to the versions listed below (when listed). Lets us force-upgrade a vulnerable
          transitive package (e.g. a CVE in System.Text.Json) by adding one <PackageVersion> entry here, with no
          spurious direct <PackageReference> in any project. Recommended baseline for new CPM repos. -->
@@ -26,8 +23,8 @@
     <PackageVersion Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageVersion Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" />
     <PackageVersion Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Directory.Packages.props
+++ b/examples/Directory.Packages.props
@@ -2,9 +2,6 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Allow floating versions (e.g. 10.0.*) in <PackageVersion>. NuGet rejects floating versions in central package
-         lists by default. -->
-    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     <!-- Pin transitive dependencies to the versions listed below (when listed). Lets us force-upgrade a vulnerable
          transitive package (e.g. a CVE in System.Text.Json) by adding one <PackageVersion> entry here, with no
          spurious direct <PackageReference> in any project. Recommended baseline for new CPM repos. -->
@@ -30,10 +27,10 @@
     <PackageVersion Include="IceRpc.Slice" Version="$(IceRpcVersion)" />
     <PackageVersion Include="IceRpc.Slice.Tools" Version="$(IceRpcVersion)" />
     <PackageVersion Include="IceRpc.Telemetry" Version="$(IceRpcVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="IceRpc.Ice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Client/IceRpc-Ice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Client/IceRpc-Ice-DI-Client.csproj
@@ -15,8 +15,8 @@
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="[3.8.2,3.9.0)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Ice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/IceRpc-Ice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/IceRpc-Ice-DI-Server.csproj
@@ -15,8 +15,8 @@
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="[3.8.2,3.9.0)" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Ice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="IceRpc.Ice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="IceRpc.Protobuf" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -9,8 +9,8 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.7.0-preview.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -9,8 +9,8 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="IceRpc.Protobuf.Tools" Version="0.7.0-preview.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Protobuf" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="IceRpc.Protobuf" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="IceRpc.Slice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -9,8 +9,8 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="0.7.0-preview.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -9,8 +9,8 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageReference Include="IceRpc.Slice.Tools" Version="0.7.0-preview.1" PrivateAssets="All" />
     <PackageReference Include="IceRpc.Slice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Extensions.DependencyInjection" Version="0.7.0-preview.1" />

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="IceRpc.Slice" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Deadline" Version="0.7.0-preview.1" />
     <PackageReference Include="IceRpc.Logger" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <!-- The 1.2 beta version is required for supporting the latest language features.
          See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">


### PR DESCRIPTION
It's unclear why we are using floating versions.  This PR switches to `10.0.0` instead of `10.0.*`.