### PR TITLE
Validate boolean values when decoding custom-mapped bool sequences

### DIFF
--- a/src/ZeroC.Slice.Generator/ITypeExtensions.cs
+++ b/src/ZeroC.Slice.Generator/ITypeExtensions.cs
@@ -94,7 +94,9 @@ internal static class ITypeExtensions
                 {
                     // cs::type on fixed-size primitives: wrap the fixed-size decode in the factory.
                     string csElemType = elemType.ToTypeString(currentNamespace);
-                    return $"new {concreteType}(decoder.DecodeSequence<{csElemType}>())";
+                    return ((Builtin)elemType).Kind == BuiltinKind.Bool ?
+                        $"new {concreteType}(decoder.DecodeSequence<{csElemType}>(checkElement: SliceDecoder.CheckBoolValue))" :
+                        $"new {concreteType}(decoder.DecodeSequence<{csElemType}>())";
                 }
                 return $$"""
                     {{method}}(

--- a/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.cs
@@ -47,6 +47,43 @@ public class SequenceDecodingTests
     }
 
     [Test]
+    public void Decode_custom_bool_sequence_field()
+    {
+        // Arrange
+        bool[] expected = [false, true, false];
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeSize(3);
+        encoder.WriteByteSpan(new byte[] { 0x00, 0x01, 0x00 });
+        var decoder = new SliceDecoder(buffer.WrittenMemory);
+
+        // Act
+        var sut = new CustomBoolS(ref decoder);
+
+        // Assert
+        Assert.That(sut.Value, Is.EqualTo(expected));
+        Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
+    }
+
+    [Test]
+    public void Decode_custom_bool_sequence_field_with_invalid_values()
+    {
+        // Arrange
+        var buffer = new MemoryBufferWriter(new byte[256]);
+        var encoder = new SliceEncoder(buffer);
+        encoder.EncodeSize(3);
+        encoder.WriteByteSpan(new byte[] { 0x00, 0x01, 0x02 });
+
+        // Act/Assert
+        Assert.Throws<InvalidDataException>(
+            () =>
+            {
+                var decoder = new SliceDecoder(buffer.WrittenMemory);
+                _ = new CustomBoolS(ref decoder);
+            });
+    }
+
+    [Test]
     public void Decode_custom_opt_int32_sequence_field()
     {
         // Arrange

--- a/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.slice
@@ -6,6 +6,10 @@ compact struct BoolS {
     value: Sequence<bool>
 }
 
+compact struct CustomBoolS {
+    value: [cs::type("List<bool>")] Sequence<bool>
+}
+
 compact struct CustomOptInt32S {
     value: [cs::type("List<int?>")] Sequence<int32?>
 }


### PR DESCRIPTION
Decoding a plain `Sequence<bool>` validates each element (`checkElement: SliceDecoder.CheckBoolValue`), rejecting bytes that are neither 0 nor 1. But when a `Sequence<bool>` field uses a `cs::type` custom collection, the generated code took the fixed-size memcpy path without the validation callback — so a noncanonical byte like `2` landed directly in the decoded `bool`s. Such a `bool` breaks ordinary boolean reasoning in .NET (`b` and `!b` can both behave unexpectedly), from peer-controlled input.

The generator's custom-collection fixed-size branch now emits the same `CheckBoolValue` validation as the plain path.

Adds tests for the custom-mapped bool sequence (valid and invalid bytes), mirroring the existing plain `Sequence<bool>` tests.

## What's Changed entry

None — only changes how invalid data received from a peer is handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)