### PR TITLE
Enforce the control frame body size limit on all non-data Slic frames

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1495,8 +1495,10 @@ internal class SlicConnection : IMultiplexedConnection
                 throw new InvalidDataException("The frame size can't be larger than int.MaxValue.", exception);
             }
 
-            // Reject oversized control frame bodies before any buffering occurs.
-            if (header.FrameType < FrameType.Stream && header.FrameSize > MaxControlFrameBodySize)
+            // Reject oversized control frame bodies before any buffering occurs. Only the stream data frames are
+            // exempt: their size is bounded by the stream's flow control window.
+            if (header.FrameType is not (FrameType.Stream or FrameType.StreamLast) &&
+                header.FrameSize > MaxControlFrameBodySize)
             {
                 throw new InvalidDataException(
                     $"The {header.FrameType} frame body size ({header.FrameSize}) exceeds the maximum allowed size ({MaxControlFrameBodySize}).");

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -1166,9 +1166,12 @@ public class SlicTransportTests
             Throws.InstanceOf<IceRpcException>());
     }
 
-    [Test]
-    public async Task Reject_slic_control_frame_with_oversized_body()
+    [TestCase(nameof(FrameType.Initialize))]
+    [TestCase(nameof(FrameType.StreamWindowUpdate))]
+    public async Task Reject_slic_control_frame_with_oversized_body(string frameTypeStr)
     {
+        FrameType frameType = Enum.Parse<FrameType>(frameTypeStr);
+
         // Arrange
         await using ServiceProvider provider = new ServiceCollection()
             .AddSlicTest()
@@ -1186,8 +1189,8 @@ public class SlicTransportTests
         await using var _ = multiplexedServerConnection;
         await connectTask;
 
-        // Act - Write an Initialize frame header that declares a body larger than MaxControlFrameBodySize (16,383).
-        await WriteOversizedFrameAsync(duplexClientConnection, FrameType.Initialize, 16_384);
+        // Act - Write a frame header that declares a body larger than MaxControlFrameBodySize (16,383).
+        await WriteOversizedFrameAsync(duplexClientConnection, frameType, 16_384);
 
         // Assert
         IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(


### PR DESCRIPTION
The Slic control frame body size limit (`MaxControlFrameBodySize`, 16,383 bytes) was applied with the predicate `header.FrameType < FrameType.Stream`, which covers `Initialize` through `Pong` only. Three frame types sort after `Stream` in the enum: `StreamReadsClosed`, `StreamWindowUpdate` and `StreamWritesClosed`. The first and last are harmless — their handler rejects any non-empty body — but `StreamWindowUpdate` is read through `ReadFrameBodyAsync`, which only rejects a size of 0 and then reads the declared number of bytes into a pipe with no pause writer threshold. A peer could therefore declare a body of up to `int.MaxValue` for a frame whose real body is a couple of bytes, and make the receiver buffer that many bytes before decoding.

The limit now applies to every frame type except `Stream` and `StreamLast`, whose size is bounded by the stream's flow control window. This is the exemption set #4516 intended when it introduced the limit.

Extends the existing oversized-body test with a `StreamWindowUpdate` case.

## What's Changed entry

None — internal hardening; no legitimate or accidental control frame is oversized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)