### PR TITLE
Remove 'rust' Dictionary from cspell Settings.

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -83,7 +83,6 @@
   ],
   "dictionaries": [
     "csharp",
-    "rust",
     "softwareTerms",
     "en_US"
   ],


### PR DESCRIPTION
While scaffolding the fresh slate of `icerpc-rust`, I cross checked it with the scaffolding for `slicec` and `icerpc-csharp`.
I noticed we still had the Rust dictionary set here, probably a hold-over from the old `slicec-cs` days.

Any reason I'm missing to keep this around?