### PR TITLE
Verify the target returns no response fields in the protocol bridging test

### DIFF
--- a/tests/IntegrationTests/ProtocolBridgingTests.cs
+++ b/tests/IntegrationTests/ProtocolBridgingTests.cs
@@ -130,26 +130,18 @@ public sealed partial class ProtocolBridgingTests
 
             IncomingResponse incomingResponse = await _target.Invoker!.InvokeAsync(outgoingRequest, cancellationToken);
 
-            // Then create an outgoing response from the incoming response.
-
             // A protocol bridge cannot forward response fields (the ice protocol doesn't support them), so this
             // forwarder doesn't forward fields at all and expects the target to return none.
             Assert.That(incomingResponse.Fields, Is.Empty);
 
-            if (incomingResponse.StatusCode == StatusCode.Ok)
-            {
-                return new OutgoingResponse(request)
-                {
-                    Payload = incomingResponse.DetachPayload()
-                };
-            }
-            else
-            {
-                return new OutgoingResponse(request, incomingResponse.StatusCode, incomingResponse.ErrorMessage!)
-                {
-                    Payload = incomingResponse.DetachPayload()
-                };
-            }
+            // Then create an outgoing response from the incoming response.
+
+            OutgoingResponse outgoingResponse = incomingResponse.StatusCode == StatusCode.Ok ?
+                new OutgoingResponse(request) :
+                new OutgoingResponse(request, incomingResponse.StatusCode, incomingResponse.ErrorMessage!);
+
+            outgoingResponse.Payload = incomingResponse.DetachPayload();
+            return outgoingResponse;
         }
 
         internal Forwarder(IIceProxy target) => _target = target;

--- a/tests/IntegrationTests/ProtocolBridgingTests.cs
+++ b/tests/IntegrationTests/ProtocolBridgingTests.cs
@@ -118,8 +118,6 @@ public sealed partial class ProtocolBridgingTests
         {
             // First create an outgoing request to _target from the incoming request:
 
-            Protocol targetProtocol = _target.ServiceAddress.Protocol!;
-
             using var outgoingRequest = new OutgoingRequest(_target.ServiceAddress)
             {
                 IsOneway = request.IsOneway,
@@ -134,18 +132,14 @@ public sealed partial class ProtocolBridgingTests
 
             // Then create an outgoing response from the incoming response.
 
-            // TODO: copy fields memory?
-            var fields = new Dictionary<ResponseFieldKey, OutgoingFieldValue>(
-                    incomingResponse.Fields.Select(
-                        pair => new KeyValuePair<ResponseFieldKey, OutgoingFieldValue>(
-                            pair.Key,
-                            new OutgoingFieldValue(pair.Value))));
+            // A protocol bridge cannot forward response fields (the ice protocol doesn't support them), so this
+            // forwarder doesn't forward fields at all and expects the target to return none.
+            Assert.That(incomingResponse.Fields, Is.Empty);
 
             if (incomingResponse.StatusCode == StatusCode.Ok)
             {
                 return new OutgoingResponse(request)
                 {
-                    Fields = fields,
                     Payload = incomingResponse.DetachPayload()
                 };
             }
@@ -153,7 +147,6 @@ public sealed partial class ProtocolBridgingTests
             {
                 return new OutgoingResponse(request, incomingResponse.StatusCode, incomingResponse.ErrorMessage!)
                 {
-                    Fields = fields,
                     Payload = incomingResponse.DetachPayload()
                 };
             }


### PR DESCRIPTION
This PR fixes the L-17 finding of #4831.

The `Forwarder` in `ProtocolBridgingTests` transferred the incoming response's field values into the forwarded response without copying them (the `// TODO: copy fields memory?` in the code). The field memory belongs to the incoming response and is reclaimed when the outgoing request is disposed — before the forwarded response is encoded — so any actual field value would have been read after its memory was reclaimed. The defect was latent: no scenario in these tests produces response fields.

Rather than copying, the forwarder now doesn't forward fields at all and asserts the target returned none: a protocol bridge can't forward response fields anyway, since the ice protocol doesn't support them. If a future scenario adds a response-field producer, the assert fails loudly instead of forwarding reclaimed memory.

Also removes a dead `targetProtocol` local.

## What's Changed entry

None — test fixes.