### PR TITLE
Validate the limit of ProtobufFeature

### DIFF
--- a/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
+++ b/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
@@ -10,6 +10,7 @@ public interface IProtobufFeature
 {
     /// <summary>Gets the maximum length of an encoded Protobuf message, in bytes.</summary>
     /// <value>The maximum length of a Protobuf message, in bytes.</value>
+    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxMessageLength { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>

--- a/src/IceRpc.Protobuf/Features/ProtobufFeature.cs
+++ b/src/IceRpc.Protobuf/Features/ProtobufFeature.cs
@@ -10,8 +10,8 @@ public sealed class ProtobufFeature : IProtobufFeature
     /// <summary>Gets a <see cref="IProtobufFeature" /> with default values for all properties.</summary>
     public static IProtobufFeature Default { get; } = new DefaultProtobufFeature();
 
-    /// <summary>Gets the maximum length of an encoded Protobuf message, in bytes.</summary>
-    /// <value>The maximum length of a Protobuf message. Defaults to <c>1</c> MB.</value>
+    /// <inheritdoc/>
+    /// <value>The maximum length of a Protobuf message, in bytes. Defaults to <c>1</c> MB.</value>
     public int MaxMessageLength { get; }
 
     /// <inheritdoc/>
@@ -22,11 +22,20 @@ public sealed class ProtobufFeature : IProtobufFeature
     /// <param name="encodeOptions">The encode options.</param>
     /// <param name="defaultFeature">A feature that provides default values for all parameters. <see langword="null" />
     /// is equivalent to <see cref="Default" />.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxMessageLength" /> is a negative
+    /// value other than <c>-1</c>.</exception>
     public ProtobufFeature(
         int maxMessageLength = -1,
         ProtobufEncodeOptions? encodeOptions = null,
         IProtobufFeature? defaultFeature = null)
     {
+        if (maxMessageLength < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxMessageLength),
+                $"The value of {nameof(maxMessageLength)} must be greater than or equal to 0, or -1.");
+        }
+
         defaultFeature ??= Default;
         MaxMessageLength = maxMessageLength >= 0 ? maxMessageLength : defaultFeature.MaxMessageLength;
         EncodeOptions = encodeOptions ?? defaultFeature.EncodeOptions;


### PR DESCRIPTION
Fixes #4887.

This PR applies the #4862 model to `ProtobufFeature`:

- The constructor now rejects a `maxMessageLength` that is a negative value other than `-1` with an `ArgumentOutOfRangeException`. `0` remains valid: an all-defaults Protobuf message encodes to 0 bytes.
- `IProtobufFeature.MaxMessageLength` documents the implementation contract (a value greater than or equal to `0`), and `ProtobufFeature.MaxMessageLength` inherits these docs and documents its default value.

The `MaxMessageLength` read sites were reviewed for `maxSize + 1`-style overflow: there is none — `DecodeMessageLength` compares the wire length against `(uint)maxMessageLength` directly, and its safety comment already relies on the non-negative contract that the interface now documents. This is also why the valid range has no `int.MaxValue` exclusion, unlike `maxPayloadSize` in `IceFeature`.

## What's Changed entry

None — only rejects invalid configurations that no reasonable program uses.