### PR TITLE
Skip locator log decorators when logging is disabled

### DIFF
--- a/src/IceRpc.Locator/LocatorPipelineExtensions.cs
+++ b/src/IceRpc.Locator/LocatorPipelineExtensions.cs
@@ -29,7 +29,8 @@ public static class LocatorPipelineExtensions
             new LocatorLocationResolver(
                 locator,
                 new LocatorOptions(),
-                loggerFactory.CreateLogger<LocatorInterceptor>()));
+                loggerFactory is NullLoggerFactory ? NullLogger.Instance :
+                    loggerFactory.CreateLogger<LocatorInterceptor>()));
 
     /// <summary>Adds a <see cref="LocatorInterceptor" /> to the pipeline, using the specified location resolver.
     /// </summary>


### PR DESCRIPTION
Fixes #4858.

`UseLocator` created the logger with `loggerFactory.CreateLogger<LocatorInterceptor>()`, which wraps every factory — including `NullLoggerFactory` — in a `Logger<LocatorInterceptor>`, so `LocatorLocationResolver`'s `logger != NullLogger.Instance` checks never matched and the three log decorators were always installed. `UseLocator` now passes `NullLogger.Instance` directly when the factory is a `NullLoggerFactory`.

## What's Changed entry

None — internal optimization; no observable behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)