### PR TITLE
Request shutdown when reading the GoAway frame fails

### DIFF
--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -1376,11 +1376,17 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
         }
         catch (IceRpcException)
         {
+            RefuseNewInvocations("The connection was lost");
+            _ = _shutdownRequestedTcs.TrySetResult();
+
             // We let the task complete with this expected exception.
             throw;
         }
         catch (InvalidDataException exception)
         {
+            RefuseNewInvocations("The connection was lost");
+            _ = _shutdownRequestedTcs.TrySetResult();
+
             // "expected" in the sense it should not trigger a Debug.Fail.
             throw new IceRpcException(
                 IceRpcError.IceRpcError,
@@ -1390,6 +1396,8 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
         catch (Exception exception)
         {
             Debug.Fail($"The read go away task failed with an unexpected exception: {exception}");
+            RefuseNewInvocations("The connection was lost");
+            _ = _shutdownRequestedTcs.TrySetResult();
             throw;
         }
     }

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -1835,24 +1835,29 @@ public sealed class IceRpcProtocolConnectionTests
             .BuildServiceProvider(validateScopes: true);
 
         ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
-        (_, Task serverShutdownRequested) = await sut.ConnectAsync();
+        (Task clientShutdownRequested, _) = await sut.ConnectAsync();
 
-        // Get a hold of the client protocol connection control stream.
-        var clientTransport = provider.GetRequiredService<TestMultiplexedClientTransportDecorator>();
-        var clientControlStream = clientTransport.LastCreatedConnection.LastCreatedStream;
+        // Get a hold of the server protocol connection control stream.
+        var serverTransport = provider.GetRequiredService<TestMultiplexedServerTransportDecorator>();
+        var serverControlStream = serverTransport.LastAcceptedConnection.LastCreatedStream;
 
         // Act
         if (invalidGoAwayFrame.Length == 0)
         {
-            clientControlStream.Output.Complete();
+            serverControlStream.Output.Complete();
         }
         else
         {
-            await clientControlStream.Output.WriteAsync(invalidGoAwayFrame);
+            await serverControlStream.Output.WriteAsync(invalidGoAwayFrame);
         }
 
         // Assert
-        Assert.That(() => serverShutdownRequested, Throws.Nothing);
+        Assert.That(() => clientShutdownRequested, Throws.Nothing);
+
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.IceRpc));
+        Assert.That(
+            () => sut.Client.InvokeAsync(request),
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.InvocationRefused));
     }
 
     [TestCaseSource(nameof(InvalidGoAwayFrames))]

--- a/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceRpcProtocolConnectionTests.cs
@@ -1826,6 +1826,36 @@ public sealed class IceRpcProtocolConnectionTests
     }
 
     [TestCaseSource(nameof(InvalidGoAwayFrames))]
+    public async Task Invalid_go_away_frame_from_peer_requests_shutdown(byte[] invalidGoAwayFrame)
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(Protocol.IceRpc)
+            .AddTestMultiplexedTransportDecorator()
+            .BuildServiceProvider(validateScopes: true);
+
+        ClientServerProtocolConnection sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        (_, Task serverShutdownRequested) = await sut.ConnectAsync();
+
+        // Get a hold of the client protocol connection control stream.
+        var clientTransport = provider.GetRequiredService<TestMultiplexedClientTransportDecorator>();
+        var clientControlStream = clientTransport.LastCreatedConnection.LastCreatedStream;
+
+        // Act
+        if (invalidGoAwayFrame.Length == 0)
+        {
+            clientControlStream.Output.Complete();
+        }
+        else
+        {
+            await clientControlStream.Output.WriteAsync(invalidGoAwayFrame);
+        }
+
+        // Assert
+        Assert.That(() => serverShutdownRequested, Throws.Nothing);
+    }
+
+    [TestCaseSource(nameof(InvalidGoAwayFrames))]
     public async Task Shutdown_exception_handling_on_invalid_go_away_frame_from_peer(byte[] invalidGoAwayFrame)
     {
         // Arrange


### PR DESCRIPTION
Fixes #4805.

When reading or decoding the peer's GoAway frame failed, the ReadGoAway task faulted without requesting shutdown: the connection stayed registered and kept accepting invocations with a permanently failed control-frame reader, and the failure was only observed if a local `ShutdownAsync` or `DisposeAsync` happened to await that task.

`ReadGoAwayAsync` now handles its failures like `AcceptRequestsAsync` already does: it refuses new invocations and completes the shutdown-requested task before letting the task fault. The connection's owner then shuts it down, and the shutdown surfaces the protocol error as an abortive closure.

The new test is the passive-side companion of `Shutdown_exception_handling_on_invalid_go_away_frame_from_peer`, reusing the same `InvalidGoAwayFrames` cases: it verifies that an invalid GoAway frame completes the ShutdownRequested task with no local shutdown in progress.

## What's Changed entry

None — only affects connections to a nonconforming peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
