### PR TITLE
Fix completion of the compressor's payload writer

### DIFF
--- a/src/IceRpc.Compressor/CompressorInterceptor.cs
+++ b/src/IceRpc.Compressor/CompressorInterceptor.cs
@@ -3,7 +3,6 @@
 using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO.Compression;
 using System.IO.Pipelines;
 using ZeroC.Slice.Codec;
@@ -57,15 +56,7 @@ public class CompressorInterceptor : IInvoker
             compress.Value &&
             !request.Fields.ContainsKey(RequestFieldKey.CompressionFormat))
         {
-            if (_compressionFormat == CompressionFormat.Brotli)
-            {
-                request.Use(next => PipeWriter.Create(new BrotliStream(next.AsStream(), _compressionLevel)));
-            }
-            else
-            {
-                Debug.Assert(_compressionFormat == CompressionFormat.Deflate);
-                request.Use(next => PipeWriter.Create(new DeflateStream(next.AsStream(), _compressionLevel)));
-            }
+            request.Use(next => new CompressorPipeWriter(next, _compressionFormat, _compressionLevel));
 
             request.Fields = request.Fields.With(RequestFieldKey.CompressionFormat, _encodedCompressionFormatValue);
         }

--- a/src/IceRpc.Compressor/CompressorMiddleware.cs
+++ b/src/IceRpc.Compressor/CompressorMiddleware.cs
@@ -3,7 +3,6 @@
 using IceRpc.Extensions.DependencyInjection;
 using IceRpc.Features;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO.Compression;
 using System.IO.Pipelines;
 using ZeroC.Slice.Codec;
@@ -80,15 +79,7 @@ public class CompressorMiddleware : IDispatcher
             compress.Value &&
             !response.Fields.ContainsKey(ResponseFieldKey.CompressionFormat))
         {
-            if (_compressionFormat == CompressionFormat.Brotli)
-            {
-                response.Use(next => PipeWriter.Create(new BrotliStream(next.AsStream(), _compressionLevel)));
-            }
-            else
-            {
-                Debug.Assert(_compressionFormat == CompressionFormat.Deflate);
-                response.Use(next => PipeWriter.Create(new DeflateStream(next.AsStream(), _compressionLevel)));
-            }
+            response.Use(next => new CompressorPipeWriter(next, _compressionFormat, _compressionLevel));
 
             response.Fields = response.Fields.With(ResponseFieldKey.CompressionFormat, _encodedCompressionFormatValue);
         }

--- a/src/IceRpc.Compressor/CompressorPipeWriter.cs
+++ b/src/IceRpc.Compressor/CompressorPipeWriter.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ZeroC, Inc.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.IO.Pipelines;
+
+namespace IceRpc.Compressor;
+
+/// <summary>A payload writer decorator that compresses the data written to it. Unlike the pipe writer created by
+/// <see cref="PipeWriter.Create(Stream, StreamPipeWriterOptions?)" /> over a compression stream, this decorator
+/// implements the completion semantics of payload writers: completing it with an exception completes the decoratee
+/// with this exception (and not gracefully), and completing it without an exception never throws — when the writing of
+/// the last compressed bytes fails, the decoratee is completed with the exception.</summary>
+internal class CompressorPipeWriter : PipeWriter
+{
+    public override bool CanGetUnflushedBytes => _compressedDataWriter.CanGetUnflushedBytes;
+
+    public override long UnflushedBytes => _compressedDataWriter.UnflushedBytes;
+
+    private readonly PipeWriter _compressedDataWriter;
+    private readonly PipeWriter _decoratee;
+    private bool _isCompleted;
+
+    public override void Advance(int bytes) => _compressedDataWriter.Advance(bytes);
+
+    public override void CancelPendingFlush() => _compressedDataWriter.CancelPendingFlush();
+
+    public override void Complete(Exception? exception = null)
+    {
+        if (!_isCompleted)
+        {
+            _isCompleted = true;
+
+            if (exception is null)
+            {
+                try
+                {
+                    // Flushes the buffered data and the compression trailer into the decoratee.
+                    _compressedDataWriter.Complete();
+                }
+                catch (Exception completeException)
+                {
+                    exception = completeException;
+                }
+
+                _decoratee.Complete(exception);
+            }
+            else
+            {
+                // Complete the decoratee first: this prevents the disposal of the compression stream below from
+                // writing the compression trailer to the transport — such a write could block on flow control with no
+                // cancellation. The trailer writes fail immediately on the completed decoratee.
+                _decoratee.Complete(exception);
+                try
+                {
+                    // Releases the compression stream.
+                    _compressedDataWriter.Complete(exception);
+                }
+                catch
+                {
+                    // Expected: see comment above.
+                }
+            }
+        }
+    }
+
+    public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) =>
+        _compressedDataWriter.FlushAsync(cancellationToken);
+
+    public override Memory<byte> GetMemory(int sizeHint = 0) => _compressedDataWriter.GetMemory(sizeHint);
+
+    public override Span<byte> GetSpan(int sizeHint = 0) => _compressedDataWriter.GetSpan(sizeHint);
+
+    public override ValueTask<FlushResult> WriteAsync(
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default) =>
+        _compressedDataWriter.WriteAsync(source, cancellationToken);
+
+    internal CompressorPipeWriter(
+        PipeWriter decoratee,
+        CompressionFormat compressionFormat,
+        CompressionLevel compressionLevel)
+    {
+        Debug.Assert(compressionFormat is CompressionFormat.Brotli or CompressionFormat.Deflate);
+
+        _decoratee = decoratee;
+
+        // leaveOpen: true so that the completion of the compressed data writer never completes the decoratee.
+        Stream decorateeStream = decoratee.AsStream(leaveOpen: true);
+        _compressedDataWriter = PipeWriter.Create(
+            compressionFormat == CompressionFormat.Brotli ?
+                new BrotliStream(decorateeStream, compressionLevel) :
+                new DeflateStream(decorateeStream, compressionLevel));
+    }
+}

--- a/tests/IceRpc.Compressor.Tests/CompressorInterceptorTests.cs
+++ b/tests/IceRpc.Compressor.Tests/CompressorInterceptorTests.cs
@@ -48,6 +48,112 @@ public class CompressorInterceptorTests
         payloadWriter.Complete();
     }
 
+    /// <summary>Verifies that completing the compressor's payload writer with an exception completes the decorated
+    /// payload writer with an exception (and not gracefully with a valid compression trailer).</summary>
+    [Test]
+    public async Task Complete_compressor_payload_writer_with_exception_completes_output_with_exception(
+        [Values(CompressionFormat.Brotli, CompressionFormat.Deflate)] CompressionFormat compressionFormat)
+    {
+        // Arrange
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+        var sut = new CompressorInterceptor(invoker, compressionFormat);
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
+        request.Features = request.Features.With(CompressFeature.Compress);
+        await sut.InvokeAsync(request, default);
+
+        var pipe = new Pipe();
+        PipeWriter payloadWriter = request.GetPayloadWriter(pipe.Writer);
+        await payloadWriter.WriteAsync(_payload);
+
+        // Act
+        payloadWriter.Complete(new InvalidOperationException("payload copy failed"));
+
+        // Assert
+        Assert.That(
+            async () =>
+            {
+                while (true)
+                {
+                    ReadResult readResult = await pipe.Reader.ReadAsync();
+                    pipe.Reader.AdvanceTo(readResult.Buffer.End);
+                    if (readResult.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+            },
+            Throws.InstanceOf<InvalidOperationException>());
+        pipe.Reader.Complete();
+    }
+
+    /// <summary>Verifies that completing the compressor's payload writer does not throw when writing the last bytes of
+    /// the compressed data fails, and completes the decorated payload writer with the exception.</summary>
+    [Test]
+    public async Task Complete_compressor_payload_writer_does_not_throw_when_write_fails(
+        [Values(CompressionFormat.Brotli, CompressionFormat.Deflate)] CompressionFormat compressionFormat)
+    {
+        // Arrange
+        var invoker = new InlineInvoker((request, cancellationToken) =>
+            Task.FromResult(new IncomingResponse(request, FakeConnectionContext.Instance)));
+        var sut = new CompressorInterceptor(invoker, compressionFormat);
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
+        request.Features = request.Features.With(CompressFeature.Compress);
+        await sut.InvokeAsync(request, default);
+
+        var failingWriter = new FailingPipeWriter();
+        PipeWriter payloadWriter = request.GetPayloadWriter(failingWriter);
+        try
+        {
+            await payloadWriter.WriteAsync(_payload);
+        }
+        catch (IOException)
+        {
+            // Ignore the write failure, if any.
+        }
+
+        // Act/Assert
+        Assert.That(() => payloadWriter.Complete(), Throws.Nothing);
+        Assert.That(failingWriter.CompleteException, Is.Not.Null);
+    }
+
+    // A pipe writer that throws IOException on every write or flush.
+    private class FailingPipeWriter : PipeWriter
+    {
+        internal Exception? CompleteException { get; private set; }
+
+        private bool _isCompleted;
+
+        private readonly Pipe _pipe = new();
+
+        public override void Advance(int bytes) => _pipe.Writer.Advance(bytes);
+
+        public override void CancelPendingFlush() => _pipe.Writer.CancelPendingFlush();
+
+        public override void Complete(Exception? exception = null)
+        {
+            if (!_isCompleted)
+            {
+                _isCompleted = true;
+                CompleteException = exception;
+                _pipe.Writer.Complete();
+                _pipe.Reader.Complete();
+            }
+        }
+
+        public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) =>
+            throw new IOException("write failed");
+
+        public override Memory<byte> GetMemory(int sizeHint = 0) => _pipe.Writer.GetMemory(sizeHint);
+
+        public override Span<byte> GetSpan(int sizeHint = 0) => _pipe.Writer.GetSpan(sizeHint);
+
+        public override ValueTask<FlushResult> WriteAsync(
+            ReadOnlyMemory<byte> source,
+            CancellationToken cancellationToken = default) =>
+            throw new IOException("write failed");
+    }
+
     /// <summary>Verifies that the compressor interceptor does not install a payload writer interceptor if the request
     /// does not contain the compress payload feature.</summary>
     [Test]

--- a/tests/IceRpc.Compressor.Tests/CompressorInterceptorTests.cs
+++ b/tests/IceRpc.Compressor.Tests/CompressorInterceptorTests.cs
@@ -103,24 +103,20 @@ public class CompressorInterceptorTests
 
         var failingWriter = new FailingPipeWriter();
         PipeWriter payloadWriter = request.GetPayloadWriter(failingWriter);
-        try
-        {
-            await payloadWriter.WriteAsync(_payload);
-        }
-        catch (IOException)
-        {
-            // Ignore the write failure, if any.
-        }
+        await payloadWriter.WriteAsync(_payload);
+        failingWriter.FailWrites = true;
 
         // Act/Assert
         Assert.That(() => payloadWriter.Complete(), Throws.Nothing);
         Assert.That(failingWriter.CompleteException, Is.Not.Null);
     }
 
-    // A pipe writer that throws IOException on every write or flush.
+    // A pipe writer that throws IOException on every write or flush once FailWrites is set.
     private class FailingPipeWriter : PipeWriter
     {
         internal Exception? CompleteException { get; private set; }
+
+        internal bool FailWrites { get; set; }
 
         private bool _isCompleted;
 
@@ -142,7 +138,7 @@ public class CompressorInterceptorTests
         }
 
         public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) =>
-            throw new IOException("write failed");
+            FailWrites ? throw new IOException("write failed") : _pipe.Writer.FlushAsync(cancellationToken);
 
         public override Memory<byte> GetMemory(int sizeHint = 0) => _pipe.Writer.GetMemory(sizeHint);
 
@@ -151,7 +147,7 @@ public class CompressorInterceptorTests
         public override ValueTask<FlushResult> WriteAsync(
             ReadOnlyMemory<byte> source,
             CancellationToken cancellationToken = default) =>
-            throw new IOException("write failed");
+            FailWrites ? throw new IOException("write failed") : _pipe.Writer.WriteAsync(source, cancellationToken);
     }
 
     /// <summary>Verifies that the compressor interceptor does not install a payload writer interceptor if the request


### PR DESCRIPTION
The compressor interceptor and middleware installed their payload writer as `PipeWriter.Create(new BrotliStream(next.AsStream(), ...))`. This BCL pipe writer does not implement the completion semantics IceRPC expects from a payload writer, with two consequences:

- **Silent truncation.** Completing the writer with an exception (a failed payload copy) discards its buffered data but still disposes the compression stream, which writes the compression trailer and completes `next` with a null exception — a graceful end-of-stream. The peer's decompressor succeeds on the short stream: the payload is truncated with no error anywhere.
- **`Complete()` can throw.** Completing the writer without an exception flushes the compression trailer through the transport writer, and that write throws when the peer already stopped reading the payload (a common, benign action). IceRPC payload writers never throw from `Complete`; this violation escapes a `finally` in the request payload-continuation send path as an unobserved task exception, skips the dispatch-invocation count decrement, and leaves a subsequent `ConnectionCache`/connection `DisposeAsync` hanging forever on a count that can never reach zero.

The fix replaces the raw BCL writer with `CompressorPipeWriter`, a small decorator that implements the expected semantics: it builds the compression stream over `next.AsStream(leaveOpen: true)` so the BCL dispose chain can never complete the transport writer, completes `next` with the exception on the failure path (before releasing the compression stream, so the trailer can't reach the transport or block on flow control), and on the success path converts a trailer-write failure into completing `next` with the exception instead of throwing.

Adds contract tests for both behaviors (Brotli and Deflate). The decompression (read) side is unchanged.

## What's Changed entry

Area: interceptors+middleware

- Fixed a bug where a compressed payload could be silently truncated: when a failure (such as an error reading
  the payload from the application) interrupted the sending of this payload, the peer received the truncated
  payload as if it was complete.
- Fixed a bug where disposing a connection could hang forever when the peer stopped reading a compressed
  payload early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)