### PR TITLE
Pass the ProtoFile AdditionalOptions metadata to protoc

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -101,7 +101,7 @@
       SearchPath="@(ProtoSearchPath->'%(FullPath)');$(IceRpcProtocPath);$(MSBuildProjectDirectory)"
       ToolsPath="$(IceRpcProtocPath)$(IceRpcProtocPrefix)"
       Plugins="@(_ProtocCodeGenPlugin)"
-      AdditionalOptions="--dependency_out=&quot;%(_ProtoFile.OutputDir)/%(_ProtoFile.OutputFileName).d&quot;"
+      AdditionalOptions="%(_ProtoFile.AdditionalOptions);--dependency_out=&quot;%(_ProtoFile.OutputDir)/%(_ProtoFile.OutputFileName).d&quot;"
       Sources="%(_ProtoFile.Identity)"
       Condition="'%(_ProtoFile.UpToDate)' != 'true'"
     />

--- a/src/IceRpc.Protobuf.Tools/README.md
+++ b/src/IceRpc.Protobuf.Tools/README.md
@@ -65,8 +65,8 @@ follows:
 
 ## ProtoFile item metadata
 
-You can use the following `ProtoFile` item metadata to customize the compilation of your Proto files. Each
-unique set of options results in a separate execution of `protoc`.
+You can use the following `ProtoFile` item metadata to customize the compilation of your Proto files. `protoc` runs
+once per Proto file.
 
 | Name              | Default   | Description                                                                                                                                      |
 |-------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -74,6 +74,10 @@ unique set of options results in a separate execution of `protoc`.
 | OutputDir         | generated | Sets the output directory for the generated code. This metadata corresponds to the `--csharp_out` and `--icerpc-csharp_out` options of `protoc`. |
 | Pack              | `false`   | Specifies whether or not to include the items (Proto files) in the NuGet package.                                                                |
 | PackagePath       | protobuf  | Sets the target path in the NuGet package. Used only when Pack is `true`.                                                                        |
+
+> [!NOTE]
+> Changing `AdditionalOptions` does not mark previously generated code as out of date. Run `dotnet clean` and then
+> build again to regenerate the code with the new options.
 
 ## Generated code and NuGet packages
 


### PR DESCRIPTION
Fixes #4816.

The Protobuf Tools README documents the `AdditionalOptions` item metadata of `ProtoFile` items, and `ProtocTask` supports it, but the `ProtoCompile` target passed only its own `--dependency_out` option — the metadata was silently ignored. The target now passes the metadata ahead of `--dependency_out`, like the Slice Tools targets do for `SliceFile` items.

Verified by setting `AdditionalOptions="--descriptor_set_out=..."` on a `ProtoFile` item: the option appears on the protoc command line and protoc writes the descriptor set file; without the fix it never does.

The README also gets a note after the metadata table: changing `AdditionalOptions` does not mark previously generated code as out of date — run `dotnet clean` and build again. And the sentence claiming that each unique set of options results in a separate protoc execution is replaced: protoc runs once per Proto file.

## What's Changed entry

Area: Protobuf

- The IceRpc.Protobuf.Tools build tasks now pass the documented `AdditionalOptions` item metadata of `ProtoFile` items to `protoc`.