### PR TITLE
Send the bundled StreamReadsClosed frame only with the last stream frame

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -865,7 +865,7 @@ internal class SlicConnection : IMultiplexedConnection
     /// <param name="endStream"><see langword="true" /> to write a <see cref="FrameType.StreamLast" /> frame and
     /// <see langword="false" /> to write a <see cref="FrameType.Stream" /> frame.</param>
     /// <param name="writeReadsClosedFrame"><see langword="true" /> if a <see cref="FrameType.StreamReadsClosed" />
-    /// frame should be written after the stream frame.</param>
+    /// frame should be written after the last stream frame.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <remarks>This method is called by streams and might be called on a closed connection. The connection might
     /// also be closed concurrently while it's in progress.</remarks>
@@ -982,7 +982,7 @@ internal class SlicConnection : IMultiplexedConnection
                         _duplexConnectionWriter.Write(sendSource2);
                     }
 
-                    if (writeReadsClosedFrame)
+                    if (writeReadsClosedFrame && lastStreamFrame)
                     {
                         WriteFrame(FrameType.StreamReadsClosed, stream.Id, encode: null);
                     }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -928,6 +928,69 @@ public class SlicTransportTests
         acceptedStream.Input.Complete();
     }
 
+    /// <summary>Verifies that the StreamReadsClosed frame bundled with the closure of writes is sent once, after the
+    /// last stream frame, when the data is written in multiple stream frames.</summary>
+    [Test]
+    public async Task Bundled_reads_closed_frame_is_sent_once_after_the_last_stream_frame()
+    {
+        // Arrange
+        await using ServiceProvider provider = new ServiceCollection()
+            .AddSlicTest()
+            .BuildServiceProvider(validateScopes: true);
+
+        var duplexClientTransport = provider.GetRequiredService<IDuplexClientTransport>();
+        var listener = provider.GetRequiredService<IListener<IMultiplexedConnection>>();
+        var acceptTask = listener.AcceptAsync(default);
+        using var duplexClientConnection = duplexClientTransport.CreateConnection(
+            listener.TransportAddress,
+            new DuplexConnectionOptions(),
+            clientAuthenticationOptions: null);
+        Task connectTask = duplexClientConnection.ConnectAsync(default);
+        (var multiplexedServerConnection, var transportConnectionInformation) = await acceptTask;
+        await using var serverConnectionHandle = multiplexedServerConnection;
+        await connectTask;
+        using var reader = new DuplexConnectionReader(duplexClientConnection, MemoryPool<byte>.Shared, 4096);
+
+        // WriteInitializeFrameAsync advertises MaxStreamFrameSize = 4096.
+        await WriteInitializeFrameAsync(duplexClientConnection, version: 1);
+        await multiplexedServerConnection.ConnectAsync(default);
+        await ReadFrameAsync(reader);
+
+        // Open the first remote bidirectional stream (stream ID 0) and close its writes with a last stream frame.
+        await WriteStreamFrameAsync(
+            duplexClientConnection,
+            FrameType.StreamLast,
+            streamId: 0ul,
+            (ref SliceEncoder encoder) => encoder.EncodeBool(false));
+        IMultiplexedStream acceptedStream = await multiplexedServerConnection.AcceptStreamAsync(default);
+
+        // Consume all the stream data to gracefully close reads; the StreamReadsClosed frame is deferred until the
+        // closure of writes.
+        ReadResult readResult = await acceptedStream.Input.ReadAsync(default);
+        Assert.That(readResult.IsCompleted, Is.True);
+        acceptedStream.Input.AdvanceTo(readResult.Buffer.End);
+
+        // Act - write data that spans multiple stream frames, closing writes.
+        await ((ReadOnlySequencePipeWriter)acceptedStream.Output).WriteAsync(
+            new ReadOnlySequence<byte>(new byte[10_000]),
+            endStream: true,
+            default);
+
+        // Assert - the StreamReadsClosed frame is sent once, after the StreamLast frame.
+        List<FrameType> frameTypes = [];
+        while (frameTypes.Count < 4)
+        {
+            (FrameType frameType, ReadOnlySequence<byte> _) = await ReadFrameAsync(reader);
+            frameTypes.Add(frameType);
+        }
+        Assert.That(
+            frameTypes,
+            Is.EqualTo(new[] { FrameType.Stream, FrameType.Stream, FrameType.StreamLast, FrameType.StreamReadsClosed }));
+
+        acceptedStream.Output.Complete();
+        acceptedStream.Input.Complete();
+    }
+
     [Test]
     public async Task Reject_stream_frame_exceeding_max_size()
     {


### PR DESCRIPTION
Fixes #4798.

When a stream's reads are gracefully closed before its writes, the sending of the `StreamReadsClosed` frame is deferred so that it can be bundled with the `StreamLast` (or `StreamWritesClosed`) frame in a single write on the duplex connection. In `WriteStreamDataFrameAsync`, however, the emit site sat inside the chunking loop with a loop-invariant flag: data larger than the peer's maximum stream frame size produced one `StreamReadsClosed` frame per chunk instead of one. The duplicates were harmless — the receiver's handling is idempotent — but redundant.

The fix guards the emit with `lastStreamFrame`, so the frame is written exactly once, bundled with the `StreamLast` frame. This is safe because `writeReadsClosedFrame` can only be true when `endStream` is true, so the last iteration always qualifies.

### Why delaying the frame to the last chunk is fine

The fix delays when the peer receives the `StreamReadsClosed` frame (previously the first duplicate went out with the first chunk). This matters for neither of the two reads-closure cases:

- When the application stops reading before consuming all the data ("I don't want more data"), `CloseReads(graceful: false)` sends the `StreamReadsClosed` frame immediately, as its own write. This is the case where delivery timing matters — it's what lets the peer abort a large write mid-flight — and it doesn't use the bundling path at all.
- The deferred/bundled path is only armed by `CloseReads(graceful: true)`, which is called only when the application consumed all the stream data including the end-of-stream — meaning the peer already closed its writes on the stream. At that point the notification is pure bookkeeping: the peer has nothing left to write, and it releases the stream only once its own reads complete, which necessarily happens after the `StreamLast` frame anyway.

The new test writes data spanning multiple stream frames on a stream whose reads were gracefully closed, and asserts the exact frame sequence received by the peer: `Stream`, `Stream`, `StreamLast`, `StreamReadsClosed`.

## What's Changed entry

None — the duplicate frames were harmless and not visible to applications.