### PR TITLE
Fix Coloc threshold validation and cancellation registration cleanup

### DIFF
--- a/src/IceRpc.Transports.Coloc/ColocTransport.cs
+++ b/src/IceRpc.Transports.Coloc/ColocTransport.cs
@@ -28,8 +28,18 @@ public sealed class ColocTransport
 
     /// <summary>Constructs a <see cref="ColocTransport" />.</summary>
     /// <param name="options">The options to configure the Coloc transport.</param>
+    /// <exception cref="ArgumentException">Thrown when the <see cref="ColocTransportOptions.ResumeWriterThreshold" />
+    /// of <paramref name="options" /> is greater than its <see cref="ColocTransportOptions.PauseWriterThreshold"
+    /// />.</exception>
     public ColocTransport(ColocTransportOptions options)
     {
+        if (options.ResumeWriterThreshold > options.PauseWriterThreshold)
+        {
+            throw new ArgumentException(
+                $"The value of {nameof(ColocTransportOptions.ResumeWriterThreshold)} cannot be greater than the value of {nameof(ColocTransportOptions.PauseWriterThreshold)}.",
+                nameof(options));
+        }
+
         var listeners = new ConcurrentDictionary<(string Host, ushort Port), ColocListener>();
         ClientTransport = new ColocClientTransport(listeners, options);
         ServerTransport = new ColocServerTransport(listeners, options);

--- a/src/IceRpc.Transports.Coloc/ColocTransportOptions.cs
+++ b/src/IceRpc.Transports.Coloc/ColocTransportOptions.cs
@@ -35,14 +35,10 @@ public sealed record class ColocTransportOptions
     public int ResumeWriterThreshold
     {
         get => _resumeWriterThreshold;
-        set => _resumeWriterThreshold =
-            value < 1024 ? throw new ArgumentOutOfRangeException(
+        set => _resumeWriterThreshold = value >= 1024 ? value :
+            throw new ArgumentOutOfRangeException(
                 nameof(value),
-                $"Invalid value '{value}' for {nameof(ResumeWriterThreshold)}, it cannot be less than 1KB.") :
-            value > _pauseWriterThreshold ? throw new ArgumentException(
-                $"The value of {nameof(ResumeWriterThreshold)} cannot be greater than the value of {nameof(PauseWriterThreshold)}.",
-                nameof(value)) :
-            value;
+                $"Invalid value '{value}' for {nameof(ResumeWriterThreshold)}, it cannot be less than 1KB.");
     }
 
     private int _listenBacklog = 511;

--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -30,7 +30,9 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
     //   pipe reader is set as the result. ClientColocConnection.ConnectAsync waits on the task completion source task.
     // - the client connection pipe reader provided to the server connection when the server connection is created by
     //   AcceptAsync.
-    private readonly Channel<(TaskCompletionSource<PipeReader>, PipeReader)> _channel;
+    // - the cancellation token registration that cancels the TaskCompletionSource; it's disposed when the request is
+    //   dequeued.
+    private readonly Channel<(TaskCompletionSource<PipeReader>, PipeReader, CancellationTokenRegistration)> _channel;
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
@@ -45,8 +47,9 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
         {
             while (true)
             {
-                (TaskCompletionSource<PipeReader> tcs, PipeReader clientPipeReader) =
+                (TaskCompletionSource<PipeReader> tcs, PipeReader clientPipeReader, CancellationTokenRegistration registration) =
                     await _channel.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
+                registration.Dispose();
 
                 var serverPipe = new Pipe(_pipeOptions);
                 if (tcs.TrySetResult(serverPipe.Reader))
@@ -95,8 +98,10 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
             // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused.
             // Use TrySetException in case the task has been already canceled.
-            while (_channel.Reader.TryRead(out (TaskCompletionSource<PipeReader> Tcs, PipeReader) item))
+            while (_channel.Reader.TryRead(
+                out (TaskCompletionSource<PipeReader> Tcs, PipeReader, CancellationTokenRegistration Registration) item))
             {
+                item.Registration.Dispose();
                 item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
             }
         }
@@ -127,7 +132,7 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
         // Create a bounded channel with a capacity that matches the listen backlog, and with
         // the default concurrency settings that allow multiple reader and writers.
-        _channel = Channel.CreateBounded<(TaskCompletionSource<PipeReader>, PipeReader)>(
+        _channel = Channel.CreateBounded<(TaskCompletionSource<PipeReader>, PipeReader, CancellationTokenRegistration)>(
             new BoundedChannelOptions(colocTransportOptions.ListenBacklog));
     }
 
@@ -147,14 +152,16 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
         // We use RunContinuationsAsynchronously to avoid the ConnectAsync continuation end up running in the AcceptAsync
         // loop that completes this tcs.
         var tcs = new TaskCompletionSource<PipeReader>(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (_channel.Writer.TryWrite((tcs, clientPipeReader)))
-        {
+        CancellationTokenRegistration registration =
             cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        if (_channel.Writer.TryWrite((tcs, clientPipeReader, registration)))
+        {
             serverPipeReaderTask = tcs.Task;
             return true;
         }
         else
         {
+            registration.Dispose();
             serverPipeReaderTask = null;
             return false;
         }

--- a/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocListener.cs
@@ -6,6 +6,11 @@ using System.IO.Pipelines;
 using System.Net;
 using System.Threading.Channels;
 
+using ConnectRequest = (
+    System.Threading.Tasks.TaskCompletionSource<System.IO.Pipelines.PipeReader> Tcs,
+    System.IO.Pipelines.PipeReader ClientPipeReader,
+    System.Threading.CancellationTokenRegistration Registration);
+
 namespace IceRpc.Transports.Coloc.Internal;
 
 /// <summary>The listener implementation for the colocated transport.</summary>
@@ -32,7 +37,7 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
     //   AcceptAsync.
     // - the cancellation token registration that cancels the TaskCompletionSource; it's disposed when the request is
     //   dequeued.
-    private readonly Channel<(TaskCompletionSource<PipeReader>, PipeReader, CancellationTokenRegistration)> _channel;
+    private readonly Channel<ConnectRequest> _channel;
 
     public async Task<(IDuplexConnection, EndPoint)> AcceptAsync(CancellationToken cancellationToken)
     {
@@ -47,17 +52,16 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
         {
             while (true)
             {
-                (TaskCompletionSource<PipeReader> tcs, PipeReader clientPipeReader, CancellationTokenRegistration registration) =
-                    await _channel.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
-                registration.Dispose();
+                ConnectRequest request = await _channel.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
+                request.Registration.Dispose();
 
                 var serverPipe = new Pipe(_pipeOptions);
-                if (tcs.TrySetResult(serverPipe.Reader))
+                if (request.Tcs.TrySetResult(serverPipe.Reader))
                 {
                     var serverConnection = new ServerColocConnection(
                         TransportAddress,
                         serverPipe.Writer,
-                        clientPipeReader);
+                        request.ClientPipeReader);
                     return (serverConnection, _networkAddress);
                 }
                 else
@@ -98,8 +102,7 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
             // Complete all the queued client connection establishment requests with IceRpcError.ConnectionRefused.
             // Use TrySetException in case the task has been already canceled.
-            while (_channel.Reader.TryRead(
-                out (TaskCompletionSource<PipeReader> Tcs, PipeReader, CancellationTokenRegistration Registration) item))
+            while (_channel.Reader.TryRead(out ConnectRequest item))
             {
                 item.Registration.Dispose();
                 item.Tcs.TrySetException(new IceRpcException(IceRpcError.ConnectionRefused));
@@ -132,7 +135,7 @@ internal class ColocListener : IListener<IDuplexConnection>, IDisposable
 
         // Create a bounded channel with a capacity that matches the listen backlog, and with
         // the default concurrency settings that allow multiple reader and writers.
-        _channel = Channel.CreateBounded<(TaskCompletionSource<PipeReader>, PipeReader, CancellationTokenRegistration)>(
+        _channel = Channel.CreateBounded<ConnectRequest>(
             new BoundedChannelOptions(colocTransportOptions.ListenBacklog));
     }
 


### PR DESCRIPTION
Addresses finding L-08 of #4832, and fixes an adjacent defect found while verifying finding L-05.

**Threshold validation (L-08)**: the `ResumeWriterThreshold <= PauseWriterThreshold` invariant was enforced only by the `ResumeWriterThreshold` setter, so it could be bypassed by assignment order (e.g. `new ColocTransportOptions { PauseWriterThreshold = 2048 }` against the default resume threshold) or by a `with` expression, and the invalid pair then failed later inside `PipeOptions` with a raw `ArgumentOutOfRangeException`. The setters now validate only their own range and the `ColocTransport` constructor — the single entry point into the transport — validates the pair, so every assignment order works and an invalid combination fails immediately with a clear message.

**Registration cleanup**: `TryQueueConnect` discarded the `CancellationTokenRegistration` returned by `Register`, leaving the callback (and the captured `TaskCompletionSource` with its pipe reader result) rooted to the caller's cancellation token for that token's lifetime, even after a successful connect. The registration now travels with the queued entry and is disposed when the entry is dequeued by `AcceptAsync`, drained by `Dispose`, or refused by a full backlog.

Finding L-05 itself — a canceled entry keeps occupying a backlog slot until an accept dequeues it — is intentionally unchanged.

## What's Changed entry

None — the Coloc transport is mainly used for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)