### PR TITLE
Abort the response stream when sending the payload continuation fails

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1093,7 +1093,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
 
                     PipeWriter payloadWriter = response.GetPayloadWriter(streamOutput);
 
-                    // Set to true only after the payload and its continuation are fully copied.
+                    // Remains false if a copy throws or is canceled.
                     bool payloadWriterSuccess = false;
 
                     try

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1093,8 +1093,8 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
 
                     PipeWriter payloadWriter = response.GetPayloadWriter(streamOutput);
 
-                    // We give flushResult an initial "failed" value, in case the first CopyFromAsync throws.
-                    var flushResult = new FlushResult(isCanceled: true, isCompleted: false);
+                    // Set to true only after the payload and its continuation are fully copied.
+                    bool payloadWriterSuccess = false;
 
                     try
                     {
@@ -1106,7 +1106,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
                         // ignored.
                         bool hasContinuation = response.PayloadContinuation is not null;
 
-                        flushResult = await payloadWriter.CopyFromAsync(
+                        FlushResult flushResult = await payloadWriter.CopyFromAsync(
                             response.Payload,
                             stream.WritesClosed,
                             endStream: !hasContinuation,
@@ -1120,10 +1120,12 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
                                 endStream: true,
                                 _disposedCts.Token).ConfigureAwait(false);
                         }
+
+                        payloadWriterSuccess = !flushResult.IsCanceled;
                     }
                     finally
                     {
-                        payloadWriter.CompleteOutput(success: !flushResult.IsCanceled);
+                        payloadWriter.CompleteOutput(payloadWriterSuccess);
                         response.Payload.Complete();
                         response.PayloadContinuation?.Complete();
                     }

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -1551,16 +1551,21 @@ public sealed class IceRpcProtocolConnectionTests
             async () => await taskExceptionObserver.DispatchFailedException,
             Is.InstanceOf<InvalidOperationException>());
 
-        // Cleanup
-        try
-        {
-            await responseTask;
-        }
-        catch (IceRpcException exception) when (exception.IceRpcError == IceRpcError.TruncatedData)
-        {
-            // Depending on the timing, the payload stream send failure might abort the invocation before the response
-            // is sent.
-        }
+        // The client never sees the incomplete response payload as complete. Depending on the timing, the payload
+        // stream send failure aborts the invocation before the response is sent, or when the client reads the payload.
+        Assert.That(
+            async () =>
+            {
+                IncomingResponse response = await responseTask;
+                ReadResult readResult;
+                do
+                {
+                    readResult = await response.Payload.ReadAsync();
+                    response.Payload.AdvanceTo(readResult.Buffer.End);
+                }
+                while (!readResult.IsCompleted);
+            },
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.TruncatedData));
     }
 
     /// <summary>Ensures that the request payload writer is completed on valid request.</summary>


### PR DESCRIPTION
Fixes #4789.

`SendResponseAsync` seeded `flushResult` with `isCanceled: true` so that a throw from the first `CopyFromAsync` would complete the payload writer abortively. It never re-armed this sentinel before copying the payload continuation, so a throw from that second copy left the successful result of the first copy in place: the `finally` completed the payload writer gracefully, the stream ended with a `StreamLast` frame, and the client read the truncated payload as a complete, successful response.

Exceptions from that second copy are ordinary rather than contract violations — `CopyFromAsync` lets reader exceptions escape, and the reader is the application's async enumerable for a server-streaming Slice or Protobuf operation.

This PR mirrors the request side, which was already correct: a `payloadWriterSuccess` flag declared outside the `try` and set only after the last copy completes. Every non-throwing path keeps its current behavior, including the one where the first copy reports the peer is no longer reading.

`PayloadContinuation_completed_on_invalid_response_payload_continuation` drove this path but tolerated either outcome in its cleanup; it now asserts the client always observes `IceRpcError.TruncatedData`, whether the invocation itself fails or the failure surfaces when reading the response payload.

## What's Changed entry

Area: Core

- Fixed a bug where a response payload could be silently truncated: when a failure (such as an error reading
  the payload from the application) interrupted the streaming of this payload, the client received the
  truncated payload as if it was complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)