### PR TITLE
Fix two ice protocol connection bugs

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -419,8 +419,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                     Payload = frameReader
                 };
 
-                frameReader = null; // response now owns frameReader
-                responseCreated = true;
+                responseCreated = true; // the response now owns frameReader
                 return response;
             }
             catch (OperationCanceledException)
@@ -442,15 +441,9 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 {
                     try
                     {
-                        PipeReader reader = await responseCompletionSource.Task.ConfigureAwait(false);
-
-                        // The read frames loop set the response frame reader (and transferred its ownership) but this
-                        // invocation was canceled before retrieving it: complete the reader here, no other code
-                        // completes it.
-                        if (!responseCreated && frameReader is null)
-                        {
-                            reader.Complete();
-                        }
+                        // Retrieve (or re-retrieve) the response PipeReader. The cleanup at the end of this finally
+                        // completes it unless a response was created, in which case the response owns it.
+                        frameReader = await responseCompletionSource.Task.ConfigureAwait(false);
                     }
                     catch
                     {
@@ -469,7 +462,11 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                     DecrementDispatchInvocationCount();
                 }
 
-                frameReader?.Complete();
+                if (!responseCreated)
+                {
+                    frameReader?.Complete();
+                }
+                // else the response owns the PipeReader
             }
         }
     }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -464,8 +464,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
 
                 if (!responseCreated)
                 {
-                    Debug.Assert(frameReader is not null);
-                    frameReader.Complete();
+                    frameReader?.Complete();
                 }
                 // else the response owns the PipeReader
             }

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -315,6 +315,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 CancellationTokenSource.CreateLinkedTokenSource(_disposedCts.Token, cancellationToken);
 
             PipeReader? frameReader = null;
+            bool responseCreated = false;
             TaskCompletionSource<PipeReader>? responseCompletionSource = null;
             int requestId = 0;
 
@@ -419,6 +420,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 };
 
                 frameReader = null; // response now owns frameReader
+                responseCreated = true;
                 return response;
             }
             catch (OperationCanceledException)
@@ -440,7 +442,15 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 {
                     try
                     {
-                        _ = await responseCompletionSource.Task.ConfigureAwait(false);
+                        PipeReader reader = await responseCompletionSource.Task.ConfigureAwait(false);
+
+                        // The read frames loop set the response frame reader (and transferred its ownership) but this
+                        // invocation was canceled before retrieving it: complete the reader here, no other code
+                        // completes it.
+                        if (!responseCreated && frameReader is null)
+                        {
+                            reader.Complete();
+                        }
                     }
                     catch
                     {
@@ -1185,6 +1195,11 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 {
                     throw new InvalidDataException(
                         $"Received frame with size ({prologue.FrameSize}) greater than max frame size.");
+                }
+                if (prologue.FrameSize < IceDefinitions.PrologueSize)
+                {
+                    throw new InvalidDataException(
+                        $"Received frame with size ({prologue.FrameSize}) smaller than the prologue size.");
                 }
 
                 if (prologue.CompressionStatus == 2)

--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -464,7 +464,8 @@ internal sealed class IceProtocolConnection : IProtocolConnection
 
                 if (!responseCreated)
                 {
-                    frameReader?.Complete();
+                    Debug.Assert(frameReader is not null);
+                    frameReader.Complete();
                 }
                 // else the response owns the PipeReader
             }

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -868,6 +868,56 @@ public sealed class IceProtocolConnectionTests
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
     }
 
+    /// <summary>Verifies that an ice frame with a frame size smaller than the prologue size is rejected as invalid
+    /// data, aborting the connection. See icerpc/icerpc-csharp-audit#19.</summary>
+    [Test]
+    public async Task Receiving_a_frame_smaller_than_the_prologue_size_aborts_the_connection()
+    {
+        // Arrange: a server-side read decorator that rewrites the frame size of the incoming request frame to zero.
+        bool invalidRead = false;
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(Protocol.Ice)
+            .AddTestDuplexTransportDecorator(
+                serverOperationsOptions: new DuplexTransportOperationsOptions()
+                {
+                    ReadDecorator = async (decoratee, buffer, cancellationToken) =>
+                        {
+                            int count = await decoratee.ReadAsync(buffer, cancellationToken);
+                            if (invalidRead && count >= IceDefinitions.PrologueSize)
+                            {
+                                // Rewrite the frame size (4 bytes at offset 10 of the ice prologue) to 0.
+                                buffer.Span.Slice(10, 4).Clear();
+                                invalidRead = false;
+                            }
+                            return count;
+                        }
+                })
+            .BuildServiceProvider(validateScopes: true);
+        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        (_, Task serverShutdownRequested) = await sut.ConnectAsync();
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.Ice));
+
+        // Act
+        invalidRead = true;
+        Task invokeTask = sut.Client.InvokeAsync(request, default);
+
+        // Assert
+        Assert.That(
+            async () =>
+            {
+                await serverShutdownRequested;
+                await sut.Server.ShutdownAsync();
+            },
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+
+        // Cleanup
+        await sut.Server.DisposeAsync();
+
+        Assert.That(
+            async () => await invokeTask,
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
+    }
+
     /// <summary>This test verifies that responses that are received after a request1 has been discarded are ignored,
     /// and doesn't interfere with other request1 and responses being send over the same connection.</summary>
     [Test]

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -869,7 +869,7 @@ public sealed class IceProtocolConnectionTests
     }
 
     /// <summary>Verifies that an ice frame with a frame size smaller than the prologue size is rejected as invalid
-    /// data, aborting the connection. See icerpc/icerpc-csharp-audit#19.</summary>
+    /// data, aborting the connection.</summary>
     [Test]
     public async Task Receiving_a_frame_smaller_than_the_prologue_size_aborts_the_connection()
     {


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#19.
Fixes icerpc/icerpc-csharp-audit#32.

Two small fixes in `IceProtocolConnection`:

- **Missing lower-bound check on the ice frame size (audit #19):** `ReadFramesAsync` validated only `FrameSize > _maxFrameSize`. A Request/Reply prologue with `FrameSize` smaller than the prologue size (14) made `frameSize - PrologueSize` negative, which threw `ArgumentOutOfRangeException` from `ReadOnlySequence.Slice` and reached the `Debug.Fail` in the generic exception handler — an assertion failure on untrusted input in debug builds. The lower bound is now rejected as `InvalidDataException` (malformed peer input), like the upper bound.

- **Reply frame reader leak on a cancellation race (audit #32):** when the read frames loop completes `responseCompletionSource` with the reply frame reader (transferring ownership — the loop no longer completes it) and the invocation's `WaitAsync(invocationCts.Token)` observes cancellation in that same window, the reader was discarded without `Complete()`: the frame reader pipe's rented `MemoryPool<byte>` segments were never returned. The invocation's `finally` now completes the reader when the completion source holds a reader that was never retrieved (`!responseCreated && frameReader is null`). This also covers the read-loop-wins micro-race against the `finally`'s own `TrySetResult`.

### Tests

- `Receiving_a_frame_smaller_than_the_prologue_size_aborts_the_connection`: a server-side duplex read decorator rewrites the incoming request's frame size to 0; the connection aborts with `ConnectionAborted`. Without the fix this test fails with the exact failure mode from the audit: `ArgumentOutOfRangeException` from `Slice` reaching `Debug.Fail` in `ReadFramesAsync`.
- The #32 race window (response landing in the completion source in the same instant the invocation observes cancellation) cannot be reached deterministically from a test — the fix is in the `finally`'s already-completed branch and is covered by review plus the existing suite (all response/cancellation paths still pass).

Full `IceRpc.Tests` suite passes (988 passed / 0 failed), `dotnet build` and `dotnet format --verify-no-changes` clean.