### PR TITLE
Pin GitHub Actions to SHAs and align Dependabot with the standard setup

### DIFF
--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -4,7 +4,7 @@ description: "Setup .NET and install libmsquic"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v5
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -12,7 +12,7 @@ runs:
           ${{ runner.os }}-nuget-
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 10.0.x
 

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -26,7 +26,7 @@ runs:
     if: always()
 
   - name: Upload blame dumps and logs
-    uses: actions/upload-artifact@v6
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     if: failure()
     with:
       name: blame-and-dumps-${{ runner.os }}
@@ -38,7 +38,7 @@ runs:
       if-no-files-found: ignore
 
   - name: Upload test results
-    uses: actions/upload-artifact@v6
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: test-results-${{ runner.os }}
       path: TestResults/*.trx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,58 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: nuget
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: monthly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
     groups:
-      microsoft-extensions:
-        patterns:
-          - "Microsoft.Extensions.*"
-      microsoft-aspnetcore:
-        patterns:
-          - "Microsoft.AspNetCore.*"
-      microsoft-build:
-        patterns:
-          - "Microsoft.Build.*"
-      microsoft-codeanalysis:
-        patterns:
-          - "Microsoft.CodeAnalysis.*"
-      system:
-        patterns:
-          - "System.*"
-      nunit:
-        patterns:
-          - "NUnit*"
-      test-sdk:
-        patterns:
-          - "Microsoft.NET.Test.Sdk"
-          - "coverlet.*"
-      grpc:
-        patterns:
-          - "Grpc.*"
-          - "Google.Protobuf"
-          - "Google.Protobuf.Tools"
-      opentelemetry:
-        patterns:
-          - "OpenTelemetry.*"
-      dunet:
-        patterns:
-          - "dunet*"
-      minor-and-patch:
-        update-types:
-          - minor
-          - patch
+      nuget:
+        patterns: ["*"]
 
-  - package-ecosystem: github-actions
-    directory: "/"
+  - package-ecosystem: "github-actions"
+    directories: ["/", "/.github/actions/*"]
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
     groups:
-      github-actions-dependencies:
-        patterns:
-          - "*"
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       VERSION: ${{ inputs.icerpc_version }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
@@ -62,7 +62,7 @@ jobs:
 
       - name: Sign .NET Assemblies
         if: inputs.authenticode_sign
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -96,7 +96,7 @@ jobs:
         run: dotnet pack --configuration Release --output ../../
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nuget-packages
           path: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set version variables
         id: set-vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: ulimit -a
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
       - name: Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,11 +56,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.36.2
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -72,6 +72,6 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.36.2
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
       - name: Build
@@ -24,13 +24,13 @@ jobs:
         shell: bash
 
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           files: tests/*/TestResults/*/coverage.cobertura.xml
           format: cobertura
 
       - name: ReportGenerator
-        uses: danielpalme/ReportGenerator-GitHub-Action@5
+        uses: danielpalme/ReportGenerator-GitHub-Action@049f7ec958c672fd31d5cc1cb01622dc8d2e23ab # v5.5.10
         with:
           reports: tests/*/TestResults/*/coverage.cobertura.xml
           targetdir: coveragereport

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --config .lychee.toml

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,9 +10,9 @@ jobs:
   spellcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: streetsidesoftware/cspell-action@v8
+      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           files: |
             **/*.{cs,rs,md,json,csproj,slice}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run whitespace validation
         uses: zeroc-ice/github-actions@main


### PR DESCRIPTION
Pins every third-party GitHub Action to a full commit SHA (with the version in a trailing comment) and brings the Dependabot config in line with the setup now used across the other repos.

- Pins all actions across the 14 workflows and the three composite actions under `.github/actions/`. `zeroc-ice/github-actions` stays on `@main` (first-party, intentionally tracked).
- Switches both ecosystems to a monthly schedule, drops `open-pull-requests-limit`, and adds a 7-day cooldown to the nuget block (it had none).
- Points the github-actions block at `["/", "/.github/actions/*"]` so the composite actions get updated too — a plain `/` only scans workflows.
- Collapses the per-product nuget groups into a single catch-all so updates arrive as one PR per ecosystem; the `Microsoft.CodeAnalysis.CSharp` ignore is preserved.

The `0.1.x`–`0.6.x` release branches are left untouched.
