### PR TITLE
Reject invalid string type IDs when decoding Ice class slices

### DIFF
--- a/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
@@ -380,6 +380,14 @@ public ref partial struct IceDecoder
             case TypeIdKind.String:
                 string typeId = DecodeString();
 
+                // A valid type ID always starts with "::". This validation is essential for preserved slices:
+                // SliceInfo.TypeId holds either a type ID or a compact ID without recording which one, and the
+                // re-encoding of a preserved slice parses TypeId as a compact ID unless it starts with "::".
+                if (!typeId.StartsWith("::", StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException($"Received invalid type ID {typeId}.");
+                }
+
                 // The typeIds of slices in indirection tables can be decoded several times: when we skip the
                 // indirection table and later on when we decode it. We only want to add this type ID to the list and
                 // assign it an index when it's the first time we decode it, so we save the largest position we

--- a/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
@@ -380,9 +380,8 @@ public ref partial struct IceDecoder
             case TypeIdKind.String:
                 string typeId = DecodeString();
 
-                // A valid type ID always starts with "::". This validation is essential for preserved slices:
-                // SliceInfo.TypeId holds either a type ID or a compact ID without recording which one, and the
-                // re-encoding of a preserved slice parses TypeId as a compact ID unless it starts with "::".
+                // A valid type ID always starts with "::" (see SliceInfo.TypeId). Without this check, the
+                // re-encoding of a preserved slice would parse this type ID as a compact ID.
                 if (!typeId.StartsWith("::", StringComparison.Ordinal))
                 {
                     throw new InvalidDataException($"Received invalid type ID {typeId}.");

--- a/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
@@ -239,8 +239,7 @@ public ref partial struct IceEncoder
         {
             SliceInfo sliceInfo = unknownSlices[i];
 
-            // If type ID is a compact ID, extract it. The parsing cannot fail: the decoder rejects string type IDs
-            // that don't start with "::", so a TypeId without this prefix is always a decoded compact ID.
+            // If type ID is a compact ID, extract it.
             int? compactId = null;
             if (!sliceInfo.TypeId.StartsWith("::", StringComparison.Ordinal))
             {

--- a/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
@@ -239,18 +239,12 @@ public ref partial struct IceEncoder
         {
             SliceInfo sliceInfo = unknownSlices[i];
 
-            // If type ID is a compact ID, extract it.
+            // If type ID is a compact ID, extract it. The parsing cannot fail: the decoder rejects string type IDs
+            // that don't start with "::", so a TypeId without this prefix is always a decoded compact ID.
             int? compactId = null;
             if (!sliceInfo.TypeId.StartsWith("::", StringComparison.Ordinal))
             {
-                try
-                {
-                    compactId = int.Parse(sliceInfo.TypeId, CultureInfo.InvariantCulture);
-                }
-                catch (FormatException exception)
-                {
-                    throw new InvalidDataException($"Received invalid type ID {sliceInfo.TypeId}.", exception);
-                }
+                compactId = int.Parse(sliceInfo.TypeId, CultureInfo.InvariantCulture);
             }
 
             StartSlice(sliceInfo.TypeId, compactId);

--- a/src/IceRpc/Ice/Codec/SliceInfo.cs
+++ b/src/IceRpc/Ice/Codec/SliceInfo.cs
@@ -6,7 +6,8 @@ namespace IceRpc.Ice.Codec;
 /// not decode.</summary>
 public sealed class SliceInfo
 {
-    /// <summary>Gets the Ice type ID or compact ID for this slice.</summary>
+    /// <summary>Gets the Ice type ID or compact ID for this slice. An Ice type ID starts with "::", while a
+    /// compact ID is a non-negative integer in decimal notation.</summary>
     public string TypeId { get; }
 
     /// <summary>Gets the encoded bytes for this slice, including the leading size integer.</summary>

--- a/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
@@ -10,6 +10,39 @@ namespace IceRpc.Ice.Generator.Base.Tests;
 public class SlicingTests
 {
     [Test]
+    public void Decoding_a_class_with_an_invalid_string_type_id_fails()
+    {
+        var buffer = new MemoryBufferWriter(new byte[1024 * 1024]);
+        var encoder = new IceEncoder(buffer, classFormat: ClassFormat.Sliced);
+        encoder.EncodeClass(new FakeTypeIdClass("9999999999")); // a string type ID that does not start with "::"
+
+        Assert.That(
+            () =>
+            {
+                var decoder = new IceDecoder(buffer.WrittenMemory, activator: null);
+                _ = decoder.DecodeClass<IceClass>();
+            },
+            Throws.TypeOf<InvalidDataException>());
+    }
+
+    private sealed class FakeTypeIdClass : IceClass
+    {
+        private readonly string _typeId;
+
+        internal FakeTypeIdClass(string typeId) => _typeId = typeId;
+
+        protected override void DecodeCore(ref IceDecoder decoder)
+        {
+        }
+
+        protected override void EncodeCore(ref IceEncoder encoder)
+        {
+            encoder.StartSlice(_typeId);
+            encoder.EndSlice(lastSlice: true);
+        }
+    }
+
+    [Test]
     public void Decoding_a_class_skips_and_preserves_unknown_slices([Values] bool partialSlicing)
     {
         // Arrange


### PR DESCRIPTION
The Ice decoder stored a peer-supplied string type ID verbatim, without validation. This matters for preserved slices: `SliceInfo.TypeId` holds either a type ID or a compact ID without recording which one, and re-encoding a preserved slice parses `TypeId` as a compact ID unless it starts with `::`. A peer could therefore send a string type ID such as `"9999999999"` or `"-5"`; re-encoding the preserved slices then escaped as `OverflowException` (from `int.Parse`) or `ArgumentException` (from `EncodeSize`) instead of `InvalidDataException` — surfacing as `StatusCode.InternalError` for what is actually bad peer data.

This PR validates at the trust boundary: `DecodeTypeId` now throws `InvalidDataException` when a string type ID does not start with `::`. A valid Ice type ID always starts with `::`, and slices with compact IDs use their own type-ID kind on the wire — so after this check, a preserved slice's `TypeId` can always be re-encoded.

On the encoder side, the `catch (FormatException)` around the compact-ID parse is now unreachable — `SliceInfo` is only created by the decoder — so it's removed rather than left to mislabel a hypothetical internal bug as invalid peer data.

Adds a regression test.

## What's Changed entry

None — only changes how invalid data received from a peer is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)