### PR TITLE
Use "Thrown when" in exception doc comments

### DIFF
--- a/src/IceRpc.Deadline/DeadlineInterceptor.cs
+++ b/src/IceRpc.Deadline/DeadlineInterceptor.cs
@@ -46,7 +46,7 @@ public class DeadlineInterceptor : IInvoker
     /// and the request carries a deadline, the interceptor creates a cancellation token source to enforce this deadline
     /// only when the invocation's cancellation token cannot be canceled. The default value is <see langword="false" />.
     /// </param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="defaultTimeout" /> is neither
+    /// <exception cref="ArgumentException">Thrown when <paramref name="defaultTimeout" /> is neither
     /// <see cref="Timeout.InfiniteTimeSpan" /> nor a positive value within the supported range.</exception>
     public DeadlineInterceptor(IInvoker next, TimeSpan defaultTimeout, bool alwaysEnforceDeadline, TimeProvider? timeProvider = null)
     {

--- a/src/IceRpc.Ice/Operations/IceProxyExtensions.cs
+++ b/src/IceRpc.Ice/Operations/IceProxyExtensions.cs
@@ -54,7 +54,7 @@ public static class IceProxyExtensions
     /// <param name="idempotent">When <see langword="true" />, the request is idempotent.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The operation's return value.</returns>
-    /// <exception cref="IceException">Thrown if the response carries an Ice exception.</exception>
+    /// <exception cref="IceException">Thrown when the response carries an Ice exception.</exception>
     public static Task<T> InvokeOperationAsync<TProxy, T>(
         this TProxy proxy,
         string operation,
@@ -123,7 +123,7 @@ public static class IceProxyExtensions
     /// immediately after sending the request.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes when the void response is returned.</returns>
-    /// <exception cref="IceException">Thrown if the response carries a failure.</exception>
+    /// <exception cref="IceException">Thrown when the response carries a failure.</exception>
     public static Task InvokeOperationAsync<TProxy>(
         this TProxy proxy,
         string operation,

--- a/src/IceRpc.Slice/Operations/PipeReaderExtensions.cs
+++ b/src/IceRpc.Slice/Operations/PipeReaderExtensions.cs
@@ -30,7 +30,7 @@ public static class PipeReaderExtensions
     /// <param name="elementSize">The size in bytes of one element.</param>
     /// <param name="sliceFeature">The Slice feature to customize the decoding.</param>
     /// <returns>The async stream to decode and return the streamed elements.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="elementSize" /> is equal of inferior to
+    /// <exception cref="ArgumentException">Thrown when <paramref name="elementSize" /> is equal of inferior to
     /// <c>0</c>.</exception>
     /// <remarks>The reader ownership is transferred to the returned async stream. The caller should no longer use
     /// the reader after this call, and must dispose the returned async stream when done to release the reader.

--- a/src/IceRpc.Transports.Coloc/Internal/ColocConnection.cs
+++ b/src/IceRpc.Transports.Coloc/Internal/ColocConnection.cs
@@ -141,7 +141,7 @@ internal abstract class ColocConnection : IDuplexConnection
         }
         if (_state.HasFlag(State.ShuttingDown))
         {
-            throw new InvalidOperationException("Writing is not allowed after the connection is shutdown.");
+            throw new InvalidOperationException("Writing is not allowed after the connection is shut down.");
         }
         if (!_state.TrySetFlag(State.Writing))
         {

--- a/src/IceRpc/ClientConnection.cs
+++ b/src/IceRpc/ClientConnection.cs
@@ -150,9 +150,9 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that provides the <see cref="TransportConnectionInformation" /> of the transport connection,
     /// once this connection is established.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this client connection is shut down or shutting down.
+    /// <exception cref="InvalidOperationException">Thrown when this client connection is shut down or shutting down.
     /// </exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this client connection is disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this client connection is disposed.</exception>
     /// <remarks><para>This method can be called multiple times and concurrently. If the connection is not established,
     /// it will be connected or reconnected.</para>
     /// <para>The returned task can also complete with one of the following exceptions:</para>
@@ -274,11 +274,11 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     /// <param name="request">The outgoing request being sent.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The corresponding <see cref="IncomingResponse" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if none of the request's server addresses matches this
+    /// <exception cref="InvalidOperationException">Thrown when none of the request's server addresses matches this
     /// connection's server address.</exception>
-    /// <exception cref="IceRpcException">Thrown with error <see cref="IceRpcError.InvocationRefused" /> if this client
-    /// connection is shutdown.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this client connection is disposed.</exception>
+    /// <exception cref="IceRpcException">Thrown with error <see cref="IceRpcError.InvocationRefused" /> when this
+    /// client connection is shut down.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this client connection is disposed.</exception>
     /// <remarks>If the connection is not established, it will be connected or reconnected.</remarks>
     public Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken = default)
     {
@@ -381,9 +381,9 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
     /// complete.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes once the shutdown is complete.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this connection is already shut down or shutting down.
+    /// <exception cref="InvalidOperationException">Thrown when this connection is already shut down or shutting down.
     /// </exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this connection is disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this connection is disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> with error <see cref="IceRpcError.OperationAborted" /> if this
@@ -587,7 +587,7 @@ public sealed class ClientConnection : IInvoker, IAsyncDisposable
 
     /// <summary>Removes the connection from _activeConnection, and when successful, shuts down and disposes this
     /// connection.</summary>
-    /// <param name="connection">The connected connection to shutdown and dispose.</param>
+    /// <param name="connection">The connected connection to shut down and dispose.</param>
     private Task RemoveFromActiveAsync(IProtocolConnection connection)
     {
         lock (_mutex)

--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -138,12 +138,12 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// <param name="request">The outgoing request being sent.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The corresponding <see cref="IncomingResponse" />.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if no <see cref="IServerAddressFeature" /> feature is set and
-    /// the request's service address has no server addresses.</exception>
-    /// <exception cref="IceRpcException">Thrown with <see cref="IceRpcError.InvocationRefused" /> if the connection
-    /// cache is shutdown, or with <see cref="IceRpcError.NoConnection" /> if the request's
+    /// <exception cref="InvalidOperationException">Thrown when no <see cref="IServerAddressFeature" /> feature is set
+    /// and the request's service address has no server addresses.</exception>
+    /// <exception cref="IceRpcException">Thrown with <see cref="IceRpcError.InvocationRefused" /> when the connection
+    /// cache is shut down, or with <see cref="IceRpcError.NoConnection" /> when the request's
     /// <see cref="IServerAddressFeature" /> feature has no server addresses.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this connection cache is disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this connection cache is disposed.</exception>
     /// <remarks><para>If the request <see cref="IServerAddressFeature" /> feature is not set, the cache sets it from
     /// the server addresses of the target service.</para>
     /// <para>It then looks for an active connection. The <see cref="ConnectionCacheOptions.PreferExistingConnection" />
@@ -248,8 +248,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// <returns>A task that completes successfully once the shutdown of all connections created by this cache has
     /// completed. This includes connections that were active when this method is called and connections whose shutdown
     /// was initiated prior to this call.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection cache is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection cache is disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> with error <see cref="IceRpcError.OperationAborted" /> if the
@@ -518,7 +518,7 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// <summary>Removes the connection from _activeConnections, and when successful, shuts down and disposes this
     /// connection.</summary>
     /// <param name="serverAddress">The server address key in _activeConnections.</param>
-    /// <param name="connection">The connection to shutdown and dispose after removal.</param>
+    /// <param name="connection">The connection to shut down and dispose after removal.</param>
     private Task RemoveFromActiveAsync(ServerAddress serverAddress, IProtocolConnection connection)
     {
         lock (_mutex)

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -40,7 +40,7 @@ public record class ConnectionOptions
             throw new ArgumentException($"0 is not a valid value for {nameof(IceIdleTimeout)}", nameof(value));
     }
 
-    /// <summary>Gets or sets the inactivity timeout. This timeout is used to gracefully shutdown the connection if
+    /// <summary>Gets or sets the inactivity timeout. This timeout is used to gracefully shut down the connection if
     /// it's inactive for longer than this timeout. A connection is considered inactive when there's no invocation or
     /// dispatch in progress.</summary>
     /// <value>The inactivity timeout. Defaults to <c>5</c> minutes.</value>

--- a/src/IceRpc/DispatchException.cs
+++ b/src/IceRpc/DispatchException.cs
@@ -24,7 +24,7 @@ public sealed class DispatchException : Exception
     /// cref="StatusCode.Ok" />.</param>
     /// <param name="message">A message that describes the exception.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="statusCode" /> is equal to <see
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="statusCode" /> is equal to <see
     /// cref="StatusCode.Ok" />.</exception>
     public DispatchException(
         StatusCode statusCode,

--- a/src/IceRpc/Extensions/DependencyInjection/IDispatcherBuilder.cs
+++ b/src/IceRpc/Extensions/DependencyInjection/IDispatcherBuilder.cs
@@ -24,7 +24,7 @@ public interface IDispatcherBuilder
     /// service must implement <see cref="IDispatcher" />.</typeparam>
     /// <param name="path">The path of this route. It must match exactly the path of the request. In particular, it
     /// must start with a <c>/</c>.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="path" /> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="path" /> is not a valid path.</exception>
     /// <returns>This builder.</returns>
     /// <remarks>With Slice, it is common for <typeparamref name="TService" /> to correspond to a generated
     /// I{name}Service interface. This generated interface does not extend <see cref="IDispatcher" />.</remarks>
@@ -36,7 +36,7 @@ public interface IDispatcherBuilder
     /// service must implement <see cref="IDispatcher" />.</typeparam>
     /// <param name="prefix">The prefix of this route. This prefix will be compared with the start of the path of
     /// the request.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="prefix" /> is not a valid path.</exception>
     /// <returns>This builder.</returns>
     /// <remarks>With Slice, it is common for <typeparamref name="TService" /> to correspond to a generated
     /// I{name}Service interface. This generated interface does not extend <see cref="IDispatcher" />.</remarks>

--- a/src/IceRpc/Features/DeadlineFeature.cs
+++ b/src/IceRpc/Features/DeadlineFeature.cs
@@ -12,7 +12,7 @@ public sealed class DeadlineFeature : IDeadlineFeature
     /// <summary>Creates a deadline from a timeout.</summary>
     /// <param name="timeout">The timeout. Must be a positive value not exceeding ~24.8 days.</param>
     /// <returns>A new deadline equal to now plus the timeout.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="timeout" /> is not a positive value
+    /// <exception cref="ArgumentException">Thrown when <paramref name="timeout" /> is not a positive value
     /// within the supported range.</exception>
     public static DeadlineFeature FromTimeout(TimeSpan timeout)
     {

--- a/src/IceRpc/IProtocolConnection.cs
+++ b/src/IceRpc/IProtocolConnection.cs
@@ -32,8 +32,8 @@ public interface IProtocolConnection : IInvoker, IAsyncDisposable
     /// cancellation token.</description></item>
     /// </list>
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this connection is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this connection is disposed.</exception>
     Task<(TransportConnectionInformation ConnectionInformation, Task ShutdownRequested)> ConnectAsync(
         CancellationToken cancellationToken = default);
 
@@ -47,8 +47,8 @@ public interface IProtocolConnection : IInvoker, IAsyncDisposable
     /// cancellation token.</description></item>
     /// </list>
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="ConnectAsync" /> did not complete successfully
-    /// prior to this call, or if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if this connection is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="ConnectAsync" /> did not complete
+    /// successfully prior to this call, or when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this connection is disposed.</exception>
     Task ShutdownAsync(CancellationToken cancellationToken = default);
 }

--- a/src/IceRpc/Internal/IceRpcProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceRpcProtocolConnection.cs
@@ -381,7 +381,7 @@ internal sealed class IceRpcProtocolConnection : IProtocolConnection
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    // Connection was shutdown or disposed and we did not read the payload at all.
+                    // Connection was shut down or disposed and we did not read the payload at all.
                     throw new IceRpcException(IceRpcError.InvocationRefused, _invocationRefusedMessage);
                 }
                 catch (IceRpcException exception)

--- a/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
+++ b/src/IceRpc/Internal/ProtocolLoggerExtensions.cs
@@ -133,7 +133,7 @@ internal static partial class ProtocolLoggerExtensions
         EventId = (int)ProtocolEventIds.ConnectionShutdownFailed,
         EventName = nameof(ProtocolEventIds.ConnectionShutdownFailed),
         Level = LogLevel.Debug,
-        Message = "{Kind} connection from '{LocalNetworkAddress}' to '{RemoteNetworkAddress}' failed to shutdown")]
+        Message = "{Kind} connection from '{LocalNetworkAddress}' to '{RemoteNetworkAddress}' failed to shut down")]
     internal static partial void LogConnectionShutdownFailed(
         this ILogger logger,
         string kind,

--- a/src/IceRpc/Pipeline.cs
+++ b/src/IceRpc/Pipeline.cs
@@ -37,7 +37,7 @@ public sealed class Pipeline : IInvoker
     /// <summary>Sets the last invoker of this pipeline. The pipeline flows into this invoker.</summary>
     /// <param name="lastInvoker">The last invoker.</param>
     /// <returns>This pipeline.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called after the first call to
+    /// <exception cref="InvalidOperationException">Thrown when this method is called after the first call to
     /// <see cref="InvokeAsync" />.</exception>
     public Pipeline Into(IInvoker lastInvoker)
     {
@@ -53,7 +53,7 @@ public sealed class Pipeline : IInvoker
     /// <summary>Installs an interceptor at the end of the pipeline.</summary>
     /// <param name="interceptor">The interceptor to install.</param>
     /// <returns>This pipeline.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called after the first call to
+    /// <exception cref="InvalidOperationException">Thrown when this method is called after the first call to
     /// <see cref="InvokeAsync" />.</exception>
     public Pipeline Use(Func<IInvoker, IInvoker> interceptor)
     {

--- a/src/IceRpc/Protocol.cs
+++ b/src/IceRpc/Protocol.cs
@@ -81,7 +81,7 @@ public class Protocol
     /// <summary>Checks if a path is valid for this protocol.</summary>
     /// <param name="uriPath">The absolute path to check. The caller guarantees it's a valid URI absolute path.
     /// </param>
-    /// <exception cref="FormatException">Thrown if the path is not valid.</exception>
+    /// <exception cref="FormatException">Thrown when the path is not valid.</exception>
     internal virtual void CheckPath(string uriPath)
     {
         // by default, any URI absolute path is ok
@@ -89,7 +89,7 @@ public class Protocol
 
     /// <summary>Checks if these service address parameters are valid for this protocol.</summary>
     /// <param name="serviceAddressParams">The service address parameters to check.</param>
-    /// <exception cref="FormatException">Thrown if the service address parameters are not valid.</exception>
+    /// <exception cref="FormatException">Thrown when the service address parameters are not valid.</exception>
     /// <remarks>This method does not and should not check if the parameter names and values are properly escaped;
     /// it does not check for the invalid empty and alt-server parameter names either.</remarks>
     internal virtual void CheckServiceAddressParams(ImmutableDictionary<string, string> serviceAddressParams)

--- a/src/IceRpc/ResettablePipeReaderDecorator.cs
+++ b/src/IceRpc/ResettablePipeReaderDecorator.cs
@@ -212,8 +212,8 @@ public sealed class ResettablePipeReaderDecorator : PipeReader
     }
 
     /// <summary>Resets this pipe reader.</summary>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IsResettable" /> is <see langword="false" /> or
-    /// if reading is in progress.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IsResettable" /> is <see langword="false" />
+    /// or when reading is in progress.</exception>
     public void Reset()
     {
         if (_isResettable)

--- a/src/IceRpc/Router.cs
+++ b/src/IceRpc/Router.cs
@@ -53,7 +53,7 @@ public sealed class Router : IDispatcher
 
     /// <summary>Constructs a router with an absolute prefix.</summary>
     /// <param name="absolutePrefix">The absolute prefix of the new router. It must start with a <c>/</c>.</param>
-    /// <exception cref="FormatException">Thrown if <paramref name="absolutePrefix" /> is not a valid path.
+    /// <exception cref="FormatException">Thrown when <paramref name="absolutePrefix" /> is not a valid path.
     /// </exception>
     public Router(string absolutePrefix)
         : this()
@@ -75,8 +75,8 @@ public sealed class Router : IDispatcher
     /// must start with a <c>/</c>.</param>
     /// <param name="dispatcher">The target of this route. It is typically a service.</param>
     /// <returns>This router.</returns>
-    /// <exception cref="FormatException">Thrown if <paramref name="path" /> is not a valid path.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
+    /// <exception cref="FormatException">Thrown when <paramref name="path" /> is not a valid path.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
     /// <seealso cref="Mount" />
     public Router Map(string path, IDispatcher dispatcher)
@@ -97,8 +97,8 @@ public sealed class Router : IDispatcher
     /// the request.</param>
     /// <param name="dispatcher">The target of this route.</param>
     /// <returns>This router.</returns>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
+    /// <exception cref="FormatException">Thrown when <paramref name="prefix" /> is not a valid path.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
     /// <seealso cref="Map(string, IDispatcher)" />
     public Router Mount(string prefix, IDispatcher dispatcher)
@@ -118,7 +118,7 @@ public sealed class Router : IDispatcher
     /// <see cref="IDispatcher.DispatchAsync" />.</summary>
     /// <param name="middleware">The middleware to install.</param>
     /// <returns>This router.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
     public Router Use(Func<IDispatcher, IDispatcher> middleware)
     {

--- a/src/IceRpc/RouterExtensions.cs
+++ b/src/IceRpc/RouterExtensions.cs
@@ -12,10 +12,10 @@ public static class RouterExtensions
     /// <param name="router">The router being configured.</param>
     /// <param name="service">The target service of this route.</param>
     /// <returns>The router being configured.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <exception cref="ArgumentException">Thrown if the interface(s) implemented by <paramref name="service" /> do not
-    /// have a <see cref="DefaultServicePathAttribute"/> attribute, or if <paramref name="service" /> implements
+    /// <exception cref="ArgumentException">Thrown when the interface(s) implemented by <paramref name="service" /> do
+    /// not have a <see cref="DefaultServicePathAttribute"/> attribute, or when <paramref name="service" /> implements
     /// multiple interfaces with a <see cref="DefaultServicePathAttribute"/> attribute.</exception>
     public static Router Map(this Router router, IDispatcher service) =>
         router.Map(service.GetType().GetDefaultServicePath(), service);
@@ -27,9 +27,9 @@ public static class RouterExtensions
     /// <param name="router">The router being configured.</param>
     /// <param name="service">The target service of this route.</param>
     /// <returns>The router being configured.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IDispatcher.DispatchAsync" /> was already
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="IDispatcher.DispatchAsync" /> was already
     /// called on this router.</exception>
-    /// <exception cref="ArgumentException">Thrown if <typeparamref name="TService"/> does not have a
+    /// <exception cref="ArgumentException">Thrown when <typeparamref name="TService"/> does not have a
     /// <see cref="DefaultServicePathAttribute"/> attribute.</exception>
     public static Router Map<TService>(this Router router, IDispatcher service)
         where TService : class =>
@@ -41,7 +41,7 @@ public static class RouterExtensions
     /// <param name="prefix">The prefix of the route to the sub-router.</param>
     /// <param name="configure">A delegate that configures the new sub-router.</param>
     /// <returns>The new sub-router.</returns>
-    /// <exception cref="FormatException">Thrown if <paramref name="prefix" /> is not a valid path.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="prefix" /> is not a valid path.</exception>
     public static Router Route(this Router router, string prefix, Action<Router> configure)
     {
         ServiceAddress.CheckPath(prefix);

--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -572,7 +572,7 @@ public sealed class Server : IAsyncDisposable
                 }
                 else
                 {
-                    // _connections is immutable and ShutdownAsync/DisposeAsync is responsible to shutdown/dispose
+                    // _connections is immutable and ShutdownAsync/DisposeAsync is responsible to shut down/dispose
                     // this connection.
                     return;
                 }
@@ -588,8 +588,8 @@ public sealed class Server : IAsyncDisposable
     /// <returns>A task that completes successfully once the shutdown of all connections accepted by the server has
     /// completed. This includes connections that were active when this method is called and connections whose shutdown
     /// was initiated prior to this call.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the server is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the server is disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> with error <see cref="IceRpcError.OperationAborted" /> if the

--- a/src/IceRpc/ServerAddress.cs
+++ b/src/IceRpc/ServerAddress.cs
@@ -120,9 +120,9 @@ public readonly record struct ServerAddress
 
     /// <summary>Constructs a server address from a <see cref="Uri" />.</summary>
     /// <param name="uri">An absolute URI.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="uri" /> is not an absolute URI, or if its scheme
-    /// is not a supported protocol, or if it has a non-empty path or fragment, or if it has an empty host, or if its
-    /// query can't be parsed or if it has an alt-server query parameter.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="uri" /> is not an absolute URI, or when its
+    /// scheme is not a supported protocol, or when it has a non-empty path or fragment, or when it has an empty host,
+    /// or when its query can't be parsed or has an alt-server query parameter.</exception>
     public ServerAddress(Uri uri)
     {
         if (!uri.IsAbsoluteUri)

--- a/src/IceRpc/ServiceAddress.cs
+++ b/src/IceRpc/ServiceAddress.cs
@@ -462,7 +462,7 @@ public sealed record class ServiceAddress
 
     /// <summary>Checks if <paramref name="params" /> contains properly escaped names and values.</summary>
     /// <param name="params">The dictionary to check.</param>
-    /// <exception cref="FormatException">Thrown if the dictionary is not valid.</exception>
+    /// <exception cref="FormatException">Thrown when the dictionary is not valid.</exception>
     /// <remarks>A dictionary returned by <see cref="UriExtensions.ParseQuery" /> is properly escaped.</remarks>
     internal static void CheckParams(ImmutableDictionary<string, string> @params)
     {
@@ -483,7 +483,7 @@ public sealed record class ServiceAddress
     /// with a <c>/</c> and contains only unreserved characters, <c>%</c>, and reserved characters other than
     /// <c>?</c> and <c>#</c>.</summary>
     /// <param name="path">The path to check.</param>
-    /// <exception cref="FormatException">Thrown if the path is not valid.</exception>
+    /// <exception cref="FormatException">Thrown when the path is not valid.</exception>
     /// <remarks>The absolute path of a URI with a supported protocol satisfies these requirements.</remarks>
     internal static void CheckPath(string path)
     {
@@ -522,7 +522,7 @@ public sealed record class ServiceAddress
     /// <summary>Checks if <paramref name="fragment" /> is a properly escaped URI fragment, i.e. it contains only
     /// unreserved characters, reserved characters, and '%'.</summary>
     /// <param name="fragment">The fragment to check.</param>
-    /// <exception cref="FormatException">Thrown if the fragment is not valid.</exception>
+    /// <exception cref="FormatException">Thrown when the fragment is not valid.</exception>
     /// <remarks>The fragment of a URI with a supported protocol satisfies these requirements.</remarks>
     private static void CheckFragment(string fragment)
     {

--- a/src/IceRpc/Transports/IDuplexClientTransport.cs
+++ b/src/IceRpc/Transports/IDuplexClientTransport.cs
@@ -22,7 +22,7 @@ public interface IDuplexClientTransport
     /// <param name="transportName">The transport name, or <see langword="null" /> which is equivalent to
     /// <see cref="DefaultName" />.</param>
     /// <returns><see langword="true" /> if SSL is required; otherwise, <see langword="false" />.</returns>
-    /// <exception cref="NotSupportedException">Thrown if <paramref name="transportName" /> is not supported by this
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="transportName" /> is not supported by this
     /// transport.</exception>
     bool IsSslRequired(string? transportName);
 

--- a/src/IceRpc/Transports/IDuplexConnection.cs
+++ b/src/IceRpc/Transports/IDuplexConnection.cs
@@ -32,9 +32,9 @@ public interface IDuplexConnection : IDisposable
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with transport connection information when the connection is
     /// established.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this connection is connected, connecting or if a previous
-    /// connection attempt failed.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this connection is connected, connecting or when a
+    /// previous connection attempt failed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection is disposed.</exception>
     /// <remarks><para>When you call this method on a client connection, the returned task can complete successfully
     /// before the server accepts the connection with <see cref="IListener{T}.AcceptAsync" />: a connected client
     /// connection may be in the server-side listen backlog when the transport has such a backlog. See for example
@@ -55,10 +55,10 @@ public interface IDuplexConnection : IDisposable
     /// <returns>A value task that completes successfully with the number of bytes read into <paramref name="buffer" />.
     /// This number is <c>0</c> when no data is available and the peer has called <see cref="ShutdownWriteAsync"/>;
     /// otherwise, it is always greater than <c>0</c>.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="buffer" /> is empty.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the connection is not connected or if a read operation is
-    /// already in progress.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection is disposed.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="buffer" /> is empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the connection is not connected or when a read operation
+    /// is already in progress.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection is disposed.</exception>
     /// <remarks><para>The returned value task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>
@@ -72,9 +72,9 @@ public interface IDuplexConnection : IDisposable
     /// </summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully when the shutdown completes successfully.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the connection is not connected, already shut down or
+    /// <exception cref="InvalidOperationException">Thrown when the connection is not connected, already shut down or
     /// shutting down, or a write operation is in progress.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection is disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection is disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>
@@ -88,10 +88,10 @@ public interface IDuplexConnection : IDisposable
     /// <param name="buffer">The buffer containing the data to write.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A value task that completes successfully when the data is written successfully.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="buffer" /> is empty.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the connection is not connected, already shut down or
+    /// <exception cref="ArgumentException">Thrown when <paramref name="buffer" /> is empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the connection is not connected, already shut down or
     /// shutting down, or a write operation is already in progress.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection is disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection is disposed.</exception>
     /// <remarks><para>The returned value task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>

--- a/src/IceRpc/Transports/IListener.cs
+++ b/src/IceRpc/Transports/IListener.cs
@@ -25,7 +25,7 @@ public interface IListener<T> : IAsyncDisposable
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with the accepted connection and network address of the client.
     /// </returns>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection has been disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>

--- a/src/IceRpc/Transports/IMultiplexedClientTransport.cs
+++ b/src/IceRpc/Transports/IMultiplexedClientTransport.cs
@@ -23,7 +23,7 @@ public interface IMultiplexedClientTransport
     /// <param name="transportName">The transport name, or <see langword="null" /> which is equivalent to
     /// <see cref="DefaultName" />.</param>
     /// <returns><see langword="true" /> if SSL is required; otherwise, <see langword="false" />.</returns>
-    /// <exception cref="NotSupportedException">Thrown if <paramref name="transportName" /> is not supported by this
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="transportName" /> is not supported by this
     /// transport.</exception>
     bool IsSslRequired(string? transportName);
 

--- a/src/IceRpc/Transports/IMultiplexedConnection.cs
+++ b/src/IceRpc/Transports/IMultiplexedConnection.cs
@@ -28,10 +28,10 @@ public interface IMultiplexedConnection : IAsyncDisposable
     /// <summary>Accepts a remote stream.</summary>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with the remote stream.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="ConnectAsync" /> did not complete successfully
-    /// prior to this call.</exception>
-    /// <exception cref="IceRpcException">Thrown if the connection is closed.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="ConnectAsync" /> did not complete
+    /// successfully prior to this call.</exception>
+    /// <exception cref="IceRpcException">Thrown when the connection is closed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection has been disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>
@@ -45,8 +45,8 @@ public interface IMultiplexedConnection : IAsyncDisposable
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with transport connection information when the connection is
     /// established.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection has been disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="AuthenticationException" /> if authentication failed.</description></item>
@@ -61,9 +61,9 @@ public interface IMultiplexedConnection : IAsyncDisposable
     /// <param name="closeError">The error to transmit to the peer.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes once the connection closure completes successfully.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="ConnectAsync" /> did not complete successfully
-    /// prior to this call, or if this method is called more than once.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="ConnectAsync" /> did not complete
+    /// successfully prior to this call, or when this method is called more than once.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection has been disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>
@@ -79,10 +79,10 @@ public interface IMultiplexedConnection : IAsyncDisposable
     /// <see langword="false"/>.</param>
     /// <param name="cancellationToken">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes successfully with the local stream.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="ConnectAsync" /> did not complete successfully
-    /// prior to this call.</exception>
-    /// <exception cref="IceRpcException">Thrown if the connection is closed.</exception>
-    /// <exception cref="ObjectDisposedException">Thrown if the connection has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="ConnectAsync" /> did not complete
+    /// successfully prior to this call.</exception>
+    /// <exception cref="IceRpcException">Thrown when the connection is closed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the connection has been disposed.</exception>
     /// <remarks><para>The returned task can also complete with one of the following exceptions:</para>
     /// <list type="bullet">
     /// <item><description><see cref="IceRpcException" /> if the transport reported an error.</description></item>

--- a/src/IceRpc/Transports/IMultiplexedStream.cs
+++ b/src/IceRpc/Transports/IMultiplexedStream.cs
@@ -11,7 +11,7 @@ public interface IMultiplexedStream : IDuplexPipe
 {
     /// <summary>Gets the stream ID.</summary>
     /// <value>The stream ID.</value>
-    /// <exception cref="InvalidOperationException">Thrown if the stream is not started. A remote stream is always
+    /// <exception cref="InvalidOperationException">Thrown when the stream is not started. A remote stream is always
     /// started; depending on the transport implementation, a local stream is started at construction or by the first
     /// write.</exception>
     /// <remarks>The stream IDs have the same format as the QUIC stream IDs

--- a/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
+++ b/src/IceRpc/Transports/Internal/DuplexConnectionReader.cs
@@ -142,7 +142,7 @@ internal class DuplexConnectionReader : IDisposable
 
     /// <summary>Reads and returns bytes from the underlying transport connection. The returned buffer has always at
     /// least minimumSize bytes or if canReturnEmptyBuffer is true, the returned buffer can be empty if the peer
-    /// shutdown the connection.</summary>
+    /// shut down the connection.</summary>
     private async ValueTask<ReadOnlySequence<byte>> ReadAsyncCore(
         int minimumSize,
         bool canReturnEmptyBuffer,

--- a/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicConnection.cs
@@ -437,8 +437,8 @@ internal class SlicConnection : IMultiplexedConnection
                     else
                     {
                         // The sending of the client-side Close frame is followed by the shutdown of the duplex
-                        // connection. For TCP, it's important to always shutdown the connection on the client-side first
-                        // to avoid TIME_WAIT states on the server-side.
+                        // connection. For TCP, it's important to always shut down the connection on the client-side
+                        // first to avoid TIME_WAIT states on the server-side.
                         _duplexConnectionWriter.Shutdown();
                         waitForWriterShutdown = true;
                     }
@@ -1309,7 +1309,7 @@ internal class SlicConnection : IMultiplexedConnection
                     peerCloseError);
             }
 
-            // The server-side of the duplex connection is only shutdown once the client-side is shutdown. When using
+            // The server-side of the duplex connection is only shut down once the client-side is shut down. When using
             // TCP, this ensures that the server TCP connection won't end-up in the TIME_WAIT state on the server-side.
             if (notAlreadyClosed && !IsServer)
             {
@@ -1562,7 +1562,7 @@ internal class SlicConnection : IMultiplexedConnection
             {
                 Debug.Assert(_isClosed);
 
-                // The server-side of the duplex connection is only shutdown once the client-side is shutdown. When
+                // The server-side of the duplex connection is only shut down once the client-side is shut down. When
                 // using TCP, this ensures that the server TCP connection won't end-up in the TIME_WAIT state on the
                 // server-side.
 

--- a/src/IceRpc/TypeExtensions.cs
+++ b/src/IceRpc/TypeExtensions.cs
@@ -12,9 +12,9 @@ public static class TypeExtensions
     /// <param name="type">The interface with the <see cref="DefaultServicePathAttribute"/> attribute, or a class
     /// that implements such an interface.</param>
     /// <returns>The default service path.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="type" /> is neither a class nor an interface, or
-    /// if it does not have a <see cref="DefaultServicePathAttribute" /> attribute, or if it is a class that implements
-    /// multiple interfaces with a <see cref="DefaultServicePathAttribute" /> attribute.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="type" /> is neither a class nor an interface, or
+    /// when it does not have a <see cref="DefaultServicePathAttribute" /> attribute, or when it is a class that
+    /// implements multiple interfaces with a <see cref="DefaultServicePathAttribute" /> attribute.</exception>
     /// <remarks>When <paramref name="type" /> is an interface, this method only searches for the attribute on the
     /// interface itself.</remarks>
     /// <seealso cref="RouterExtensions.Map(Router, IDispatcher)" />

--- a/tests/IceRpc.Tests.Common/TransportOperations.cs
+++ b/tests/IceRpc.Tests.Common/TransportOperations.cs
@@ -67,7 +67,7 @@ public class TransportOperations<T> where T : struct, Enum
     /// <summary>Gets a task which can be awaited to wait for the given operation to be called. The task must be
     /// obtained before the operation is called. It can't be obtained again until the operation is called.</summary>
     /// <param name="operation">The operation for which the task will complete when the operation is called.</param>
-    /// <exception cref="InvalidOperationException">Thrown if the task has already been returned and the operation has
+    /// <exception cref="InvalidOperationException">Thrown when the task has already been returned and the operation has
     /// not been called yet. The caller should only obtain a new task after the operation has been called.</exception>
     public Task GetCalledTask(T operation)
     {

--- a/tests/IceRpc.Tests/ProtocolLoggerTests.cs
+++ b/tests/IceRpc.Tests/ProtocolLoggerTests.cs
@@ -270,7 +270,7 @@ public sealed class ProtocolLoggerTests
                     ServerAddress = serverAddress
                 });
 
-            // Send a request to ensure the server side is connected before than we shutdown the connection
+            // Send a request to ensure the server side is connected before we shut down the connection
             _ = await clientConnection.InvokeAsync(request);
         }
 


### PR DESCRIPTION
Fixes #4894.

This PR replaces "Thrown if" with "Thrown when" in all `<exception>` doc comments, following Microsoft's convention. Sentences that continued with "or if ..." now use "or when ..." to match.

It also fixes "shutdown" used as a verb — in doc comments, code comments, one exception message, and one log message: the verb is "shut down"; "shutdown" is the noun.

The `slice/IceRpc/Internal/IceRpcDefinitions.slice` doc comment has the same verb misuse but is vendored from icerpc-slice, so it's not touched here.

## What's Changed entry

None.