### PR TITLE
Document the synchronous Complete convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,16 @@ ordinary `using` directives and unqualified names, not `global::` qualification 
 reserved namespace breaks the compilation of the generated code; that's an error in the consuming project, not in the
 generators. Don't file findings proposing to `global::`-qualify the generated references to these namespaces as a
 defense against shadowing. (#4813.)
+
+### 15. `Complete` is synchronous and non-blocking by convention
+
+IceRPC completes every `PipeReader` and `PipeWriter` — including the payload writers installed by interceptors and
+middleware — with `Complete`, never `CompleteAsync` (#965). We interpret `Complete` as a fast, non-blocking call, the
+way modern C# treats a synchronous method that also has an async counterpart. This is our interpretation, not
+Microsoft's (which considers such a method potentially blocking), and it was adopted deliberately. Two rules make it
+work: IceRPC never calls `Complete()` on a writer with unflushed bytes (the payload is flushed before completion, and
+the transport writers throw `InvalidOperationException` when this rule is broken), and a decorator or transport
+implementation must not implement `Complete` by waiting. A decorator that has to emit a trailer (the compressor's
+compression stream) writes those few bytes synchronously in `Complete` and completes its decoratee with the exception
+when the write fails. Don't propose an asynchronous finalization step ahead of `Complete`, switching call sites to
+`CompleteAsync`, or flagging a synchronous `Complete` as sync-over-async. (#965, #4840.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,11 @@ way modern C# treats a synchronous method that also has an async counterpart. Th
 Microsoft's (which considers such a method potentially blocking), and it was adopted deliberately. Two rules make it
 work: IceRPC never calls `Complete()` on a writer with unflushed bytes (the payload is flushed before completion, and
 the transport writers throw `InvalidOperationException` when this rule is broken), and a decorator or transport
-implementation must not implement `Complete` by waiting. A decorator that has to emit a trailer (the compressor's
-compression stream) writes those few bytes synchronously in `Complete` and completes its decoratee with the exception
-when the write fails. Don't propose an asynchronous finalization step ahead of `Complete`, switching call sites to
-`CompleteAsync`, or flagging a synchronous `Complete` as sync-over-async. (#965, #4840.)
+implementation must not implement `Complete` by waiting. Switching call sites to `CompleteAsync` would fix nothing
+anyway: `CompleteAsync` takes no cancellation token, so it cannot bound anything `Complete` couldn't. Don't propose an
+asynchronous finalization step ahead of `Complete` or a switch to `CompleteAsync`, and don't flag a `Complete`
+implementation that follows the rules above as sync-over-async. (#965, #4840.)
+
+Known deviation: the compressor's payload writer writes the compression trailer during its graceful `Complete` — a
+network write that can block on flow control when the peer stops reading without closing its input. That's a real bug,
+tracked by #4911; don't file it again, and don't dismiss it as by-design.


### PR DESCRIPTION
Adds a dismissed-audit pattern for the decision recorded in #965: IceRPC completes pipe readers and writers with `Complete`, never `CompleteAsync`, and treats `Complete` as a fast, non-blocking call. The pattern also records why this works (no `Complete()` with unflushed bytes; decorators and transports don't wait in `Complete`), why switching to `CompleteAsync` wouldn't help (no cancellation token), and the one known deviation: the compressor's trailer write, a real bug tracked by #4911.

The review of #4840 showed this decision was not captured anywhere an AI reviewer would find it.

## What's Changed entry

None — documentation for AI coding agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
