### PR TITLE
Fix the Protobuf payload completion tests

### DIFF
--- a/tests/IceRpc.Protobuf.Tests/OperationTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/OperationTests.cs
@@ -326,8 +326,8 @@ public partial class OperationTests
         await client.UnaryOpAsync(message);
 
         // Assert
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(await requestPayload!.Completed, Is.Null);
+        Assert.That(await responsePayload!.Completed, Is.Null);
     }
 
     [Test]
@@ -361,8 +361,8 @@ public partial class OperationTests
 
         // Act//Assert
         Assert.ThrowsAsync<DispatchException>(async () => await client.UnaryOpAsync(message));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(requestPayload!.Completed.IsCompletedSuccessfully, Is.True);
+        Assert.That(responsePayload!.Completed.IsCompletedSuccessfully, Is.True);
     }
 
     [Test]
@@ -371,33 +371,31 @@ public partial class OperationTests
         // Arrange
         PayloadPipeReaderDecorator? requestPayload = null;
         PayloadPipeReaderDecorator? responsePayload = null;
+        var service = new MyOperationsService();
 
         var pipeline = new Pipeline().Use(next =>
             new InlineInvoker(
                 async (request, cancellationToken) =>
                 {
-                    requestPayload = new PayloadPipeReaderDecorator(request.Payload);
+                    // The stream of messages is carried by the payload continuation; the payload is empty.
+                    Assert.That(request.Payload, Is.SameAs(EmptyPipeReader.Instance));
+                    requestPayload = new PayloadPipeReaderDecorator(request.PayloadContinuation!);
                     request.PayloadContinuation = requestPayload;
                     var response = await next.InvokeAsync(request, cancellationToken);
                     responsePayload = new PayloadPipeReaderDecorator(response.Payload);
                     response.Payload = responsePayload;
                     return response;
-                })).Into(new ColocInvoker(new MyOperationsService()));
+                })).Into(new ColocInvoker(service));
 
         var client = new MyOperationsClient(pipeline);
-
-        var message = new InputMessage()
-        {
-            P1 = "P1",
-            P2 = 2,
-        };
 
         // Act
         await client.ClientStreamingOpAsync(GetDataAsync());
 
         // Assert
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(service.Messages, Has.Count.EqualTo(10));
+        Assert.That(await requestPayload!.Completed, Is.Null);
+        Assert.That(await responsePayload!.Completed, Is.Null);
 
         static async IAsyncEnumerable<InputMessage> GetDataAsync()
         {
@@ -425,7 +423,9 @@ public partial class OperationTests
             new InlineInvoker(
                 async (request, cancellationToken) =>
                 {
-                    requestPayload = new PayloadPipeReaderDecorator(request.Payload);
+                    // The stream of messages is carried by the payload continuation; the payload is empty.
+                    Assert.That(request.Payload, Is.SameAs(EmptyPipeReader.Instance));
+                    requestPayload = new PayloadPipeReaderDecorator(request.PayloadContinuation!);
                     request.PayloadContinuation = requestPayload;
                     var response = await next.InvokeAsync(request, cancellationToken);
                     responsePayload = new PayloadPipeReaderDecorator(response.Payload);
@@ -437,16 +437,10 @@ public partial class OperationTests
 
         var client = new MyOperationsClient(pipeline);
 
-        var message = new InputMessage()
-        {
-            P1 = "P1",
-            P2 = 2,
-        };
-
         // Act/Assert
         Assert.ThrowsAsync<DispatchException>(async () => await client.ClientStreamingOpAsync(GetDataAsync()));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(requestPayload!.Completed.IsCompletedSuccessfully, Is.True);
+        Assert.That(responsePayload!.Completed.IsCompletedSuccessfully, Is.True);
 
         static async IAsyncEnumerable<InputMessage> GetDataAsync()
         {
@@ -494,8 +488,8 @@ public partial class OperationTests
         }
 
         Assert.That(messages, Has.Count.EqualTo(10));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(await requestPayload!.Completed, Is.Null);
+        Assert.That(await responsePayload!.Completed, Is.Null);
     }
 
     [Test]
@@ -523,8 +517,8 @@ public partial class OperationTests
 
         // Act/Assert
         Assert.ThrowsAsync<DispatchException>(async () => await client.ServerStreamingOpAsync(new Empty()));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(requestPayload!.Completed.IsCompletedSuccessfully, Is.True);
+        Assert.That(responsePayload!.Completed.IsCompletedSuccessfully, Is.True);
     }
 
     [Test]
@@ -533,18 +527,21 @@ public partial class OperationTests
         // Arrange
         PayloadPipeReaderDecorator? requestPayload = null;
         PayloadPipeReaderDecorator? responsePayload = null;
+        var service = new MyOperationsService();
 
         var pipeline = new Pipeline().Use(next =>
             new InlineInvoker(
                 async (request, cancellationToken) =>
                 {
-                    requestPayload = new PayloadPipeReaderDecorator(request.Payload);
+                    // The stream of messages is carried by the payload continuation; the payload is empty.
+                    Assert.That(request.Payload, Is.SameAs(EmptyPipeReader.Instance));
+                    requestPayload = new PayloadPipeReaderDecorator(request.PayloadContinuation!);
                     request.PayloadContinuation = requestPayload;
                     var response = await next.InvokeAsync(request, cancellationToken);
                     responsePayload = new PayloadPipeReaderDecorator(response.Payload);
                     response.Payload = responsePayload;
                     return response;
-                })).Into(new ColocInvoker(new MyOperationsService()));
+                })).Into(new ColocInvoker(service));
 
         var client = new MyOperationsClient(pipeline);
 
@@ -559,8 +556,9 @@ public partial class OperationTests
         }
 
         Assert.That(messages.Count, Is.EqualTo(10));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(service.Messages, Has.Count.EqualTo(10));
+        Assert.That(await requestPayload!.Completed, Is.Null);
+        Assert.That(await responsePayload!.Completed, Is.Null);
 
         static async IAsyncEnumerable<InputMessage> GetDataAsync()
         {
@@ -588,7 +586,9 @@ public partial class OperationTests
             new InlineInvoker(
                 async (request, cancellationToken) =>
                 {
-                    requestPayload = new PayloadPipeReaderDecorator(request.Payload);
+                    // The stream of messages is carried by the payload continuation; the payload is empty.
+                    Assert.That(request.Payload, Is.SameAs(EmptyPipeReader.Instance));
+                    requestPayload = new PayloadPipeReaderDecorator(request.PayloadContinuation!);
                     request.PayloadContinuation = requestPayload;
                     var response = await next.InvokeAsync(request, cancellationToken);
                     responsePayload = new PayloadPipeReaderDecorator(response.Payload);
@@ -602,8 +602,8 @@ public partial class OperationTests
 
         // Act
         Assert.ThrowsAsync<DispatchException>(async () => await client.BidiStreamingOpAsync(GetDataAsync()));
-        Assert.That(() => requestPayload!.Completed, Throws.Nothing);
-        Assert.That(() => responsePayload!.Completed, Throws.Nothing);
+        Assert.That(requestPayload!.Completed.IsCompletedSuccessfully, Is.True);
+        Assert.That(responsePayload!.Completed.IsCompletedSuccessfully, Is.True);
 
         static async IAsyncEnumerable<InputMessage> GetDataAsync()
         {


### PR DESCRIPTION
This PR fixes the L-13 finding of #4831.

The four client-streaming and bidi-streaming payload completion tests in `OperationTests` wrapped `request.Payload` — which is empty for these RPC shapes — and assigned the wrapper to `request.PayloadContinuation`, replacing the stream reader created by the generated code. As a result the client stream was never sent, the replaced reader was never completed, and the assertions observed the replacement. The tests now decorate `request.PayloadContinuation` and assert that the empty `request.Payload` invariant holds, and the two streaming success tests verify that all streamed messages reach the service.

In addition, all eight tests asserted completion with `Assert.That(() => payload.Completed, Throws.Nothing)` — a lambda that reads a `Task` property and can never throw, so completion was never actually verified. The success tests now assert `await payload.Completed` is null and the failure tests assert `payload.Completed.IsCompletedSuccessfully`, matching the idiom used in `InvokeOperationAsyncTests`.

Also removes an unused `message` local copy-pasted from the unary tests.

## What's Changed entry

None — test fixes.