### PR TITLE
Fix reading publication cleanup in the Thermostat examples

### DIFF
--- a/examples/protobuf/Thermostat/Server/ThermoFacade.cs
+++ b/examples/protobuf/Thermostat/Server/ThermoFacade.cs
@@ -72,21 +72,28 @@ internal sealed partial class ThermoFacade : IThermostatService
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
 
-            while (!cts.IsCancellationRequested)
+            try
             {
-                Reading reading;
-                try
+                while (!cts.IsCancellationRequested)
                 {
-                    reading = await channel.Reader.ReadAsync(cts.Token);
+                    Reading reading;
+                    try
+                    {
+                        reading = await channel.Reader.ReadAsync(cts.Token);
+                    }
+                    catch
+                    {
+                        break; // while
+                    }
+                    yield return reading;
                 }
-                catch
-                {
-                    break; // while
-                }
-                yield return reading;
             }
-
-            RemoveChannelWriter(node);
+            finally
+            {
+                // The consumer can dispose the enumerator while it's suspended at a yield return; only the
+                // finally block runs then.
+                RemoveChannelWriter(node);
+            }
         }
     }
 
@@ -146,14 +153,22 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // Expected on shutdown or when superseded by a newer publish task.
         }
-
-        lock (_mutex)
+        catch (IceRpcException exception)
         {
-            // Cleanup unless a new publish task has already disposed publishCts.
-            if (_publishCts == publishCts)
+            // Expected when the device connection is lost. This method's task is not awaited, so we must not let
+            // the exception escape.
+            Console.WriteLine($"Stopped publishing readings: {exception.Message}");
+        }
+        finally
+        {
+            lock (_mutex)
             {
-                publishCts.Dispose();
-                _publishCts = null;
+                // Cleanup unless a new publish task has already disposed publishCts.
+                if (_publishCts == publishCts)
+                {
+                    publishCts.Dispose();
+                    _publishCts = null;
+                }
             }
         }
     }

--- a/examples/protobuf/Thermostat/Server/ThermoFacade.cs
+++ b/examples/protobuf/Thermostat/Server/ThermoFacade.cs
@@ -61,7 +61,8 @@ internal sealed partial class ThermoFacade : IThermostatService
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
 
-            // Each enumeration gets its own bounded channel with a single element.
+            // Each enumeration gets its own bounded channel holding a single reading: when the client falls behind, the
+            // channel keeps only the latest reading and drops the older ones.
             var channel = Channel.CreateBounded<Reading>(
                 new BoundedChannelOptions(1)
                 {
@@ -70,8 +71,8 @@ internal sealed partial class ThermoFacade : IThermostatService
                     FullMode = BoundedChannelFullMode.DropOldest
                 });
 
-            // We pair AddChannelWriter with RemoveChannelWriter in the finally block: both run when the enumeration
-            // starts, or neither runs when the consumer disposes the enumerator without ever starting it.
+            // Register the writer when the iteration starts and unregister it in the finally block when the iteration
+            // ends or the enumerator is disposed.
             LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
 
             try

--- a/examples/protobuf/Thermostat/Server/ThermoFacade.cs
+++ b/examples/protobuf/Thermostat/Server/ThermoFacade.cs
@@ -53,17 +53,6 @@ internal sealed partial class ThermoFacade : IThermostatService
         IFeatureCollection features,
         CancellationToken cancellationToken)
     {
-        // Each call to MonitorAsync gets its own bounded channel with a single element.
-        var channel = Channel.CreateBounded<Reading>(
-            new BoundedChannelOptions(1)
-            {
-                SingleReader = true,
-                SingleWriter = true,
-                FullMode = BoundedChannelFullMode.DropOldest
-            });
-
-        LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
-
         return new(ReadAsync(CancellationToken.None));
 
         // The injected cancellation token is canceled when the client disconnects or stops reading.
@@ -71,6 +60,19 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
+
+            // Each enumeration gets its own bounded channel with a single element.
+            var channel = Channel.CreateBounded<Reading>(
+                new BoundedChannelOptions(1)
+                {
+                    SingleReader = true,
+                    SingleWriter = true,
+                    FullMode = BoundedChannelFullMode.DropOldest
+                });
+
+            // We pair AddChannelWriter with RemoveChannelWriter in the finally block: both run when the enumeration
+            // starts, or neither runs when the consumer disposes the enumerator without ever starting it.
+            LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
 
             try
             {

--- a/examples/protobuf/Thermostat/Server/ThermoFacade.cs
+++ b/examples/protobuf/Thermostat/Server/ThermoFacade.cs
@@ -155,10 +155,10 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // Expected on shutdown or when superseded by a newer publish task.
         }
-        catch (IceRpcException exception)
+        catch (Exception exception)
         {
-            // Expected when the device connection is lost. This method's task is not awaited, so we must not let
-            // the exception escape.
+            // This method's task is not awaited, so we must not let any exception escape. An IceRpcException is
+            // expected when the device connection is lost.
             Console.WriteLine($"Stopped publishing readings: {exception.Message}");
         }
         finally

--- a/examples/slice/Thermostat/Server/ThermoFacade.cs
+++ b/examples/slice/Thermostat/Server/ThermoFacade.cs
@@ -58,7 +58,8 @@ internal sealed partial class ThermoFacade : IThermostatService
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
 
-            // Each enumeration gets its own bounded channel with a single element.
+            // Each enumeration gets its own bounded channel holding a single reading: when the client falls behind, the
+            // channel keeps only the latest reading and drops the older ones.
             var channel = Channel.CreateBounded<Reading>(
                 new BoundedChannelOptions(1)
                 {
@@ -67,8 +68,8 @@ internal sealed partial class ThermoFacade : IThermostatService
                     FullMode = BoundedChannelFullMode.DropOldest
                 });
 
-            // We pair AddChannelWriter with RemoveChannelWriter in the finally block: both run when the enumeration
-            // starts, or neither runs when the consumer disposes the enumerator without ever starting it.
+            // Register the writer when the iteration starts and unregister it in the finally block when the iteration
+            // ends or the enumerator is disposed.
             LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
 
             try

--- a/examples/slice/Thermostat/Server/ThermoFacade.cs
+++ b/examples/slice/Thermostat/Server/ThermoFacade.cs
@@ -69,21 +69,28 @@ internal sealed partial class ThermoFacade : IThermostatService
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
 
-            while (!cts.IsCancellationRequested)
+            try
             {
-                Reading reading;
-                try
+                while (!cts.IsCancellationRequested)
                 {
-                    reading = await channel.Reader.ReadAsync(cts.Token);
+                    Reading reading;
+                    try
+                    {
+                        reading = await channel.Reader.ReadAsync(cts.Token);
+                    }
+                    catch
+                    {
+                        break; // while
+                    }
+                    yield return reading;
                 }
-                catch
-                {
-                    break; // while
-                }
-                yield return reading;
             }
-
-            RemoveChannelWriter(node);
+            finally
+            {
+                // The consumer can dispose the enumerator while it's suspended at a yield return; only the
+                // finally block runs then.
+                RemoveChannelWriter(node);
+            }
         }
     }
 
@@ -143,14 +150,22 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // Expected on shutdown or when superseded by a newer publish task.
         }
-
-        lock (_mutex)
+        catch (IceRpcException exception)
         {
-            // Cleanup unless a new publish task has already disposed publishCts.
-            if (_publishCts == publishCts)
+            // Expected when the device connection is lost. This method's task is not awaited, so we must not let
+            // the exception escape.
+            Console.WriteLine($"Stopped publishing readings: {exception.Message}");
+        }
+        finally
+        {
+            lock (_mutex)
             {
-                publishCts.Dispose();
-                _publishCts = null;
+                // Cleanup unless a new publish task has already disposed publishCts.
+                if (_publishCts == publishCts)
+                {
+                    publishCts.Dispose();
+                    _publishCts = null;
+                }
             }
         }
     }

--- a/examples/slice/Thermostat/Server/ThermoFacade.cs
+++ b/examples/slice/Thermostat/Server/ThermoFacade.cs
@@ -152,10 +152,10 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // Expected on shutdown or when superseded by a newer publish task.
         }
-        catch (IceRpcException exception)
+        catch (Exception exception)
         {
-            // Expected when the device connection is lost. This method's task is not awaited, so we must not let
-            // the exception escape.
+            // This method's task is not awaited, so we must not let any exception escape. An IceRpcException is
+            // expected when the device connection is lost.
             Console.WriteLine($"Stopped publishing readings: {exception.Message}");
         }
         finally

--- a/examples/slice/Thermostat/Server/ThermoFacade.cs
+++ b/examples/slice/Thermostat/Server/ThermoFacade.cs
@@ -50,17 +50,6 @@ internal sealed partial class ThermoFacade : IThermostatService
         IFeatureCollection features,
         CancellationToken cancellationToken)
     {
-        // Each call to MonitorAsync gets its own bounded channel with a single element.
-        var channel = Channel.CreateBounded<Reading>(
-            new BoundedChannelOptions(1)
-            {
-                SingleReader = true,
-                SingleWriter = true,
-                FullMode = BoundedChannelFullMode.DropOldest
-            });
-
-        LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
-
         return new(ReadAsync(CancellationToken.None));
 
         // The injected cancellation token is canceled when the client disconnects or stops reading.
@@ -68,6 +57,19 @@ internal sealed partial class ThermoFacade : IThermostatService
         {
             // We stop yielding new values when the server shuts down or the client disconnects or stops reading.
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken, cancellationToken);
+
+            // Each enumeration gets its own bounded channel with a single element.
+            var channel = Channel.CreateBounded<Reading>(
+                new BoundedChannelOptions(1)
+                {
+                    SingleReader = true,
+                    SingleWriter = true,
+                    FullMode = BoundedChannelFullMode.DropOldest
+                });
+
+            // We pair AddChannelWriter with RemoveChannelWriter in the finally block: both run when the enumeration
+            // starts, or neither runs when the consumer disposes the enumerator without ever starting it.
+            LinkedListNode<ChannelWriter<Reading>> node = AddChannelWriter(channel.Writer);
 
             try
             {


### PR DESCRIPTION
Fixes #4830 — finding L-18; the other findings of this issue are addressed by #4868.

In both Thermostat servers, `ThermoBridge` intentionally does not await `PublishAsync`, so `PublishAsync` must not let exceptions escape. It caught only `OperationCanceledException`: a device connection loss made the `await foreach` throw `IceRpcException`, which faulted the discarded task (an unobserved task exception) and skipped the `publishCts` cleanup. `PublishAsync` now also catches `IceRpcException` with a console message and performs the cleanup in a `finally` block.

In `MonitorAsync`, the removal of the per-client channel writer ran after the iterator loop, so it was skipped when the consumer disposed the enumerator while it was suspended at a `yield return` — retaining the writer (and publishing to it) until server shutdown. The removal now runs in a `finally` block.

## What's Changed entry

None — example fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)