### PR TITLE
Fix tiny bug in constructor

### DIFF
--- a/src/IceRpc/OutgoingResponse.cs
+++ b/src/IceRpc/OutgoingResponse.cs
@@ -49,11 +49,12 @@ public sealed class OutgoingResponse : OutgoingFrame
         Exception? exception = null)
         : base(request.Protocol)
     {
-        request.Response = this;
         StatusCode = statusCode > StatusCode.Ok ? statusCode :
             throw new ArgumentException(
                 $"The status code for an exception must be greater than {nameof(StatusCode.Ok)}.",
                 nameof(statusCode));
+
+        request.Response = this;
 
         string errorMessage = message ?? $"The dispatch failed with status code {statusCode}.";
         if (exception is not null)


### PR DESCRIPTION
We want to validate the status code before setting request.Response. Very minor bug.