### PR TITLE
Guard SslAuthenticationOptions ShallowClone against new .NET properties

### DIFF
--- a/src/IceRpc/Transports/Internal/SslAuthenticationOptionsExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SslAuthenticationOptionsExtensions.cs
@@ -7,9 +7,9 @@ namespace IceRpc.Transports.Internal;
 /// <summary>Provides extension methods for <see cref="SslClientAuthenticationOptions" /> and <see
 /// cref="SslServerAuthenticationOptions" />.</summary>
 /// <remarks>The clone methods copy each property by hand and sit on the security-configuration path: a property
-/// added by a future .NET release and not copied here would be silently dropped from the user's TLS configuration.
-/// The SslAuthenticationOptionsExtensionsTests reflection tests fail when the .NET property set changes; when they
-/// do, add the new property here and to the test's property list.</remarks>
+/// added by a future .NET release is not copied and is silently set to its initial value in the user's
+/// authentication options. The SslAuthenticationOptionsExtensionsTests reflection tests fail when the .NET
+/// property set changes; when they do, add the new property here and to the test's property list.</remarks>
 internal static class SslAuthenticationOptionsExtensions
 {
     /// <summary>Makes a shallow copy of an SSL client authentication options.</summary>

--- a/src/IceRpc/Transports/Internal/SslAuthenticationOptionsExtensions.cs
+++ b/src/IceRpc/Transports/Internal/SslAuthenticationOptionsExtensions.cs
@@ -6,6 +6,10 @@ namespace IceRpc.Transports.Internal;
 
 /// <summary>Provides extension methods for <see cref="SslClientAuthenticationOptions" /> and <see
 /// cref="SslServerAuthenticationOptions" />.</summary>
+/// <remarks>The clone methods copy each property by hand and sit on the security-configuration path: a property
+/// added by a future .NET release and not copied here would be silently dropped from the user's TLS configuration.
+/// The SslAuthenticationOptionsExtensionsTests reflection tests fail when the .NET property set changes; when they
+/// do, add the new property here and to the test's property list.</remarks>
 internal static class SslAuthenticationOptionsExtensions
 {
     /// <summary>Makes a shallow copy of an SSL client authentication options.</summary>

--- a/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
+++ b/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
@@ -61,8 +61,9 @@ public class SslAuthenticationOptionsExtensionsTests
     public void ShallowClone_copies_all_ssl_server_authentication_options_properties() =>
         Assert.That(GetSettablePropertyNames(typeof(SslServerAuthenticationOptions)), Is.EquivalentTo(_serverProperties));
 
+    // Only properties with a public setter: ShallowClone can't copy others, and the application can't set them.
     private static IEnumerable<string> GetSettablePropertyNames(Type type) =>
         type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.CanWrite)
+            .Where(property => property.SetMethod?.IsPublic is true)
             .Select(property => property.Name);
 }

--- a/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
+++ b/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
@@ -8,8 +8,8 @@ using System.Reflection;
 namespace IceRpc.Tests.Transports;
 
 /// <summary>Guards SslAuthenticationOptionsExtensions.ShallowClone. The drift tests fail when the .NET
-/// Ssl*AuthenticationOptions property set changes (a new property would be silently dropped by the hand-written
-/// clone); the round-trip tests fail when ShallowClone stops copying a property it used to copy. When a drift test
+/// Ssl*AuthenticationOptions property set changes (a new property is silently reset in the authentication options);
+/// the round-trip tests fail when ShallowClone stops copying a property it used to copy. When a drift test
 /// fails, add the new property to the corresponding ShallowClone method and to the property list below.</summary>
 [Parallelizable(ParallelScope.All)]
 public class SslAuthenticationOptionsExtensionsTests

--- a/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
+++ b/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ZeroC, Inc.
+
+using NUnit.Framework;
+using System.Net.Security;
+using System.Reflection;
+
+namespace IceRpc.Tests.Transports;
+
+/// <summary>Guards SslAuthenticationOptionsExtensions.ShallowClone against new properties added to the .NET
+/// Ssl*AuthenticationOptions classes: ShallowClone copies each property by hand, so a property added by a future
+/// .NET release would be silently dropped from the user's TLS configuration. When one of these tests fails, add the
+/// new property to the corresponding ShallowClone method and to the property list below.</summary>
+[Parallelizable(ParallelScope.All)]
+public class SslAuthenticationOptionsExtensionsTests
+{
+    // The properties copied by SslAuthenticationOptionsExtensions.ShallowClone(SslClientAuthenticationOptions).
+    private static readonly string[] _clientProperties =
+    [
+        "AllowRenegotiation",
+        "AllowRsaPkcs1Padding",
+        "AllowRsaPssPadding",
+        "AllowTlsResume",
+        "ApplicationProtocols",
+        "CertificateChainPolicy",
+        "CertificateRevocationCheckMode",
+        "CipherSuitesPolicy",
+        "ClientCertificateContext",
+        "ClientCertificates",
+        "EnabledSslProtocols",
+        "EncryptionPolicy",
+        "LocalCertificateSelectionCallback",
+        "RemoteCertificateValidationCallback",
+        "TargetHost"
+    ];
+
+    // The properties copied by SslAuthenticationOptionsExtensions.ShallowClone(SslServerAuthenticationOptions).
+    private static readonly string[] _serverProperties =
+    [
+        "AllowRenegotiation",
+        "AllowRsaPkcs1Padding",
+        "AllowRsaPssPadding",
+        "AllowTlsResume",
+        "ApplicationProtocols",
+        "CertificateChainPolicy",
+        "CertificateRevocationCheckMode",
+        "CipherSuitesPolicy",
+        "ClientCertificateRequired",
+        "EnabledSslProtocols",
+        "EncryptionPolicy",
+        "RemoteCertificateValidationCallback",
+        "ServerCertificate",
+        "ServerCertificateContext",
+        "ServerCertificateSelectionCallback"
+    ];
+
+    [Test]
+    public void ShallowClone_copies_all_ssl_client_authentication_options_properties() =>
+        Assert.That(GetSettablePropertyNames(typeof(SslClientAuthenticationOptions)), Is.EquivalentTo(_clientProperties));
+
+    [Test]
+    public void ShallowClone_copies_all_ssl_server_authentication_options_properties() =>
+        Assert.That(GetSettablePropertyNames(typeof(SslServerAuthenticationOptions)), Is.EquivalentTo(_serverProperties));
+
+    private static IEnumerable<string> GetSettablePropertyNames(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanWrite)
+            .Select(property => property.Name);
+}

--- a/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
+++ b/tests/IceRpc.Tests/Transports/SslAuthenticationOptionsExtensionsTests.cs
@@ -1,15 +1,16 @@
 // Copyright (c) ZeroC, Inc.
 
+using IceRpc.Transports.Internal;
 using NUnit.Framework;
 using System.Net.Security;
 using System.Reflection;
 
 namespace IceRpc.Tests.Transports;
 
-/// <summary>Guards SslAuthenticationOptionsExtensions.ShallowClone against new properties added to the .NET
-/// Ssl*AuthenticationOptions classes: ShallowClone copies each property by hand, so a property added by a future
-/// .NET release would be silently dropped from the user's TLS configuration. When one of these tests fails, add the
-/// new property to the corresponding ShallowClone method and to the property list below.</summary>
+/// <summary>Guards SslAuthenticationOptionsExtensions.ShallowClone. The drift tests fail when the .NET
+/// Ssl*AuthenticationOptions property set changes (a new property would be silently dropped by the hand-written
+/// clone); the round-trip tests fail when ShallowClone stops copying a property it used to copy. When a drift test
+/// fails, add the new property to the corresponding ShallowClone method and to the property list below.</summary>
 [Parallelizable(ParallelScope.All)]
 public class SslAuthenticationOptionsExtensionsTests
 {
@@ -54,16 +55,112 @@ public class SslAuthenticationOptionsExtensionsTests
     ];
 
     [Test]
-    public void ShallowClone_copies_all_ssl_client_authentication_options_properties() =>
+    public void ShallowClone_property_list_matches_ssl_client_authentication_options() =>
         Assert.That(GetSettablePropertyNames(typeof(SslClientAuthenticationOptions)), Is.EquivalentTo(_clientProperties));
 
     [Test]
-    public void ShallowClone_copies_all_ssl_server_authentication_options_properties() =>
+    public void ShallowClone_property_list_matches_ssl_server_authentication_options() =>
         Assert.That(GetSettablePropertyNames(typeof(SslServerAuthenticationOptions)), Is.EquivalentTo(_serverProperties));
 
+    [Test]
+    public void ShallowClone_copies_every_ssl_client_authentication_options_property()
+    {
+        var source = new SslClientAuthenticationOptions();
+        IReadOnlyList<string> set = SetDistinctValues(source);
+
+        SslClientAuthenticationOptions clone = source.ShallowClone();
+
+        AssertCopied(source, clone, set);
+    }
+
+    [Test]
+    public void ShallowClone_copies_every_ssl_server_authentication_options_property()
+    {
+        var source = new SslServerAuthenticationOptions();
+        IReadOnlyList<string> set = SetDistinctValues(source);
+
+        SslServerAuthenticationOptions clone = source.ShallowClone();
+
+        AssertCopied(source, clone, set);
+    }
+
     // Only properties with a public setter: ShallowClone can't copy others, and the application can't set them.
-    private static IEnumerable<string> GetSettablePropertyNames(Type type) =>
+    private static IEnumerable<PropertyInfo> GetSettableProperties(Type type) =>
         type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.SetMethod?.IsPublic is true)
-            .Select(property => property.Name);
+            .Where(property => property.SetMethod?.IsPublic is true);
+
+    private static IEnumerable<string> GetSettablePropertyNames(Type type) =>
+        GetSettableProperties(type).Select(property => property.Name);
+
+    // Assigns each settable public property a distinct non-default value and returns the names of the properties that
+    // were successfully assigned. Properties whose value can't be cheaply constructed (certificates, certificate
+    // contexts, the cipher suites policy, and the selection/validation callbacks) are skipped; they remain covered by
+    // the drift tests above.
+    private static IReadOnlyList<string> SetDistinctValues(object options)
+    {
+        var assigned = new List<string>();
+        foreach (PropertyInfo property in GetSettableProperties(options.GetType()))
+        {
+            if (TryCreateDistinctValue(property.PropertyType, property.GetValue(options), out object? value))
+            {
+                property.SetValue(options, value);
+                assigned.Add(property.Name);
+            }
+        }
+        // Guard against the helper silently skipping everything (e.g. a refactor breaking value creation).
+        Assert.That(assigned, Has.Count.GreaterThan(6), "Too few properties exercised; the round-trip test is not meaningful.");
+        return assigned;
+    }
+
+    private static bool TryCreateDistinctValue(Type type, object? current, out object? value)
+    {
+        try
+        {
+            if (type == typeof(bool))
+            {
+                value = !(bool)(current ?? false);
+                return true;
+            }
+            if (type == typeof(string))
+            {
+                value = "icerpc-sentinel";
+                return true;
+            }
+            if (type.IsEnum)
+            {
+                value = Enum.GetValues(type).Cast<object>().FirstOrDefault(v => !v.Equals(current))
+                    ?? Enum.GetValues(type).Cast<object>().First();
+                return !value.Equals(current);
+            }
+            // Reference types with a public parameterless constructor (e.g. ApplicationProtocols, ClientCertificates,
+            // CertificateChainPolicy). A fresh instance is a distinct reference, which a shallow copy must preserve.
+            if (!type.IsValueType && type.GetConstructor(Type.EmptyTypes) is not null)
+            {
+                value = Activator.CreateInstance(type);
+                return value is not null && !ReferenceEquals(value, current);
+            }
+        }
+        catch
+        {
+            // Fall through: value can't be constructed for this property; it stays covered by the drift tests.
+        }
+        value = null;
+        return false;
+    }
+
+    private static void AssertCopied(object source, object clone, IReadOnlyList<string> propertyNames)
+    {
+        Type type = source.GetType();
+        Assert.Multiple(() =>
+        {
+            foreach (string name in propertyNames)
+            {
+                PropertyInfo property = type.GetProperty(name)!;
+                Assert.That(
+                    property.GetValue(clone),
+                    Is.EqualTo(property.GetValue(source)),
+                    $"ShallowClone did not copy {type.Name}.{name}.");
+            }
+        });
+    }
 }


### PR DESCRIPTION
Fixes icerpc/icerpc-csharp-audit#20.

`SslAuthenticationOptionsExtensions.ShallowClone` copies each `SslClientAuthenticationOptions` / `SslServerAuthenticationOptions` property by hand and sits directly on the security-configuration path (`TcpClientTransport`, `QuicClientTransport`, `Server`). The list is complete against the current .NET property set, but a security-relevant property added by a future .NET release and set by the user would be silently discarded before the handshake — a silent weakening of the TLS configuration on a runtime upgrade.

Per the audit recommendation, this adds:

- Two reflection tests (`SslAuthenticationOptionsExtensionsTests`) asserting the settable public property set of each options class matches the list `ShallowClone` copies — they fail on the runtime upgrade that adds (or removes) a property, prompting the update.
- A `<remarks>` on the extension class explaining the constraint and pointing to the tests.

No behavior change; both tests pass against the current .NET 10 property set.

### Limitation

The tests run against the runtime this repository targets, so they catch the drift when IceRPC bumps its `TargetFramework` — not before. .NET servicing updates (10.0.x) don't add public API, so the property set is stable within .NET 10; but an application targeting a newer .NET major can run the `net10.0`-built IceRpc package on that newer runtime, where `Ssl*AuthenticationOptions` has new properties. If such an application sets a new property, the net10-compiled `ShallowClone` still drops it and these tests can't detect that. The exposure window is "new .NET major released → IceRPC ships a TFM-bumped package", and only for users who set a brand-new TLS property in that window.

### Alternatives considered

1. **Hand-copy + tripwire tests (this PR):** zero runtime cost, trimming/AOT-friendly; accepts the limitation above.
2. **Reflection-based copy in `ShallowClone`:** enumerate the settable public properties at runtime and copy them all. Future-proof across runtime upgrades with no recompile; costs a little reflection per connection creation (negligible next to a TLS handshake) and would break if assembly trimming is ever enabled (it isn't today).
3. **Eliminate the clone:** the call sites clone only to set `TargetHost` / `ApplicationProtocols` without mutating the user's instance; restructuring them to not need a copy removes the problem entirely, at the cost of a larger change.