### PR TITLE
Throw InvalidDataException when class slice decoding overruns

### DIFF
--- a/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.Class.cs
@@ -93,7 +93,12 @@ public ref partial struct IceDecoder
             Debug.Assert(_classContext.Current.PosAfterIndirectionTable is not null &&
                          _classContext.Current.IndirectionTable is not null);
 
-            _reader.Advance(_classContext.Current.PosAfterIndirectionTable.Value - _reader.Consumed);
+            long count = _classContext.Current.PosAfterIndirectionTable.Value - _reader.Consumed;
+            if (count < 0)
+            {
+                throw new InvalidDataException("The slice fields extend beyond the declared slice size.");
+            }
+            _reader.Advance(count);
             _classContext.Current.PosAfterIndirectionTable = null;
             _classContext.Current.IndirectionTable = null;
         }
@@ -279,7 +284,12 @@ public ref partial struct IceDecoder
                 // else remains empty
             }
 
-            _reader.Advance(savedPos - _reader.Consumed);
+            long count = savedPos - _reader.Consumed;
+            if (count < 0)
+            {
+                throw new InvalidDataException("An indirection table extends beyond the end of its slice.");
+            }
+            _reader.Advance(count);
         }
 
         if (decodeIndirectionTable)
@@ -527,7 +537,9 @@ public ref partial struct IceDecoder
             Debug.Assert(_classContext.Current.PosAfterIndirectionTable is not null);
 
             // Move past indirection table
-            _reader.Advance(_classContext.Current.PosAfterIndirectionTable.Value - _reader.Consumed);
+            long count = _classContext.Current.PosAfterIndirectionTable.Value - _reader.Consumed;
+            Debug.Assert(count > 0);
+            _reader.Advance(count);
             _classContext.Current.PosAfterIndirectionTable = null;
         }
 


### PR DESCRIPTION
Addresses finding L-09 of #4832.

When decoding an Ice class or exception, two code paths in `IceDecoder.Class.cs` skip to a previously recorded position by advancing the reader by a computed delta: `EndSlice` jumps over the indirection table, and `DecodeInstance` returns to the resume position after decoding deferred indirection tables. With malformed data — slice fields that consume more bytes than the declared slice size, or an indirection table that overruns its slice — the delta goes negative and `SequenceReader.Advance` throws `ArgumentOutOfRangeException` instead of the `InvalidDataException` the decoder throws for all other malformed input. Both sites were verified to throw `ArgumentOutOfRangeException` before the fix; they now check the delta and throw `InvalidDataException`.

The similar advance in `SkipSlice` cannot go negative — the skip consumes exactly the declared slice size, the same value used to locate the indirection table — so it gets a `Debug.Assert` instead of a guard.

## What's Changed entry

None — improves the error thrown on malformed input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)