### PR TITLE
Add missing _throwIfConnectionClosedOrDisposed in QuicPipeReader

### DIFF
--- a/src/IceRpc/Transports/Quic/Internal/QuicPipeReader.cs
+++ b/src/IceRpc/Transports/Quic/Internal/QuicPipeReader.cs
@@ -116,6 +116,21 @@ internal class QuicPipeReader : PipeReader
         int minimumSize,
         CancellationToken cancellationToken)
     {
+        // First check if there's sufficient buffered data. If the connection is closed, we still want to return this
+        // data.
+        if (TryRead(out ReadResult readResult))
+        {
+            if (readResult.Buffer.Length >= minimumSize || readResult.IsCompleted || readResult.IsCanceled)
+            {
+                return readResult;
+            }
+            else
+            {
+                // We need more data, keep going.
+                _pipeReader.AdvanceTo(readResult.Buffer.Start);
+            }
+        }
+
         _throwIfConnectionClosedOrDisposed();
 
         try

--- a/src/IceRpc/Transports/Quic/Internal/QuicPipeReader.cs
+++ b/src/IceRpc/Transports/Quic/Internal/QuicPipeReader.cs
@@ -116,6 +116,8 @@ internal class QuicPipeReader : PipeReader
         int minimumSize,
         CancellationToken cancellationToken)
     {
+        _throwIfConnectionClosedOrDisposed();
+
         try
         {
             return await _pipeReader.ReadAtLeastAsync(minimumSize, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
We call this action before all async reads - it was missing in one method.