### PR TITLE
Add AddIceRpcClientConnection overloads with a server address

### DIFF
--- a/src/IceRpc.Extensions.DependencyInjection/ClientConnectionServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ClientConnectionServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ using System.Net.Quic;
 
 namespace IceRpc.Extensions.DependencyInjection;
 
-/// <summary>Provides an extension method for <see cref="IServiceCollection" /> to add a client connection.</summary>
+/// <summary>Provides extension methods for <see cref="IServiceCollection" /> to add a client connection.</summary>
 public static class ClientConnectionServiceCollectionExtensions
 {
     /// <summary>Adds a <see cref="ClientConnection" /> singleton that connects to the specified server address to this

--- a/src/IceRpc.Extensions.DependencyInjection/ClientConnectionServiceCollectionExtensions.cs
+++ b/src/IceRpc.Extensions.DependencyInjection/ClientConnectionServiceCollectionExtensions.cs
@@ -14,8 +14,34 @@ namespace IceRpc.Extensions.DependencyInjection;
 /// <summary>Provides an extension method for <see cref="IServiceCollection" /> to add a client connection.</summary>
 public static class ClientConnectionServiceCollectionExtensions
 {
-    /// <summary>Adds a <see cref="ClientConnection" /> and an <see cref="IInvoker" /> to this service collection.
-    /// </summary>
+    /// <summary>Adds a <see cref="ClientConnection" /> singleton that connects to the specified server address to this
+    /// service collection; this singleton is also registered as the <see cref="IInvoker" /> singleton.</summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="serverAddress">The server address of the client connection.</param>
+    /// <returns>The service collection.</returns>
+    /// <remarks>This method sets <see cref="ClientConnectionOptions.ServerAddress" /> in the client connection options
+    /// provided by the <see cref="IOptions{T}" /> of <see cref="ClientConnectionOptions" />; the client connection uses
+    /// all the other options from these injected options.</remarks>
+    /// <seealso cref="AddIceRpcClientConnection(IServiceCollection)" />
+    public static IServiceCollection AddIceRpcClientConnection(
+        this IServiceCollection services,
+        ServerAddress serverAddress)
+    {
+        services.AddOptions<ClientConnectionOptions>().Configure(options => options.ServerAddress = serverAddress);
+        return services.AddIceRpcClientConnection();
+    }
+
+    /// <summary>Adds a <see cref="ClientConnection" /> singleton that connects to the specified server address URI to
+    /// this service collection; this singleton is also registered as the <see cref="IInvoker" /> singleton.</summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="serverAddressUri">The server address URI of the client connection.</param>
+    /// <returns>The service collection.</returns>
+    /// <seealso cref="AddIceRpcClientConnection(IServiceCollection, ServerAddress)" />
+    public static IServiceCollection AddIceRpcClientConnection(this IServiceCollection services, Uri serverAddressUri) =>
+        services.AddIceRpcClientConnection(new ServerAddress(serverAddressUri));
+
+    /// <summary>Adds a <see cref="ClientConnection" /> singleton to this service collection; this singleton is also
+    /// registered as the <see cref="IInvoker" /> singleton.</summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The service collection.</returns>
     /// <remarks>This method uses the client connection options provided by the <see cref="IOptions{T}" /> of

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/ClientConnectionServiceCollectionExtensionsTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/ClientConnectionServiceCollectionExtensionsTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ZeroC, Inc.
+
+using IceRpc.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace IceRpc.Extensions.DependencyInjection.Tests;
+
+public sealed class ClientConnectionServiceCollectionExtensionsTests
+{
+    /// <summary>Verifies that a <see cref="ClientConnection" /> registered with a server address URI can be resolved.
+    /// </summary>
+    [Test]
+    public async Task Add_client_connection_with_server_address_uri()
+    {
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddColocTransport()
+            .AddSlicTransport()
+            .AddIceRpcClientConnection(new Uri("icerpc://localhost"))
+            .BuildServiceProvider(validateScopes: true);
+
+        // Constructing the client connection requires a server address, so a successful resolution verifies the
+        // server address URI was applied.
+        Assert.That(() => provider.GetRequiredService<ClientConnection>(), Throws.Nothing);
+    }
+}

--- a/tests/IceRpc.Extensions.DependencyInjection.Tests/ClientConnectionServiceCollectionExtensionsTests.cs
+++ b/tests/IceRpc.Extensions.DependencyInjection.Tests/ClientConnectionServiceCollectionExtensionsTests.cs
@@ -2,14 +2,15 @@
 
 using IceRpc.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 namespace IceRpc.Extensions.DependencyInjection.Tests;
 
 public sealed class ClientConnectionServiceCollectionExtensionsTests
 {
-    /// <summary>Verifies that a <see cref="ClientConnection" /> registered with a server address URI can be resolved.
-    /// </summary>
+    /// <summary>Verifies that a <see cref="ClientConnection" /> registered with a server address URI can be resolved
+    /// and uses this server address.</summary>
     [Test]
     public async Task Add_client_connection_with_server_address_uri()
     {
@@ -19,8 +20,9 @@ public sealed class ClientConnectionServiceCollectionExtensionsTests
             .AddIceRpcClientConnection(new Uri("icerpc://localhost"))
             .BuildServiceProvider(validateScopes: true);
 
-        // Constructing the client connection requires a server address, so a successful resolution verifies the
-        // server address URI was applied.
         Assert.That(() => provider.GetRequiredService<ClientConnection>(), Throws.Nothing);
+        Assert.That(
+            provider.GetRequiredService<IOptions<ClientConnectionOptions>>().Value.ServerAddress,
+            Is.EqualTo(new ServerAddress(new Uri("icerpc://localhost"))));
     }
 }


### PR DESCRIPTION
Fixes #4822.

Seven package READMEs show `services.AddIceRpcClientConnection(new Uri("icerpc://localhost"))`, but the only overload was parameterless — the snippets never compiled. Rather than making seven README snippets more ceremonial, this PR adds the overloads the snippets assume, mirroring the `ClientConnection` constructors: an `AddIceRpcClientConnection(ServerAddress)` overload that sets `ClientConnectionOptions.ServerAddress` through the options pipeline, and an `AddIceRpcClientConnection(Uri)` convenience overload that delegates to it. The READMEs are correct as written.

Also reworks the doc comments of all three overloads to say what they register: a `ClientConnection` singleton, also registered as the `IInvoker` singleton.

## What's Changed entry

Area: Dependency injection

- Added AddIceRpcClientConnection overloads that accept the client connection's server address or server
  address URI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)