### PR TITLE
Pin libmsquic to 2.6.0 on Linux CI

### DIFF
--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -23,7 +23,8 @@ runs:
         sudo dpkg -i packages-microsoft-prod.deb
         rm packages-microsoft-prod.deb
         sudo apt update
-        sudo apt install libmsquic
+        # 2.6.1 fails every QUIC handshake to an IP address (see #4906); pin until a fixed release ships.
+        sudo apt install libmsquic=2.6.0
       shell: bash
 
     - name: Install libmsquic on macOS


### PR DESCRIPTION
libmsquic 2.6.1 fails every QUIC handshake to an IP address with `QUIC_STATUS_TLS_ERROR` (#4906), which takes down the ubuntu-24.04 test job.

- Pins the apt install to 2.6.0 until a fixed msquic release ships.

macOS CI floats on Homebrew and currently gets unaffected 2.5.9; it only breaks if the runner's brew index catches up before msquic ships a fix.
