### PR TITLE
Reject encoding a fully-sliced class instance with the Compact class format

### DIFF
--- a/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
@@ -166,10 +166,18 @@ public ref partial struct IceEncoder
             _classContext.Current.InstanceType = InstanceType.Class;
             _classContext.Current.FirstSlice = true;
 
-            if (v.UnknownSlices.Count > 0 && _classContext.ClassFormat == ClassFormat.Sliced)
+            if (v.UnknownSlices.Count > 0)
             {
-                EncodeUnknownSlices(v.UnknownSlices, fullySliced: v is UnknownIceClass);
-                _classContext.Current.FirstSlice = false;
+                if (_classContext.ClassFormat == ClassFormat.Sliced)
+                {
+                    EncodeUnknownSlices(v.UnknownSlices, fullySliced: v is UnknownIceClass);
+                    _classContext.Current.FirstSlice = false;
+                }
+                else if (v is UnknownIceClass)
+                {
+                    throw new NotSupportedException(
+                        $"Cannot encode a fully-sliced class instance using the {_classContext.ClassFormat} class format.");
+                }
             }
             v.Encode(ref this);
 
@@ -227,13 +235,9 @@ public ref partial struct IceEncoder
     {
         Debug.Assert(_classContext.Current.InstanceType != InstanceType.None);
 
-        // We only re-encode preserved slices if we are using the sliced format. Otherwise, we ignore the preserved
-        // slices, which essentially "slices" the instance into the most-derived type known by the sender.
-        if (_classContext.ClassFormat != ClassFormat.Sliced)
-        {
-            throw new NotSupportedException(
-                $"Cannot encode sliced data into payload using {_classContext.ClassFormat} format.");
-        }
+        // The caller only re-encodes preserved slices when using the Sliced format. With another format, it ignores
+        // the preserved slices, which "slices" the instance into the most-derived type known by the sender.
+        Debug.Assert(_classContext.ClassFormat == ClassFormat.Sliced);
 
         for (int i = 0; i < unknownSlices.Count; ++i)
         {

--- a/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
@@ -10,6 +10,31 @@ namespace IceRpc.Ice.Generator.Base.Tests;
 public class SlicingTests
 {
     [Test]
+    public void Encoding_a_fully_sliced_class_with_the_compact_format_fails()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[1024 * 1024]);
+        var encoder = new IceEncoder(buffer, classFormat: ClassFormat.Sliced);
+        encoder.EncodeClass(new SlicingMostDerivedClass("p1-m1", "p1-m2", null, null));
+
+        // Decode with an activator that knows none of the type IDs.
+        var decoder = new IceDecoder(buffer.WrittenMemory, activator: null);
+        IceClass r1 = decoder.DecodeClass<IceClass>()!;
+        Assert.That(r1, Is.TypeOf<UnknownIceClass>());
+
+        var compactBuffer = new MemoryBufferWriter(new byte[1024 * 1024]);
+
+        // Act/Assert
+        Assert.That(
+            () =>
+            {
+                var compactEncoder = new IceEncoder(compactBuffer); // Compact is the default class format.
+                compactEncoder.EncodeClass(r1);
+            },
+            Throws.TypeOf<NotSupportedException>());
+    }
+
+    [Test]
     public void Decoding_a_class_skips_and_preserves_unknown_slices([Values] bool partialSlicing)
     {
         // Arrange


### PR DESCRIPTION
When a class instance decoded with an activator that knows none of its type IDs (a fully-sliced `UnknownIceClass`) is re-encoded using the Compact class format — the default — `EncodeInstance` writes the class instance marker and then nothing: the preserved slices are only re-encoded in Sliced format, and `UnknownIceClass.EncodeCore` is empty. The peer then misparses whatever bytes follow as the instance's first slice header, typically failing with `InvalidDataException: Cannot skip a class slice with no type ID`, and the corruption desynchronizes the rest of the encapsulation.

This PR makes the encoder reject this locally instead of emitting a corrupt payload:

- `EncodeInstance` now throws `NotSupportedException` when encoding an `UnknownIceClass` with a class format other than Sliced. Partially-known instances are unaffected: they still drop their preserved slices in Compact format and encode their known slices, as intended.
- The now-unreachable throw in `EncodeUnknownSlices` (its only call site requires the Sliced format) is replaced by a `Debug.Assert`, and the stale comment above it is corrected.
- Adds a regression test.

## What's Changed entry

Area: Ice codec

- Encoding a fully-sliced class instance with the Compact class format now fails with `NotSupportedException` instead of producing a corrupt payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)