### PR TITLE
Fix Server ShutdownAsync/DisposeAsync race condition

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -293,12 +293,21 @@ public sealed class Server : IAsyncDisposable
 
             // _listenTask etc are immutable when _disposeTask is not null.
 
+            // Wait for shutdown before disposing connections.
+            try
+            {
+                await _shutdownTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore exceptions.
+            }
+
             if (_listenTask is not null)
             {
-                // Wait for shutdown before disposing connections.
                 try
                 {
-                    await Task.WhenAll(_listenTask, _shutdownTask).ConfigureAwait(false);
+                    await _listenTask.ConfigureAwait(false);
                 }
                 catch
                 {


### PR DESCRIPTION
This PR fixes a very unlikely race condition between a DisposeAsync on a server that never listened, and a concurrent ShutdownAsync on the same server.

