### PR TITLE
Emit field attributes on variant enum record parameters

### DIFF
--- a/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
+++ b/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
@@ -134,7 +134,7 @@ internal static class VariantEnumGenerator
 
         // Build parameter list for the record constructor.
         string nameWithParams = variant.Fields.Count > 0
-            ? $"{variantName}({BuildParameterList(variant.Fields, "")})"
+            ? $"{variantName}({BuildParameterList(variant.Fields, currentNamespace)})"
             : variantName;
 
         return new ContainerBuilder("partial record class", nameWithParams)
@@ -324,13 +324,25 @@ internal static class VariantEnumGenerator
         return code;
     }
 
+    /// <summary>Builds the positional parameter list of a variant's record declaration: one parameter per field, with
+    /// the field's <c>cs::attribute</c> and <c>deprecated</c> attributes emitted on the property that the record
+    /// generates for the parameter.</summary>
     private static string BuildParameterList(ImmutableList<Field> fields, string currentNamespace)
     {
         return string.Join(", ", fields.Select(f =>
         {
+            string attributes = string.Concat(
+                f.Attributes.CSAttributes().Select(attr => $"[property: {attr.Args[0]}] "));
+            if (f.Attributes.IsDeprecated)
+            {
+                attributes += f.Attributes.DeprecatedMessage is string message ?
+                    $"[property: global::System.Obsolete(\"{message}\")] " :
+                    "[property: global::System.Obsolete] ";
+            }
+
             string typeString = f.DataType.FieldTypeString(f.DataTypeIsOptional, currentNamespace);
             string paramName = f.Name;
-            return $"{typeString} {paramName}";
+            return $"{attributes}{typeString} {paramName}";
         }));
     }
 }

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
@@ -166,6 +166,18 @@ public class VariantEnumTests
             Assert.That(decoder.Consumed, Is.EqualTo(1 + 1 + 1 + name.Length + 4 + 4));
         }
     }
+
+    [Test]
+    public void Cs_attribute_on_variant_field()
+    {
+        // Arrange / Act
+        var propertyInfo = typeof(ShapeWithFieldAttributes.Circle).GetProperty("Radius")!;
+        var attributes = propertyInfo.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
+        var description = ((System.ComponentModel.DescriptionAttribute)attributes[0]).Description;
+
+        // Assert
+        Assert.That(description, Is.EqualTo("The radius"));
+    }
 }
 
 [AttributeUsage(AttributeTargets.Class)]

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.slice
@@ -44,3 +44,7 @@ compact enum CompactShape {
     Triangle(side1: uint32, side2: uint32, side3: uint32)
     Oval(name: string?, major: uint32, minor: uint32)
 }
+
+enum ShapeWithFieldAttributes {
+    Circle([cs::attribute("System.ComponentModel.Description(\"The radius\")")] radius: uint32)
+}


### PR DESCRIPTION
Addresses finding L-11 of #4832.

The attribute validator accepts `cs::attribute` on variant enum fields, but `VariantEnumGenerator` emitted bare `type name` positional parameters, silently dropping the attributes. The generator now emits `cs::attribute` and `deprecated` attributes with the `property:` target, which applies them to the property the record generates for the parameter — the same place struct fields put theirs.

Also fixes `BuildParameterList` receiving `""` instead of the current namespace, which made entity-typed fields fully qualified (`global::...`) even for types in the same namespace.

The remaining piece of L-11 — the `@param` doc comments of variant fields — is not fixable in this repository: slicec never fills the `entityInfo.comment` of variant fields. This is the same converter gap as the `@returns` loss tracked by L-12; both are now filed upstream as icerpc/slicec#809.

## What's Changed entry

Area: Slice codec

- The Slice compiler now applies `cs::attribute` and `deprecated` attributes on variant enum fields to the properties it generates for these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
