### PR TITLE
Document the QUIC platform prerequisites

### DIFF
--- a/examples/json/CurrentWeather/README.md
+++ b/examples/json/CurrentWeather/README.md
@@ -21,6 +21,9 @@ flowchart LR
     ForecastService -- https --> OpenWeather[OpenMeteo Weather Forecast Service]
 ```
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -42,3 +45,4 @@ dotnet run Paris
 ```
 
 [Open Meteo]: https://open-meteo.com/
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/json/Greeter/README.md
+++ b/examples/json/Greeter/README.md
@@ -2,6 +2,9 @@
 
 A simple Greeter that uses the core IceRPC APIs - and encodes request/response payloads with JSON.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Deadline/README.md
+++ b/examples/protobuf/Deadline/README.md
@@ -4,6 +4,9 @@ The Deadline example illustrates how to use the deadline interceptor to add an i
 how invocations that exceed the deadline fail with TimeoutException. It also demonstrates how the [IDeadlineFeature]
 can be used to set the deadline for an invocation.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -25,3 +28,4 @@ dotnet run
 ```
 
 [IDeadlineFeature]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Features.IDeadlineFeature.html
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/GenericHost/README.md
+++ b/examples/protobuf/GenericHost/README.md
@@ -2,6 +2,9 @@
 
 This example shows how to use dependency injection and the .NET Generic Host with IceRPC client and server applications.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Greeter/README.md
+++ b/examples/protobuf/Greeter/README.md
@@ -2,6 +2,9 @@
 
 The Greeter example illustrates how to send a request and wait for the response.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -24,3 +27,5 @@ dotnet run
 
 > This is a concise example with minimal code. If you are looking for a more realistic example, see the
 > [Logger](../Logger/README.md) example.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Logger/README.md
+++ b/examples/protobuf/Logger/README.md
@@ -8,6 +8,9 @@ interceptor in this pipeline (the logger interceptor).
 And the server is a more typical server than Greeter's server because it creates a router (dispatch pipeline) and
 installs a middleware in this pipeline (the logger middleware).
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -31,3 +34,5 @@ dotnet run
 You will notice the two logger categories in the output. The client shows log messages for `IceRpc.ClientConnection` and
 `IceRpc.Logger.LoggerInterceptor`, while the server shows log messages for `IceRpc.Server` and
 `IceRpc.Logger.LoggerMiddleware`.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Metrics/README.md
+++ b/examples/protobuf/Metrics/README.md
@@ -7,6 +7,9 @@ To collect counter metrics, you need to install the `dotnet-counters` tools.
 
 https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -38,3 +41,5 @@ To monitor the client counter metrics, in a separate window run:
 ```shell
 dotnet-counters monitor --name Client --counters IceRpc.Invocation
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/MultipleServices/README.md
+++ b/examples/protobuf/MultipleServices/README.md
@@ -2,6 +2,9 @@
 
 This example shows an IceRPC service that implements multiple Protobuf services.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/RequestContext/README.md
+++ b/examples/protobuf/RequestContext/README.md
@@ -4,6 +4,9 @@ This example illustrates how to use the request context interceptor to encode re
 context fields. It also shows how to use the request context middleware to decode request context fields into request
 context features.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -23,3 +26,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Retry/README.md
+++ b/examples/protobuf/Retry/README.md
@@ -8,6 +8,9 @@ on a different server address. The retry interceptor will automatically retry fa
 max attempts. If the retry interceptor reaches the max retry attempts, or if it exhausted all available server
 addresses, it gives up on retrying and reports the failure.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -48,3 +51,5 @@ attempts, or if it has exhausted all available server addresses.
 
 You can also stop some of the servers while the client is running. The client will keep sending invocations unless all
 remaining servers throw `DispatchException(StatusCode.Unavailable)`.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Stream/README.md
+++ b/examples/protobuf/Stream/README.md
@@ -2,6 +2,9 @@
 
 This example application illustrates how to stream random numbers from a server to a client.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/TcpFallback/README.md
+++ b/examples/protobuf/TcpFallback/README.md
@@ -9,6 +9,9 @@ The server program creates a server for QUIC and another server for TCP; both se
 The client program first attempts to establish a QUIC connection; if this connection establishment fails, it falls back
 to a TCP connection.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -30,3 +33,5 @@ dotnet run
 ```
 
 In order to see the fallback to TCP, run the TCP fallback client with the server from the [../Secure] example.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Telemetry/README.md
+++ b/examples/protobuf/Telemetry/README.md
@@ -5,6 +5,9 @@ with OpenTelemetry to export traces over the OpenTelemetry Protocol (OTLP). The 
 context is propagated from the client to the server, by just configuring the IceRPC telemetry interceptor and
 middleware.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -36,3 +39,5 @@ dotnet run
 The trace information should now be available in the Jaeger UI:
 
 - <http://localhost:16686>
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Thermostat/README.md
+++ b/examples/protobuf/Thermostat/README.md
@@ -49,6 +49,9 @@ Server also calls a service on the device that implements Protobuf service `Ther
 
 ## Build and run
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client, server and device with:
 
 ``` shell
@@ -86,3 +89,5 @@ set point to 70°F with:
 cd Client
 dotnet run set 70
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/protobuf/Thermostat/README.md
+++ b/examples/protobuf/Thermostat/README.md
@@ -52,7 +52,7 @@ Server also calls a service on the device that implements Protobuf service `Ther
 This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
 steps; see .NET's [QUIC platform dependencies][quic-platform].
 
-You can build the client, server and device with:
+You can build the client, server, and device applications with:
 
 ``` shell
 dotnet build

--- a/examples/slice/Compress/README.md
+++ b/examples/slice/Compress/README.md
@@ -3,6 +3,9 @@
 This example application illustrates how to use the compress interceptor and middleware to
 transparently compress and decompress requests and responses.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -22,3 +25,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/CustomError/README.md
+++ b/examples/slice/CustomError/README.md
@@ -5,6 +5,9 @@ type returned upon success while Failure is the type returned upon failure.
 
 In this example, Success holds a string while Failure holds a user-defined type (an enum).
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -24,3 +27,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Deadline/README.md
+++ b/examples/slice/Deadline/README.md
@@ -4,6 +4,9 @@ The Deadline example illustrates how to use the deadline interceptor to add an i
 how invocations that exceed the deadline fail with TimeoutException. It also demonstrates how the [IDeadlineFeature]
 can be used to set the deadline for an invocation.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -25,3 +28,4 @@ dotnet run
 ```
 
 [IDeadlineFeature]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Features.IDeadlineFeature.html
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/DiscriminatedUnion/README.md
+++ b/examples/slice/DiscriminatedUnion/README.md
@@ -10,6 +10,9 @@ Since C# does not provide native support for discriminated unions, the Slice cod
 enum to several C# record classes and relies on the [Dunet] source generator to provide various methods for these record
 classes.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -31,3 +34,4 @@ dotnet run
 ```
 
 [Dunet]: https://github.com/domn1995/dunet
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Download/README.md
+++ b/examples/slice/Download/README.md
@@ -2,6 +2,9 @@
 
 This example application illustrates how to transmit a file from a server to a client as a stream of bytes.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/GenericHost/README.md
+++ b/examples/slice/GenericHost/README.md
@@ -2,6 +2,9 @@
 
 This example shows how to use dependency injection and the .NET Generic Host with IceRPC client and server applications.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Greeter/README.md
+++ b/examples/slice/Greeter/README.md
@@ -2,6 +2,9 @@
 
 The Greeter example illustrates how to send a request and wait for the response.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -24,3 +27,5 @@ dotnet run
 
 > This is a concise example with minimal code. If you are looking for a more realistic example, see the
 > [Logger](../Logger/README.md) example.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Logger/README.md
+++ b/examples/slice/Logger/README.md
@@ -8,6 +8,9 @@ interceptor in this pipeline (the logger interceptor).
 And the server is a more typical server than Greeter's server because it creates a router (dispatch pipeline) and
 installs a middleware in this pipeline (the logger middleware).
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -31,3 +34,5 @@ dotnet run
 You will notice the two logger categories in the output. The client shows log messages for `IceRpc.ClientConnection` and
 `IceRpc.Logger.LoggerInterceptor`, while the server shows log messages for `IceRpc.Server` and
 `IceRpc.Logger.LoggerMiddleware`.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Metrics/README.md
+++ b/examples/slice/Metrics/README.md
@@ -7,6 +7,9 @@ To collect counter metrics, you need to install the `dotnet-counters` tools.
 
 https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -38,3 +41,5 @@ To monitor the client counter metrics, in a separate window run:
 ```shell
 dotnet-counters monitor --name Client --counters IceRpc.Invocation
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/MultipleInterfaces/README.md
+++ b/examples/slice/MultipleInterfaces/README.md
@@ -2,6 +2,9 @@
 
 This example shows a service that implements multiple Slice interfaces.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/RequestContext/README.md
+++ b/examples/slice/RequestContext/README.md
@@ -4,6 +4,9 @@ This example illustrates how to use the request context interceptor to encode re
 context fields. It also shows how to use the request context middleware to decode request context fields into request
 context features.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -23,3 +26,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Retry/README.md
+++ b/examples/slice/Retry/README.md
@@ -8,6 +8,9 @@ on a different server address. The retry interceptor will automatically retry fa
 max attempts. If the retry interceptor reaches the max retry attempts, or if it exhausted all available server
 addresses, it gives up on retrying and reports the failure.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -48,3 +51,5 @@ attempts, or if it has exhausted all available server addresses.
 
 You can also stop some of the servers while the client is running. The client will keep sending invocations unless all
 remaining servers throw `DispatchException(StatusCode.Unavailable)`.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Stream/README.md
+++ b/examples/slice/Stream/README.md
@@ -2,6 +2,9 @@
 
 This example application illustrates how to stream random numbers from a server to a client.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/TcpFallback/README.md
+++ b/examples/slice/TcpFallback/README.md
@@ -9,6 +9,9 @@ The server program creates a server for QUIC and another server for TCP; both se
 The client program first attempts to establish a QUIC connection; if this connection establishment fails, it falls back
 to a TCP connection.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -30,3 +33,5 @@ dotnet run
 ```
 
 In order to see the fallback to TCP, run the TCP fallback client with the server from the [../Secure] example.
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Telemetry/README.md
+++ b/examples/slice/Telemetry/README.md
@@ -5,6 +5,9 @@ with OpenTelemetry to export traces over the OpenTelemetry Protocol (OTLP). The 
 context is propagated from the client to the server, by just configuring the IceRPC telemetry interceptor and
 middleware.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -36,3 +39,5 @@ dotnet run
 The trace information should now be available in the Jaeger UI:
 
 - <http://localhost:16686>
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Thermostat/README.md
+++ b/examples/slice/Thermostat/README.md
@@ -48,6 +48,9 @@ Server also calls a service on the device that implements Slice interface `Therm
 
 ## Build and run
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client, server and device with:
 
 ``` shell
@@ -85,3 +88,5 @@ set point to 70°F with:
 cd Client
 dotnet run set 70
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/examples/slice/Thermostat/README.md
+++ b/examples/slice/Thermostat/README.md
@@ -51,7 +51,7 @@ Server also calls a service on the device that implements Slice interface `Therm
 This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
 steps; see .NET's [QUIC platform dependencies][quic-platform].
 
-You can build the client, server and device with:
+You can build the client, server, and device applications with:
 
 ``` shell
 dotnet build

--- a/examples/slice/Upload/README.md
+++ b/examples/slice/Upload/README.md
@@ -2,6 +2,9 @@
 
 This example application illustrates how to stream bytes from a local file to a server.
 
+This example uses QUIC, IceRPC's default multiplexed transport. On Linux and macOS, QUIC requires extra setup
+steps; see .NET's [QUIC platform dependencies][quic-platform].
+
 You can build the client and server applications with:
 
 ``` shell
@@ -21,3 +24,5 @@ In a separate terminal, start the Client program:
 cd Client
 dotnet run
 ```
+
+[quic-platform]: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview#platform-dependencies

--- a/src/IceRpc/README.md
+++ b/src/IceRpc/README.md
@@ -13,7 +13,7 @@ protocols.
 The QUIC transport implementation is included in the main IceRpc assembly, so you can build an application that uses
 QUIC on any platform. At runtime, this implementation relies on `System.Net.Quic`, which works out of the box on
 Windows but requires extra setup steps on Linux and macOS, as documented in .NET's
-[QUIC Platform dependencies][platform].
+[QUIC platform dependencies][platform].
 
 ## Sample Code
 

--- a/src/IceRpc/README.md
+++ b/src/IceRpc/README.md
@@ -7,10 +7,13 @@ and package represent the base assembly and package for the [C# implementation o
 
 ## QUIC Transport
 
-IceRPC's default transport is QUIC, a new UDP-based multiplexed transport used by HTTP/3 and other modern application
+IceRPC's default multiplexed transport is QUIC, a new UDP-based transport used by HTTP/3 and other modern application
 protocols.
 
-IceRPC has the same platform dependencies as `System.Net.Quic`. See .NET's [QUIC Platform dependencies][platform].
+The QUIC transport implementation is included in the main IceRpc assembly, so you can build an application that uses
+QUIC on any platform. At runtime, this implementation relies on `System.Net.Quic`, which works out of the box on
+Windows but requires extra setup steps on Linux and macOS, as documented in .NET's
+[QUIC Platform dependencies][platform].
 
 ## Sample Code
 


### PR DESCRIPTION
This PR fixes the L-22 finding of #4829: the examples that use QUIC — the default multiplexed transport, so every example that doesn't select another transport — didn't mention that running them requires QUIC to be set up on the system, even though the QUIC transport throws when it isn't.

Since each example is meant to be studied in isolation, every QUIC-using example README (31 in total: 17 slice, 12 protobuf, 2 json) now carries a short self-contained note: QUIC works out of the box on Windows, while Linux and macOS need extra setup steps, with a link to .NET's QUIC platform dependencies documentation. The platform specifics themselves stay in the Microsoft documentation.

The QUIC Transport section of the IceRpc package README is also reworked: it now makes clear that you can build a QUIC application on any platform — the QUIC transport ships in the main IceRpc assembly — and that only the runtime depends on the system's QUIC setup, instead of the vague "IceRPC has the same platform dependencies as System.Net.Quic".

## What's Changed entry

None — documentation fixes.