### PR TITLE
Ship the Ice Slice files in the IceRpc.Ice package

### DIFF
--- a/src/IceRpc.Ice/IceRpc.Ice.csproj
+++ b/src/IceRpc.Ice/IceRpc.Ice.csproj
@@ -36,5 +36,10 @@
     <Content Include="../../LICENSE" Pack="true" PackagePath="/" />
     <Content Include="README.md" Pack="true" PackagePath="/" />
     <None Include="../../build/icerpc-icon.png" Pack="true" PackagePath="/" />
+    <Content
+      Include="../../slice/Ice/Identity.ice;../../slice/Ice/Locator.ice;../../slice/Ice/LocatorRegistry.ice;../../slice/Ice/Process.ice"
+      Pack="true"
+      PackagePath="slice/Ice"
+    />
   </ItemGroup>
 </Project>

--- a/src/IceRpc.Locator/IceRpc.Locator.csproj
+++ b/src/IceRpc.Locator/IceRpc.Locator.csproj
@@ -27,6 +27,5 @@
     <Content Include="../../LICENSE" Pack="true" PackagePath="/" />
     <Content Include="README.md" Pack="true" PackagePath="/" />
     <None Include="../../build/icerpc-icon.png" Pack="true" PackagePath="/" />
-    <Content Include="IceRpc.Locator.props" Pack="true" PackagePath="buildTransitive" />
   </ItemGroup>
 </Project>

--- a/src/IceRpc.Locator/IceRpc.Locator.props
+++ b/src/IceRpc.Locator/IceRpc.Locator.props
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright (c) ZeroC, Inc. -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <SliceDirectory Include="$(MSBuildThisFileDirectory)../slice" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
Fixes #4819.

The IceRpc.Locator package shipped a `buildTransitive/IceRpc.Locator.props` that added `$(MSBuildThisFileDirectory)../slice` as a `SliceDirectory` — but the package contains no `slice` directory. This props is a leftover from 0.5.x, when this package compiled `.slice` files packed via `SliceFile Pack="true".

The `.ice` files now ship with the IceRpc.Ice package instead: `Identity.ice`, `Locator.ice`, `LocatorRegistry.ice` and `Process.ice`, in the package's `slice/Ice` directory. All `Ice/*.ice` files ship in this one package regardless of which assembly compiles them: the Slice convention is to include them as `Ice/Locator.ice` with `-I <dir>/slice`, and the files include each other with `#include "Identity.ice"` (unchanged from upstream), which only resolves when they share a directory. Splitting them across packages would require consumers to add a `-I` on a `slice/Ice` subdirectory, which is never done.

A project that includes `Ice/Process.ice` with only IceRpc.Ice referenced gets a compile error on the generated code until it references IceRpc.Locator, which provides the generated types — rare, and the fix is a package reference.

The set excludes the wire-level enums (`OperationMode.ice`, `ReplyStatus.ice`) and `Object.ice`, which are implementation details.

## What's Changed entry

Area: icerpc+ice integration

- The IceRpc.Ice package now ships Identity.ice, Locator.ice, LocatorRegistry.ice and Process.ice in its slice
  directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

