### PR TITLE
Require a milestone in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,9 @@ observes. -->
 
 ## What's Changed entry
 
-<!-- This section feeds the "What's Changed" section of the GitHub release notes; it's collected from merged PRs at
-release time. It should be in one of two forms:
+<!-- This section feeds the "What's Changed" section of the GitHub release notes; it's collected from the milestone's
+merged PRs at release time. Every PR therefore needs a milestone: the release that will include this entry. The
+section should be in one of two forms:
 
 1) For a user-facing change, specify the area (usually an area label name, such as "Core", "Slic" or "Ice codec") and
 write one bullet per user-visible change:


### PR DESCRIPTION
Follow-up to #4838: the What's Changed entries are collected from the milestone's merged PRs at release time, so a PR without a milestone is never collected. The template now states that every PR needs a milestone — the release that will include its entry.

## What's Changed entry

None — contributor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)