### PR TITLE
Restrict the query string to the query component of the URI in the CurrentWeather example

### DIFF
--- a/examples/json/CurrentWeather/Server/WebService.cs
+++ b/examples/json/CurrentWeather/Server/WebService.cs
@@ -54,8 +54,8 @@ internal class WebService : IDispatcher
         request.Payload.AdvanceTo(readResult.Buffer.End); // Reading a PipeReader is a two-step process.
         request.Payload.Complete(); // Done with the request payload.
 
-        // Create the request URI.
-        var requestUri = new Uri(_baseUri, query);
+        // Create the request URI from the base URI and the client-provided query string.
+        Uri requestUri = new UriBuilder(_baseUri) { Query = query }.Uri;
 
         // Send the HTTP request.
         Console.WriteLine($"GET {requestUri}");


### PR DESCRIPTION
The CurrentWeather server example built its outbound HTTP request URI with `new Uri(_baseUri, query)`, where `query` comes from the IceRPC request payload. `Uri(Uri, string)` replaces the base URI entirely when the second argument is an absolute URI (and replaces its path for a path-relative one), so a client could redirect the example server's HTTP GET to an arbitrary destination and read back the response — the classic server-side request forgery pattern.

The example now builds the request URI with `new UriBuilder(_baseUri) { Query = query }.Uri`, which confines the client-provided string to the query component: the scheme, host, and path always come from the configured base URI.

No wire change — the client half of the example is untouched, and legitimate queries produce identical request URIs.

## What's Changed entry

None — example code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)