### PR TITLE
Require the exact IceRpc package version in IceRpc.Protobuf

### DIFF
--- a/src/IceRpc.Protobuf/IceRpc.Protobuf.csproj
+++ b/src/IceRpc.Protobuf/IceRpc.Protobuf.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/IceRpc/IceRpc.csproj" />
+    <ProjectReference Include="../IceRpc/IceRpc.csproj" ExactVersion="true" />
     <PackageReference Include="Google.Protobuf" />
     <ProjectReference Include="../IceRpc.ServiceGenerator/IceRpc.ServiceGenerator.csproj"
                       Condition="'$(DocFxBuild)' != 'true'"


### PR DESCRIPTION
Fixes #4815.

`IceRpc.Protobuf` was the only package whose `IceRpc` project reference lacked `ExactVersion="true"`, so its nuspec declared a minimum version instead of the exact `[x.y.z]` range all other IceRPC packages use — allowing NuGet to pair it with a newer, incompatible core package. A sweep of all 34 packed nuspecs confirmed this was the only instance.

## What's Changed entry

None — packaging metadata fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)