### PR TITLE
Fix documentation inaccuracies

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -44,7 +44,7 @@
       }
     ],
     "sitemap": {
-      "baseUrl": "https://docs.icerpc.dev"
+      "baseUrl": "https://code.icerpc.dev/csharp/main/api"
     },
     "overwrite": [
       {

--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -15,7 +15,7 @@ you can use proto2, proto3, or editions (e.g. `edition = "2024"`) in your own pr
 | [MultipleServices](./MultipleServices) | Shows how a service can implement multiple Protobuf services.                                                                       |
 | [RequestContext](./RequestContext/)    | Shows how to attach information to an invocation and retrieve this information from the dispatch in the server.                     |
 | [Retry](./Retry/)                      | Shows how to use the retry interceptor to retry failed requests.                                                                    |
-| [Stream](./Stream/)                    | Shows how to stream data from a client to a server.                                                                                 |
+| [Stream](./Stream/)                    | Shows how to stream data from a server to a client.                                                                                 |
 | [Tcp](./Tcp/)                          | Shows how to use the TCP transport.                                                                                                 |
 | [TcpFallback](./TcpFallback/)          | Shows how to create client and server applications that communicate over QUIC when possible but can fall back to TCP.               |
 | [Telemetry](./Telemetry/)              | Shows how to use the telemetry interceptor and middleware.                                                                          |

--- a/examples/protobuf/TcpFallback/README.md
+++ b/examples/protobuf/TcpFallback/README.md
@@ -32,6 +32,7 @@ cd Client
 dotnet run
 ```
 
-In order to see the fallback to TCP, run the TCP fallback client with the server from the [../Secure] example.
+In order to see the fallback to TCP, comment out `quicServer.Listen();` in the Server program and restart it: the
+client's QUIC connection attempt fails and the client falls back to a TCP connection.
 
 [quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/README.md
+++ b/examples/slice/README.md
@@ -16,7 +16,7 @@ This folder contains example applications that showcase the IceRPC + Slice integ
 | [MultipleInterfaces](./MultipleInterfaces) | Shows how a service can implement multiple interfaces.                                                                              |
 | [RequestContext](./RequestContext/)        | Shows how to attach information to an invocation and retrieve this information from the dispatch in the server.                     |
 | [Retry](./Retry/)                          | Shows how to use the retry interceptor to retry failed requests.                                                                    |
-| [Stream](./Stream/)                        | Shows how to stream data from a client to a server.                                                                                 |
+| [Stream](./Stream/)                        | Shows how to stream data from a server to a client.                                                                                 |
 | [Tcp](./Tcp/)                              | Shows how to use the TCP transport.                                                                                                 |
 | [TcpFallback](./TcpFallback/)              | Shows how to create client and server applications that communicate over QUIC when possible but can fall back to TCP.               |
 | [Telemetry](./Telemetry/)                  | Shows how to use the telemetry interceptor and middleware.                                                                          |

--- a/examples/slice/TcpFallback/README.md
+++ b/examples/slice/TcpFallback/README.md
@@ -32,6 +32,7 @@ cd Client
 dotnet run
 ```
 
-In order to see the fallback to TCP, run the TCP fallback client with the server from the [../Secure] example.
+In order to see the fallback to TCP, comment out `quicServer.Listen();` in the Server program and restart it: the
+client's QUIC connection attempt fails and the client falls back to a TCP connection.
 
 [quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/src/IceRpc.Ice/README.md
+++ b/src/IceRpc.Ice/README.md
@@ -86,7 +86,7 @@ internal partial class Chatbot : IGreeterService
 ```
 
 [api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Ice.html
-[docs]: TBD
+[docs]: https://docs.icerpc.dev/icerpc-for-ice-users
 [ice]: https://zeroc.com/ice
 [examples]: https://github.com/icerpc/icerpc-csharp/tree/main/examples
 [package]: https://www.nuget.org/packages/IceRpc.Ice

--- a/src/IceRpc.Protobuf.Tools/README.md
+++ b/src/IceRpc.Protobuf.Tools/README.md
@@ -4,8 +4,8 @@ The `IceRpc.Protobuf.Tools` NuGet package allows you to compile Protobuf definit
 within MSBuild projects.
 
 This package includes the Protobuf compiler, `protoc`, and the `protoc-gen-icerpc-csharp` generator. The `protoc`
-compiler is a native tool with binaries for Linux x64, Linux arm64, macOS x64, macOS arm64, and Windows x64. The
-`protoc-gen-icerpc-csharp` generator is a .NET program and requires .NET 8 or later.
+compiler is a native tool with binaries for Linux (x64 and arm64), macOS (x64 and arm64) and Windows (x64). The
+`protoc-gen-icerpc-csharp` generator is a cross-platform .NET program.
 
 Once you've added the IceRpc.Protobuf.Tools NuGet package to your project, the Protobuf files of your project are
 automatically compiled into C# files every time you build this project.
@@ -84,8 +84,9 @@ You need to reference the `IceRpc.Protobuf` NuGet package to compile the generat
 ## Protobuf compiler
 
 This package includes the `protoc` compiler binaries, and the Protobuf well-known type definitions from the
-[Google.Protobuf.Tools][google-protobuf-tools] package. Additionally, it includes the `protoc` ARM64 binaries
-for Linux and macOS from the [Google Protobuf release page][google-protobuf-release].
+[Google.Protobuf.Tools][google-protobuf-tools] package. Additionally, it includes the `protoc` macOS ARM64 binary
+from the [Google Protobuf release page][google-protobuf-release], as the Google.Protobuf.Tools package doesn't
+provide this binary.
 
 ## Build telemetry
 

--- a/src/IceRpc.ServiceGenerator/README.md
+++ b/src/IceRpc.ServiceGenerator/README.md
@@ -5,7 +5,7 @@ decorated with the `[IceRpc.Service]` attribute.
 
 [Package][package] | [Source code][source]
 
-This package is a dependency of the [IceRPC + Slice][icerpc+slice], [IceRPC + Protobuf][icerpc+protobuf] and
+This package is a dependency of the [IceRPC + Slice][icerpc+slice], [IceRPC + Protobuf][icerpc+protobuf], and
 [IceRPC + Ice][icerpc+ice] integrations.
 
 [icerpc+ice]: https://www.nuget.org/packages/IceRpc.Ice

--- a/src/IceRpc.ServiceGenerator/README.md
+++ b/src/IceRpc.ServiceGenerator/README.md
@@ -5,9 +5,11 @@ decorated with the `[IceRpc.Service]` attribute.
 
 [Package][package] | [Source code][source]
 
-This package is a dependency of the [IceRPC + Slice][icerpc+slice] and [IceRPC + Ice][icerpc+ice] integrations.
+This package is a dependency of the [IceRPC + Slice][icerpc+slice], [IceRPC + Protobuf][icerpc+protobuf] and
+[IceRPC + Ice][icerpc+ice] integrations.
 
 [icerpc+ice]: https://www.nuget.org/packages/IceRpc.Ice
+[icerpc+protobuf]: https://www.nuget.org/packages/IceRpc.Protobuf
 [icerpc+slice]: https://www.nuget.org/packages/IceRpc.Slice
 [package]: https://www.nuget.org/packages/IceRpc.ServiceGenerator
 [source]: https://github.com/icerpc/icerpc-csharp/tree/main/src/IceRpc.ServiceGenerator

--- a/src/IceRpc.Telemetry/README.md
+++ b/src/IceRpc.Telemetry/README.md
@@ -7,6 +7,9 @@ activity context is propagated with the request using the trace context request 
 an activity per dispatch. When the trace context request field is present in the incoming request the telemetry
 middleware restores the activity context and uses it to set the parent activity of the dispatch activity it starts.
 
+The telemetry interceptor and middleware create activities only for requests that use the `icerpc` protocol; they
+don't create activities for requests that use the `ice` protocol.
+
 [Source code][source] | [Package][package] | [Example][example] | [API reference][api] | [Interceptor documentation][interceptor] | [Middleware documentation][middleware]
 
 ## Sample code

--- a/src/IceRpc/Ice/Codec/IceDecoder.cs
+++ b/src/IceRpc/Ice/Codec/IceDecoder.cs
@@ -343,7 +343,7 @@ public ref partial struct IceDecoder
                 break;
             }
 
-            var format = (TagFormat)(v & 0x07); // Read first 3 bits.
+            var format = (TagFormat)(v & 0x07); // Read the low-order 3 bits.
             if ((v >> 3) == 30)
             {
                 SkipSize();
@@ -417,7 +417,7 @@ public ref partial struct IceDecoder
                 return false;
             }
 
-            var format = (TagFormat)(v & 0x07); // First 3 bits.
+            var format = (TagFormat)(v & 0x07); // The low-order 3 bits.
             tag = v >> 3;
             if (tag == 30)
             {

--- a/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
+++ b/src/IceRpc/Ice/Codec/IceEncoder.Class.cs
@@ -103,7 +103,7 @@ public ref partial struct IceEncoder
 
     /// <summary>Marks the start of the encoding of a class or exception slice.</summary>
     /// <param name="typeId">The type ID of this slice.</param>
-    /// <param name="compactId ">The compact ID of this slice, if any.</param>
+    /// <param name="compactId">The compact ID of this slice, if any.</param>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void StartSlice(string typeId, int? compactId = null)
     {
@@ -230,7 +230,8 @@ public ref partial struct IceEncoder
 
     /// <summary>Encodes sliced-off slices.</summary>
     /// <param name="unknownSlices">The sliced-off slices to encode.</param>
-    /// <param name="fullySliced">When <see langword="true" />, slicedData holds all the data of this instance.</param>
+    /// <param name="fullySliced">When <see langword="true" />, <paramref name="unknownSlices" /> holds all the data of
+    /// this instance.</param>
     private void EncodeUnknownSlices(ImmutableList<SliceInfo> unknownSlices, bool fullySliced)
     {
         Debug.Assert(_classContext.Current.InstanceType != InstanceType.None);

--- a/src/IceRpc/Ice/Codec/IceEncoder.cs
+++ b/src/IceRpc/Ice/Codec/IceEncoder.cs
@@ -171,7 +171,7 @@ public ref partial struct IceEncoder
     // Other methods
 
     /// <summary>Encodes a non-null tagged value. The number of bytes needed to encode the value is known before
-    /// encoding the value. This method always use the VSize tag format.</summary>
+    /// encoding the value. This method always uses the VSize tag format.</summary>
     /// <typeparam name="T">The type of the value being encoded.</typeparam>
     /// <param name="tag">The tag.</param>
     /// <param name="size">The number of bytes needed to encode the value.</param>
@@ -202,11 +202,13 @@ public ref partial struct IceEncoder
     /// <summary>Encodes a tagged value. The number of bytes needed to encode the value is not known before
     /// encoding this value. T can be a proxy such as IceObjectProxy? and therefore nullable.</summary>
     /// <typeparam name="T">The type of the value being encoded.</typeparam>
-    /// <param name="tag">The tag. Must be either FSize or OptimizedVSize.</param>
-    /// <param name="tagFormat">The tag format.</param>
+    /// <param name="tag">The tag.</param>
+    /// <param name="tagFormat">The tag format. Must not be <see cref="TagFormat.VSize" /> or
+    /// <see cref="TagFormat.Class" />.</param>
     /// <param name="v">The value to encode.</param>
     /// <param name="encodeAction">The delegate that encodes the value after the tag header.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="tagFormat" /> is VSize.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="tagFormat" /> is not a tag format supported by
+    /// this method.</exception>
     public void EncodeTagged<T>(
         int tag,
         TagFormat tagFormat,

--- a/src/IceRpc/Ice/Codec/SliceInfo.cs
+++ b/src/IceRpc/Ice/Codec/SliceInfo.cs
@@ -10,7 +10,8 @@ public sealed class SliceInfo
     /// compact ID is a non-negative integer in decimal notation.</summary>
     public string TypeId { get; }
 
-    /// <summary>Gets the encoded bytes for this slice, including the leading size integer.</summary>
+    /// <summary>Gets the encoded bytes for this slice, excluding the leading slice size. When the slice has tagged
+    /// fields, the trailing tag end marker is also excluded.</summary>
     public ReadOnlyMemory<byte> Bytes { get; }
 
     /// <summary>Gets a value indicating whether or not the slice contains tagged fields.</summary>


### PR DESCRIPTION
This PR fixes the trivial documentation findings of #4829:

- **L-19**: The TcpFallback READMEs referenced the `Secure` example, removed by #4211. The instructions to observe the TCP fallback are now self-contained: comment out `quicServer.Listen()` in the Server program.
- **L-21**: The Slice and Protobuf example indexes described the Stream example as streaming from client to server; it streams from server to client.
- **L-31**: `SliceInfo.Bytes` was documented as including the leading slice size; it excludes it, along with the tag end marker when the slice has tagged fields. The `EncodeTagged` doc attached a false format constraint to the `tag` parameter (the accepted formats are F1/F2/F4/F8/Size/FSize/OptimizedVSize) and documented only `VSize` as throwing.
- **L-33**: The Telemetry README now states that activities are created only for requests that use the `icerpc` protocol, matching the interceptor/middleware API docs.
- **L-35**: The docfx sitemap `baseUrl` still pointed at `docs.icerpc.dev`; the API reference is published at `code.icerpc.dev/csharp/<branch>/api/` (leftover from #4674).
- **L-37**: The IceRpc.Ice package README shipped a literal `[docs]: TBD` link; it now points to the IceRPC for Ice users documentation.
- **L-38**: The Protobuf.Tools README claimed the generator requires .NET 8 (it targets .NET 10) and credited the Linux ARM64 `protoc` to the Protobuf release page (it comes from Google.Protobuf.Tools; only the macOS ARM64 binary is downloaded separately). The tool description now matches the Slice.Tools README wording.
- **L-39**: The ServiceGenerator README now lists the Protobuf integration alongside Slice and Ice.
- **L-36** (grouped XML comment drift) is otherwise declined as unactionable — its transport-stream-state claim names a member that doesn't exist — but the sweep surfaced three micro-nits fixed here: a trailing space that unbound the `compactId` param doc, a param doc referencing the old `slicedData` parameter name, and two "first 3 bits" comments that meant the low-order bits.

L-32 (README snippets), L-22 (QUIC prerequisites) and L-34 (template builds) are addressed in separate PRs.

## What's Changed entry

None — documentation fixes.