### PR TITLE
Fix Slic stream lifecycle bugs triggered by canceled writes

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -75,6 +75,7 @@
     "uninstantiated",
     "unmarshal",
     "unregisters",
+    "unstarted",
     "varint",
     "varuint",
     "ZeroC",

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -703,9 +703,7 @@ internal class SlicConnection : IMultiplexedConnection
     /// <param name="stream">The released stream.</param>
     internal void ReleaseStream(SlicStream stream)
     {
-        // A stream that was created but never started is always local; only started streams are registered in _streams.
-        Debug.Assert(stream.IsStarted || !stream.IsRemote);
-
+        // Only a started stream has an Id and is registered in _streams.
         if (stream.IsStarted)
         {
             _streams.Remove(stream.Id, out SlicStream? _);

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -703,9 +703,13 @@ internal class SlicConnection : IMultiplexedConnection
     /// <param name="stream">The released stream.</param>
     internal void ReleaseStream(SlicStream stream)
     {
-        Debug.Assert(stream.IsStarted);
+        // A stream that was created but never started is always local; only started streams are registered in _streams.
+        Debug.Assert(stream.IsStarted || !stream.IsRemote);
 
-        _streams.Remove(stream.Id, out SlicStream? _);
+        if (stream.IsStarted)
+        {
+            _streams.Remove(stream.Id, out SlicStream? _);
+        }
 
         if (stream.IsRemote)
         {
@@ -719,26 +723,6 @@ internal class SlicConnection : IMultiplexedConnection
             }
         }
         else if (!_isClosed)
-        {
-            if (stream.IsBidirectional)
-            {
-                _bidirectionalStreamSemaphore!.Release();
-            }
-            else
-            {
-                _unidirectionalStreamSemaphore!.Release();
-            }
-        }
-    }
-
-    /// <summary>Releases the stream-count semaphore permit acquired by <see cref="CreateStreamAsync" /> for a local
-    /// stream that was created but never started.</summary>
-    /// <param name="stream">The unstarted stream.</param>
-    internal void ReleaseUnstartedStream(SlicStream stream)
-    {
-        Debug.Assert(!stream.IsRemote && !stream.IsStarted);
-
-        if (!_isClosed)
         {
             if (stream.IsBidirectional)
             {

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -731,6 +731,26 @@ internal class SlicConnection : IMultiplexedConnection
         }
     }
 
+    /// <summary>Releases the stream-count semaphore permit acquired by <see cref="CreateStreamAsync" /> for a local
+    /// stream that was created but never started.</summary>
+    /// <param name="stream">The unstarted stream.</param>
+    internal void ReleaseUnstartedStream(SlicStream stream)
+    {
+        Debug.Assert(!stream.IsRemote && !stream.IsStarted);
+
+        if (!_isClosed)
+        {
+            if (stream.IsBidirectional)
+            {
+                _bidirectionalStreamSemaphore!.Release();
+            }
+            else
+            {
+                _unidirectionalStreamSemaphore!.Release();
+            }
+        }
+    }
+
     /// <summary>Throws the connection closure exception if the connection is already closed.</summary>
     internal void ThrowIfClosed()
     {

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -359,7 +359,7 @@ internal class SlicStream : IMultiplexedStream
     /// <param name="endStream"><see langword="true" /> to write a <see cref="FrameType.StreamLast" /> frame; otherwise,
     /// <see langword="false" />.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
-    internal ValueTask<FlushResult> WriteStreamFrameAsync(
+    internal async ValueTask<FlushResult> WriteStreamFrameAsync(
         ReadOnlySequence<byte> source1,
         ReadOnlySequence<byte> source2,
         bool endStream,
@@ -375,13 +375,31 @@ internal class SlicStream : IMultiplexedStream
             }
         }
 
-        return _connection.WriteStreamDataFrameAsync(
-            this,
-            source1,
-            source2,
-            endStream,
-            writeReadsClosedFrame,
-            cancellationToken);
+        try
+        {
+            return await _connection.WriteStreamDataFrameAsync(
+                this,
+                source1,
+                source2,
+                endStream,
+                writeReadsClosedFrame,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // If the write failed before the StreamLast frame was queued on the connection (WroteLastStreamFrame
+            // completes _writesClosedTcs when the frame is queued), roll back _writesClosePending so that completing
+            // the stream output can still close writes and notify the peer with a StreamWritesClosed frame. The
+            // bundled reads closure isn't lost either since _closeReadsOnWritesClosure wasn't cleared.
+            if (endStream && !_writesClosedTcs.Task.IsCompleted)
+            {
+                lock (_mutex)
+                {
+                    _writesClosePending = false;
+                }
+            }
+            throw;
+        }
     }
 
     /// <summary>Notifies the stream that the <see cref="FrameType.StreamLast" /> was written by the
@@ -426,6 +444,12 @@ internal class SlicStream : IMultiplexedStream
                 if (IsStarted)
                 {
                     _connection.ReleaseStream(this);
+                }
+                else if (!IsRemote)
+                {
+                    // The stream was created but never started: release the stream-count semaphore permit acquired by
+                    // CreateStreamAsync.
+                    _connection.ReleaseUnstartedStream(this);
                 }
             }
             return true;

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -452,13 +452,8 @@ internal class SlicStream : IMultiplexedStream
             if (newState.HasFlag(State.ReadsClosed | State.WritesClosed))
             {
                 // The stream reads and writes are closed, it's time to release the stream to either allow creating or
-                // accepting a new stream. We don't release an unstarted remote stream (which can briefly exist when
-                // AddStream fails on a closing connection) since it never acquired any resource. Releasing an unstarted
-                // local stream returns the stream-count semaphore permit acquired by CreateStreamAsync.
-                if (IsStarted || !IsRemote)
-                {
-                    _connection.ReleaseStream(this);
-                }
+                // accepting a new stream.
+                _connection.ReleaseStream(this);
             }
             return true;
         }

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -359,46 +359,58 @@ internal class SlicStream : IMultiplexedStream
     /// <param name="endStream"><see langword="true" /> to write a <see cref="FrameType.StreamLast" /> frame; otherwise,
     /// <see langword="false" />.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
-    internal async ValueTask<FlushResult> WriteStreamFrameAsync(
+    internal ValueTask<FlushResult> WriteStreamFrameAsync(
         ReadOnlySequence<byte> source1,
         ReadOnlySequence<byte> source2,
         bool endStream,
         CancellationToken cancellationToken)
     {
-        bool writeReadsClosedFrame = false;
-        if (endStream)
+        if (!endStream)
         {
+            // Hot path: a non-final stream frame requires no writes-closure bookkeeping, so forward the inner
+            // ValueTask directly without an async state machine.
+            return _connection.WriteStreamDataFrameAsync(
+                this,
+                source1,
+                source2,
+                endStream: false,
+                writeReadsClosedFrame: false,
+                cancellationToken);
+        }
+
+        return WriteLastStreamFrameAsync();
+
+        async ValueTask<FlushResult> WriteLastStreamFrameAsync()
+        {
+            bool writeReadsClosedFrame;
             lock (_mutex)
             {
                 writeReadsClosedFrame = _closeReadsOnWritesClosure;
                 _writesClosePending = true;
             }
-        }
 
-        try
-        {
-            return await _connection.WriteStreamDataFrameAsync(
-                this,
-                source1,
-                source2,
-                endStream,
-                writeReadsClosedFrame,
-                cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // If the write failed before the StreamLast frame was queued on the connection (WroteLastStreamFrame
-            // completes _writesClosedTcs when the frame is queued), roll back _writesClosePending so that completing
-            // the stream output can still close writes and notify the peer with a StreamWritesClosed frame. The
-            // bundled reads closure isn't lost either since _closeReadsOnWritesClosure wasn't cleared.
-            if (endStream && !_writesClosedTcs.Task.IsCompleted)
+            try
             {
+                return await _connection.WriteStreamDataFrameAsync(
+                    this,
+                    source1,
+                    source2,
+                    endStream: true,
+                    writeReadsClosedFrame,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch when (!_writesClosedTcs.Task.IsCompleted)
+            {
+                // The write failed before the StreamLast frame was queued on the connection (WroteLastStreamFrame
+                // completes _writesClosedTcs when the frame is queued), so roll back _writesClosePending so that
+                // completing the stream output can still close writes and notify the peer with a StreamWritesClosed
+                // frame. The bundled reads closure isn't lost either since _closeReadsOnWritesClosure wasn't cleared.
                 lock (_mutex)
                 {
                     _writesClosePending = false;
                 }
+                throw;
             }
-            throw;
         }
     }
 
@@ -440,16 +452,12 @@ internal class SlicStream : IMultiplexedStream
             if (newState.HasFlag(State.ReadsClosed | State.WritesClosed))
             {
                 // The stream reads and writes are closed, it's time to release the stream to either allow creating or
-                // accepting a new stream.
-                if (IsStarted)
+                // accepting a new stream. We don't release an unstarted remote stream (which can briefly exist when
+                // AddStream fails on a closing connection) since it never acquired any resource. Releasing an unstarted
+                // local stream returns the stream-count semaphore permit acquired by CreateStreamAsync.
+                if (IsStarted || !IsRemote)
                 {
                     _connection.ReleaseStream(this);
-                }
-                else if (!IsRemote)
-                {
-                    // The stream was created but never started: release the stream-count semaphore permit acquired by
-                    // CreateStreamAsync.
-                    _connection.ReleaseUnstartedStream(this);
                 }
             }
             return true;

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1784,6 +1784,157 @@ public class SlicTransportTests
         }
     }
 
+    /// <summary>Verifies that completing a stream that was created but never started releases the stream-count
+    /// semaphore permit acquired by CreateStreamAsync. See icerpc/icerpc-csharp-audit#25.</summary>
+    [Test]
+    public async Task Completing_unstarted_stream_releases_the_stream_count_permit([Values] bool bidirectional)
+    {
+        // Arrange: the peer allows a single stream.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<MultiplexedConnectionOptions>().Configure(options =>
+        {
+            options.MaxBidirectionalStreams = 1;
+            options.MaxUnidirectionalStreams = 1;
+        });
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        // Create a stream and complete it without ever writing: the stream is never started.
+        IMultiplexedStream stream = await sut.Client.CreateStreamAsync(bidirectional, default);
+        stream.Output.Complete();
+        if (bidirectional)
+        {
+            stream.Input.Complete();
+        }
+
+        // Act/Assert: creating a new stream succeeds; if the permit was not released this would wait forever. The
+        // WaitAsync margin exceeds CI's --blame-hang-timeout (60 s) so that a hang is detected and dumped by the hang
+        // detection first; the timeout is only a fallback that fails this test instead of hanging the test run when
+        // hang detection is not enabled.
+        IMultiplexedStream nextStream = await sut.Client.CreateStreamAsync(bidirectional, default)
+            .AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+
+        // Cleanup
+        nextStream.Output.Complete();
+        if (bidirectional)
+        {
+            nextStream.Input.Complete();
+        }
+    }
+
+    /// <summary>Verifies that when a blocked WriteAsync with endStream is canceled before the StreamLast frame is
+    /// written, completing the stream output still notifies the peer of the writes closure with a StreamWritesClosed
+    /// frame. See icerpc/icerpc-csharp-audit#26.</summary>
+    [Test]
+    public async Task Canceled_end_stream_write_does_not_lose_the_writes_closed_frame()
+    {
+        // Arrange: use a small peer window so it's easy to exhaust.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 4 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync(bidirectional: false);
+
+        // Exhaust the peer's window without reading.
+        byte[] payload = new byte[(4 * 1024) - 1];
+        _ = await streams.Local.Output.WriteAsync(payload, default);
+
+        using var writeCts = new CancellationTokenSource();
+
+        // The endStream write blocks on AcquireSendCreditAsync because the peer window is exhausted; cancel it
+        // before the StreamLast frame is written.
+        ValueTask<FlushResult> writeTask = ((ReadOnlySequencePipeWriter)streams.Local.Output).WriteAsync(
+            new ReadOnlySequence<byte>(payload),
+            endStream: true,
+            writeCts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(writeTask.IsCompleted, Is.False);
+        writeCts.Cancel();
+        Assert.That(async () => await writeTask, Throws.InstanceOf<OperationCanceledException>());
+
+        // Act: complete the output with an exception, like a failed invocation does.
+        streams.Local.Output.Complete(new OperationCanceledException());
+
+        // Assert: the peer observes the writes closure (TruncatedData) after consuming the buffered data, instead
+        // of waiting for data forever. The WaitAsync margin exceeds CI's --blame-hang-timeout (60 s) so that a hang
+        // is detected and dumped by the hang detection first; the timeout is only a fallback that fails this test
+        // instead of hanging the test run when hang detection is not enabled.
+        Assert.That(
+            async () =>
+            {
+                while (true)
+                {
+                    ReadResult readResult = await streams.Remote.Input.ReadAsync(default)
+                        .AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+                    streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+                }
+            },
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.TruncatedData));
+    }
+
+    /// <summary>Verifies that when a WriteAsync with endStream is canceled after the StreamLast frame was queued on
+    /// the connection (parked on the connection-level pipe pause), completing the stream output doesn't send a
+    /// StreamWritesClosed frame after the StreamLast frame: the peer reads all the data and observes a graceful end
+    /// of the stream.</summary>
+    [Test]
+    public async Task End_stream_write_canceled_after_frame_queued_preserves_graceful_peer_reads()
+    {
+        // Arrange: small client-side PauseWriterThreshold and a held duplex Write so the endStream write parks on
+        // FlushAsync after queueing the StreamLast frame.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 128 * 1024);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.PauseWriterThreshold = 4 * 1024);
+        services.AddTestDuplexTransportDecorator();
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        var duplexClientConnection =
+            provider.GetRequiredService<TestDuplexClientTransportDecorator>().LastCreatedConnection;
+
+        using var streams = await sut.CreateAndAcceptStreamAsync(bidirectional: false);
+
+        // Hold duplex writes so the background writer task can't drain the connection-level pipe.
+        duplexClientConnection.Operations.Hold = DuplexTransportOperations.Write;
+
+        using var writeCts = new CancellationTokenSource();
+        byte[] payload = new byte[8 * 1024];
+
+        // This write queues the data and the StreamLast frame on the connection's outbound pipe, then parks on
+        // FlushAsync; cancel it while parked.
+        ValueTask<FlushResult> writeTask = ((ReadOnlySequencePipeWriter)streams.Local.Output).WriteAsync(
+            new ReadOnlySequence<byte>(payload),
+            endStream: true,
+            writeCts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.That(writeTask.IsCompleted, Is.False);
+        writeCts.Cancel();
+        Assert.That(async () => await writeTask, Throws.InstanceOf<OperationCanceledException>());
+
+        // Act: complete the output with an exception, like a failed invocation does, then release the hold so the
+        // queued data and StreamLast frame reach the peer.
+        streams.Local.Output.Complete(new OperationCanceledException());
+        duplexClientConnection.Operations.Hold = DuplexTransportOperations.None;
+
+        // Assert: the peer reads all the data and a graceful end of stream, not a TruncatedData error.
+        int totalRead = 0;
+        bool isCompleted = false;
+        while (!isCompleted)
+        {
+            ReadResult readResult = await streams.Remote.Input.ReadAsync(default)
+                .AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+            totalRead += (int)readResult.Buffer.Length;
+            isCompleted = readResult.IsCompleted;
+            streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+        }
+        Assert.That(totalRead, Is.EqualTo(payload.Length));
+    }
+
     /// <summary>Verifies that a write blocked on the connection-level pipe pause (PauseWriterThreshold reached)
     /// can be canceled.</summary>
     [Test]

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1870,6 +1870,10 @@ public class SlicTransportTests
                     ReadResult readResult = await streams.Remote.Input.ReadAsync(default)
                         .AsTask().WaitAsync(TimeSpan.FromMinutes(2));
                     streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+
+                    // Fail fast instead of spinning if the peer observes a graceful end of stream instead of the
+                    // expected TruncatedData error.
+                    Assert.That(readResult.IsCompleted, Is.False, "Expected TruncatedData, got end of stream.");
                 }
             },
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.TruncatedData));


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#25.
Fixes icerpc/icerpc-csharp-audit#26.

Two bugs left a Slic connection degraded when an invocation was canceled at the wrong time:

- **Stream-count permit leak (audit #25):** a stream created by `CreateStreamAsync` acquires a stream-count semaphore permit that was only released for *started* streams (`TrySetState` → `ReleaseStream`, gated on `IsStarted`). A stream abandoned before its first write — e.g. invocation canceled while waiting on payload data or send credit — burned its permit forever; after `MaxBidirectionalStreams`/`MaxUnidirectionalStreams` such leaks, every new `CreateStreamAsync` on an otherwise healthy connection blocked forever. The permit is now released when an unstarted local stream reaches its terminal state (new `SlicConnection.ReleaseUnstartedStream`).

- **`_writesClosePending` never rolled back (audit #26):** `SlicStream.WriteStreamFrameAsync` set `_writesClosePending` before the endStream write and never rolled it back when that write failed before the `StreamLast` frame was queued (cancellation while blocked on send credit or the write semaphore). The later `Complete(exception)` on the stream output was then suppressed by the `CloseWrites` guard: neither `StreamLast` nor `StreamWritesClosed` was sent, and the peer hung reading the payload until connection closure. `_writesClosePending` is now rolled back when the endStream write fails before the `StreamLast` frame was queued — detected via `_writesClosedTcs`, which `WroteLastStreamFrame` completes exactly when the frame is queued — so `CloseWrites` sends the `StreamWritesClosed` frame and the peer observes `TruncatedData`. The bundled `_closeReadsOnWritesClosure` is preserved as well since it is never cleared on this path.

### Tests

- `Completing_unstarted_stream_releases_the_stream_count_permit` (bidirectional and unidirectional): with max streams = 1, completes an unstarted stream and verifies a new stream can still be created.
- `Canceled_end_stream_write_does_not_lose_the_writes_closed_frame`: cancels an endStream write blocked on send credit, completes the output with an exception, and verifies the peer observes `TruncatedData` instead of waiting for data forever.
- `End_stream_write_canceled_after_frame_queued_preserves_graceful_peer_reads`: pins the opposite case — when the `StreamLast` frame was already queued (write parked on the connection-level pipe pause), no `StreamWritesClosed` frame is sent after it and the peer reads all the data with a graceful end of stream. This guards against an over-eager rollback; it passes before and after the fix.

Verified the first three fail without the fix (all time out on their 2 min fallback guards); the `WaitAsync` margins follow the convention that CI's `--blame-hang-timeout` (60 s) detects and dumps a hang first.

Full `IceRpc.Tests` suite passes (991 passed / 0 failed), `dotnet build` and `dotnet format --verify-no-changes` clean.