### PR TITLE
Add PR template with the What's Changed entry convention

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Describe the change and why it's needed. For a bug fix, describe the bug: when it occurs and what a user
+observes. -->
+
+## What's Changed entry
+
+<!-- This section feeds the "What's Changed" section of the GitHub release notes; it's collected from merged PRs at
+release time. Keep it, in one of two forms.
+
+For a user-facing change, specify the area (usually an area label name, such as "Core", "Slic" or "Ice codec") and
+write one bullet per user-visible change:
+
+Area: <area>
+
+- <entry>
+
+Write each entry from the user's perspective: the observable symptom or new behavior, in the documentation's
+vocabulary — not the internal mechanism. A fix that only changes how invalid or malicious data received from a peer
+is handled is not user-facing.
+
+For a change with no user-facing impact, explain briefly why:
+
+None — <short reason>.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,20 +4,27 @@ observes. -->
 ## What's Changed entry
 
 <!-- This section feeds the "What's Changed" section of the GitHub release notes; it's collected from merged PRs at
-release time. Keep it, in one of two forms.
+release time. It should be in one of two forms:
 
-For a user-facing change, specify the area (usually an area label name, such as "Core", "Slic" or "Ice codec") and
+1) For a user-facing change, specify the area (usually an area label name, such as "Core", "Slic" or "Ice codec") and
 write one bullet per user-visible change:
 
+```
 Area: <area>
 
 - <entry>
+```
+
+Most PRs have a single entry. A PR with several user-visible changes gets one bullet each, under one Area block
+per area.
 
 Write each entry from the user's perspective: the observable symptom or new behavior, in the documentation's
 vocabulary — not the internal mechanism. A fix that only changes how invalid or malicious data received from a peer
 is handled is not user-facing.
 
-For a change with no user-facing impact, explain briefly why:
+2) For a change with no user-facing impact, explain briefly why:
 
+```
 None — <short reason>.
+```
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ per area.
 
 Write each entry from the user's perspective: the observable symptom or new behavior, in the documentation's
 vocabulary — not the internal mechanism. A fix that only changes how invalid or malicious data received from a peer
-is handled is not user-facing.
+is handled is not generally user-facing.
 
 2) For a change with no user-facing impact, explain briefly why:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ These conventions apply to all AI coding assistants (Copilot, Claude Code, etc.)
 - Run all tests: `dotnet test`
 - Run a single test project: `dotnet test tests/<Project>/<Project>.csproj --filter "FullyQualifiedName~<TestClass>"`
 
+## Pull requests
+
+- Every PR description ends with a `## What's Changed entry` section. Read
+  [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) for the format and the rules before writing
+  it — the template is not injected automatically when a PR is created from the command line.
+
 ## Dismissed audit patterns
 
 This section captures the reasoning behind `ai-audit` findings that have been closed as "not planned". Before opening a


### PR DESCRIPTION
Each release's GitHub release notes carry a hand-written "What's Changed" section (see the v0.5.2 release). Writing it by revisiting every merged PR at release time doesn't scale, so this PR establishes a convention: every PR description ends with a `## What's Changed entry` section that records, at fix time, either the release-notes entry (with its area) or an explicit `None — <reason>`. At release time, the entries are collected from the milestone's merged PRs and only need a light editorial pass.

- `.github/pull_request_template.md` (new) carries the section skeleton and the rules in an HTML comment: entries describe observable behavior from the user's perspective, and fixes that only change the handling of invalid or malicious peer data get no entry.
- `AGENTS.md` gets a "Pull requests" section requiring the section and pointing at the template, since the template is not injected automatically for PRs created from the command line.

See #4836 and #4837 for the first two PRs using the convention.

## What's Changed entry

None — contributor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)