### PR TITLE
Always complete the pipe reader in the Upload and Download examples

### DIFF
--- a/examples/slice/Download/Client/Program.cs
+++ b/examples/slice/Download/Client/Program.cs
@@ -17,11 +17,19 @@ var downloader = new DownloaderProxy(connection);
 // Receive the stream from the server.
 PipeReader image = await downloader.DownloadImageAsync();
 
-// Create the file, or overwrite the file if it already exists.
-using FileStream fs = File.Create("Client/downloads/downloaded_earth.png");
+try
+{
+    // Create the file, or overwrite the file if it already exists.
+    using FileStream fs = File.Create("Client/downloads/downloaded_earth.png");
 
-// Copy the image stream to the file stream.
-await image.CopyToAsync(fs);
+    // Copy the image stream to the file stream.
+    await image.CopyToAsync(fs);
+}
+finally
+{
+    // Complete and cleanup the pipe reader.
+    image.Complete();
+}
 
 Console.WriteLine("Image downloaded");
 

--- a/examples/slice/Upload/Server/EarthImageStore.cs
+++ b/examples/slice/Upload/Server/EarthImageStore.cs
@@ -17,14 +17,19 @@ internal partial class EarthImageStore : IUploaderService
     {
         Console.WriteLine("Reading image...");
 
-        // Create the file, or overwrite if the file exists.
-        using FileStream fs = File.Create("Server/uploads/uploaded_earth.png");
+        try
+        {
+            // Create the file, or overwrite if the file exists.
+            using FileStream fs = File.Create("Server/uploads/uploaded_earth.png");
 
-        // Copy the image to the file stream.
-        await image.CopyToAsync(fs, cancellationToken);
-
-        // Complete and cleanup the pipe reader.
-        image.Complete();
+            // Copy the image to the file stream.
+            await image.CopyToAsync(fs, cancellationToken);
+        }
+        finally
+        {
+            // Complete and cleanup the pipe reader.
+            image.Complete();
+        }
 
         Console.WriteLine("Image fully read and saved to disk.");
     }


### PR DESCRIPTION
Fixes #4825.

When the generated code gives a `PipeReader` to the application — the response stream on the client side, the stream argument on the dispatch side — the application owns this pipe reader and must complete it. The Download client never completed the reader it received, and the Upload server completed it only on the success path: a failed or canceled copy skipped it. Both examples now complete the reader in a `finally` block, since these examples are the pattern users copy for byte streaming.

## What's Changed entry

None — example fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)