### PR TITLE
Unblock held dispatches when disposing TestDispatcher

### DIFF
--- a/tests/IceRpc.Tests.Common/TestDispatcher.cs
+++ b/tests/IceRpc.Tests.Common/TestDispatcher.cs
@@ -27,7 +27,12 @@ public sealed class TestDispatcher : IDispatcher, IDisposable
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly byte[]? _responsePayload;
+
+    // Each of the first _holdDispatchCount dispatches waits on the _hold semaphore; it's also the maximum number of
+    // dispatches that can be waiting on this semaphore at any point.
     private readonly int _holdDispatchCount;
+
+    // The number of dispatches started so far.
     private int _dispatchCount;
 
     /// <inheritdoc/>
@@ -72,9 +77,10 @@ public sealed class TestDispatcher : IDispatcher, IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        if (_hold.CurrentCount > 0)
+        if (_holdDispatchCount > 0)
         {
-            _hold.Release(_hold.CurrentCount);
+            // Release enough permits to unblock any dispatch still waiting on the semaphore.
+            _hold.Release(_holdDispatchCount);
         }
         _hold.Dispose();
     }


### PR DESCRIPTION
This PR fixes the L-14 finding of #4831.

`TestDispatcher.Dispose` released the `_hold` semaphore only when `SemaphoreSlim.CurrentCount` was positive. The count is positive only when no dispatch is waiting on the semaphore, so the release could never unblock a waiting dispatch. `Dispose` now unconditionally releases `_holdDispatchCount` permits — the maximum number of dispatches that can be waiting.

No current test hangs because of this: every held dispatch waits with a connection-scoped cancellation token, and the tests dispose the connection before the dispatcher. The fix protects future tests that hold a dispatch on a token that isn't canceled first.

Also documents the `_holdDispatchCount` and `_dispatchCount` fields.

## What's Changed entry

None — test fixes.