### PR TITLE
Encode optional custom types in Result and stream encoders

### DIFF
--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -352,7 +352,10 @@ internal static class OperationExtensions
     {
         IType elemType = streamField.DataType.Type;
         string csType = streamField.DataType.FieldTypeString(true, currentNamespace);
-        string valueExpr = streamField.DataType.IsValueType ? "value!.Value" : "value!";
+        // CustomType → (value ?? default!), value types → value!.Value, reference types → value!
+        string valueExpr = elemType is CustomType
+            ? "(value ?? default!)"
+            : streamField.DataType.IsValueType ? "value!.Value" : "value!";
         string encodeExpr = elemType.EncodeExpression(currentNamespace, valueExpr);
         return $$"""
             (ref SliceEncoder encoder, {{csType}} value) =>

--- a/src/ZeroC.Slice.Generator/ITypeExtensions.cs
+++ b/src/ZeroC.Slice.Generator/ITypeExtensions.cs
@@ -238,7 +238,11 @@ internal static class ITypeExtensions
                 return typeRef.GetEncodeLambda(isOptional: false, currentNamespace);
             }
             string csType = typeRef.FieldTypeString(true, currentNamespace);
-            string valueParam = typeRef.IsValueType ? "value!.Value" : "value!";
+
+            // CustomType → (value ?? default!), value types → value!.Value, reference types → value!
+            string valueParam = type is CustomType
+                ? "(value ?? default!)"
+                : typeRef.IsValueType ? "value!.Value" : "value!";
             CodeBlock encodeBody = type.EncodeExpression(currentNamespace, valueParam);
             return $$"""
                 (ref SliceEncoder encoder, {{csType}} value) =>

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -308,6 +308,35 @@ public partial class OperationTests
     }
 
     [Test]
+    public async Task Operation_with_optional_time_stamp_stream_argument_and_return()
+    {
+        // Arrange
+        var invoker = new ColocInvoker(new MyOperationsAService());
+        var proxy = new MyOperationsAProxy(invoker);
+        var timeStamp = new DateTime(2026, 8, 24, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var stream = await proxy.OpWithOptionalTimeStampStreamArgumentAndReturnAsync(GetDataAsync(timeStamp));
+
+        // Assert
+        var enumerator = stream.GetAsyncEnumerator();
+        Assert.That(await enumerator.MoveNextAsync(), Is.True);
+        Assert.That(enumerator.Current, Is.EqualTo(timeStamp));
+
+        Assert.That(await enumerator.MoveNextAsync(), Is.True);
+        Assert.That(enumerator.Current, Is.Null);
+
+        Assert.That(await enumerator.MoveNextAsync(), Is.False);
+
+        static async IAsyncEnumerable<DateTime?> GetDataAsync(DateTime timeStamp)
+        {
+            await Task.Yield();
+            yield return timeStamp;
+            yield return null;
+        }
+    }
+
+    [Test]
     public async Task Operation_with_string_stream_argument_and_return()
     {
         // Arrange
@@ -770,6 +799,11 @@ public partial class OperationTests
 
         public ValueTask<IAsyncEnumerable<string?>> OpWithOptionalStringStreamArgumentAndReturnAsync(
             IAsyncStream<string?> p,
+            IFeatureCollection features,
+            CancellationToken cancellationToken) => new(p);
+
+        public ValueTask<IAsyncEnumerable<DateTime?>> OpWithOptionalTimeStampStreamArgumentAndReturnAsync(
+            IAsyncStream<DateTime?> p,
             IFeatureCollection features,
             CancellationToken cancellationToken) => new(p);
 

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.slice
@@ -28,6 +28,8 @@ interface MyOperationsA {
     opWithOptionalIntStreamArgumentAndReturn(p: stream int32?) -> stream int32?
     opWithStringStreamArgumentAndReturn(p: stream string) -> stream string
     opWithOptionalStringStreamArgumentAndReturn(p: stream string?) -> stream string?
+    opWithOptionalTimeStampStreamArgumentAndReturn(p: stream WellKnownTypes::TimeStamp?)
+        -> stream WellKnownTypes::TimeStamp?
 
     // Stream parameters and return along regular return and parameters
     opWithBothRegularAndStreamParameterAndReturn(p1: int32, p2: stream int32) -> (r1: int32, r2: stream int32)

--- a/tests/ZeroC.Slice.Generator.Tests/ResultTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/ResultTests.slice
@@ -38,3 +38,12 @@ struct OptionalCollectionResults {
 
     r10: Result<Sequence<Dictionary<string, bool?>?>?, string>?
 }
+
+// Just to test that the generated code compiles.
+struct OptionalCustomTypeResults {
+    r1: Result<WellKnownTypes::TimeStamp?, string>
+    r2: Result<string, WellKnownTypes::TimeStamp?>
+    r3: Result<WellKnownTypes::Uri?, string>
+    r4: Result<string, WellKnownTypes::Uri?>
+    r5: Result<CustomType?, string>
+}


### PR DESCRIPTION
Fixes #4810.

For an optional custom type, the generated encode lambdas for `Result` success/failure types and for streams of optionals passed the nullable value directly to the encode extension method, with only a null-forgiving operator. This compiles when the custom type maps to a C# reference type (like `WellKnownTypes::Uri`) but not when it maps to a value type (like `WellKnownTypes::TimeStamp`): `error CS1503: cannot convert from 'System.DateTime?' to 'System.DateTime'`.

This PR applies the `(value ?? default!)` pattern already used by the other optional encode paths (plain optionals, sequence elements), which compiles for both value and reference type mappings.

## What's Changed entry

Area: Slice codec
- The generated code for a `Result` with an optional custom success or failure type (such as `Result<WellKnownTypes::TimeStamp?, string>`) now compiles.

Area: icerpc+slice integration
- The generated code for an operation that streams an optional custom type (such as `stream WellKnownTypes::TimeStamp?`) now compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)