### PR TITLE
Write Slic Pong frames in the background and cap queued Pongs

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1317,15 +1317,14 @@ internal class SlicConnection : IMultiplexedConnection
                 (ref SliceDecoder decoder) => new PingBody(ref decoder),
                 cancellationToken).ConfigureAwait(false);
 
-            // Only the read frames loop increments _outstandingPongCount, so the check before the increment doesn't
-            // race with other increments; concurrent decrements can only make the count smaller.
-            if (Volatile.Read(ref _outstandingPongCount) >= _maxOutstandingPongs)
+            if (Interlocked.Increment(ref _outstandingPongCount) > _maxOutstandingPongs)
             {
+                // Roll back the increment so the count keeps matching the number of queued Pong frames.
+                Interlocked.Decrement(ref _outstandingPongCount);
                 throw new IceRpcException(
                     IceRpcError.IceRpcError,
                     $"Received a {nameof(FrameType.Ping)} frame while {_maxOutstandingPongs} {nameof(FrameType.Pong)} frames are already queued for sending.");
             }
-            Interlocked.Increment(ref _outstandingPongCount);
 
             // Return a pong frame with the ping payload, written in the background: writing it from the read frames
             // loop would block the loop when another writer holds _writeSemaphore while parked on a full outbound

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -76,6 +76,7 @@ internal class SlicConnection : IMultiplexedConnection
     private ulong? _lastRemoteUnidirectionalStreamId;
     private readonly TimeSpan _localIdleTimeout;
     private readonly int _maxBidirectionalStreams;
+    private readonly int _maxOutstandingPongs;
     private readonly int _maxStreamFrameSize;
     private readonly int _maxUnidirectionalStreams;
     // _mutex ensure the assignment of _lastRemoteXxx members and the addition of the stream to _streams is
@@ -83,8 +84,15 @@ internal class SlicConnection : IMultiplexedConnection
     private readonly Lock _mutex = new();
     private ulong _nextBidirectionalId;
     private ulong _nextUnidirectionalId;
+
+    // The number of Pong frames queued for sending (in response to Ping frames) but not yet written to the duplex
+    // connection. The connection is aborted when a Ping frame is received while this count has reached
+    // _maxOutstandingPongs.
+    private int _outstandingPongCount;
     private IceRpcError? _peerCloseError;
     private TimeSpan _peerIdleTimeout = Timeout.InfiniteTimeSpan;
+
+    // The number of Ping frames sent to the peer that have not been answered yet by a Pong frame.
     private int _pendingPongCount;
     private Task? _readFramesTask;
 
@@ -600,6 +608,7 @@ internal class SlicConnection : IMultiplexedConnection
         InitialStreamWindowSize = slicOptions.InitialStreamWindowSize;
         PauseWriterThreshold = slicOptions.PauseWriterThreshold;
         _localIdleTimeout = slicOptions.IdleTimeout;
+        _maxOutstandingPongs = slicOptions.MaxOutstandingPongs;
         _maxStreamFrameSize = slicOptions.MaxStreamFrameSize;
 
         _acceptStreamChannel = Channel.CreateUnbounded<IMultiplexedStream>(new UnboundedChannelOptions
@@ -1308,11 +1317,43 @@ internal class SlicConnection : IMultiplexedConnection
                 (ref SliceDecoder decoder) => new PingBody(ref decoder),
                 cancellationToken).ConfigureAwait(false);
 
-            // Return a pong frame with the ping payload.
-            await WriteConnectionFrameAsync(
-                FrameType.Pong,
-                new PongBody(pingBody.Payload).Encode,
-                cancellationToken).ConfigureAwait(false);
+            if (Interlocked.Increment(ref _outstandingPongCount) > _maxOutstandingPongs)
+            {
+                throw new InvalidDataException(
+                    $"Received a {nameof(FrameType.Ping)} frame while {_maxOutstandingPongs} {nameof(FrameType.Pong)} frames are already queued for sending.");
+            }
+
+            // Return a pong frame with the ping payload, written in the background: writing it from the read frames
+            // loop would block the loop when another writer holds _writeSemaphore while parked on a full outbound
+            // pipe, suppressing further reads (and idle timeout detection) until the pipe drains.
+            _ = WritePongFrameAsync(pingBody.Payload);
+        }
+
+        async Task WritePongFrameAsync(long payload)
+        {
+            try
+            {
+                await WriteConnectionFrameAsync(
+                    FrameType.Pong,
+                    new PongBody(payload).Encode,
+                    _closedCancellationToken).ConfigureAwait(false);
+            }
+            catch (IceRpcException)
+            {
+                // Expected if the connection is closed.
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected if the connection is closed.
+            }
+            catch (Exception exception)
+            {
+                Debug.Fail($"The sending of a Pong frame failed with an unexpected exception: {exception}");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _outstandingPongCount);
+            }
         }
 
         async Task ReadPongFrameAsync(int size, CancellationToken cancellationToken)

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1319,8 +1319,6 @@ internal class SlicConnection : IMultiplexedConnection
 
             if (Interlocked.Increment(ref _outstandingPongCount) > _maxOutstandingPongs)
             {
-                // Roll back the increment so the count keeps matching the number of queued Pong frames.
-                Interlocked.Decrement(ref _outstandingPongCount);
                 throw new IceRpcException(
                     IceRpcError.IceRpcError,
                     $"Received a {nameof(FrameType.Ping)} frame while {_maxOutstandingPongs} {nameof(FrameType.Pong)} frames are already queued for sending.");

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1317,11 +1317,15 @@ internal class SlicConnection : IMultiplexedConnection
                 (ref SliceDecoder decoder) => new PingBody(ref decoder),
                 cancellationToken).ConfigureAwait(false);
 
-            if (Interlocked.Increment(ref _outstandingPongCount) > _maxOutstandingPongs)
+            // Only the read frames loop increments _outstandingPongCount, so the check before the increment doesn't
+            // race with other increments; concurrent decrements can only make the count smaller.
+            if (Volatile.Read(ref _outstandingPongCount) >= _maxOutstandingPongs)
             {
-                throw new InvalidDataException(
+                throw new IceRpcException(
+                    IceRpcError.IceRpcError,
                     $"Received a {nameof(FrameType.Ping)} frame while {_maxOutstandingPongs} {nameof(FrameType.Pong)} frames are already queued for sending.");
             }
+            Interlocked.Increment(ref _outstandingPongCount);
 
             // Return a pong frame with the ping payload, written in the background: writing it from the read frames
             // loop would block the loop when another writer holds _writeSemaphore while parked on a full outbound
@@ -1349,6 +1353,10 @@ internal class SlicConnection : IMultiplexedConnection
             catch (Exception exception)
             {
                 Debug.Fail($"The sending of a Pong frame failed with an unexpected exception: {exception}");
+
+                // Rethrow so in release builds the exception is not swallowed and can be presented to the application
+                // as an unobserved task exception.
+                throw;
             }
             finally
             {

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -45,7 +45,8 @@ public sealed record class SlicTransportOptions
     /// <summary>Gets or sets the maximum number of Pong frames that can be queued for sending. A Pong frame is queued
     /// for sending when a Ping frame is received, and remains queued until it is written to the underlying duplex
     /// connection. The connection is aborted when a Ping frame is received while this limit is reached; this protects
-    /// against a peer that sends Ping frames faster than the connection can write the Pong frames.</summary>
+    /// against a peer that doesn't read from the connection but keeps sending Ping frames, which would otherwise
+    /// queue Pong frame writes without limit.</summary>
     /// <value>The maximum number of Pong frames queued for sending. It can't be less than <c>1</c>. Defaults to
     /// <c>100</c>.</value>
     public int MaxOutstandingPongs

--- a/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
+++ b/src/IceRpc/Transports/Slic/SlicTransportOptions.cs
@@ -42,6 +42,23 @@ public sealed record class SlicTransportOptions
             value;
     }
 
+    /// <summary>Gets or sets the maximum number of Pong frames that can be queued for sending. A Pong frame is queued
+    /// for sending when a Ping frame is received, and remains queued until it is written to the underlying duplex
+    /// connection. The connection is aborted when a Ping frame is received while this limit is reached; this protects
+    /// against a peer that sends Ping frames faster than the connection can write the Pong frames.</summary>
+    /// <value>The maximum number of Pong frames queued for sending. It can't be less than <c>1</c>. Defaults to
+    /// <c>100</c>.</value>
+    public int MaxOutstandingPongs
+    {
+        get => _maxOutstandingPongs;
+        set => _maxOutstandingPongs =
+            value < 1 ?
+            throw new ArgumentException(
+                $"The {nameof(MaxOutstandingPongs)} value cannot be less than 1.",
+                nameof(value)) :
+            value;
+    }
+
     /// <summary>Gets or sets the maximum stream frame size in bytes.</summary>
     /// <value>The maximum stream frame size in bytes. It can't be less than <c>1024</c> or greater than
     /// <c>16,777,215</c> (2^24 - 1). Defaults to <c>32,768</c>.</value>
@@ -93,5 +110,6 @@ public sealed record class SlicTransportOptions
 
     // The default specified in the HTTP/2 specification.
     private int _initialStreamWindowSize = 65_536;
+    private int _maxOutstandingPongs = 100;
     private int _maxStreamFrameSize = 32_768;
 }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1747,7 +1747,7 @@ public class SlicTransportTests
 
     /// <summary>Verifies that the read frames loop is not blocked by the Pong frame write that responds to a Ping
     /// frame when another write holds the connection's write semaphore while parked on the connection-level pipe
-    /// pause (PauseWriterThreshold reached). See icerpc/icerpc-csharp-audit#17.</summary>
+    /// pause (PauseWriterThreshold reached).</summary>
     [Test]
     public async Task Read_frames_loop_is_not_blocked_by_pong_write_when_a_write_is_parked_on_pipe_threshold()
     {

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1475,6 +1475,20 @@ public class SlicTransportTests
         Assert.That(options.PauseWriterThreshold, Is.Zero);
     }
 
+    [Test]
+    public void MaxOutstandingPongs_default_value()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(options.MaxOutstandingPongs, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void MaxOutstandingPongs_below_minimum_throws()
+    {
+        var options = new SlicTransportOptions();
+        Assert.That(() => options.MaxOutstandingPongs = 0, Throws.TypeOf<ArgumentException>());
+    }
+
     /// <summary>Verifies that <see cref="SlicTransportOptions.PauseWriterThreshold"/> = 0 disables connection-level
     /// flow control: a write can fill the outbound pipe arbitrarily without parking on FlushAsync, even when the
     /// background writer task can't drain the pipe.</summary>
@@ -1722,6 +1736,163 @@ public class SlicTransportTests
         catch
         {
         }
+        try
+        {
+            await serverWriteTask;
+        }
+        catch
+        {
+        }
+    }
+
+    /// <summary>Verifies that the read frames loop is not blocked by the Pong frame write that responds to a Ping
+    /// frame when another write holds the connection's write semaphore while parked on the connection-level pipe
+    /// pause (PauseWriterThreshold reached). See icerpc/icerpc-csharp-audit#17.</summary>
+    [Test]
+    public async Task Read_frames_loop_is_not_blocked_by_pong_write_when_a_write_is_parked_on_pipe_threshold()
+    {
+        // Arrange: small server-side PauseWriterThreshold so a server stream write fills the connection-level
+        // outbound pipe and parks on FlushAsync while holding the write semaphore.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(options => options.PauseWriterThreshold = 1024);
+        services.AddTestDuplexTransportDecorator();
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var _ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Connect the multiplexed connection.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open a bidirectional stream (the first client bidirectional stream ID is 0) and accept it on the server.
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream serverStream = await acceptStreamTask;
+
+        // Hold server duplex writes so the background writer task can't drain the connection-level outbound pipe.
+        var serverDuplexConnection =
+            provider.GetRequiredService<TestDuplexServerTransportDecorator>().LastAcceptedConnection;
+        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.Write;
+
+        // This write fills the outbound pipe past PauseWriterThreshold and parks on FlushAsync while holding the
+        // write semaphore.
+        Task<FlushResult> serverWriteTask = serverStream.Output.WriteAsync(new byte[4 * 1024], default).AsTask();
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(serverWriteTask.IsCompleted, Is.False);
+
+        // Act: the Pong frame write that responds to this Ping frame can't make progress while the write semaphore
+        // is held.
+        await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0L).Encode);
+
+        // Open a second stream (the next client bidirectional stream ID is 4) to verify that the read frames loop
+        // still processes incoming frames.
+        ValueTask<IMultiplexedStream> nextAcceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 4ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+
+        // Assert
+        Assert.That(
+            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromSeconds(10)),
+            Throws.Nothing);
+
+        // Cleanup: release the hold so the parked write (and the queued pong write) can complete.
+        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.None;
+        Assert.That(async () => await serverWriteTask, Throws.Nothing);
+    }
+
+    /// <summary>Verifies that the connection is aborted when a Ping frame is received while
+    /// <see cref="SlicTransportOptions.MaxOutstandingPongs" /> Pong frames are already queued for sending. See
+    /// icerpc/icerpc-csharp-audit#17.</summary>
+    [Test]
+    public async Task Connection_is_aborted_when_max_outstanding_pongs_is_exceeded()
+    {
+        // Arrange: same parked-write arrangement as the previous test, plus a small MaxOutstandingPongs.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(options =>
+        {
+            options.MaxOutstandingPongs = 3;
+            options.PauseWriterThreshold = 1024;
+        });
+        services.AddTestDuplexTransportDecorator();
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var _ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Connect the multiplexed connection.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open a bidirectional stream (the first client bidirectional stream ID is 0) and accept it on the server.
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream serverStream = await acceptStreamTask;
+
+        // Hold server duplex writes so the background writer task can't drain the connection-level outbound pipe.
+        var serverDuplexConnection =
+            provider.GetRequiredService<TestDuplexServerTransportDecorator>().LastAcceptedConnection;
+        serverDuplexConnection.Operations.Hold = DuplexTransportOperations.Write;
+
+        // This write fills the outbound pipe past PauseWriterThreshold and parks on FlushAsync while holding the
+        // write semaphore.
+        Task<FlushResult> serverWriteTask = serverStream.Output.WriteAsync(new byte[4 * 1024], default).AsTask();
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(serverWriteTask.IsCompleted, Is.False);
+
+        ValueTask<IMultiplexedStream> nextAcceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Act: each Ping frame queues a Pong frame write that can't make progress while the write semaphore is
+        // held; the fourth Ping frame exceeds MaxOutstandingPongs.
+        for (int i = 0; i < 4; ++i)
+        {
+            await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0L).Encode);
+        }
+
+        // Assert: a WaitAsync timeout fails this test instead of hanging the test run if the connection is not
+        // aborted.
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
+            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
+        Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
+        Assert.That(
+            exception.InnerException?.Message,
+            Is.EqualTo("Received a Ping frame while 3 Pong frames are already queued for sending."));
+
+        // Cleanup: the connection abort unblocks the parked write with an exception.
         try
         {
             await serverWriteTask;

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1809,9 +1809,11 @@ public class SlicTransportTests
             streamId: 4ul,
             (ref SliceEncoder encoder) => encoder.EncodeBool(false));
 
-        // Assert
+        // Assert. The WaitAsync margin exceeds CI's --blame-hang-timeout (60 s) so that a hang is detected and
+        // dumped by the hang detection first; the timeout is only a fallback that fails this test instead of
+        // hanging the test run when hang detection is not enabled.
         Assert.That(
-            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromSeconds(10)),
+            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromMinutes(2)),
             Throws.Nothing);
 
         // Cleanup: release the hold so the parked write (and the queued pong write) can complete.
@@ -1882,10 +1884,11 @@ public class SlicTransportTests
             await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0L).Encode);
         }
 
-        // Assert: a WaitAsync timeout fails this test instead of hanging the test run if the connection is not
-        // aborted.
+        // Assert. The WaitAsync margin exceeds CI's --blame-hang-timeout (60 s) so that a hang is detected and
+        // dumped by the hang detection first; the timeout is only a fallback that fails this test instead of
+        // hanging the test run when hang detection is not enabled.
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
-            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
+            async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromMinutes(2)));
         Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
         Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
         Assert.That(

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1904,6 +1904,54 @@ public class SlicTransportTests
         }
     }
 
+    /// <summary>Verifies that a Ping frame received after a local CloseAsync doesn't fault the read frames loop:
+    /// the read frames loop keeps reading until the peer shuts down the duplex connection, and the Pong write
+    /// failure on the closed connection must be ignored. See icerpc/icerpc-csharp-audit#29.</summary>
+    [Test]
+    public async Task Ping_received_after_local_close_does_not_fail_graceful_close()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var _ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Connect the multiplexed connection.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Close the server connection; the read frames loop keeps reading until the client shuts down the duplex
+        // connection.
+        Task closeTask = multiplexedServerConnection.CloseAsync(MultiplexedConnectionCloseError.NoError, default);
+
+        // Wait for the Close frame.
+        (FrameType frameType, ReadOnlySequence<byte> buffer) = await ReadFrameAsync(reader)
+            .WaitAsync(TimeSpan.FromMinutes(2));
+        Assert.That(frameType, Is.EqualTo(FrameType.Close));
+
+        // Act: send a Ping frame on the closed connection, then shut down the duplex connection.
+        await WriteFrameAsync(duplexClientConnection, FrameType.Ping, new PingBody(0L).Encode);
+        await duplexClientConnection.ShutdownWriteAsync(default);
+
+        // Assert: the graceful close completes successfully. The WaitAsync margin exceeds CI's --blame-hang-timeout
+        // (60 s) so that a hang is detected and dumped by the hang detection first; the timeout is only a fallback
+        // that fails this test instead of hanging the test run when hang detection is not enabled.
+        Assert.That(async () => await closeTask.WaitAsync(TimeSpan.FromMinutes(2)), Throws.Nothing);
+    }
+
     [Test]
     public async Task Large_write_completes_with_small_pause_writer_threshold()
     {

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1816,6 +1816,10 @@ public class SlicTransportTests
             async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromMinutes(2)),
             Throws.Nothing);
 
+        // The parked write is still blocked while the read frames loop accepted the second stream above: reads
+        // make progress independently of the stalled write (and its still-queued pong).
+        Assert.That(serverWriteTask.IsCompleted, Is.False);
+
         // Cleanup: release the hold so the parked write (and the queued pong write) can complete.
         serverDuplexConnection.Operations.Hold = DuplexTransportOperations.None;
         Assert.That(async () => await serverWriteTask, Throws.Nothing);

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1890,9 +1890,8 @@ public class SlicTransportTests
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(
             async () => await nextAcceptStreamTask.AsTask().WaitAsync(TimeSpan.FromMinutes(2)));
         Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
-        Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
         Assert.That(
-            exception.InnerException?.Message,
+            exception.Message,
             Is.EqualTo("Received a Ping frame while 3 Pong frames are already queued for sending."));
 
         // Cleanup: the connection abort unblocks the parked write with an exception.


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#17.
Fixes icerpc/icerpc-csharp-audit#29.

Since #4578, the Slic read frames loop awaits the Pong frame write that responds to a Ping frame. This write acquires `_writeSemaphore`, which another writer can hold for an arbitrarily long time while parked on `FlushAsync` when the connection's outbound pipe reaches `PauseWriterThreshold` (peer not reading). While the loop is blocked on the semaphore, no further frames are read and the idle timeout cannot fire, since the idle abort is only armed during `ReadAsync`: the connection hangs until it's disposed.

### Changes

- The Pong frame is now written by a background task, so the read frames loop keeps processing incoming frames (and the idle timeout keeps working) when writes are slow or stuck.
- New `SlicTransportOptions.MaxOutstandingPongs` option (default: 100, minimum: 1) that bounds the number of Pong frames queued for sending. The connection is aborted with a protocol error when a Ping frame is received while this limit is reached, so a peer can't queue Pong writes without limit by flooding the connection with Ping frames.

### Tests

- `Read_frames_loop_is_not_blocked_by_pong_write_when_a_write_is_parked_on_pipe_threshold`: parks a server stream write on the connection-level pipe pause (small `PauseWriterThreshold` plus a held duplex write) and verifies, using a raw duplex client, that the server still reads frames and accepts a new stream after receiving a Ping frame. Verified that this test fails (the accept times out) without the `SlicConnection` fix.
- `Connection_is_aborted_when_max_outstanding_pongs_is_exceeded`: with `MaxOutstandingPongs = 3` and a parked write, a fourth Ping frame aborts the connection with `Received a Ping frame while 3 Pong frames are already queued for sending.`
- Default value and validation tests for the new option.

- `Ping_received_after_local_close_does_not_fail_graceful_close`: writing the Pong frame in the background (with connection-closed exceptions swallowed) also fixes audit #29 — a Ping frame received after a local CloseAsync no longer faults the read frames loop. Verified that this test fails without the fix with the exact audit #29 failure mode (the graceful close throws `IceRpcException` from the Pong write).
