### PR TITLE
Configure the dispatcher through the options pipeline in AddIceRpcServer

### DIFF
--- a/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ServerServiceCollectionExtensions.cs
@@ -115,23 +115,17 @@ public static class ServerServiceCollectionExtensions
     public static IServiceCollection AddIceRpcServer(
         this IServiceCollection services,
         string optionsName,
-        Action<IDispatcherBuilder> configure) =>
-        services
-            .TryAddIceRpcServerTransport()
-            .AddSingleton(provider =>
+        Action<IDispatcherBuilder> configure)
+    {
+        services.AddOptions<ServerOptions>(optionsName).Configure<IServiceProvider>(
+            (options, provider) =>
             {
                 var dispatcherBuilder = new DispatcherBuilder(provider);
                 configure(dispatcherBuilder);
-
-                ServerOptions options = provider.GetRequiredService<IOptionsMonitor<ServerOptions>>().Get(optionsName);
                 options.ConnectionOptions.Dispatcher = dispatcherBuilder.Build();
-
-                return new Server(
-                    options,
-                    provider.GetRequiredService<IDuplexServerTransport>(),
-                    provider.GetRequiredService<IMultiplexedServerTransport>(),
-                    provider.GetService<ILogger<Server>>());
             });
+        return services.AddIceRpcServer(optionsName);
+    }
 
     /// <summary>Adds a <see cref="Server" /> to this service collection; you specify the server's options by injecting
     /// an <see cref="IOptionsMonitor{T}" /> of <see cref="ServerOptions" /> named <paramref name="optionsName" />.


### PR DESCRIPTION
Fixes #4802.

The `AddIceRpcServer(string, Action<IDispatcherBuilder>)` overload resolved the named `ServerOptions` from the options monitor and assigned the built dispatcher to `options.ConnectionOptions.Dispatcher` — mutating the monitor's cached, shared options instance outside the options pipeline.

The overload now registers the dispatcher with `AddOptions<ServerOptions>(optionsName).Configure<IServiceProvider>(...)` and delegates to the base `AddIceRpcServer(string)` overload, mirroring the `AddIceRpcServer(string, IDispatcher)` overload. The dispatcher is part of the options definition, set by the options pipeline when the named options are built.

Any consumer of the named options sees the same final value as before; the difference is that it's now produced by the options pipeline instead of a later mutation. The overload is exercised end-to-end by `ProtocolBridgingTests` (two named servers in one container) and `OperationCompressorTests`.

## What's Changed entry

None — cleanup with no observable behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)