### PR TITLE
Propagate FromCache on recursive adapter-id resolution

### DIFF
--- a/src/IceRpc.Locator/Internal/LocationResolver.cs
+++ b/src/IceRpc.Locator/Internal/LocationResolver.cs
@@ -135,6 +135,8 @@ internal class LocationResolver : ILocationResolver
             _ = RefreshInBackgroundAsync();
         }
 
+        bool adapterIdFromCache = false;
+
         // A well-known service address resolution can return a service address with an adapter-id.
         if (serviceAddress is not null && serviceAddress.Params.TryGetValue("adapter-id", out string? escapedAdapterId))
         {
@@ -142,7 +144,7 @@ internal class LocationResolver : ILocationResolver
             {
                 // Resolves adapter ID recursively, by checking first the cache. If we resolved the well-known
                 // service address, we request a cache refresh for the adapter ID.
-                (serviceAddress, _) = await PerformResolveAsync(
+                (serviceAddress, adapterIdFromCache) = await PerformResolveAsync(
                     new Location { IsAdapterId = true, Value = Uri.UnescapeDataString(escapedAdapterId) },
                     refreshCache || resolved,
                     cancellationToken).ConfigureAwait(false);
@@ -163,7 +165,9 @@ internal class LocationResolver : ILocationResolver
             }
         }
 
-        return (serviceAddress, serviceAddress is not null && !resolved);
+        // The resolution is from the cache if this location's lookup was served from the cache, or if the recursive
+        // adapter-id resolution was served from the cache.
+        return (serviceAddress, serviceAddress is not null && (!resolved || adapterIdFromCache));
 
         async Task RefreshInBackgroundAsync()
         {

--- a/src/IceRpc.Locator/LocatorInterceptor.cs
+++ b/src/IceRpc.Locator/LocatorInterceptor.cs
@@ -170,9 +170,11 @@ public interface ILocationResolver
     /// <param name="refreshCache">When <see langword="true" />, requests a cache refresh.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A tuple with a nullable dummy service address that holds the server addresses (if resolved), and a bool
-    /// that indicates whether these server addresses were retrieved from the implementation's cache. ServiceAddress is
-    /// <see langword="null" /> when the location resolver fails to resolve a location. When ServiceAddress is not null,
-    /// its ServerAddress is not <see langword="null" />.</returns>
+    /// that indicates whether the resolution was served from the implementation's cache: <see langword="true" /> when
+    /// the location lookup — or, for a well-known service address carrying an adapter-id, the recursive adapter-id
+    /// lookup — was served from the cache, in which case requesting a cache refresh on a retry can produce a different
+    /// resolution. ServiceAddress is <see langword="null" /> when the location resolver fails to resolve a location.
+    /// When ServiceAddress is not null, its ServerAddress is not <see langword="null" />.</returns>
     ValueTask<(ServiceAddress? ServiceAddress, bool FromCache)> ResolveAsync(
         Location location,
         bool refreshCache,

--- a/src/IceRpc.Locator/LocatorInterceptor.cs
+++ b/src/IceRpc.Locator/LocatorInterceptor.cs
@@ -171,7 +171,7 @@ public interface ILocationResolver
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A tuple with a nullable dummy service address that holds the server addresses (if resolved), and a bool
     /// that indicates whether the resolution was served from the implementation's cache: <see langword="true" /> when
-    /// the location lookup — or, for a well-known service address carrying an adapter-id, the recursive adapter-id
+    /// the location lookup — or, for a well-known service address carrying an adapter ID, the recursive adapter ID
     /// lookup — was served from the cache, in which case requesting a cache refresh on a retry can produce a different
     /// resolution. ServiceAddress is <see langword="null" /> when the location resolver fails to resolve a location.
     /// When ServiceAddress is not null, its ServerAddress is not <see langword="null" />.</returns>

--- a/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
@@ -111,8 +111,8 @@ public class LocationResolverTests
     [NonParallelizable]
     public async Task Location_recursive_resolution_with_cached_adapter_id_is_from_cache()
     {
-        var wellKnownServiceAddress = new ServiceAddress(new Uri("ice:/foo?adapter-id=bar"));
-        var cachedServiceAddress = new ServiceAddress(new Uri("ice://localhost/cached"));
+        var wellKnownServiceAddress = new ServiceAddress(new Uri("ice:/hello?adapter-id=bar"));
+        var cachedServiceAddress = new ServiceAddress(new Uri("ice://localhost/hello"));
         var serverAddressFinder = new MockServerAddressFinder(wellKnownServiceAddress);
         var resolver = new LocationResolver(
                 serverAddressFinder,

--- a/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
@@ -106,7 +106,7 @@ public class LocationResolverTests
     }
 
     /// <summary>Verifies that when the well-known lookup is fresh but the recursive adapter-id resolution is served
-    /// from the cache, the resolution reports FromCache=true. See icerpc/icerpc-csharp-audit#39.</summary>
+    /// from the cache, the resolution reports FromCache=true.</summary>
     [Test]
     [NonParallelizable]
     public async Task Location_recursive_resolution_with_cached_adapter_id_is_from_cache()

--- a/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
+++ b/tests/IceRpc.Locator.Tests/LocationResolverTests.cs
@@ -105,6 +105,39 @@ public class LocationResolverTests
         Assert.That(serverAddressFinder.Calls, Is.EqualTo(2));
     }
 
+    /// <summary>Verifies that when the well-known lookup is fresh but the recursive adapter-id resolution is served
+    /// from the cache, the resolution reports FromCache=true. See icerpc/icerpc-csharp-audit#39.</summary>
+    [Test]
+    [NonParallelizable]
+    public async Task Location_recursive_resolution_with_cached_adapter_id_is_from_cache()
+    {
+        var wellKnownServiceAddress = new ServiceAddress(new Uri("ice:/foo?adapter-id=bar"));
+        var cachedServiceAddress = new ServiceAddress(new Uri("ice://localhost/cached"));
+        var serverAddressFinder = new MockServerAddressFinder(wellKnownServiceAddress);
+        var resolver = new LocationResolver(
+                serverAddressFinder,
+                new MockServerAddressCache(
+                    adapterIdServiceAddress: cachedServiceAddress,
+                    insertionTime: TimeSpan.Zero),
+                background: true,
+                TimeSpan.FromSeconds(1),
+                ttl: TimeSpan.FromSeconds(30),
+                NullLogger.Instance);
+
+        (ServiceAddress? resolved, bool fromCache) = await resolver.ResolveAsync(
+            new Location
+            {
+                Value = "/hello",
+                IsAdapterId = false,
+            },
+            refreshCache: false,
+            default);
+
+        Assert.That(fromCache, Is.True);
+        Assert.That(resolved, Is.EqualTo(cachedServiceAddress));
+        Assert.That(serverAddressFinder.Calls, Is.EqualTo(1));
+    }
+
     [Test]
     public async Task Failure_to_recursively_resolve_adapter_id_removes_proxy_from_cache()
     {


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#39.

When a well-known lookup returns a service address with an adapter-id, `LocationResolver.PerformResolveAsync` resolves the adapter-id recursively and discarded the inner resolution's `FromCache` flag, computing the returned `FromCache` solely from the outer lookup. A fresh well-known lookup followed by an adapter-id resolution served from the cache (entry younger than `RefreshThreshold`) returned `FromCache = false` even though the server addresses came from the cache, violating the `ILocationResolver` contract: `LocatorInterceptor` then didn't set `ICachedResolutionFeature`, so a retry didn't request `refreshCache` and the cache refresh was delayed by one extra attempt.

The resolution now reports `FromCache = true` if either lookup was served from the cache.

### Tests

- `Location_recursive_resolution_with_cached_adapter_id_is_from_cache`: fresh well-known lookup + cached adapter-id entry; asserts `FromCache` is true, the cached address is returned, and the finder is called exactly once. Fails without the fix (`FromCache` was false).

All `IceRpc.Locator.Tests` pass (48/48), `dotnet build` and `dotnet format --verify-no-changes` clean.