### PR TITLE
Reject invalid Slic StreamWindowUpdate frames

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -1243,7 +1243,7 @@ internal class SlicConnection : IMultiplexedConnection
                     throw new InvalidDataException($"Received {frameType} frame for unknown stream.");
                 }
 
-                return ReadStreamWindowUpdateFrameAsync(size, streamId!.Value, cancellationToken);
+                return ReadStreamWindowUpdateFrameAsync(size, streamId.Value, cancellationToken);
             }
             case FrameType.StreamReadsClosed:
             case FrameType.StreamWritesClosed:
@@ -1410,6 +1410,12 @@ internal class SlicConnection : IMultiplexedConnection
                 cancellationToken).ConfigureAwait(false);
             if (_streams.TryGetValue(streamId, out SlicStream? stream))
             {
+                if (stream.IsRemote && !stream.IsBidirectional)
+                {
+                    // The local side doesn't write on a remote unidirectional stream, so there is no window to update.
+                    throw new InvalidDataException(
+                        $"Received unexpected {nameof(FrameType.StreamWindowUpdate)} frame on remote unidirectional stream.");
+                }
                 stream.ReceivedWindowUpdateFrame(frame);
             }
         }

--- a/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicPipeWriter.cs
@@ -216,9 +216,8 @@ internal class SlicPipeWriter : ReadOnlySequencePipeWriter
         int newPeerWindowSize = Interlocked.Add(ref _peerWindowSize, size);
         if (newPeerWindowSize <= 0)
         {
-            throw new IceRpcException(
-                IceRpcError.IceRpcError,
-                $"The window update is trying to increase the window size to a value larger than allowed.");
+            throw new InvalidDataException(
+                "The window update is trying to increase the window size to a value larger than allowed.");
         }
 
         int previousPeerWindowSize = newPeerWindowSize - size;

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -316,13 +316,21 @@ internal class SlicStream : IMultiplexedStream
     /// <param name="frame">The body of the <see cref="FrameType.StreamWindowUpdate" /> frame.</param>
     internal void ReceivedWindowUpdateFrame(StreamWindowUpdateBody frame)
     {
+        // The connection rejects window updates on remote unidirectional streams, the only streams with no output
+        // pipe writer.
+        Debug.Assert(_outputPipeWriter is not null);
+
+        if (frame.WindowSizeIncrement == 0)
+        {
+            throw new InvalidDataException(
+                $"Received {nameof(FrameType.StreamWindowUpdate)} frame with a zero window size increment.");
+        }
         if (frame.WindowSizeIncrement > SlicTransportOptions.MaxWindowSize)
         {
-            throw new IceRpcException(
-                IceRpcError.IceRpcError,
-                $"The window update is trying to increase the window size to a value larger than allowed.");
+            throw new InvalidDataException(
+                "The window update is trying to increase the window size to a value larger than allowed.");
         }
-        _outputPipeWriter!.ReceivedWindowUpdateFrame((int)frame.WindowSizeIncrement);
+        _outputPipeWriter.ReceivedWindowUpdateFrame((int)frame.WindowSizeIncrement);
     }
 
     /// <summary>Notifies the stream of the reception of a <see cref="FrameType.StreamWritesClosed" /> frame.</summary>

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -906,6 +906,7 @@ public class SlicTransportTests
             streamId: 0ul,
             (ref SliceEncoder encoder) => encoder.EncodeBool(false));
         IMultiplexedStream acceptedStream = await multiplexedServerConnection.AcceptStreamAsync(default);
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
 
         // Act - send a StreamWindowUpdate that pushes the server's cumulative window over int.MaxValue.
         await WriteStreamFrameAsync(
@@ -914,15 +915,118 @@ public class SlicTransportTests
             streamId: 0ul,
             (ref SliceEncoder encoder) => new StreamWindowUpdateBody(1).Encode(ref encoder));
 
-        // Assert - the overflow rejection tears down the connection. Depending on whether AcceptStreamAsync
-        // observes the close state via the already-set _isClosed path or via the accept-channel completion, it
-        // may surface the close error (ConnectionAborted) or the original SlicPipeWriter exception (IceRpcError),
-        // so accept either.
-        IceRpcException exception = Assert.ThrowsAsync<IceRpcException>(
-            async () => await multiplexedServerConnection.AcceptStreamAsync(default))!;
+        // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
+        Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
         Assert.That(
-            exception.IceRpcError,
-            Is.EqualTo(IceRpcError.ConnectionAborted).Or.EqualTo(IceRpcError.IceRpcError));
+            exception.InnerException?.Message,
+            Is.EqualTo("The window update is trying to increase the window size to a value larger than allowed."));
+
+        acceptedStream.Output.Complete();
+        acceptedStream.Input.Complete();
+    }
+
+    [Test]
+    public async Task Reject_window_update_on_remote_unidirectional_stream()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open the first remote unidirectional stream (stream ID 2).
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 2ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream acceptedStream = await multiplexedServerConnection.AcceptStreamAsync(default);
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Act - send a StreamWindowUpdate on the stream the client writes to; the server has no output on it.
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.StreamWindowUpdate,
+            streamId: 2ul,
+            (ref SliceEncoder encoder) => new StreamWindowUpdateBody(1).Encode(ref encoder));
+
+        // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
+        Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
+        Assert.That(
+            exception.InnerException?.Message,
+            Is.EqualTo("Received unexpected StreamWindowUpdate frame on remote unidirectional stream."));
+
+        acceptedStream.Input.Complete();
+    }
+
+    [Test]
+    public async Task Reject_window_update_with_zero_increment()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open the first remote bidirectional stream (stream ID 0).
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.Stream,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream acceptedStream = await multiplexedServerConnection.AcceptStreamAsync(default);
+        ValueTask<IMultiplexedStream> acceptStreamTask = multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Act
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.StreamWindowUpdate,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => new StreamWindowUpdateBody(0).Encode(ref encoder));
+
+        // Assert
+        IceRpcException? exception = Assert.ThrowsAsync<IceRpcException>(async () => await acceptStreamTask);
+        Assert.That(exception!.IceRpcError, Is.EqualTo(IceRpcError.IceRpcError));
+        Assert.That(exception.Message, Is.EqualTo("The connection was aborted by a Slic protocol error."));
+        Assert.That(
+            exception.InnerException?.Message,
+            Is.EqualTo("Received StreamWindowUpdate frame with a zero window size increment."));
 
         acceptedStream.Output.Complete();
         acceptedStream.Input.Complete();


### PR DESCRIPTION
This PR fixes the handling of two invalid `StreamWindowUpdate` frames a peer can send on a Slic connection:

- A `StreamWindowUpdate` frame on a remote unidirectional stream. The local side doesn't write on such a stream, so there is no window to update; the frame previously triggered a `NullReferenceException` in the read frames task (`SlicStream` creates no output pipe writer for a remote unidirectional stream), closing the connection as `ConnectionAborted` instead of reporting a protocol error.
- A `StreamWindowUpdate` frame with a zero window size increment, which previously tripped a `Debug.Assert` in `SlicPipeWriter`.

Both are now rejected with an `InvalidDataException`, which the read frames task reports as a Slic protocol error. The adjacent max window size checks now also throw `InvalidDataException` instead of `IceRpcException` so that all window update validation failures get the same protocol-error classification; this allowed tightening the error assertions in the existing `Reject_window_update_causing_overflow` test.

## What's Changed entry

None — improves the error thrown on malformed input.