### PR TITLE
Consume the MoveNextAsync ValueTask only once

### DIFF
--- a/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncEnumerableExtensions.cs
+++ b/src/IceRpc.Protobuf/RpcMethods/Internal/AsyncEnumerableExtensions.cs
@@ -172,7 +172,7 @@ internal static class AsyncEnumerableExtensions
                         // If we reached the stream flush threshold, it's time to flush.
                         if (written >= _streamFlushThreshold)
                         {
-                            result = hasNext ? moveNext.AsTask() : null;
+                            result = hasNext ? Task.FromResult(true) : null;
                             keepEncoding = false;
                         }
                         else

--- a/src/IceRpc.Slice/Operations/AsyncEnumerableExtensions.cs
+++ b/src/IceRpc.Slice/Operations/AsyncEnumerableExtensions.cs
@@ -182,7 +182,7 @@ public static class AsyncEnumerableExtensions
                         // If we reached the stream flush threshold, it's time to flush.
                         if (encoder.EncodedByteCount - sizePlaceholder.Length >= _streamFlushThreshold)
                         {
-                            result = hasNext ? moveNext.AsTask() : null;
+                            result = hasNext ? Task.FromResult(true) : null;
                             keepEncoding = false;
                         }
                         else


### PR DESCRIPTION
Fixes #4795.

In the stream-flush-threshold branch of `AsyncEnumerablePipeReader`, the `ValueTask<bool>` returned by `MoveNextAsync` was consumed twice: first by reading `moveNext.Result`, then by calling `moveNext.AsTask()`. A `ValueTask` may only be consumed once — awaiting it, reading `Result` or calling `AsTask()` are all consumptions — so this is plain incorrect, even though it is never hit in practice today:

- When the `ValueTask` wraps a result directly or wraps a `Task`, both consumptions are harmless reads.
- When it wraps an `IValueTaskSource<bool>`, the second consumption uses a token that the first one may have invalidated. A pooled source that resets itself in `GetResult` — the documented pattern for reusing a source — makes `AsTask()` throw `InvalidOperationException`.

Compiler-generated `async IAsyncEnumerable<T>` iterators fall in the benign category: their value task source is reset at the beginning of the next `MoveNextAsync`, not in `GetResult`, so the token is still valid for the second consumption. That is why no enumerator used in practice fails today.

In this branch `hasNext` is known to be `true`, so the fix is to produce the task from that value instead of consuming the `ValueTask` again. The resulting `Task<bool>` is the same. The Protobuf copy of this code gets the same fix.

## What's Changed entry

None — no supported enumerator implementation is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)