### PR TITLE
Align transport implementations with their documented contracts

### DIFF
--- a/src/IceRpc/ClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/ClientProtocolConnectionFactory.cs
@@ -70,6 +70,7 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
 
             // Add an additional stream for the icerpc protocol control stream.
             MaxUnidirectionalStreams = connectionOptions.Dispatcher is null ? 1 :
+                connectionOptions.MaxIceRpcUnidirectionalStreams == int.MaxValue ? int.MaxValue :
                 connectionOptions.MaxIceRpcUnidirectionalStreams + 1,
 
             Pool = connectionOptions.Pool,

--- a/src/IceRpc/ClientProtocolConnectionFactory.cs
+++ b/src/IceRpc/ClientProtocolConnectionFactory.cs
@@ -70,8 +70,7 @@ public sealed class ClientProtocolConnectionFactory : IClientProtocolConnectionF
 
             // Add an additional stream for the icerpc protocol control stream.
             MaxUnidirectionalStreams = connectionOptions.Dispatcher is null ? 1 :
-                connectionOptions.MaxIceRpcUnidirectionalStreams == int.MaxValue ? int.MaxValue :
-                connectionOptions.MaxIceRpcUnidirectionalStreams + 1,
+                int.Min(connectionOptions.MaxIceRpcUnidirectionalStreams + 1, ushort.MaxValue),
 
             Pool = connectionOptions.Pool,
             MinSegmentSize = connectionOptions.MinSegmentSize,

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -82,14 +82,14 @@ public record class ConnectionOptions
     /// accepted on an icerpc connection. When this limit is reached, the peer is not allowed to open any new
     /// bidirectional stream. Since an bidirectional stream is opened for each two-way invocation, the sending of the
     /// two-way invocation will be delayed until another two-way invocation's stream completes.</summary>
-    /// <value>The maximum number of bidirectional streams. It can't be less than <c>1</c>. Defaults to <c>100</c>.
-    /// </value>
+    /// <value>The maximum number of bidirectional streams. It can't be less than <c>1</c> or greater than
+    /// <c>65,535</c>. Defaults to <c>100</c>.</value>
     public int MaxIceRpcBidirectionalStreams
     {
         get => _maxIceRpcBidirectionalStreams;
-        set => _maxIceRpcBidirectionalStreams = value > 0 ? value :
+        set => _maxIceRpcBidirectionalStreams = value is > 0 and <= ushort.MaxValue ? value :
             throw new ArgumentException(
-                $"{nameof(MaxIceRpcBidirectionalStreams)} can't be less than 1",
+                $"{nameof(MaxIceRpcBidirectionalStreams)} must be between 1 and {ushort.MaxValue}",
                 nameof(value));
     }
 
@@ -106,14 +106,14 @@ public record class ConnectionOptions
     /// accepted on an icerpc connection. When this limit is reached, the peer is not allowed to open any new
     /// unidirectional stream. Since an unidirectional stream is opened for each one-way invocation, the sending of the
     /// one-way invocation will be delayed until another one-way invocation's stream completes.</summary>
-    /// <value>The maximum number of unidirectional streams. It can't be less than <c>1</c>. Defaults to
-    /// <c>100</c>.</value>
+    /// <value>The maximum number of unidirectional streams. It can't be less than <c>1</c> or greater than
+    /// <c>65,535</c>. Defaults to <c>100</c>.</value>
     public int MaxIceRpcUnidirectionalStreams
     {
         get => _maxIceRpcUnidirectionalStreams;
-        set => _maxIceRpcUnidirectionalStreams = value > 0 ? value :
+        set => _maxIceRpcUnidirectionalStreams = value is > 0 and <= ushort.MaxValue ? value :
             throw new ArgumentException(
-                $"{nameof(MaxIceRpcUnidirectionalStreams)} can't be less than 1",
+                $"{nameof(MaxIceRpcUnidirectionalStreams)} must be between 1 and {ushort.MaxValue}",
                 nameof(value));
     }
 

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -142,7 +142,9 @@ public sealed class Server : IAsyncDisposable
                         HandshakeTimeout = options.ConnectTimeout,
                         MaxBidirectionalStreams = options.ConnectionOptions.MaxIceRpcBidirectionalStreams,
                         // Add an additional stream for the icerpc protocol control stream.
-                        MaxUnidirectionalStreams = options.ConnectionOptions.MaxIceRpcUnidirectionalStreams + 1,
+                        MaxUnidirectionalStreams =
+                            options.ConnectionOptions.MaxIceRpcUnidirectionalStreams == int.MaxValue ? int.MaxValue :
+                                options.ConnectionOptions.MaxIceRpcUnidirectionalStreams + 1,
                         MinSegmentSize = options.ConnectionOptions.MinSegmentSize,
                         Pool = options.ConnectionOptions.Pool
                     },

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -143,8 +143,7 @@ public sealed class Server : IAsyncDisposable
                         MaxBidirectionalStreams = options.ConnectionOptions.MaxIceRpcBidirectionalStreams,
                         // Add an additional stream for the icerpc protocol control stream.
                         MaxUnidirectionalStreams =
-                            options.ConnectionOptions.MaxIceRpcUnidirectionalStreams == int.MaxValue ? int.MaxValue :
-                                options.ConnectionOptions.MaxIceRpcUnidirectionalStreams + 1,
+                            int.Min(options.ConnectionOptions.MaxIceRpcUnidirectionalStreams + 1, ushort.MaxValue),
                         MinSegmentSize = options.ConnectionOptions.MinSegmentSize,
                         Pool = options.ConnectionOptions.Pool
                     },

--- a/src/IceRpc/Transports/IMultiplexedStream.cs
+++ b/src/IceRpc/Transports/IMultiplexedStream.cs
@@ -11,8 +11,9 @@ public interface IMultiplexedStream : IDuplexPipe
 {
     /// <summary>Gets the stream ID.</summary>
     /// <value>The stream ID.</value>
-    /// <exception cref="InvalidOperationException">Thrown if the stream is not started. Local streams are not started
-    /// until data is written. A remote stream is always started.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the stream is not started. A remote stream is always
+    /// started; depending on the transport implementation, a local stream is started at construction or by the first
+    /// write.</exception>
     /// <remarks>The stream IDs have the same format as the QUIC stream IDs
     /// <see href="https://datatracker.ietf.org/doc/html/rfc9000#name-stream-types-and-identifier"/>.</remarks>
     ulong Id { get; }
@@ -30,8 +31,8 @@ public interface IMultiplexedStream : IDuplexPipe
 
     /// <summary>Gets a value indicating whether the stream is started.</summary>
     /// <value><see langword="true" /> if the stream is started; otherwise, <see langword="false" />.</value>
-    /// <remarks>Remote streams are always started after construction. A local stream is started by the first write.
-    /// </remarks>
+    /// <remarks>Remote streams are always started after construction. Depending on the transport implementation, a
+    /// local stream is started at construction or by the first write.</remarks>
     bool IsStarted { get; }
 
     /// <summary>Gets a task that completes when all write network activity ceases for this stream. This occurs when:

--- a/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
@@ -131,6 +131,12 @@ internal abstract class TcpConnection : IDuplexConnection
     public ValueTask WriteAsync(ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+        if (buffer.IsEmpty)
+        {
+            throw new ArgumentException($"The {nameof(buffer)} cannot be empty.", nameof(buffer));
+        }
+
         return PerformWriteAsync();
 
         async ValueTask PerformWriteAsync()

--- a/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs
+++ b/tests/IceRpc.Conformance.Tests/Transports/DuplexConnectionConformanceTests.cs
@@ -334,6 +334,19 @@ public abstract class DuplexConnectionConformanceTests
         Assert.That(async () => await serverShutdownTask, Throws.Nothing);
     }
 
+    /// <summary>Verifies that a write with an empty buffer throws <see cref="ArgumentException" />.</summary>
+    [Test]
+    public async Task Write_with_empty_buffer_fails()
+    {
+        await using ServiceProvider provider = CreateServiceCollection().BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerDuplexConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        Assert.That(
+            async () => await sut.Client.WriteAsync(ReadOnlySequence<byte>.Empty, default),
+            Throws.TypeOf<ArgumentException>());
+    }
+
     /// <summary>Verifies that we can write and read using the duplex connection.</summary>
     [TestCase(3)]
     [TestCase(11)]


### PR DESCRIPTION
Addresses findings L-04, L-06 and L-07 of #4832.

- L-04: `IDuplexConnection.WriteAsync` documents `ArgumentException` for an empty buffer, and Coloc implements it, but `TcpConnection.WriteAsync` performed the empty socket/TLS write. It now throws like `TcpConnection.ReadAsync` already does for an empty read. A new `Write_with_empty_buffer_fails` conformance test covers all duplex transports — the read counterpart existed, the write one didn't.
- L-06: the `IMultiplexedStream.Id` and `IsStarted` docs stated that a local stream has no ID and is not started until the first write. That describes Slic; QUIC streams are started with an ID from construction. The docs now make the late start implementation-dependent.
- L-07: the client and server connection factories add one stream to `MaxIceRpcUnidirectionalStreams` for the icerpc protocol control stream; with `int.MaxValue` (previously a valid value) the addition wrapped negative. `MaxIceRpcBidirectionalStreams` and `MaxIceRpcUnidirectionalStreams` now reject values greater than `65,535` — the quic transport caps inbound stream counts at this value and Slic doesn't need more — and the control-stream addition saturates at `65,535`. #4880 tracks switching these properties to `ushort` in 0.7.

## What's Changed entry

Area: Core

- `ConnectionOptions.MaxIceRpcBidirectionalStreams` and `ConnectionOptions.MaxIceRpcUnidirectionalStreams` now reject values greater than `65,535`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
