### PR TITLE
Throw IceRpcException when an ice response header is invalid

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -398,15 +398,28 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 Debug.Assert(responseCompletionSource is not null);
                 frameReader = await responseCompletionSource.Task.WaitAsync(invocationCts.Token).ConfigureAwait(false);
 
-                if (!frameReader.TryRead(out ReadResult readResult))
+                StatusCode statusCode;
+                string? errorMessage;
+                SequencePosition consumed;
+                try
                 {
-                    throw new InvalidDataException($"Received empty response frame for request with id '{requestId}'.");
+                    if (!frameReader.TryRead(out ReadResult readResult))
+                    {
+                        throw new InvalidDataException(
+                            $"Received empty response frame for request with ID '{requestId}'.");
+                    }
+
+                    Debug.Assert(readResult.IsCompleted);
+
+                    (statusCode, errorMessage, consumed) = DecodeResponseHeader(readResult.Buffer, requestId);
                 }
-
-                Debug.Assert(readResult.IsCompleted);
-
-                (StatusCode statusCode, string? errorMessage, SequencePosition consumed) =
-                    DecodeResponseHeader(readResult.Buffer, requestId);
+                catch (InvalidDataException exception)
+                {
+                    throw new IceRpcException(
+                        IceRpcError.IceRpcError,
+                        "Received an ice response with an invalid header.",
+                        exception);
+                }
 
                 frameReader.AdvanceTo(consumed);
 
@@ -734,6 +747,11 @@ internal sealed class IceProtocolConnection : IProtocolConnection
         ReadOnlySequence<byte> buffer,
         int requestId)
     {
+        if (buffer.IsEmpty)
+        {
+            throw new InvalidDataException($"Received empty response header for request with ID '{requestId}'.");
+        }
+
         var replyStatus = (ReplyStatus)buffer.FirstSpan[0];
 
         if (replyStatus <= ReplyStatus.UserException)
@@ -744,7 +762,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
 
             if (buffer.Length < headerSize)
             {
-                throw new InvalidDataException($"Received invalid frame header for request with id '{requestId}'.");
+                throw new InvalidDataException($"Received invalid frame header for request with ID '{requestId}'.");
             }
 
             EncapsulationHeader encapsulationHeader =

--- a/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
+++ b/tests/IceRpc.Tests/IceProtocolConnectionTests.cs
@@ -918,6 +918,51 @@ public sealed class IceProtocolConnectionTests
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionAborted));
     }
 
+    /// <summary>Verifies that a response with a malformed header fails the invocation with an <see
+    /// cref="IceRpcException" />.</summary>
+    [Test]
+    public async Task Receiving_a_response_with_an_invalid_header_fails_the_invocation()
+    {
+        // Arrange: a client-side read decorator that rewrites the encapsulation size of the incoming response frame
+        // to zero. The dispatch returns an empty Ok response, so this frame arrives as a single 25-byte read: the
+        // 14-byte prologue, the 4-byte request ID, the reply status byte (Ok), and an empty encapsulation (6-byte
+        // header with its size, 6, at offset 19).
+        bool invalidRead = false;
+        using var dispatcher = new TestDispatcher(holdDispatchCount: 1);
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddProtocolTest(Protocol.Ice, dispatcher: dispatcher)
+            .AddTestDuplexTransportDecorator(
+                clientOperationsOptions: new DuplexTransportOperationsOptions()
+                {
+                    ReadDecorator = async (decoratee, buffer, cancellationToken) =>
+                        {
+                            int count = await decoratee.ReadAsync(buffer, cancellationToken);
+                            if (invalidRead && count == 25)
+                            {
+                                buffer.Span.Slice(19, 4).Clear(); // Rewrite the encapsulation size to 0.
+                            }
+                            return count;
+                        }
+                })
+            .BuildServiceProvider(validateScopes: true);
+
+        var sut = provider.GetRequiredService<ClientServerProtocolConnection>();
+        await sut.ConnectAsync();
+
+        using var request = new OutgoingRequest(new ServiceAddress(Protocol.Ice));
+
+        // Act
+        Task invokeTask = sut.Client.InvokeAsync(request);
+        invalidRead = true;
+        dispatcher.ReleaseDispatch(); // Triggers the sending of the response.
+
+        // Assert
+        Assert.That(
+            () => invokeTask,
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.IceRpcError)
+                .And.InnerException.InstanceOf<InvalidDataException>());
+    }
+
     /// <summary>This test verifies that responses that are received after a request1 has been discarded are ignored,
     /// and doesn't interfere with other request1 and responses being send over the same connection.</summary>
     [Test]


### PR DESCRIPTION
Addresses finding L-02 of #4832.

With the ice protocol, the response header is decoded on the invocation code path, after the read frames loop hands over the reply frame. A malformed header made this decoding throw a raw `InvalidDataException` — or an `IndexOutOfRangeException` when the frame ended right after the request ID — directly to the application.

`InvokeAsync` now wraps response header decoding failures in an `IceRpcException` with error `IceRpcError.IceRpcError`, like the icerpc protocol connection does, and `DecodeResponseHeader` rejects an empty header with an `InvalidDataException`. The failure remains scoped to the invocation.

## What's Changed entry

None — improves the error thrown on malformed input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
