### PR TITLE
Document the little-endian host assumption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,11 @@ is no buffer to overflow, so the "zip bomb" framing (amplification of a small in
 does not apply. Bounding still happens, just at the consumer's decoder: Slice / Protobuf reject malformed bytes
 (`InvalidDataException`) and enforce per-decoder collection-allocation budgets. Don't propose a size cap inside the
 decompressor; the limit belongs to the decoder that materializes structured data from the stream. (#4507.)
+
+### 12. Little-endian host assumption
+
+The Slice and Ice encodings always encode multi-byte primitives in little-endian byte order. This C# implementation
+performs no byte-order conversion — it assumes the host is little-endian, so host order and wire order coincide, and
+the fast paths copy arrays of fixed-size primitives directly to and from the wire. A little-endian host is a
+supported-platform constraint, consistent with the platforms .NET itself supports. Don't file findings about missing
+endianness guards or propose routing these codecs through `BinaryPrimitives`. (#4804.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,4 +130,6 @@ The Slice and Ice encodings always encode multi-byte primitives in little-endian
 performs no byte-order conversion — it assumes the host is little-endian, so host order and wire order coincide, and
 the fast paths copy arrays of fixed-size primitives directly to and from the wire. A little-endian host is a
 supported-platform constraint, consistent with the platforms .NET itself supports. Don't file findings about missing
-endianness guards or propose routing these codecs through `BinaryPrimitives`. (#4804.)
+host byte-order guards in these codecs or propose routing them through `BinaryPrimitives`. This pattern is only about
+host byte order: a type whose specified wire format is big-endian (such as `WellKnownTypes::Uuid`, RFC 9562 — #4801)
+still needs its byte-order conversion. (#4804.)


### PR DESCRIPTION
Fixes #4804.

The Slice and Ice encodings always encode multi-byte primitives in little-endian byte order. This implementation performs no byte-order conversion: it assumes the host is little-endian, so host order and wire order coincide and the codecs can copy arrays of fixed-size primitives directly to and from the wire.

This PR records that assumption as a supported-platform constraint in AGENTS.md's dismissed audit patterns, so future audits don't refile it or propose endianness guards / `BinaryPrimitives` conversions that would forfeit the copy fast paths for platforms .NET doesn't support.

## What's Changed entry

None — contributor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)