### PR TITLE
Exclude ZeroC.Tests.Common from code coverage

### DIFF
--- a/build/Tests.runsettings
+++ b/build/Tests.runsettings
@@ -12,7 +12,7 @@
                     <!-- Exclude test assemblies and the IceRpc.ServiceGenerator source generator (loaded as an
                          analyzer into the test process; its behavior is exercised through generated code, not by
                          tracking which lines of the generator itself execute) -->
-                    <Exclude>[IceRpc.Conformance.Tests]*,[IceRpc.Tests.Common]*,[IceRpc.ServiceGenerator]*</Exclude>
+                    <Exclude>[IceRpc.Conformance.Tests]*,[IceRpc.Tests.Common]*,[IceRpc.ServiceGenerator]*,[ZeroC.Tests.Common]*</Exclude>
                     <!-- Filter out generated files -->
                     <ExcludeByFile>**/generated/**/*.cs,**/LoggerMessage.g.cs</ExcludeByFile>
                 </Configuration>


### PR DESCRIPTION
This PR fixes the L-15 finding of #4831: the coverage configuration excluded `IceRpc.Tests.Common` but not its `ZeroC.Tests.Common` sibling, so the shared test helpers showed up as a covered package in the coverage reports.

## What's Changed entry

None — test configuration fix.