### PR TITLE
Better slice size validation during decoding of an Ice class/exception

### DIFF
--- a/src/ZeroC.Slice/SliceDecoder.Class.cs
+++ b/src/ZeroC.Slice/SliceDecoder.Class.cs
@@ -354,7 +354,8 @@ public ref partial struct SliceDecoder
         // Decode the slice size if available.
         if ((_classContext.Current.SliceFlags & SliceFlags.HasSliceSize) != 0)
         {
-            _classContext.Current.SliceSize = DecodeSliceSize();
+            _classContext.Current.SliceSize =
+                DecodeSliceSize((_classContext.Current.SliceFlags & SliceFlags.HasTaggedFields) != 0);
         }
         else
         {
@@ -369,14 +370,18 @@ public ref partial struct SliceDecoder
     }
 
     /// <summary>Decodes the size of the current slice.</summary>
-    /// <returns>The slice of the current slice, not including the size length.</returns>
-    private int DecodeSliceSize()
+    /// <param name="sliceHasTaggedFields">Indicates whether the slice has tagged fields.</param>
+    /// <returns>The size of the current slice, not including the size length.</returns>
+    private int DecodeSliceSize(bool sliceHasTaggedFields)
     {
+        int minSize = sliceHasTaggedFields ? 5 : 4; // extra byte for the tag end marker
+
         int size = DecodeInt32();
-        if (size < 4)
+        if (size < minSize || size - 4 > _reader.Remaining)
         {
-            throw new InvalidDataException($"Invalid Slice size: {size}.");
+            throw new InvalidDataException($"Received invalid slice size: {size}.");
         }
+
         // The encoded size includes the size length.
         return size - 4;
     }
@@ -460,7 +465,7 @@ public ref partial struct SliceDecoder
                     {
                         throw new InvalidDataException("The Slice size flag is missing.");
                     }
-                    _reader.Advance(DecodeSliceSize());
+                    _reader.Advance(DecodeSliceSize((sliceFlags & SliceFlags.HasTaggedFields) != 0));
 
                     // If this slice has an indirection table, skip it too.
                     if ((sliceFlags & SliceFlags.HasIndirectionTable) != 0)


### PR DESCRIPTION
Backport #4742 to 0.5.x.