### PR TITLE
Copy the certs directory to the output directory in the non-DI templates

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
@@ -30,6 +30,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Client/IceRpc-Ice-Client.csproj
@@ -29,4 +29,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Client/IceRpc-Ice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Client/IceRpc-Ice-DI-Client.csproj
@@ -34,6 +34,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/IceRpc-Ice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/IceRpc-Ice-DI-Server.csproj
@@ -34,6 +34,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
@@ -30,6 +30,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/IceRpc-Ice-Server.csproj
@@ -29,4 +29,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -24,6 +24,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Client/IceRpc-Protobuf-Client.csproj
@@ -23,4 +23,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Client/IceRpc-Protobuf-DI-Client.csproj
@@ -28,6 +28,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-DI-Server/IceRpc-Protobuf-DI-Server.csproj
@@ -28,6 +28,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -24,6 +24,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Protobuf-Server/IceRpc-Protobuf-Server.csproj
@@ -23,4 +23,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -24,6 +24,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Client/IceRpc-Slice-Client.csproj
@@ -23,4 +23,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Client/IceRpc-Slice-DI-Client.csproj
@@ -28,6 +28,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-DI-Server/IceRpc-Slice-DI-Server.csproj
@@ -28,6 +28,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -24,6 +24,7 @@
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Copy the test certificates to the output directory. -->
     <None Update="certs\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
+++ b/src/IceRpc.Templates/Templates/IceRpc-Slice-Server/IceRpc-Slice-Server.csproj
@@ -23,4 +23,9 @@
     </PackageReference>
     <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.globalconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="certs\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #4820.

The six non-DI templates load their certificates from `certs/` but their project files had no rule copying this directory to the build output, so an application created from these templates built fine and failed on startup when launched from its output directory. The six DI templates already have the copy rule; this PR adds the same rule to the non-DI templates.

No smoke test — the templates are exercised by the test-templates CI action, which builds but does not run them; #4852 tracks adding a run smoke test.

## What's Changed entry

Area: Templates

- Fixed a bug in the non-DI templates: you could build but not run the applications created with these
  templates because the certificates were missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)