### PR TITLE
Cache canceled read results in SlicPipeReader

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
@@ -222,26 +222,19 @@ internal class SlicPipeReader : PipeReader
                 }
             }
             // else: the application called CancelPendingRead, return the canceled read result as-is.
-
-            // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
-            // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
-            // compute the offsets against a stale buffer and corrupt the window accounting.
-            _readResult = result;
         }
-        else
+        else if (result.IsCompleted)
         {
-            // Cache the read result for the implementation of AdvanceTo that needs to figure out how much data got
-            // examined and consumed.
-            _readResult = result;
-
             // All the data from the peer is considered read at this point. It's time to close reads on the stream. This
             // will write the StreamReadsClosed frame to the peer and allow it to release the stream semaphore.
-            if (result.IsCompleted)
-            {
-                _stream.CloseReads(graceful: true);
-            }
+            _stream.CloseReads(graceful: true);
         }
 
+        // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
+        // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
+        // compute the offsets against a stale buffer and corrupt the window accounting. The throw above is the only
+        // path that skips this cache, and it hands the caller an exception rather than a result to advance.
+        _readResult = result;
         return result;
     }
 

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
@@ -77,7 +77,13 @@ internal class SlicPipeReader : PipeReader
         ReadResult result = await _pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
         if (result.IsCanceled)
         {
-            return GetReadResult(result);
+            result = GetReadResult(result);
+
+            // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
+            // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
+            // compute the offsets against a stale buffer and corrupt the window accounting.
+            _readResult = result;
+            return result;
         }
 
         // Cache the read result for the implementation of AdvanceTo that needs to figure out how much data got examined
@@ -108,6 +114,11 @@ internal class SlicPipeReader : PipeReader
             if (result.IsCanceled)
             {
                 result = GetReadResult(result);
+
+                // Cache the read result returned to the application: AdvanceTo computes the consumed and examined
+                // offsets against the cached buffer. Without this, AdvanceTo called with positions from the returned
+                // buffer would compute the offsets against a stale buffer and corrupt the window accounting.
+                _readResult = result;
                 return true;
             }
 

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
@@ -2,7 +2,6 @@
 
 using IceRpc.Internal;
 using IceRpc.Transports.Internal;
-using System.Diagnostics;
 using System.IO.Pipelines;
 
 namespace IceRpc.Transports.Slic.Internal;
@@ -74,30 +73,7 @@ internal class SlicPipeReader : PipeReader
             _stream.ThrowIfConnectionClosed();
         }
 
-        ReadResult result = await _pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        if (result.IsCanceled)
-        {
-            result = GetReadResult(result);
-
-            // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
-            // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
-            // compute the offsets against a stale buffer and corrupt the window accounting.
-            _readResult = result;
-            return result;
-        }
-
-        // Cache the read result for the implementation of AdvanceTo that needs to figure out how much data got examined
-        // and consumed.
-        _readResult = result;
-
-        // All the data from the peer is considered read at this point. It's time to close reads on the stream. This
-        // will write the StreamReadsClosed frame to the peer and allow it to release the stream semaphore.
-        if (result.IsCompleted)
-        {
-            _stream.CloseReads(graceful: true);
-        }
-
-        return result;
+        return ProcessReadResult(await _pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false));
     }
 
     public override bool TryRead(out ReadResult result)
@@ -111,27 +87,7 @@ internal class SlicPipeReader : PipeReader
 
         if (_pipe.Reader.TryRead(out result))
         {
-            if (result.IsCanceled)
-            {
-                result = GetReadResult(result);
-
-                // Cache the read result returned to the application: AdvanceTo computes the consumed and examined
-                // offsets against the cached buffer. Without this, AdvanceTo called with positions from the returned
-                // buffer would compute the offsets against a stale buffer and corrupt the window accounting.
-                _readResult = result;
-                return true;
-            }
-
-            // Cache the read result for the implementation of AdvanceTo that needs to figure out how much data got
-            // examined and consumed.
-            _readResult = result;
-
-            // All the data from the peer is considered read at this point. It's time to close reads on the stream. This
-            // will write the StreamReadsClosed frame to the peer and allow it to release the stream semaphore.
-            if (result.IsCompleted)
-            {
-                _stream.CloseReads(graceful: true);
-            }
+            result = ProcessReadResult(result);
             return true;
         }
         else
@@ -242,33 +198,51 @@ internal class SlicPipeReader : PipeReader
         }
     }
 
-    private ReadResult GetReadResult(ReadResult readResult)
+    private ReadResult ProcessReadResult(ReadResult result)
     {
-        // This method is called by ReadAsync or TryRead when the read operation on _pipe.Reader returns a canceled read
-        // result (IsCanceled=true). The _pipe.Reader ReadAsync/TryRead operations can return a canceled read result for
-        // two different reasons:
-        // - the application called CancelPendingRead
-        // - the connection is closed while data is written on _pipe.Writer
-        Debug.Assert(readResult.IsCanceled);
-
-        if (_state.HasFlag(State.PipeWriterCompleted))
+        // This method is called by ReadAsync or TryRead with the read result returned by the _pipe.Reader read
+        // operation.
+        if (result.IsCanceled)
         {
-            // The connection was closed while the pipe writer was in use. Either throw or return a non-canceled result
-            // depending on the completion exception.
-            if (_exception is null)
+            // The _pipe.Reader ReadAsync/TryRead operations can return a canceled read result for two different
+            // reasons:
+            // - the application called CancelPendingRead
+            // - the connection is closed while data is written on _pipe.Writer
+            if (_state.HasFlag(State.PipeWriterCompleted))
             {
-                return new ReadResult(readResult.Buffer, isCanceled: false, isCompleted: true);
+                // The connection was closed while the pipe writer was in use. Either throw or return a non-canceled
+                // result depending on the completion exception.
+                if (_exception is null)
+                {
+                    result = new ReadResult(result.Buffer, isCanceled: false, isCompleted: true);
+                }
+                else
+                {
+                    throw ExceptionUtil.Throw(_exception);
+                }
             }
-            else
-            {
-                throw ExceptionUtil.Throw(_exception);
-            }
+            // else: the application called CancelPendingRead, return the canceled read result as-is.
+
+            // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
+            // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
+            // compute the offsets against a stale buffer and corrupt the window accounting.
+            _readResult = result;
         }
         else
         {
-            // The application called CancelPendingRead, return the read result as-is.
-            return readResult;
+            // Cache the read result for the implementation of AdvanceTo that needs to figure out how much data got
+            // examined and consumed.
+            _readResult = result;
+
+            // All the data from the peer is considered read at this point. It's time to close reads on the stream. This
+            // will write the StreamReadsClosed frame to the peer and allow it to release the stream semaphore.
+            if (result.IsCompleted)
+            {
+                _stream.CloseReads(graceful: true);
+            }
         }
+
+        return result;
     }
 
     private void ThrowIfCompleted()

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeReader.cs
@@ -231,9 +231,7 @@ internal class SlicPipeReader : PipeReader
         }
 
         // Cache the read result returned to the application: AdvanceTo computes the consumed and examined offsets
-        // against the cached buffer. Without this, AdvanceTo called with positions from the returned buffer would
-        // compute the offsets against a stale buffer and corrupt the window accounting. The throw above is the only
-        // path that skips this cache, and it hands the caller an exception rather than a result to advance.
+        // against the cached buffer.
         _readResult = result;
         return result;
     }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1619,6 +1619,156 @@ public class SlicTransportTests
             Throws.InstanceOf<OperationCanceledException>());
     }
 
+    /// <summary>Verifies that a read returning a canceled result with buffered data can be advanced with positions
+    /// from the returned buffer, and that reading resumes correctly afterwards. See
+    /// icerpc/icerpc-csharp-audit#30.</summary>
+    [Test]
+    public async Task Canceled_read_with_buffered_data_then_resume_reading([Values] bool useTryRead)
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+        using var streams = await sut.CreateAndAcceptStreamAsync(bidirectional: false);
+
+        // Buffer data on the remote stream input.
+        _ = await streams.Local.Output.WriteAsync(new byte[1024], default);
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        // Act: cancel the next read; it returns the buffered data with IsCanceled=true.
+        streams.Remote.Input.CancelPendingRead();
+        ReadResult readResult;
+        if (useTryRead)
+        {
+            Assert.That(streams.Remote.Input.TryRead(out readResult), Is.True);
+        }
+        else
+        {
+            readResult = await streams.Remote.Input.ReadAsync(default);
+        }
+        Assert.That(readResult.IsCanceled, Is.True);
+        Assert.That(readResult.Buffer, Has.Length.EqualTo(1024));
+
+        // Examine everything without consuming: the next read won't complete until more data arrives.
+        streams.Remote.Input.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+
+        // Assert: the stream still works. Write the last stream frame; the next read returns all the data.
+        _ = await ((ReadOnlySequencePipeWriter)streams.Local.Output).WriteAsync(
+            new ReadOnlySequence<byte>(new byte[1]),
+            endStream: true,
+            default);
+        readResult = await streams.Remote.Input.ReadAsync(default).AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+        Assert.That(readResult.IsCanceled, Is.False);
+        Assert.That(readResult.IsCompleted, Is.True);
+        Assert.That(readResult.Buffer, Has.Length.EqualTo(1025));
+        streams.Remote.Input.AdvanceTo(readResult.Buffer.End);
+    }
+
+    /// <summary>Verifies that AdvanceTo following a canceled read computes the window accounting against the buffer
+    /// returned by the canceled read: the total of the StreamWindowUpdate increments sent to the peer never exceeds
+    /// the number of bytes the peer wrote on the stream. See icerpc/icerpc-csharp-audit#30.</summary>
+    [Test]
+    public async Task Canceled_read_advance_does_not_corrupt_window_accounting()
+    {
+        // Arrange: small server-side stream window so window updates are sent frequently (the window update
+        // threshold is half the window size, 2048 bytes here).
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<SlicTransportOptions>("server").Configure(
+            options => options.InitialStreamWindowSize = 4 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var _ = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // Connect the multiplexed connection.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open a unidirectional stream (the first client unidirectional stream ID is 2) with 4096 bytes and consume
+        // them on the server; this exercises the regular window accounting (one or more window updates).
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+        await WriteRawStreamFrameAsync(duplexClientConnection, streamId: 2ul, size: 4096);
+        IMultiplexedStream serverStream = await acceptStreamTask;
+        await ReadStreamDataAsync(serverStream.Input, 4096);
+
+        // Write 1000 additional bytes and give the server time to buffer them on the stream input.
+        await WriteRawStreamFrameAsync(duplexClientConnection, streamId: 2ul, size: 1000);
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        // Act: cancel the next read; it returns the buffered data with IsCanceled=true. Advance without consuming
+        // or examining anything.
+        serverStream.Input.CancelPendingRead();
+        ReadResult readResult = await serverStream.Input.ReadAsync(default);
+        Assert.That(readResult.IsCanceled, Is.True);
+        Assert.That(readResult.Buffer, Has.Length.EqualTo(1000));
+        serverStream.Input.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.Start);
+
+        // Resume reading: consume the 1000 buffered bytes, then 1100 more.
+        await ReadStreamDataAsync(serverStream.Input, 1000);
+        await WriteRawStreamFrameAsync(duplexClientConnection, streamId: 2ul, size: 1100);
+        await ReadStreamDataAsync(serverStream.Input, 1100);
+
+        // Completing the input sends the StreamReadsClosed frame, which bounds the frame collection below.
+        serverStream.Input.Complete();
+
+        // Assert: the sum of the window update increments can't exceed the bytes written on the stream.
+        long windowUpdateTotal = 0;
+        while (true)
+        {
+            (FrameType frameType, ReadOnlySequence<byte> buffer) =
+                await ReadFrameAsync(reader).WaitAsync(TimeSpan.FromMinutes(2));
+            if (frameType == FrameType.StreamWindowUpdate)
+            {
+                var decoder = new SliceDecoder(buffer);
+                Assert.That(decoder.DecodeVarUInt62(), Is.EqualTo(2ul)); // stream ID
+                windowUpdateTotal += (long)new StreamWindowUpdateBody(ref decoder).WindowSizeIncrement;
+            }
+            else if (frameType == FrameType.StreamReadsClosed)
+            {
+                break;
+            }
+        }
+        Assert.That(windowUpdateTotal, Is.LessThanOrEqualTo(4096 + 1000 + 1100));
+
+        static async Task ReadStreamDataAsync(PipeReader input, long byteCount)
+        {
+            long read = 0;
+            while (read < byteCount)
+            {
+                ReadResult readResult = await input.ReadAsync(default).AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+                read += readResult.Buffer.Length;
+                input.AdvanceTo(readResult.Buffer.End, readResult.Buffer.End);
+            }
+        }
+
+        // Like WriteStreamFrameAsync but with a buffer sized for the frame body.
+        static Task WriteRawStreamFrameAsync(IDuplexConnection connection, ulong streamId, int size)
+        {
+            var writer = new MemoryBufferWriter(new byte[size + 16]);
+            var encoder = new SliceEncoder(writer);
+            encoder.EncodeFrameType(FrameType.Stream);
+            Span<byte> sizePlaceholder = encoder.GetPlaceholderSpan(4);
+            int startPos = encoder.EncodedByteCount;
+            encoder.EncodeVarUInt62(streamId);
+            encoder.WriteByteSpan(new byte[size]);
+            SliceEncoder.EncodeVarUInt62((ulong)(encoder.EncodedByteCount - startPos), sizePlaceholder);
+            return connection.WriteAsync(new ReadOnlySequence<byte>(writer.WrittenMemory), default).AsTask();
+        }
+    }
+
     /// <summary>Verifies that a write blocked on the connection-level pipe pause (PauseWriterThreshold reached)
     /// can be canceled.</summary>
     [Test]
@@ -1913,9 +2063,12 @@ public class SlicTransportTests
             {
                 reader.AdvanceTo(buffer.GetPosition(consumed));
                 buffer = await reader.ReadAtLeastAsync(header.FrameSize);
+
+                // The buffer can hold more than one frame; only copy and consume this frame's bytes so that
+                // back-to-back frames can be read with successive calls.
                 Memory<byte> frameBuffer = new byte[header.FrameSize];
-                buffer.CopyTo(frameBuffer.Span);
-                reader.AdvanceTo(buffer.End);
+                buffer.Slice(0, header.FrameSize).CopyTo(frameBuffer.Span);
+                reader.AdvanceTo(buffer.GetPosition(header.FrameSize));
                 return (header.FrameType, new ReadOnlySequence<byte>(frameBuffer));
             }
             else

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1754,9 +1754,11 @@ public class SlicTransportTests
             }
         }
 
-        // Like WriteStreamFrameAsync but with a buffer sized for the frame body.
+        // Like WriteStreamFrameAsync but encodes the frame into a single fixed-size buffer.
         static Task WriteRawStreamFrameAsync(IDuplexConnection connection, ulong streamId, int size)
         {
+            // size + headroom for the frame header that precedes the body: 1-byte frame type + 4-byte size
+            // placeholder + up to 8-byte stream ID (varuint62) = at most 13 bytes; 16 is a safe round bound.
             var writer = new MemoryBufferWriter(new byte[size + 16]);
             var encoder = new SliceEncoder(writer);
             encoder.EncodeFrameType(FrameType.Stream);

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1667,7 +1667,7 @@ public class SlicTransportTests
 
     /// <summary>Verifies that AdvanceTo following a canceled read computes the window accounting against the buffer
     /// returned by the canceled read: the total of the StreamWindowUpdate increments sent to the peer never exceeds
-    /// the number of bytes the peer wrote on the stream. See icerpc/icerpc-csharp-audit#30.</summary>
+    /// the number of bytes the peer wrote on the stream.</summary>
     [Test]
     public async Task Canceled_read_advance_does_not_corrupt_window_accounting()
     {

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1620,8 +1620,7 @@ public class SlicTransportTests
     }
 
     /// <summary>Verifies that a read returning a canceled result with buffered data can be advanced with positions
-    /// from the returned buffer, and that reading resumes correctly afterwards. See
-    /// icerpc/icerpc-csharp-audit#30.</summary>
+    /// from the returned buffer, and that reading resumes correctly afterwards.</summary>
     [Test]
     public async Task Canceled_read_with_buffered_data_then_resume_reading([Values] bool useTryRead)
     {


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#30.

`ReadAsync` and `TryRead` returned canceled read results without caching them in `_readResult`. `AdvanceTo` computes the consumed and examined offsets against `_readResult.Buffer`, so advancing a canceled read with positions from the returned buffer computed the offsets against a stale buffer — or the default read result when the first read is canceled: `GetOffset` either throws `ArgumentOutOfRangeException` or produces garbage offsets that corrupt the window accounting (`_examined`/`_windowSize`) fed to the StreamWindowUpdate frames. The repository's own conformance tests advance canceled results, but only in arrangements where the stale offsets happen to be benign, which is why this stayed latent.

Canceled read results are now cached like regular ones, so `AdvanceTo` operates on the buffer the application actually received.

### Tests

- `Canceled_read_with_buffered_data_then_resume_reading` (`ReadAsync` and `TryRead` variants): cancels a read that returns buffered data, advances with positions from the returned buffer (examine all, consume nothing), and verifies reading resumes correctly through the end of the stream. **Both variants fail without the fix** with `ArgumentOutOfRangeException` from the stale-buffer offset computation.
- `Canceled_read_advance_does_not_corrupt_window_accounting`: wire-level test (raw duplex client) pinning the flow-control invariant that the sum of `StreamWindowUpdate` increments sent to the peer never exceeds the bytes written on the stream, across a cancel/advance/resume sequence. This one is invariant-pinning rather than regression-detecting: with the unfixed code its particular advance positions happen to produce benign offsets.
- The `ReadFrameAsync` test helper copied and consumed the **whole** buffered sequence into a frame-sized array, which throws (and would drop trailing frames) when several frames are buffered back to back — single-frame arrangements never hit this. It now slices exactly one frame per call, which the wire-level test relies on to read consecutive window updates.

Full `IceRpc.Tests` suite passes (990 passed / 0 failed), `dotnet build` and `dotnet format --verify-no-changes` clean.