### PR TITLE
Store IPv6 hosts without brackets in ServerAddress

### DIFF
--- a/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyIceDecoderExtensions.cs
@@ -294,7 +294,8 @@ public static class IceProxyIceDecoderExtensions
     {
         var body = new TcpServerAddressBody(ref decoder);
 
-        if (Uri.CheckHostName(body.Host) == UriHostNameType.Unknown)
+        // The host name in an Ice tcp/ssl server address is never bracketed, even when it's an IPv6 address.
+        if (body.Host.StartsWith('[') || Uri.CheckHostName(body.Host) == UriHostNameType.Unknown)
         {
             throw new InvalidDataException($"Received service address with invalid host '{body.Host}'.");
         }

--- a/src/IceRpc/ServerAddress.cs
+++ b/src/IceRpc/ServerAddress.cs
@@ -32,7 +32,9 @@ public readonly record struct ServerAddress
             {
                 throw new ArgumentException($"Cannot set {nameof(Host)} to '{value}'.", nameof(value));
             }
-            _host = value;
+            // Brackets are only valid around an IPv6 address; store the address without them, like the Uri
+            // constructor does.
+            _host = value.StartsWith('[') ? value[1..^1] : value;
             OriginalUri = null; // new host invalidates OriginalUri
         }
     }

--- a/src/IceRpc/ServerAddress.cs
+++ b/src/IceRpc/ServerAddress.cs
@@ -22,6 +22,8 @@ public readonly record struct ServerAddress
     /// <summary>Gets or initializes the host.</summary>
     /// <value>The host of this server address. Defaults to <c>::0</c> meaning that the server will listen on all the
     /// network interfaces. This default value is parsed into <see cref="IPAddress.IPv6Any" />.</value>
+    /// <remarks>When you initialize this property with a bracketed IPv6 address such as <c>[::1]</c>, the brackets
+    /// are stripped: the property value is the IPv6 address without brackets.</remarks>
     public string Host
     {
         get => _host;
@@ -32,8 +34,9 @@ public readonly record struct ServerAddress
             {
                 throw new ArgumentException($"Cannot set {nameof(Host)} to '{value}'.", nameof(value));
             }
-            // Brackets are only valid around an IPv6 address; store the address without them, like the Uri
-            // constructor does.
+            // A value that starts with '[' is necessarily a well-formed bracketed IPv6 address: for any other value
+            // with brackets, including mismatched brackets, CheckHostName returns Unknown. We store the address
+            // without the brackets, like the Uri constructor does.
             _host = value.StartsWith('[') ? value[1..^1] : value;
             OriginalUri = null; // new host invalidates OriginalUri
         }

--- a/tests/IceRpc.Tests/ServerAddressTests.cs
+++ b/tests/IceRpc.Tests/ServerAddressTests.cs
@@ -176,18 +176,20 @@ public class ServerAddressTests
         Assert.That(serverAddress.Params, Is.EquivalentTo(parameters));
     }
 
-    /// <summary>Verifies that setting the host works with a supported host name.</summary>
+    /// <summary>Verifies that setting the host works with a supported host name, and that an IPv6 address specified
+    /// with brackets is stored without them.</summary>
     /// <param name="host">The value to set the <see cref="ServerAddress.Host" /> property to.</param>
-    [TestCase("localhost")]
-    [TestCase("[::0]")]
-    [TestCase("::1")]
-    public void Setting_the_server_address_host(string host)
+    /// <param name="expectedHost">The expected value of the <see cref="ServerAddress.Host" /> property.</param>
+    [TestCase("localhost", "localhost")]
+    [TestCase("[::0]", "::0")]
+    [TestCase("::1", "::1")]
+    public void Setting_the_server_address_host(string host, string expectedHost)
     {
         var serverAddress = new ServerAddress(new Uri("icerpc://localhost"));
 
         serverAddress = serverAddress with { Host = host };
 
-        Assert.That(serverAddress.Host, Is.EqualTo(host));
+        Assert.That(serverAddress.Host, Is.EqualTo(expectedHost));
     }
 
     [Test]


### PR DESCRIPTION
Addresses finding L-01 of #4832.

`Uri.CheckHostName` accepts both `::1` and `[::1]` as IPv6 hosts, but everything downstream of `ServerAddress.Host` assumes the unbracketed form: the URI serialization brackets any host containing `:`, so a bracketed host produced `icerpc://[[::1]]` and `ToUri()` threw `UriFormatException`. The `ServerAddress(Uri)` constructor was unaffected — `Uri.IdnHost` strips the brackets.

- The `Host` init setter now stores a bracketed IPv6 address without its brackets, like the `Uri` constructor does.
- `DecodeTcpServerAddressBody` (the other host validation relying on `Uri.CheckHostName`) now rejects a bracketed host: the host name in an Ice tcp/ssl server address is never bracketed, even when it's an IPv6 address.

## What's Changed entry

Area: Core

- Fixed a bug where setting `ServerAddress.Host` to a bracketed IPv6 address such as `[::1]` produced a server address whose `ToUri` throws `UriFormatException`. The brackets are now stripped on assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)