### PR TITLE
Make Set throw on a read-only feature collection

### DIFF
--- a/src/IceRpc/Features/IFeatureCollection.cs
+++ b/src/IceRpc/Features/IFeatureCollection.cs
@@ -16,6 +16,8 @@ public interface IFeatureCollection : IEnumerable<KeyValuePair<Type, object>>
     /// <summary>Gets or sets a feature. Setting null removes the feature.</summary>
     /// <param name="key">The feature key.</param>
     /// <returns>The requested feature.</returns>
+    /// <exception cref="InvalidOperationException">Thrown by the setter when this feature collection is read-only.
+    /// </exception>
     object? this[Type key] { get; set; }
 
     /// <summary>Gets the requested feature. If the feature is not set, returns <see langword="null" />.</summary>
@@ -26,5 +28,6 @@ public interface IFeatureCollection : IEnumerable<KeyValuePair<Type, object>>
     /// <summary>Sets a new feature. Setting null removes the feature.</summary>
     /// <typeparam name="TFeature">The feature key.</typeparam>
     /// <param name="feature">The feature value.</param>
+    /// <exception cref="InvalidOperationException">Thrown when this feature collection is read-only.</exception>
     void Set<TFeature>(TFeature? feature);
 }

--- a/src/IceRpc/Features/Internal/ReadOnlyFeatureCollectionDecorator.cs
+++ b/src/IceRpc/Features/Internal/ReadOnlyFeatureCollectionDecorator.cs
@@ -30,7 +30,8 @@ internal class ReadOnlyFeatureCollectionDecorator : IFeatureCollection
     public TFeature? Get<TFeature>() => _decoratee.Get<TFeature>();
 
     /// <inheritdoc />
-    public void Set<TFeature>(TFeature? feature) => _decoratee.Set(feature);
+    public void Set<TFeature>(TFeature? feature) =>
+        throw new InvalidOperationException("Cannot update a read-only feature collection.");
 
     /// <summary>Constructs a read-only feature collection over another feature collection.</summary>
     /// <param name="decoratee">The decoratee.</param>

--- a/tests/IceRpc.Tests/FeatureCollectionTests.cs
+++ b/tests/IceRpc.Tests/FeatureCollectionTests.cs
@@ -75,8 +75,8 @@ public class FeatureCollectionTests
         IFeatureCollection features = new FeatureCollection().AsReadOnly();
 
         Assert.That(() => features.Set("foo"), Throws.InvalidOperationException);
+        Assert.That(() => features.Set<string>(null), Throws.InvalidOperationException);
         Assert.That(() => features[typeof(string)] = "foo", Throws.InvalidOperationException);
-        Assert.That(() => FeatureCollection.Empty.Set("foo"), Throws.InvalidOperationException);
     }
 
     /// <summary>Verifies that we can set a feature using the index operator.</summary>

--- a/tests/IceRpc.Tests/FeatureCollectionTests.cs
+++ b/tests/IceRpc.Tests/FeatureCollectionTests.cs
@@ -68,6 +68,17 @@ public class FeatureCollectionTests
         Assert.That(features.Any(), Is.False);
     }
 
+    /// <summary>Verifies that a read-only feature collection cannot be updated.</summary>
+    [Test]
+    public void Setting_a_feature_in_read_only_feature_collection_fails()
+    {
+        IFeatureCollection features = new FeatureCollection().AsReadOnly();
+
+        Assert.That(() => features.Set("foo"), Throws.InvalidOperationException);
+        Assert.That(() => features[typeof(string)] = "foo", Throws.InvalidOperationException);
+        Assert.That(() => FeatureCollection.Empty.Set("foo"), Throws.InvalidOperationException);
+    }
+
     /// <summary>Verifies that we can set a feature using the index operator.</summary>
     [Test]
     public void Setting_a_feature_using_index_operator()


### PR DESCRIPTION
Fixes #4806.

`ReadOnlyFeatureCollectionDecorator` threw from its indexer setter but let `Set<TFeature>` delegate to the mutable decoratee, so the generic setter bypassed the read-only guard. Since `FeatureCollection.Empty` is a read-only decorator over a static singleton — and `IncomingRequest.Features` defaults to it — an application calling `request.Features.Set(feature)` instead of `request.Features = request.Features.With(feature)` silently mutated process-wide shared state, corrupting the features of unrelated requests.

`Set<TFeature>` now throws the same `InvalidOperationException` as the indexer setter.

## What's Changed entry

Area: Core

- Fixed a bug where setting a feature in a read-only feature collection updated this collection instead of
  throwing `InvalidOperationException`. In particular, setting a feature in `FeatureCollection.Empty` corrupted
  this shared feature collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)