### PR TITLE
Send Protobuf Telemetry example requests through the pipeline

### DIFF
--- a/examples/protobuf/Telemetry/Client/Program.cs
+++ b/examples/protobuf/Telemetry/Client/Program.cs
@@ -28,7 +28,7 @@ await using var connection = new ClientConnection(
 // Create an invocation pipeline and add the telemetry interceptor to it.
 Pipeline pipeline = new Pipeline().UseTelemetry(activitySource).Into(connection);
 
-var greeter = new GreeterClient(connection);
+var greeter = new GreeterClient(pipeline);
 
 var request = new GreetRequest { Name = Environment.UserName };
 GreetResponse response = await greeter.GreetAsync(request);


### PR DESCRIPTION
Fixes #4826.

The Protobuf Telemetry example client built an invocation pipeline with the telemetry interceptor, then handed the raw `ClientConnection` to `GreeterClient` — so requests bypassed the pipeline entirely and the example demonstrated none of the telemetry it advertises.

- `GreeterClient` now takes the pipeline, matching the Slice Telemetry example.

## What's Changed entry

None — example code only.