### PR TITLE
Reject invalid opaque server addresses when decoding a proxy

### DIFF
--- a/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
@@ -72,7 +72,12 @@ public static class IceProxyIceDecoderExtensions
         // With the Ice encoding, the ice server addresses are transport-specific, with a transport-specific encoding.
 
         ServerAddress? serverAddress = null;
-        var transportCode = (TransportCode)decoder.DecodeShort();
+        short transportCodeValue = decoder.DecodeShort();
+        if (transportCodeValue < 0)
+        {
+            throw new InvalidDataException($"Received invalid transport code: {transportCodeValue}.");
+        }
+        var transportCode = (TransportCode)transportCodeValue;
 
         int size = decoder.DecodeInt();
         if (size < 6)
@@ -117,6 +122,11 @@ public static class IceProxyIceDecoderExtensions
                         break;
 
                     default:
+                        if (size == 0)
+                        {
+                            throw new InvalidDataException("Received opaque server address with an empty body.");
+                        }
+
                         // Create a server address for transport opaque
                         ImmutableDictionary<string, string>.Builder builder =
                             ImmutableDictionary.CreateBuilder<string, string>();


### PR DESCRIPTION
Fixes #4796.

Decoding a proxy could produce an opaque server address that cannot be encoded back:

- The transport code was decoded as a signed short and written verbatim into the `t` parameter, but no transport code is negative and the encoder rejects a negative `t`.
- An encapsulation whose body is empty produced an empty `v` parameter, and the encoder rejects an opaque server address without a body.

An application that decodes such a proxy and re-encodes it — when forwarding it, for instance — got a `FormatException`, an exception otherwise reserved for server addresses built from a URI.

Both values are invalid per the wire format, so this PR rejects them where the invalid data is received: `DecodeServerAddress` now throws `InvalidDataException` for a negative transport code and for an opaque server address with an empty body. The encoder is unchanged.

## What's Changed entry

None — only affects proxies from a nonconforming peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
