### PR TITLE
Complete the request payloads when invoking with a null invoker

### DIFF
--- a/src/IceRpc.Ice/Operations/IceProxyExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyExtensions.cs
@@ -66,6 +66,7 @@ public static class IceProxyExtensions
     {
         if (proxy.Invoker is not IInvoker invoker)
         {
+            payload.Complete();
             throw new InvalidOperationException("Cannot send requests using a proxy with a null invoker.");
         }
 
@@ -135,6 +136,7 @@ public static class IceProxyExtensions
     {
         if (proxy.Invoker is not IInvoker invoker)
         {
+            payload.Complete();
             throw new InvalidOperationException("Cannot send requests using a proxy with a null invoker.");
         }
 

--- a/src/IceRpc.Slice/Operations/SliceProxyExtensions.cs
+++ b/src/IceRpc.Slice/Operations/SliceProxyExtensions.cs
@@ -65,6 +65,8 @@ public static class SliceProxyExtensions
     {
         if (proxy.Invoker is not IInvoker invoker)
         {
+            payload.Complete();
+            payloadContinuation?.Complete();
             throw new InvalidOperationException("Cannot send requests using a proxy with a null invoker.");
         }
 
@@ -135,6 +137,8 @@ public static class SliceProxyExtensions
     {
         if (proxy.Invoker is not IInvoker invoker)
         {
+            payload.Complete();
+            payloadContinuation?.Complete();
             throw new InvalidOperationException("Cannot send requests using a proxy with a null invoker.");
         }
 


### PR DESCRIPTION
Addresses finding L-10 of #4832.

The generated proxy code creates the request payload — and, for a streamed Slice operation, the payload continuation whose construction starts the application's async enumerator — before calling `InvokeOperationAsync`. When the proxy has a null invoker, `InvokeOperationAsync` threw before any `OutgoingRequest` existed, so nothing completed these readers and the enumerator was unreachable. The Slice and Ice `InvokeOperationAsync` overloads now complete the payloads before throwing.

## What's Changed entry

None — resource cleanup on an error path caused by an application bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)