### PR TITLE
Validate the limits of IceFeature and SliceFeature

### DIFF
--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -24,18 +24,20 @@ public interface IIceFeature
     IceEncodeOptions? EncodeOptions { get; }
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
-    /// <value>The maximum collection allocation. Must be greater than or equal to <c>0</c>.</value>
+    /// <value>The maximum collection allocation.</value>
+    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum depth when decoding a class recursively.</summary>
-    /// <value>The maximum depth. Must be greater than <c>0</c>.</value>
+    /// <value>The maximum depth.</value>
+    /// <remarks>Implementations must return a value greater than <c>0</c>.</remarks>
     int MaxDepth { get; }
 
     /// <summary>Gets the maximum size of an Ice-encoded payload, in bytes. An Ice-encoded payload corresponds to the
     /// encoded arguments of an operation, or the encoded return values of an operation.</summary>
-    /// <value>The maximum size of an Ice-encoded payload, in bytes. Must be greater than or equal to <c>0</c> and less
-    /// than <see cref="int.MaxValue" />.</value>
+    /// <value>The maximum size of an Ice-encoded payload, in bytes.</value>
     /// <remarks>The payload size does not include the size of any header for this payload, such as the encapsulation
-    /// header with the ice protocol.</remarks>
+    /// header with the ice protocol. Implementations must return a value greater than or equal to <c>0</c> and less
+    /// than <see cref="int.MaxValue" />.</remarks>
     int MaxPayloadSize { get; }
 }

--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -33,8 +33,8 @@ public interface IIceFeature
 
     /// <summary>Gets the maximum size of an Ice-encoded payload, in bytes. An Ice-encoded payload corresponds to the
     /// encoded arguments of an operation, or the encoded return values of an operation.</summary>
-    /// <value>The maximum size of an Ice-encoded payload, in bytes. Must be greater than <c>0</c> and less than
-    /// <see cref="int.MaxValue" />.</value>
+    /// <value>The maximum size of an Ice-encoded payload, in bytes. Must be greater than or equal to <c>0</c> and less
+    /// than <see cref="int.MaxValue" />.</value>
     /// <remarks>The payload size does not include the size of any header for this payload, such as the encapsulation
     /// header with the ice protocol.</remarks>
     int MaxPayloadSize { get; }

--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -24,16 +24,17 @@ public interface IIceFeature
     IceEncodeOptions? EncodeOptions { get; }
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
-    /// <value>The maximum collection allocation.</value>
+    /// <value>The maximum collection allocation. Must be greater than or equal to <c>0</c>.</value>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum depth when decoding a class recursively.</summary>
-    /// <value>The maximum depth.</value>
+    /// <value>The maximum depth. Must be greater than <c>0</c>.</value>
     int MaxDepth { get; }
 
     /// <summary>Gets the maximum size of an Ice-encoded payload, in bytes. An Ice-encoded payload corresponds to the
     /// encoded arguments of an operation, or the encoded return values of an operation.</summary>
-    /// <value>The maximum size of an Ice-encoded payload, in bytes.</value>
+    /// <value>The maximum size of an Ice-encoded payload, in bytes. Must be greater than <c>0</c> and less than
+    /// <see cref="int.MaxValue" />.</value>
     /// <remarks>The payload size does not include the size of any header for this payload, such as the encapsulation
     /// header with the ice protocol.</remarks>
     int MaxPayloadSize { get; }

--- a/src/IceRpc.Ice/Features/IceFeature.cs
+++ b/src/IceRpc.Ice/Features/IceFeature.cs
@@ -21,17 +21,15 @@ public sealed class IceFeature : IIceFeature
     public IceEncodeOptions? EncodeOptions { get; }
 
     /// <inheritdoc/>
+    /// <value>The maximum collection allocation. Defaults to 8 times <see cref="MaxPayloadSize" />.</value>
     public int MaxCollectionAllocation { get; }
 
-    /// <summary>Gets the maximum depth when decoding a class recursively.</summary>
+    /// <inheritdoc/>
     /// <value>The maximum depth. Defaults to <c>100</c>.</value>
     public int MaxDepth { get; }
 
-    /// <summary>Gets the maximum size of an Ice-encoded payload, in bytes. An Ice-encoded payload corresponds to the
-    /// encoded arguments of an operation, or the encoded return values of an operation.</summary>
+    /// <inheritdoc/>
     /// <value>The maximum size of an Ice-encoded payload, in bytes. Defaults to <c>1</c> MB.</value>
-    /// <remarks>The payload size does not include the size of any header for this payload, such as the encapsulation
-    /// header with the ice protocol.</remarks>
     public int MaxPayloadSize { get; }
 
     /// <summary>Constructs an Ice feature.</summary>

--- a/src/IceRpc.Ice/Features/IceFeature.cs
+++ b/src/IceRpc.Ice/Features/IceFeature.cs
@@ -48,8 +48,8 @@ public sealed class IceFeature : IIceFeature
     /// is equivalent to <see cref="Default" />.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCollectionAllocation" /> is a
     /// negative value other than <c>-1</c>, when <paramref name="maxDepth" /> is <c>0</c> or a negative value other
-    /// than <c>-1</c>, when <paramref name="maxPayloadSize" /> is <c>0</c>, <see cref="int.MaxValue" /> or a negative
-    /// value other than <c>-1</c>, or when <paramref name="maxPayloadSize" /> is greater than <c>int.MaxValue / 8</c>
+    /// than <c>-1</c>, when <paramref name="maxPayloadSize" /> is <see cref="int.MaxValue" /> or a negative value other
+    /// than <c>-1</c>, or when <paramref name="maxPayloadSize" /> is greater than <c>int.MaxValue / 8</c>
     /// (256 MB) while <paramref name="maxCollectionAllocation" /> is <c>-1</c>.</exception>
     public IceFeature(
         IActivator? activator = null,
@@ -72,11 +72,11 @@ public sealed class IceFeature : IIceFeature
                 nameof(maxDepth),
                 $"The value of {nameof(maxDepth)} must be greater than 0, or -1.");
         }
-        if (maxPayloadSize is < -1 or 0 or int.MaxValue)
+        if (maxPayloadSize is < -1 or int.MaxValue)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxPayloadSize),
-                $"The value of {nameof(maxPayloadSize)} must be greater than 0 and less than int.MaxValue, or -1.");
+                $"The value of {nameof(maxPayloadSize)} must be greater than or equal to 0 and less than int.MaxValue, or -1.");
         }
         if (maxCollectionAllocation == -1 && maxPayloadSize > int.MaxValue / 8)
         {
@@ -93,7 +93,7 @@ public sealed class IceFeature : IIceFeature
         MaxCollectionAllocation = maxCollectionAllocation >= 0 ? maxCollectionAllocation :
             (maxPayloadSize >= 0 ? 8 * maxPayloadSize : defaultFeature.MaxCollectionAllocation);
 
-        MaxDepth = maxDepth >= 0 ? maxDepth : defaultFeature.MaxDepth;
+        MaxDepth = maxDepth > 0 ? maxDepth : defaultFeature.MaxDepth;
 
         MaxPayloadSize = maxPayloadSize >= 0 ? maxPayloadSize : defaultFeature.MaxPayloadSize;
 

--- a/src/IceRpc.Ice/Features/IceFeature.cs
+++ b/src/IceRpc.Ice/Features/IceFeature.cs
@@ -46,6 +46,11 @@ public sealed class IceFeature : IIceFeature
     /// <param name="baseProxy">The base proxy, used when decoding service addresses into proxies.</param>
     /// <param name="defaultFeature">A feature that provides default values for all parameters. <see langword="null" />
     /// is equivalent to <see cref="Default" />.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCollectionAllocation" /> is a
+    /// negative value other than <c>-1</c>, when <paramref name="maxDepth" /> is <c>0</c> or a negative value other
+    /// than <c>-1</c>, when <paramref name="maxPayloadSize" /> is <c>0</c>, <see cref="int.MaxValue" /> or a negative
+    /// value other than <c>-1</c>, or when <paramref name="maxPayloadSize" /> is greater than <c>int.MaxValue / 8</c>
+    /// (256 MB) while <paramref name="maxCollectionAllocation" /> is <c>-1</c>.</exception>
     public IceFeature(
         IActivator? activator = null,
         IceEncodeOptions? encodeOptions = null,
@@ -55,6 +60,31 @@ public sealed class IceFeature : IIceFeature
         IIceProxy? baseProxy = null,
         IIceFeature? defaultFeature = null)
     {
+        if (maxCollectionAllocation < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxCollectionAllocation),
+                $"The value of {nameof(maxCollectionAllocation)} must be 0, a positive value, or -1.");
+        }
+        if (maxDepth is < -1 or 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDepth),
+                $"The value of {nameof(maxDepth)} must be a positive value or -1.");
+        }
+        if (maxPayloadSize is < -1 or 0 or int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxPayloadSize),
+                $"The value of {nameof(maxPayloadSize)} must be a positive value smaller than int.MaxValue, or -1.");
+        }
+        if (maxCollectionAllocation == -1 && maxPayloadSize > int.MaxValue / 8)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxPayloadSize),
+                $"The value of {nameof(maxPayloadSize)} must be less than or equal to int.MaxValue / 8 when {nameof(maxCollectionAllocation)} is -1.");
+        }
+
         defaultFeature ??= Default;
 
         Activator = activator ?? defaultFeature.Activator;

--- a/src/IceRpc.Ice/Features/IceFeature.cs
+++ b/src/IceRpc.Ice/Features/IceFeature.cs
@@ -64,19 +64,19 @@ public sealed class IceFeature : IIceFeature
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxCollectionAllocation),
-                $"The value of {nameof(maxCollectionAllocation)} must be 0, a positive value, or -1.");
+                $"The value of {nameof(maxCollectionAllocation)} must be greater than or equal to 0, or -1.");
         }
         if (maxDepth is < -1 or 0)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxDepth),
-                $"The value of {nameof(maxDepth)} must be a positive value or -1.");
+                $"The value of {nameof(maxDepth)} must be greater than 0, or -1.");
         }
         if (maxPayloadSize is < -1 or 0 or int.MaxValue)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxPayloadSize),
-                $"The value of {nameof(maxPayloadSize)} must be a positive value smaller than int.MaxValue, or -1.");
+                $"The value of {nameof(maxPayloadSize)} must be greater than 0 and less than int.MaxValue, or -1.");
         }
         if (maxCollectionAllocation == -1 && maxPayloadSize > int.MaxValue / 8)
         {

--- a/src/IceRpc.Ice/Operations/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/Internal/PipeReaderExtensions.cs
@@ -23,7 +23,7 @@ internal static class PipeReaderExtensions
         int maxSize,
         CancellationToken cancellationToken)
     {
-        Debug.Assert(maxSize is > 0 and < int.MaxValue);
+        Debug.Assert(maxSize is >= 0 and < int.MaxValue);
 
         // This method does not attempt to read the reader synchronously. A caller that wants a sync attempt can
         // call TryReadFullPayload.
@@ -59,7 +59,7 @@ internal static class PipeReaderExtensions
         int maxSize,
         out ReadResult readResult)
     {
-        Debug.Assert(maxSize is > 0 and < int.MaxValue);
+        Debug.Assert(maxSize is >= 0 and < int.MaxValue);
 
         if (reader.TryRead(out readResult))
         {

--- a/src/IceRpc.Slice/Features/ISliceFeature.cs
+++ b/src/IceRpc.Slice/Features/ISliceFeature.cs
@@ -18,12 +18,12 @@ public interface ISliceFeature
     SliceEncodeOptions? EncodeOptions { get; }
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
-    /// <value>The maximum collection allocation.</value>
+    /// <value>The maximum collection allocation. Must be greater than or equal to <c>0</c>.</value>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum size of a Slice payload segment, in bytes. A Slice payload segment corresponds to the
     /// encoded arguments of an operation, the encoded return values of an operation, or a portion of a stream of
     /// variable-size elements.</summary>
-    /// <value>The maximum size of a Slice payload segment, in bytes.</value>
+    /// <value>The maximum size of a Slice payload segment, in bytes. Must be greater than <c>0</c>.</value>
     int MaxSegmentSize { get; }
 }

--- a/src/IceRpc.Slice/Features/ISliceFeature.cs
+++ b/src/IceRpc.Slice/Features/ISliceFeature.cs
@@ -18,12 +18,14 @@ public interface ISliceFeature
     SliceEncodeOptions? EncodeOptions { get; }
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
-    /// <value>The maximum collection allocation. Must be greater than or equal to <c>0</c>.</value>
+    /// <value>The maximum collection allocation.</value>
+    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum size of a Slice payload segment, in bytes. A Slice payload segment corresponds to the
     /// encoded arguments of an operation, the encoded return values of an operation, or a portion of a stream of
     /// variable-size elements.</summary>
-    /// <value>The maximum size of a Slice payload segment, in bytes. Must be greater than <c>0</c>.</value>
+    /// <value>The maximum size of a Slice payload segment, in bytes.</value>
+    /// <remarks>Implementations must return a value greater than <c>0</c>.</remarks>
     int MaxSegmentSize { get; }
 }

--- a/src/IceRpc.Slice/Features/SliceFeature.cs
+++ b/src/IceRpc.Slice/Features/SliceFeature.cs
@@ -49,13 +49,13 @@ public sealed class SliceFeature : ISliceFeature
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxCollectionAllocation),
-                $"The value of {nameof(maxCollectionAllocation)} must be 0, a positive value, or -1.");
+                $"The value of {nameof(maxCollectionAllocation)} must be greater than or equal to 0, or -1.");
         }
         if (maxSegmentSize is < -1 or 0)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(maxSegmentSize),
-                $"The value of {nameof(maxSegmentSize)} must be a positive value or -1.");
+                $"The value of {nameof(maxSegmentSize)} must be greater than 0, or -1.");
         }
         if (maxCollectionAllocation == -1 && maxSegmentSize > int.MaxValue / 8)
         {

--- a/src/IceRpc.Slice/Features/SliceFeature.cs
+++ b/src/IceRpc.Slice/Features/SliceFeature.cs
@@ -17,12 +17,11 @@ public sealed class SliceFeature : ISliceFeature
     public SliceEncodeOptions? EncodeOptions { get; }
 
     /// <inheritdoc/>
+    /// <value>The maximum collection allocation. Defaults to 8 times <see cref="MaxSegmentSize" />.</value>
     public int MaxCollectionAllocation { get; }
 
-    /// <summary>Gets the maximum size of a Slice payload segment, in bytes. A Slice payload segment corresponds to the
-    /// encoded arguments of an operation, the encoded return values of an operation, or a portion of a stream of
-    /// variable-size elements.</summary>
-    /// <value>The maximum segment size. Defaults to <c>1</c> MB.</value>
+    /// <inheritdoc/>
+    /// <value>The maximum size of a Slice payload segment, in bytes. Defaults to <c>1</c> MB.</value>
     public int MaxSegmentSize { get; }
 
     /// <summary>Constructs a Slice feature.</summary>

--- a/src/IceRpc.Slice/Features/SliceFeature.cs
+++ b/src/IceRpc.Slice/Features/SliceFeature.cs
@@ -69,9 +69,9 @@ public sealed class SliceFeature : ISliceFeature
         EncodeOptions = encodeOptions ?? defaultFeature.EncodeOptions;
 
         MaxCollectionAllocation = maxCollectionAllocation >= 0 ? maxCollectionAllocation :
-            (maxSegmentSize >= 0 ? 8 * maxSegmentSize : defaultFeature.MaxCollectionAllocation);
+            (maxSegmentSize > 0 ? 8 * maxSegmentSize : defaultFeature.MaxCollectionAllocation);
 
-        MaxSegmentSize = maxSegmentSize >= 0 ? maxSegmentSize : defaultFeature.MaxSegmentSize;
+        MaxSegmentSize = maxSegmentSize > 0 ? maxSegmentSize : defaultFeature.MaxSegmentSize;
 
         BaseProxy = baseProxy ?? defaultFeature.BaseProxy;
     }

--- a/src/IceRpc.Slice/Features/SliceFeature.cs
+++ b/src/IceRpc.Slice/Features/SliceFeature.cs
@@ -34,6 +34,10 @@ public sealed class SliceFeature : ISliceFeature
     /// <param name="baseProxy">The base proxy, used when decoding service addresses into proxies.</param>
     /// <param name="defaultFeature">A feature that provides default values for all parameters. <see langword="null" />
     /// is equivalent to <see cref="Default" />.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCollectionAllocation" /> is a
+    /// negative value other than <c>-1</c>, when <paramref name="maxSegmentSize" /> is <c>0</c> or a negative value
+    /// other than <c>-1</c>, or when <paramref name="maxSegmentSize" /> is greater than <c>int.MaxValue / 8</c>
+    /// (256 MB) while <paramref name="maxCollectionAllocation" /> is <c>-1</c>.</exception>
     public SliceFeature(
         SliceEncodeOptions? encodeOptions = null,
         int maxCollectionAllocation = -1,
@@ -41,6 +45,25 @@ public sealed class SliceFeature : ISliceFeature
         ISliceProxy? baseProxy = null,
         ISliceFeature? defaultFeature = null)
     {
+        if (maxCollectionAllocation < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxCollectionAllocation),
+                $"The value of {nameof(maxCollectionAllocation)} must be 0, a positive value, or -1.");
+        }
+        if (maxSegmentSize is < -1 or 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxSegmentSize),
+                $"The value of {nameof(maxSegmentSize)} must be a positive value or -1.");
+        }
+        if (maxCollectionAllocation == -1 && maxSegmentSize > int.MaxValue / 8)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxSegmentSize),
+                $"The value of {nameof(maxSegmentSize)} must be less than or equal to int.MaxValue / 8 when {nameof(maxCollectionAllocation)} is -1.");
+        }
+
         defaultFeature ??= Default;
 
         EncodeOptions = encodeOptions ?? defaultFeature.EncodeOptions;

--- a/src/IceRpc/Internal/PipeReaderExtensions.cs
+++ b/src/IceRpc/Internal/PipeReaderExtensions.cs
@@ -25,7 +25,7 @@ internal static class PipeReaderExtensions
         int maxSize,
         CancellationToken cancellationToken)
     {
-        Debug.Assert(maxSize is > 0 and < int.MaxValue);
+        Debug.Assert(maxSize > 0);
 
         // This method does not attempt to read the reader synchronously. A caller that wants a sync attempt can
         // call TryReadSliceSegment.
@@ -103,7 +103,7 @@ internal static class PipeReaderExtensions
         int maxSize,
         out ReadResult readResult)
     {
-        Debug.Assert(maxSize is > 0 and < int.MaxValue);
+        Debug.Assert(maxSize > 0);
 
         if (reader.TryRead(out readResult))
         {


### PR DESCRIPTION
Fixes #4808.

The `IceFeature` and `SliceFeature` constructors accepted limits their consumers can't handle:

- The derived collection-allocation budget (`8 * maxPayloadSize` / `8 * maxSegmentSize`) wrapped negative for sizes above `int.MaxValue / 8`.
- `IceFeature` accepted a max payload size of `int.MaxValue` while the Ice payload reader computes `maxSize + 1`, and accepted a max depth of `0` that `IceDecoder` rejects later, at decode time.
- Negative values other than `-1` were silently treated as "use the default", while the doc-comments only allow `-1`.

The constructors now throw `ArgumentOutOfRangeException` for all of these, per the documented contract:

- `maxCollectionAllocation`: `0`, a positive value, or `-1`.
- `maxSegmentSize`: a positive value or `-1` — the smallest Slice segment is 1 byte (the tag end marker).
- `maxPayloadSize`: `0`, a positive value, or `-1` — the smallest Ice payload is empty (a void operation); also rejects `int.MaxValue` (the Ice read path computes `maxSize + 1`).
- Both: at most `int.MaxValue / 8` (256 MB) when `maxCollectionAllocation` is `-1` (the derived `8 ×` budget must not overflow).
- `maxDepth`: a positive value or `-1`.

The Slice segment reader's asserts required `maxSize < int.MaxValue` without an arithmetic reason (the segment size decode uses a checked cast and a plain comparison), so they are relaxed to `maxSize > 0`; the Ice reader's asserts are relaxed to `maxSize >= 0` since the empty payload is a valid Ice payload.

## What's Changed entry

None — only rejects invalid configurations that no reasonable program uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

