### PR TITLE
Document that the activator cache pins generated-code assemblies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,11 @@ is no buffer to overflow, so the "zip bomb" framing (amplification of a small in
 does not apply. Bounding still happens, just at the consumer's decoder: Slice / Protobuf reject malformed bytes
 (`InvalidDataException`) and enforce per-decoder collection-allocation budgets. Don't propose a size cap inside the
 decompressor; the limit belongs to the decoder that materializes structured data from the stream. (#4507.)
+
+### 13. Activator caches pin generated-code assemblies
+
+`IActivator.FromAssembly` caches the activator it builds for each assembly marked with `IceGeneratedCodeAttribute` —
+and, through its recursive merge, for every marked assembly it references — in a process-wide cache holding strong
+references. Unloading such assemblies (e.g. with a collectible `AssemblyLoadContext`) is unsupported: the cache pins
+them for the lifetime of the process. Don't file findings proposing weak-key caching or unload-safety for this cache.
+(#4827.)


### PR DESCRIPTION
Fixes #4827.

`IActivator.FromAssembly` caches the activator it builds for each assembly marked with `IceGeneratedCodeAttribute` — and, through its recursive merge, for every marked assembly it references — in a process-wide cache holding strong references. As a result, such assemblies cannot be unloaded (e.g. with a collectible `AssemblyLoadContext`).

This is a supported-behavior decision, not a defect to fix: the audience is the intersection of ice interop and collectible plugin hosts, and full unload support would require more than weak-key caching (the recursive merge resolves referenced assemblies through the default load context). This PR records the decision as a dismissed audit pattern in AGENTS.md.

Note that assemblies without the `IceGeneratedCodeAttribute` are never cached, so only generated-code assemblies are pinned.

## What's Changed entry

None — contributor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)