### PR TITLE
Make generated code compile without implicit usings

### DIFF
--- a/src/IceRpc.Slice.Generator/EncodeHelper.cs
+++ b/src/IceRpc.Slice.Generator/EncodeHelper.cs
@@ -17,7 +17,7 @@ internal static class EncodeHelper
                 {{encodeOptionsName}}?.PipeOptions ?? SliceEncodeOptions.Default.PipeOptions);
             var encoder_ = new SliceEncoder(pipe_.Writer);
 
-            Span<byte> sizePlaceholder_ = encoder_.GetPlaceholderSpan(4);
+            global::System.Span<byte> sizePlaceholder_ = encoder_.GetPlaceholderSpan(4);
             int startPos_ = encoder_.EncodedByteCount;
 
             {{encodeBody}}

--- a/src/IceRpc.Slice.Generator/Program.cs
+++ b/src/IceRpc.Slice.Generator/Program.cs
@@ -16,6 +16,14 @@ await GeneratorDriver.RunAsync(
         ? CodeBlock.FromBlocks([ProxyGenerator.Generate(interfaceDef), ServiceGenerator.Generate(interfaceDef)])
         : null,
     mapOutputPath: path => Path.ChangeExtension(Path.GetFileName(path), ".IceRpc.cs"),
-    usings: ["IceRpc.Slice", "IceRpc.Slice.Operations", "ZeroC.Slice.Codec"]).ConfigureAwait(false);
+    usings:
+    [
+        "IceRpc.Slice",
+        "IceRpc.Slice.Operations",
+        "System",
+        "System.Collections.Generic",
+        "System.Linq",
+        "ZeroC.Slice.Codec"
+    ]).ConfigureAwait(false);
 
 return 0;

--- a/src/IceRpc.Slice.Generator/Program.cs
+++ b/src/IceRpc.Slice.Generator/Program.cs
@@ -16,14 +16,6 @@ await GeneratorDriver.RunAsync(
         ? CodeBlock.FromBlocks([ProxyGenerator.Generate(interfaceDef), ServiceGenerator.Generate(interfaceDef)])
         : null,
     mapOutputPath: path => Path.ChangeExtension(Path.GetFileName(path), ".IceRpc.cs"),
-    usings:
-    [
-        "IceRpc.Slice",
-        "IceRpc.Slice.Operations",
-        "System",
-        "System.Collections.Generic",
-        "System.Linq",
-        "ZeroC.Slice.Codec"
-    ]).ConfigureAwait(false);
+    usings: ["IceRpc.Slice", "IceRpc.Slice.Operations", "ZeroC.Slice.Codec"]).ConfigureAwait(false);
 
 return 0;

--- a/src/ZeroC.Slice.Generator/FieldExtensions.cs
+++ b/src/ZeroC.Slice.Generator/FieldExtensions.cs
@@ -75,7 +75,7 @@ internal static class FieldExtensions
                 $$"""
                 if ({{param}} is {{csType}} {{varName}})
                 {
-                    int count_ = {{param}}.Count();
+                    int count_ = global::System.Linq.Enumerable.Count({{varName}});
                     {{encoderName}}.EncodeTagged({{tag}}, size: {{sizeExpr}}, {{varName}}, {{encodeLambda}});
                 }
                 """).ToString();

--- a/src/ZeroC.Slice.Generator/Program.cs
+++ b/src/ZeroC.Slice.Generator/Program.cs
@@ -18,6 +18,6 @@ await GeneratorDriver.RunAsync(
         _ => null,
     },
     mapOutputPath: path => Path.ChangeExtension(Path.GetFileName(path), ".cs"),
-    usings: ["ZeroC.Slice.Codec"]).ConfigureAwait(false);
+    usings: ["System.Collections.Generic", "System.Linq", "ZeroC.Slice.Codec"]).ConfigureAwait(false);
 
 return 0;

--- a/src/ZeroC.Slice.Generator/Program.cs
+++ b/src/ZeroC.Slice.Generator/Program.cs
@@ -18,6 +18,6 @@ await GeneratorDriver.RunAsync(
         _ => null,
     },
     mapOutputPath: path => Path.ChangeExtension(Path.GetFileName(path), ".cs"),
-    usings: ["System.Collections.Generic", "System.Linq", "ZeroC.Slice.Codec"]).ConfigureAwait(false);
+    usings: ["ZeroC.Slice.Codec"]).ConfigureAwait(false);
 
 return 0;

--- a/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/A/A.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/A/A.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/B/B.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/B/B.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/C/C.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/C/C.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/D/D.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/D/D.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/DPrime/DPrime.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies/DPrime/DPrime.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IceRpc.Ice.Generator.Base.Tests/ActivatorTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/ActivatorTests.cs
@@ -3,6 +3,9 @@
 using Ice.Generator.Base.Tests.ReferencedAssemblies;
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/ClassTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/ClassTests.cs
@@ -3,6 +3,7 @@
 using IceRpc.Ice.Codec;
 using IceRpc.Ice.Codec.Internal;
 using NUnit.Framework;
+using System.IO;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/CustomSequence.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/CustomSequence.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IceRpc.Ice.Generator.Base.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Base.Tests/EnumTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/EnumTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/IceRpc.Ice.Generator.Base.Tests.csproj
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/IceRpc.Ice.Generator.Base.Tests.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/IceRpc.Ice.Generator.Base.Tests/SequenceDecodingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/SequenceDecodingTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System.IO;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/SequenceMappingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/SequenceMappingTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System.Collections.Generic;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/SlicingTests.cs
@@ -2,6 +2,8 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
+using System.IO;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/TaggedTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/TaggedTests.cs
@@ -3,6 +3,7 @@
 using IceRpc.Ice.Codec;
 using IceRpc.Ice.Codec.Internal;
 using NUnit.Framework;
+using System.Collections.Generic;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Base.Tests;

--- a/tests/IceRpc.Ice.Generator.Base.Tests/TypeIdAttributeTests.cs
+++ b/tests/IceRpc.Ice.Generator.Base.Tests/TypeIdAttributeTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
 
 namespace IceRpc.Ice.Generator.Base.Tests.TypeIdAttributeTestNamespace;
 

--- a/tests/IceRpc.Ice.Generator.Tests/ClassTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ClassTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
 using System.IO.Pipelines;
 
 namespace IceRpc.Ice.Generator.Tests;

--- a/tests/IceRpc.Ice.Generator.Tests/CsIdentifierOnModuleTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/CsIdentifierOnModuleTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/CustomSequence.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/CustomSequence.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/DictionaryMappingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/DictionaryMappingTests.cs
@@ -3,7 +3,9 @@
 using IceRpc.Ice.Codec;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Tests;

--- a/tests/IceRpc.Ice.Generator.Tests/ExceptionTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ExceptionTests.cs
@@ -3,6 +3,11 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/IceRpc.Ice.Generator.Tests.csproj
+++ b/tests/IceRpc.Ice.Generator.Tests/IceRpc.Ice.Generator.Tests.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/IceRpc.Ice.Generator.Tests/IdentifierAttributeTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/IdentifierAttributeTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests.Identifiers;
 

--- a/tests/IceRpc.Ice.Generator.Tests/InterfaceTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/InterfaceTests.cs
@@ -2,6 +2,7 @@
 
 using IceRpc.Ice.Codec;
 using NUnit.Framework;
+using System;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/InvalidProxy.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/InvalidProxy.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+using System;
+
 namespace IceRpc.Ice.Generator.Tests;
 
 internal class InvalidProxy : IIceProxy

--- a/tests/IceRpc.Ice.Generator.Tests/InvokeOperationAsyncTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/InvokeOperationAsyncTests.cs
@@ -4,6 +4,8 @@ using IceRpc.Ice.Codec;
 using IceRpc.Ice.Operations;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/OperationTests.cs
@@ -4,7 +4,10 @@ using IceRpc.Features;
 using IceRpc.Ice.Derived.Generator.Tests;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
 using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ProxyTests.cs
@@ -4,6 +4,9 @@ using IceRpc.Features;
 using IceRpc.Ice.Codec;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Tests;

--- a/tests/IceRpc.Ice.Generator.Tests/SequenceMappingTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/SequenceMappingTests.cs
@@ -2,7 +2,9 @@
 
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/ServiceTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/ServiceTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Ice.Generator.Tests/StructTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/StructTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Ice.Codec;
 using IceRpc.Ice.Operations;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using ZeroC.Tests.Common;
 
 namespace IceRpc.Ice.Generator.Tests;

--- a/tests/IceRpc.Ice.Generator.Tests/TypeNameQualificationTests.cs
+++ b/tests/IceRpc.Ice.Generator.Tests/TypeNameQualificationTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Ice.Generator.Tests;
 

--- a/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/AsyncStreamTests.cs
@@ -3,8 +3,12 @@
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Protobuf.RpcMethods.Internal;
 using NUnit.Framework;
+using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Protobuf.Tests;
 

--- a/tests/IceRpc.Protobuf.Tests/IceRpc.Protobuf.Tests.csproj
+++ b/tests/IceRpc.Protobuf.Tests/IceRpc.Protobuf.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props" />
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <!-- Missing XML comment for publicly visible type or member -->
     <NoWarn>CS1591</NoWarn>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/IceRpc.Protobuf.Tests/OperationTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/OperationTests.cs
@@ -6,9 +6,14 @@ using IceRpc.Features;
 using IceRpc.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Protobuf.Tests;
 

--- a/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/PipeReaderExtensionsTests.cs
@@ -4,9 +4,13 @@ using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using IceRpc.Protobuf.RpcMethods.Internal;
 using NUnit.Framework;
+using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.IO;
 using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Protobuf.Tests;
 

--- a/tests/IceRpc.Protobuf.Tests/ServiceTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/ServiceTests.cs
@@ -4,7 +4,10 @@ using Google.Protobuf.WellKnownTypes;
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Protobuf.Tests;
 

--- a/tests/IceRpc.Protobuf.Tests/StreamTests.cs
+++ b/tests/IceRpc.Protobuf.Tests/StreamTests.cs
@@ -6,9 +6,15 @@ using IceRpc.Protobuf.RpcMethods;
 using IceRpc.Protobuf.RpcMethods.Internal;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Protobuf.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/CustomDictionary.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/CustomDictionary.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/CustomSequence.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/CustomSequence.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using System.Collections;
+using System.Collections.Generic;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/DictionaryMappingTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/DictionaryMappingTests.cs
@@ -2,7 +2,10 @@
 
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/IceRpc.Slice.Generator.Tests/EnumTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/EnumTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System;
 using System.IO.Pipelines;
 using ZeroC.Slice.Codec;
 

--- a/tests/IceRpc.Slice.Generator.Tests/IceRpc.Slice.Generator.Tests.csproj
+++ b/tests/IceRpc.Slice.Generator.Tests/IceRpc.Slice.Generator.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props" />
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/IceRpc.Slice.Generator.Tests/IdentifierAttributeTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/IdentifierAttributeTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests.Identifiers;
 

--- a/tests/IceRpc.Slice.Generator.Tests/InterfaceTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/InterfaceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/InvalidProxy.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/InvalidProxy.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+using System;
+
 namespace IceRpc.Slice.Generator.Tests;
 
 internal class InvalidProxy : ISliceProxy

--- a/tests/IceRpc.Slice.Generator.Tests/InvokeOperationAsyncTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/InvokeOperationAsyncTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Slice.Operations;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/ModuleIdentifierTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/ModuleIdentifierTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/OperationEncodingTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationEncodingTests.cs
@@ -4,6 +4,7 @@ using IceRpc.Tests.Common;
 using NUnit.Framework;
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/OperationTests.cs
@@ -4,8 +4,12 @@ using IceRpc.Features;
 using IceRpc.Slice.Derived.Generator.Tests;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
 using ZeroC.Slice;
 
 namespace IceRpc.Slice.Generator.Tests;

--- a/tests/IceRpc.Slice.Generator.Tests/ProxyTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/ProxyTests.cs
@@ -4,6 +4,9 @@ using IceRpc.Features;
 using IceRpc.Slice.Operations;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/IceRpc.Slice.Generator.Tests/SequenceMappingTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/SequenceMappingTests.cs
@@ -2,7 +2,10 @@
 
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/SequenceMappingTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/SequenceMappingTests.slice
@@ -70,8 +70,8 @@ interface SequenceMappingOperations {
     returnCustomSequenceOfOptionalMyUncheckedEnum() -> [cs::type("CustomSequence<MyUncheckedEnum?>")] Sequence<MyUncheckedEnum?>
     sendCustomSequenceOfOptionalMyUncheckedEnum(p: [cs::type("CustomSequence<MyUncheckedEnum?>")] Sequence<MyUncheckedEnum?>)
 
-    returnHashSetOfInt32() -> [cs::type("HashSet<int>")] Sequence<int32>
-    sendHashSetOfInt32(p: [cs::type("HashSet<int>")] Sequence<int32>)
+    returnHashSetOfInt32() -> [cs::type("global::System.Collections.Generic.HashSet<int>")] Sequence<int32>
+    sendHashSetOfInt32(p: [cs::type("global::System.Collections.Generic.HashSet<int>")] Sequence<int32>)
 
     opNumericTypeNestedSequence(p1: Sequence<Sequence<Sequence<uint8>>>) -> Sequence<Sequence<Sequence<uint8>>>
     opStructNestedSequence(p1: Sequence<Sequence<Sequence<MyStruct>>>) -> Sequence<Sequence<Sequence<MyStruct>>>

--- a/tests/IceRpc.Slice.Generator.Tests/ServiceTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/ServiceTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/IceRpc.Slice.Generator.Tests/StreamTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/StreamTests.cs
@@ -5,9 +5,15 @@ using IceRpc.Internal; // For InvalidPipeReader
 using IceRpc.Slice.Operations;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using ZeroC.Slice.Codec;
 
 namespace IceRpc.Slice.Generator.Tests;

--- a/tests/IceRpc.Slice.Generator.Tests/StructTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/StructTests.cs
@@ -2,6 +2,8 @@
 
 using IceRpc.Slice.Operations;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/IceRpc.Slice.Generator.Tests/TypeNameQualificationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/TypeNameQualificationTests.cs
@@ -3,6 +3,8 @@
 using IceRpc.Features;
 using IceRpc.Tests.Common;
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IceRpc.Slice.Generator.Tests;
 

--- a/tests/ZeroC.Slice.Generator.Tests/DictionaryDecodingTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/DictionaryDecodingTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;

--- a/tests/ZeroC.Slice.Generator.Tests/DictionaryEncodingTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/DictionaryEncodingTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/EnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/EnumTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System;
+using System.IO;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.IO;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/SequenceDecodingTests.slice
@@ -7,9 +7,9 @@ compact struct BoolS {
 }
 
 compact struct CustomBoolS {
-    value: [cs::type("List<bool>")] Sequence<bool>
+    value: [cs::type("global::System.Collections.Generic.List<bool>")] Sequence<bool>
 }
 
 compact struct CustomOptInt32S {
-    value: [cs::type("List<int?>")] Sequence<int32?>
+    value: [cs::type("global::System.Collections.Generic.List<int?>")] Sequence<int32?>
 }

--- a/tests/ZeroC.Slice.Generator.Tests/StructTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/StructTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Linq;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/TaggedTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/TaggedTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System.Collections.Generic;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 
@@ -60,14 +61,18 @@ internal class TaggedTests
             new MyStruct(20, 20),
             MyEnum.Enum1,
             new byte[] { 1, 2, 3 },
-            "hello world!"),
+            "hello world!",
+            new int[] { 4, 5, 6 },
+            new Dictionary<int, int> { [1] = 10, [2] = 20 }),
         new MyStructWithTaggedFields(),
         new MyStructWithTaggedFields(
             10,
             null,
             MyEnum.Enum1,
             null,
-            "hello world!"),
+            "hello world!",
+            null,
+            new Dictionary<int, int> { [1] = 10 }),
     };
 
     [Test]
@@ -99,6 +104,25 @@ internal class TaggedTests
         {
             encoder.EncodeTagged(5, e, (ref SliceEncoder encoder, string value) => encoder.EncodeString(e));
         }
+        if (expected.F is IList<int> f)
+        {
+            encoder.EncodeTagged(
+                6,
+                size: SliceEncoder.GetSizeLength(f.Count) + (4 * f.Count),
+                f,
+                (ref SliceEncoder encoder, IList<int> value) => encoder.EncodeSequence(value));
+        }
+        if (expected.G is IDictionary<int, int> g)
+        {
+            encoder.EncodeTagged(
+                7,
+                size: SliceEncoder.GetSizeLength(g.Count) + (8 * g.Count),
+                g,
+                (ref SliceEncoder encoder, IDictionary<int, int> value) => encoder.EncodeDictionary(
+                    value,
+                    (ref SliceEncoder encoder, int value) => encoder.EncodeInt32(value),
+                    (ref SliceEncoder encoder, int value) => encoder.EncodeInt32(value)));
+        }
         encoder.EncodeVarInt32(SliceDefinitions.TagEndMarker);
         var decoder = new SliceDecoder(buffer.WrittenMemory);
 
@@ -108,6 +132,8 @@ internal class TaggedTests
         Assert.That(decoded.C, Is.EqualTo(expected.C));
         Assert.That(decoded.D, Is.EqualTo(expected.D));
         Assert.That(decoded.E, Is.EqualTo(expected.E));
+        Assert.That(decoded.F, Is.EqualTo(expected.F));
+        Assert.That(decoded.G, Is.EqualTo(expected.G));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));
     }
 
@@ -141,6 +167,17 @@ internal class TaggedTests
         Assert.That(
             decoder.DecodeTagged(5, (ref SliceDecoder decoder) => decoder.DecodeString()),
             Is.EqualTo(expected.E));
+
+        Assert.That(
+            decoder.DecodeTagged(6, (ref SliceDecoder decoder) => decoder.DecodeSequence<int>()),
+            Is.EqualTo(expected.F));
+
+        Assert.That(
+            decoder.DecodeTagged(7, (ref SliceDecoder decoder) => decoder.DecodeDictionary(
+                size => new Dictionary<int, int>(size),
+                (ref SliceDecoder decoder) => decoder.DecodeInt32(),
+                (ref SliceDecoder decoder) => decoder.DecodeInt32())),
+            Is.EqualTo(expected.G));
 
         Assert.That(decoder.DecodeVarInt32(), Is.EqualTo(SliceDefinitions.TagEndMarker));
         Assert.That(decoder.Consumed, Is.EqualTo(buffer.WrittenMemory.Length));

--- a/tests/ZeroC.Slice.Generator.Tests/TaggedTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/TaggedTests.slice
@@ -8,6 +8,8 @@ struct MyStructWithTaggedFields {
     tag(3) c: MyEnum?
     tag(4) d: Sequence<uint8>?
     tag(5) e: string?
+    tag(6) f: Sequence<int32>?
+    tag(7) g: Dictionary<int32, int32>?
 }
 
 struct MyStructWithoutTaggedFields {}

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
@@ -2,6 +2,7 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/WellKnownTypesTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/WellKnownTypesTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 

--- a/tests/ZeroC.Slice.Generator.Tests/ZeroC.Slice.Generator.Tests.csproj
+++ b/tests/ZeroC.Slice.Generator.Tests/ZeroC.Slice.Generator.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.props" />
   <PropertyGroup>
+    <!-- Verify that the generated code compiles without implicit usings. -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <!-- Missing XML comment for publicly visible type or member. -->
     <NoWarn>CS1591</NoWarn>
     <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
Fixes #4791.

The Slice generators emit fully qualified names for BCL types — except in two spots that relied on the consuming project enabling `ImplicitUsings`: the `Span<byte>` local emitted in every `Request.Encode*`/`Response.Encode*` helper, and the `.Count()` call emitted for tagged fixed-size collection fields. A consuming project without implicit usings — the SDK default — failed to compile the generated code.

Both emissions are now fully qualified, like everything else the generators emit: `global::System.Span<byte>`, and `global::System.Linq.Enumerable.Count(...)` in its static form — which also works when a `cs::type` attribute maps a sequence to an array, and drops a redundant nullable dereference by counting the non-null pattern variable.

To keep this from regressing, the Slice, Ice and Protobuf generator test projects (including the `IceRpc.Ice.Generator.Base.Tests.ReferencedAssemblies` projects) now build with `<ImplicitUsings>disable</ImplicitUsings>`, and their handwritten test files declare their usings explicitly. This also verifies that the `slice2cs` and `protoc-gen-icerpc-csharp` outputs compile without implicit usings — both already qualify all their references.

The new `Sequence<int32>?` and `Dictionary<int32, int32>?` tagged fields in `TaggedTests.slice` cover the previously untested fixed-size tagged collection encoding.

`cs::type` text is passed through verbatim: in a project that doesn't enable implicit usings, qualify the C# type names you write in `cs::type` — the test corpora now do (`cs::type("global::System.Collections.Generic.List<bool>")`).

The checked-in `src/ZeroC.Slice.Symbols/Compiler` files are deliberately not regenerated here: regenerating them is blocked by #4896.

## What's Changed entry

The Slice compiler now generates code that compiles in projects that don't enable `ImplicitUsings`.