### PR TITLE
Wait for detached connections when shutting down a client connection

### DIFF
--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -386,7 +386,8 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     /// <exception cref="ObjectDisposedException">Thrown if this connection is disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
-    /// <item><description><see cref="IceRpcException" /> if the connection shutdown failed.</description></item>
+    /// <item><description><see cref="IceRpcException" /> with error <see cref="IceRpcError.OperationAborted" /> if this
+    /// connection is disposed while being shut down.</description></item>
     /// <item><description><see cref="OperationCanceledException" /> if cancellation was requested through the
     /// cancellation token.</description></item>
     /// <item><description><see cref="TimeoutException" /> if this shutdown attempt or a previous attempt exceeded <see
@@ -419,16 +420,30 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposedCts.Token);
             cts.CancelAfter(_shutdownTimeout);
 
-            // Since a pending connection is "detached", it's shutdown and disposed via the connectTask, not directly by
-            // this method.
             try
             {
-                if (_activeConnection is not null)
+                // Since a pending connection is "detached", it's shutdown and disposed via the connectTask, not
+                // directly by this method.
+                try
                 {
-                    await _activeConnection.Value.Connection.ShutdownAsync(cts.Token).ConfigureAwait(false);
-                }
+                    Task shutdownTask = _activeConnection is null ?
+                        Task.CompletedTask :
+                        _activeConnection.Value.Connection.ShutdownAsync(cts.Token);
 
-                await _detachedConnectionsTcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+                    await Task.WhenAll(shutdownTask, _detachedConnectionsTcs.Task.WaitAsync(cts.Token))
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // Ignore other connection shutdown failures.
+
+                    // Throw OperationCanceledException if this WhenAll exception is hiding an OCE.
+                    cts.Token.ThrowIfCancellationRequested();
+                }
             }
             catch (OperationCanceledException)
             {
@@ -445,10 +460,6 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
                     throw new TimeoutException(
                         $"The client connection shut down timed out after {_shutdownTimeout.TotalSeconds} s.");
                 }
-            }
-            catch
-            {
-                // ignore other shutdown exception
             }
         }
     }


### PR DESCRIPTION
Fixes #4793.

`ClientConnection.PerformShutdownAsync` awaited the active connection's shutdown and the detached-connections wait sequentially inside a single `try`, followed by a `catch` that ignored shutdown failures. Both protocol implementations rethrow a non-`OperationCanceledException` `IceRpcException` from `ShutdownAsync`, so a failing active connection jumped past the detached-connections wait and `ShutdownAsync` reported success while detached connections were still shutting down.

This PR mirrors `ConnectionCache.PerformShutdownAsync` and `Server.PerformShutdownAsync`: a single `Task.WhenAll` over both, in the same nested-try shape, so a shutdown failure is ignored without skipping the wait. The `OperationCanceledException` translation to `OperationAborted` / `TimeoutException` is unchanged.

The `ShutdownAsync` doc comment listed an `IceRpcException` "if the connection shutdown failed", which this method does not throw, and omitted the `OperationAborted` it does throw when the connection is disposed mid-shutdown. It now uses the same wording as its `ConnectionCache` and `Server` counterparts.

## What's Changed entry

None — internal: the shutdown could misreport completion in a window that disposal already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)