### PR TITLE
Reject empty Slice segment in the middle of an element stream

### DIFF
--- a/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
+++ b/src/IceRpc.Slice/Operations/Internal/AsyncStream.cs
@@ -110,6 +110,8 @@ internal sealed class AsyncStream<T> : IAsyncStream<T>
                     }
                     if (readResult.Buffer.IsEmpty)
                     {
+                        // An empty buffer means the reader completed with no more bytes, which is how the end of a
+                        // stream is signaled. (A zero-size Slice segment is rejected when the segment is read.)
                         Debug.Assert(readResult.IsCompleted);
                         yield break;
                     }

--- a/src/IceRpc/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc/Internal/PipeReaderExtensions.cs
@@ -174,6 +174,15 @@ internal static class PipeReaderExtensions
                 throw new InvalidDataException("The segment size can't be larger than int.MaxValue.", exception);
             }
 
+            if (segmentSize == 0)
+            {
+                // An encoded segment size of 0 is never valid: a segment holding non-streamed args or a return
+                // value is at least 1 byte (the tag end marker), and a segment holding streamed elements is at
+                // least 1 byte. The end of a stream is signaled by the reader completing with no bytes, not by a
+                // zero-size segment.
+                throw new InvalidDataException("Received a Slice segment with a size of 0.");
+            }
+
             if (segmentSize > maxSize)
             {
                 throw new InvalidDataException("The segment size exceeds the maximum value.");
@@ -181,7 +190,6 @@ internal static class PipeReaderExtensions
 
             if (readResult.Buffer.Length >= consumed + segmentSize)
             {
-                // When segmentSize is 0, we return a read result with an empty buffer.
                 readResult = new ReadResult(
                     readResult.Buffer.Slice(readResult.Buffer.GetPosition(consumed), segmentSize),
                     isCanceled: false,

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -62,8 +62,7 @@ public class AsyncStreamTests
     public void Zero_size_segment_in_the_middle_of_the_stream_throws_InvalidDataException()
     {
         // A zero-size segment is never valid: the end of a stream is signaled by the reader completing with no
-        // bytes, not by a zero-size segment. See https://github.com/icerpc/icerpc-csharp/issues/4755. We use a
-        // variable-size element (string) because only variable-size element streams are encoded with segments.
+        // bytes, not by a zero-size segment.
         byte[] payload = EncodeStringSegments(["a", "b"], [], ["c"]);
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
         using IAsyncStream<string> stream = trackingReader.ToAsyncStream(

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -59,6 +59,59 @@ public class AsyncStreamTests
     }
 
     [Test]
+    public void Zero_size_segment_in_the_middle_of_the_stream_throws_InvalidDataException()
+    {
+        // A zero-size segment is never valid: the end of a stream is signaled by the reader completing with no
+        // bytes, not by a zero-size segment. See https://github.com/icerpc/icerpc-csharp/issues/4755.
+        byte[] payload = EncodeInt32Segments([1, 2], [], [3]);
+        var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
+        using IAsyncStream<int> stream = trackingReader.ToAsyncStream(
+            (ref SliceDecoder decoder) => decoder.DecodeInt32());
+
+        var items = new List<int>();
+
+        Assert.That(
+            async () =>
+            {
+                await foreach (int item in stream)
+                {
+                    items.Add(item);
+                }
+            },
+            Throws.TypeOf<InvalidDataException>());
+
+        Assert.That(items, Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Zero_size_segment_at_the_end_of_the_stream_throws_InvalidDataException()
+    {
+        // A zero-size segment is never valid, including at the end of the stream: the end of a stream is signaled
+        // by the reader completing with no bytes, not by a zero-size segment.
+        // See https://github.com/icerpc/icerpc-csharp/issues/4755.
+        byte[] payload = EncodeInt32Segments([1, 2, 3], []);
+        var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
+        using IAsyncStream<int> stream = trackingReader.ToAsyncStream(
+            (ref SliceDecoder decoder) => decoder.DecodeInt32());
+
+        var items = new List<int>();
+
+        Assert.That(
+            async () =>
+            {
+                await foreach (int item in stream)
+                {
+                    items.Add(item);
+                }
+            },
+            Throws.TypeOf<InvalidDataException>());
+
+        Assert.That(items, Is.EqualTo(new[] { 1, 2, 3 }));
+        Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task Break_during_iteration_completes_reader()
     {
         byte[] payload = EncodeInt32Values(1, 2, 3);
@@ -215,6 +268,21 @@ public class AsyncStreamTests
 
             Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1), $"iteration {i}");
         }
+    }
+
+    private static byte[] EncodeInt32Segments(params int[][] segments)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        var encoder = new SliceEncoder(writer);
+        foreach (int[] segment in segments)
+        {
+            encoder.EncodeVarUInt62((ulong)(segment.Length * 4));
+            foreach (int value in segment)
+            {
+                encoder.EncodeInt32(value);
+            }
+        }
+        return writer.WrittenSpan.ToArray();
     }
 
     private static byte[] EncodeInt32Values(params int[] values)

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -62,25 +62,26 @@ public class AsyncStreamTests
     public void Zero_size_segment_in_the_middle_of_the_stream_throws_InvalidDataException()
     {
         // A zero-size segment is never valid: the end of a stream is signaled by the reader completing with no
-        // bytes, not by a zero-size segment. See https://github.com/icerpc/icerpc-csharp/issues/4755.
-        byte[] payload = EncodeInt32Segments([1, 2], [], [3]);
+        // bytes, not by a zero-size segment. See https://github.com/icerpc/icerpc-csharp/issues/4755. We use a
+        // variable-size element (string) because only variable-size element streams are encoded with segments.
+        byte[] payload = EncodeStringSegments(["a", "b"], [], ["c"]);
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
-        using IAsyncStream<int> stream = trackingReader.ToAsyncStream(
-            (ref SliceDecoder decoder) => decoder.DecodeInt32());
+        using IAsyncStream<string> stream = trackingReader.ToAsyncStream(
+            (ref SliceDecoder decoder) => decoder.DecodeString());
 
-        var items = new List<int>();
+        var items = new List<string>();
 
         Assert.That(
             async () =>
             {
-                await foreach (int item in stream)
+                await foreach (string item in stream)
                 {
                     items.Add(item);
                 }
             },
             Throws.TypeOf<InvalidDataException>());
 
-        Assert.That(items, Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(items, Is.EqualTo(new[] { "a", "b" }));
         Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1));
     }
 
@@ -89,25 +90,26 @@ public class AsyncStreamTests
     {
         // A zero-size segment is never valid, including at the end of the stream: the end of a stream is signaled
         // by the reader completing with no bytes, not by a zero-size segment.
-        // See https://github.com/icerpc/icerpc-csharp/issues/4755.
-        byte[] payload = EncodeInt32Segments([1, 2, 3], []);
+        // See https://github.com/icerpc/icerpc-csharp/issues/4755. We use a variable-size element (string) because
+        // only variable-size element streams are encoded with segments.
+        byte[] payload = EncodeStringSegments(["a", "b", "c"], []);
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
-        using IAsyncStream<int> stream = trackingReader.ToAsyncStream(
-            (ref SliceDecoder decoder) => decoder.DecodeInt32());
+        using IAsyncStream<string> stream = trackingReader.ToAsyncStream(
+            (ref SliceDecoder decoder) => decoder.DecodeString());
 
-        var items = new List<int>();
+        var items = new List<string>();
 
         Assert.That(
             async () =>
             {
-                await foreach (int item in stream)
+                await foreach (string item in stream)
                 {
                     items.Add(item);
                 }
             },
             Throws.TypeOf<InvalidDataException>());
 
-        Assert.That(items, Is.EqualTo(new[] { 1, 2, 3 }));
+        Assert.That(items, Is.EqualTo(new[] { "a", "b", "c" }));
         Assert.That(trackingReader.CompleteCallCount, Is.EqualTo(1));
     }
 
@@ -270,17 +272,24 @@ public class AsyncStreamTests
         }
     }
 
-    private static byte[] EncodeInt32Segments(params int[][] segments)
+    // Encodes a sequence of Slice segments, each holding the given variable-size (string) elements, prefixed by its
+    // encoded byte size. A segment with no elements produces a zero-size segment.
+    private static byte[] EncodeStringSegments(params string[][] segments)
     {
         var writer = new ArrayBufferWriter<byte>();
         var encoder = new SliceEncoder(writer);
-        foreach (int[] segment in segments)
+        foreach (string[] segment in segments)
         {
-            encoder.EncodeVarUInt62((ulong)(segment.Length * 4));
-            foreach (int value in segment)
+            // Encode the segment body first to measure its byte size.
+            var segmentWriter = new ArrayBufferWriter<byte>();
+            var segmentEncoder = new SliceEncoder(segmentWriter);
+            foreach (string value in segment)
             {
-                encoder.EncodeInt32(value);
+                segmentEncoder.EncodeString(value);
             }
+
+            encoder.EncodeVarUInt62((ulong)segmentWriter.WrittenCount);
+            encoder.WriteByteSpan(segmentWriter.WrittenSpan);
         }
         return writer.WrittenSpan.ToArray();
     }

--- a/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Slice.Tests/AsyncStreamTests.cs
@@ -89,8 +89,6 @@ public class AsyncStreamTests
     {
         // A zero-size segment is never valid, including at the end of the stream: the end of a stream is signaled
         // by the reader completing with no bytes, not by a zero-size segment.
-        // See https://github.com/icerpc/icerpc-csharp/issues/4755. We use a variable-size element (string) because
-        // only variable-size element streams are encoded with segments.
         byte[] payload = EncodeStringSegments(["a", "b", "c"], []);
         var trackingReader = new TrackingPipeReader(PipeReader.Create(new ReadOnlySequence<byte>(payload)));
         using IAsyncStream<string> stream = trackingReader.ToAsyncStream(

--- a/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
+++ b/tests/IceRpc.Slice.Tests/PipeReaderTests.cs
@@ -11,16 +11,31 @@ namespace IceRpc.Slice.Tests;
 public class PipeReaderTests
 {
     [Test]
-    public async Task Calling_advance_to_on_an_empty_segment()
+    public async Task Reading_a_zero_size_segment_fails()
     {
         var pipe = new Pipe();
-        await pipe.Writer.WriteAsync(new byte[] { 0 }); // empty segment
+        await pipe.Writer.WriteAsync(new byte[] { 0 }); // zero-size segment
+
+        Assert.That(
+            async () => await pipe.Reader.ReadSliceSegmentAsync(maxSize: 100, default),
+            Throws.TypeOf<InvalidDataException>());
+
+        pipe.Writer.Complete();
+        pipe.Reader.Complete();
+    }
+
+    [Test]
+    public async Task Calling_advance_to_on_an_empty_segment_at_end_of_stream()
+    {
+        // The end of a stream is signaled by completing the writer with no bytes, not by a zero-size segment.
+        var pipe = new Pipe();
+        pipe.Writer.Complete();
+
         ReadResult readResult = await pipe.Reader.ReadSliceSegmentAsync(maxSize: 100, default);
 
+        Assert.That(readResult.Buffer.IsEmpty, Is.True);
+        Assert.That(readResult.IsCompleted, Is.True);
         pipe.Reader.AdvanceTo(readResult.Buffer.End);
-
-        Assert.That(readResult.IsCompleted, Is.False);
-        pipe.Writer.Complete();
         pipe.Reader.Complete();
     }
 


### PR DESCRIPTION
Fixes #4755.

`AsyncStream<T>.EnumerateAsync` treated any empty buffer as the end of the stream. A zero-size Slice segment followed by more data also produces an empty buffer with `IsCompleted` false (see `PipeReaderExtensions.IsCompleteSegment`): a `Debug.Assert` fired in debug builds, and in release builds the element stream ended silently, dropping the remaining elements.

The only expected empty segment is the one that ends the stream. `EnumerateAsync` now throws `InvalidDataException` when it reads an empty segment in the middle of an element stream.

Changes:
- `AsyncStream.EnumerateAsync`: distinguish "empty + completed" (end of stream) from "empty + not completed" (protocol violation, `InvalidDataException`).
- New test `Zero_size_segment_in_the_middle_of_the_stream_throws_InvalidDataException`: written first against the unfixed code, where it failed with `Debug.Fail`; also checks that elements decoded before the invalid segment are still yielded and that the reader is completed exactly once.
- New test `Zero_size_segment_at_the_end_of_the_stream_completes_iteration`: pins the legal case, a trailing zero-size segment ends the stream normally.

The C# encoder (`AsyncEnumerablePipeReader`) never emits zero-size segments, so this only affects streams received from a peer that does.