### PR TITLE
Fix stale consumed position in ResettablePipeReaderDecorator

### DIFF
--- a/src/IceRpc/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc/ResettablePipeReaderDecorator.cs
@@ -53,13 +53,14 @@ public sealed class ResettablePipeReaderDecorator : PipeReader
         }
     }
 
-    // The latest consumed given by caller; reset by Reset.
+    // The latest consumed given by caller; cleared by Reset and by the first non-resettable AdvanceTo.
     private SequencePosition? _consumed;
     private readonly PipeReader _decoratee;
     // The latest examined given by caller.
     private SequencePosition? _examined;
 
-    // The highest examined given to _decoratee; not affected by Reset.
+    // The highest examined given to _decoratee; not affected by Reset but cleared by the first non-resettable
+    // AdvanceTo.
     private SequencePosition? _highestExamined;
 
     // True when read returned a canceled read result.
@@ -127,6 +128,11 @@ public sealed class ResettablePipeReaderDecorator : PipeReader
                 examined = _highestExamined.Value;
             }
             _decoratee.AdvanceTo(consumed, examined);
+
+            // The decoratee can now recycle the buffers of the consumed data: the positions saved while this
+            // decorator was resettable are no longer valid in subsequent read results.
+            _consumed = null;
+            _highestExamined = null;
         }
     }
 

--- a/tests/IceRpc.Tests/ResettablePipeReaderDecoratorTests.cs
+++ b/tests/IceRpc.Tests/ResettablePipeReaderDecoratorTests.cs
@@ -322,6 +322,108 @@ public sealed class ResettablePipeReaderDecoratorTests
     }
 
     [Test]
+    public async Task Read_after_reader_decorator_becomes_non_resettable_for_large_buffer()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        var sut = new ResettablePipeReaderDecorator(pipe.Reader, maxBufferSize: 100);
+
+        await pipe.Writer.WriteAsync(MakeBuffer(1, 50));
+        ReadResult result = await sut.ReadAsync();
+        // Records the consumed position in the decorator without consuming on the decoratee.
+        sut.AdvanceTo(result.Buffer.End);
+
+        // The cumulative buffered data (150 bytes) exceeds maxBufferSize: the decorator becomes non-resettable.
+        await pipe.Writer.WriteAsync(MakeBuffer(2, 100));
+        result = await sut.ReadAsync();
+        Assert.That(sut.IsResettable, Is.False);
+        Assert.That(result.Buffer.Length, Is.EqualTo(100));
+        sut.AdvanceTo(result.Buffer.End); // consumes on the decoratee
+
+        await pipe.Writer.WriteAsync(MakeBuffer(3, 10));
+
+        // Act
+        result = await sut.ReadAsync();
+
+        // Assert
+        Assert.That(result.Buffer.Length, Is.EqualTo(10));
+        Assert.That(result.Buffer.ToArray(), Is.All.EqualTo(3));
+
+        sut.AdvanceTo(result.Buffer.End);
+        sut.Complete();
+        pipe.Writer.Complete();
+    }
+
+    [Test]
+    public async Task ReadAtLeast_after_reader_decorator_becomes_non_resettable_for_large_buffer()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        var sut = new ResettablePipeReaderDecorator(pipe.Reader, maxBufferSize: 100);
+
+        await pipe.Writer.WriteAsync(MakeBuffer(1, 50));
+        ReadResult result = await sut.ReadAsync();
+        // Records the consumed position in the decorator without consuming on the decoratee.
+        sut.AdvanceTo(result.Buffer.End);
+
+        // The cumulative buffered data (150 bytes) exceeds maxBufferSize: the decorator becomes non-resettable.
+        await pipe.Writer.WriteAsync(MakeBuffer(2, 100));
+        result = await sut.ReadAsync();
+        Assert.That(sut.IsResettable, Is.False);
+        Assert.That(result.Buffer.Length, Is.EqualTo(100));
+        sut.AdvanceTo(result.Buffer.End); // consumes on the decoratee
+
+        // Complete the writer; otherwise a minimumSize incorrectly adjusted with the consumed position would block
+        // the read below forever.
+        await pipe.Writer.WriteAsync(MakeBuffer(3, 10));
+        pipe.Writer.Complete();
+
+        // Act
+        result = await sut.ReadAtLeastAsync(10);
+
+        // Assert
+        Assert.That(result.Buffer.Length, Is.EqualTo(10));
+        Assert.That(result.Buffer.ToArray(), Is.All.EqualTo(3));
+
+        sut.AdvanceTo(result.Buffer.End);
+        sut.Complete();
+    }
+
+    [Test]
+    public async Task Read_after_setter_makes_reader_decorator_non_resettable()
+    {
+        // Arrange
+        var pipe = new Pipe();
+        var sut = new ResettablePipeReaderDecorator(pipe.Reader, maxBufferSize: 1000);
+
+        await pipe.Writer.WriteAsync(MakeBuffer(1, 50));
+        ReadResult result = await sut.ReadAsync();
+        // Records the consumed position in the decorator without consuming on the decoratee.
+        sut.AdvanceTo(result.Buffer.End);
+
+        sut.IsResettable = false;
+
+        // This read slices off the 50 bytes consumed above (the decoratee has not consumed them yet).
+        await pipe.Writer.WriteAsync(MakeBuffer(2, 100));
+        result = await sut.ReadAsync();
+        Assert.That(result.Buffer.Length, Is.EqualTo(100));
+        sut.AdvanceTo(result.Buffer.End); // consumes on the decoratee
+
+        await pipe.Writer.WriteAsync(MakeBuffer(3, 10));
+
+        // Act
+        result = await sut.ReadAsync();
+
+        // Assert
+        Assert.That(result.Buffer.Length, Is.EqualTo(10));
+        Assert.That(result.Buffer.ToArray(), Is.All.EqualTo(3));
+
+        sut.AdvanceTo(result.Buffer.End);
+        sut.Complete();
+        pipe.Writer.Complete();
+    }
+
+    [Test]
     public async Task Non_resettable_reader_decorator_is_pass_through()
     {
         var readResult = new ReadResult(
@@ -343,6 +445,13 @@ public sealed class ResettablePipeReaderDecoratorTests
         Assert.That(mock.Consumed, Is.EqualTo(readResult.Buffer.End));
         Assert.That(mock.CancelPendingReadCalled, Is.False);
         Assert.That(mock.Examined, Is.EqualTo(readResult.Buffer.End));
+    }
+
+    private static byte[] MakeBuffer(byte value, int size)
+    {
+        var buffer = new byte[size];
+        Array.Fill(buffer, value);
+        return buffer;
     }
 
     private sealed class MockPipeReader : PipeReader


### PR DESCRIPTION
Fixes #4745.

The non-resettable `AdvanceTo` branch now clears `_consumed` and `_highestExamined` after calling `_decoratee.AdvanceTo`: once the decoratee consumes, it can recycle the buffers these positions point into. They are intentionally not cleared at flip time, because `ProcessReadResult` must keep slicing off the consumed prefix until the first real consume.

Includes three regression tests covering the `maxBufferSize` flip (via `ReadAsync` and `ReadAtLeastAsync`) and the `IsResettable` setter variant.
