### PR TITLE
Make _detachedConnectionTcs run coninuation asynchronously

### DIFF
--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -30,7 +30,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     // connection is "detached" because it's not in _activeConnection.
     private int _detachedConnectionCount;
 
-    private readonly TaskCompletionSource _detachedConnectionsTcs = new();
+    private readonly TaskCompletionSource _detachedConnectionsTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     // A cancellation token source that is canceled when DisposeAsync is called.
     private readonly CancellationTokenSource _disposedCts = new();

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -29,7 +29,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     // connection is "detached" because it's not in _activeConnections.
     private int _detachedConnectionCount;
 
-    private readonly TaskCompletionSource _detachedConnectionsTcs = new();
+    private readonly TaskCompletionSource _detachedConnectionsTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     // A cancellation token source that is canceled when DisposeAsync is called.
     private readonly CancellationTokenSource _disposedCts = new();

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -26,7 +26,8 @@ public sealed class Server : IAsyncDisposable
     // in _connections.
     private int _detachedConnectionCount;
 
-    private readonly TaskCompletionSource _detachedConnectionsTcs = new();
+    private readonly TaskCompletionSource _detachedConnectionsTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     // A cancellation token source that is canceled by DisposeAsync.
     private readonly CancellationTokenSource _disposedCts = new();


### PR DESCRIPTION
Since we call `SetResult` and `TrySetResult` within a mutex lock, the continuation must runs asynchronously.