### PR TITLE
Contribute the IceRpc.Ice Slice directory to SliceCompile items

### DIFF
--- a/src/IceRpc.Ice/IceRpc.Ice.csproj
+++ b/src/IceRpc.Ice/IceRpc.Ice.csproj
@@ -36,6 +36,7 @@
     <Content Include="../../LICENSE" Pack="true" PackagePath="/" />
     <Content Include="README.md" Pack="true" PackagePath="/" />
     <None Include="../../build/icerpc-icon.png" Pack="true" PackagePath="/" />
+    <Content Include="IceRpc.Ice.props" Pack="true" PackagePath="buildTransitive" />
     <Content
       Include="../../slice/Ice/Identity.ice;../../slice/Ice/Locator.ice;../../slice/Ice/LocatorRegistry.ice;../../slice/Ice/Process.ice"
       Pack="true"

--- a/src/IceRpc.Ice/IceRpc.Ice.props
+++ b/src/IceRpc.Ice/IceRpc.Ice.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) ZeroC, Inc. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <SliceCompile>
+      <IncludeDirectories>%(IncludeDirectories);$(MSBuildThisFileDirectory)../slice</IncludeDirectories>
+    </SliceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/IceRpc.Ice/README.md
+++ b/src/IceRpc.Ice/README.md
@@ -87,6 +87,13 @@ internal partial class Chatbot : IGreeterService
 }
 ```
 
+## Slice files
+
+This package ships `Identity.ice`, `Locator.ice`, `LocatorRegistry.ice` and `Process.ice` in its `slice` directory,
+and adds this directory to the include directories of every `SliceCompile` item: referencing the package is all you
+need to `#include <Ice/Identity.ice>`. A `SliceCompile` item that sets the `IncludeDirectories` metadata explicitly
+must write `%(IncludeDirectories)` back into the value to keep this directory.
+
 [api]: https://code.icerpc.dev/csharp/main/api/reference/IceRpc.Ice.html
 [docs]: https://docs.icerpc.dev/icerpc-for-ice-users
 [ice]: https://zeroc.com/ice


### PR DESCRIPTION
Fixes #4909.

The IceRpc.Ice package now ships a `buildTransitive/IceRpc.Ice.props` with an `ItemDefinitionGroup` that appends the package's `slice` directory to the default `IncludeDirectories` metadata of every `SliceCompile` item — the same model as the ZeroC.Ice package. Referencing the package is all you need to `#include <Ice/Identity.ice>`; no more `GeneratePathProperty` + `$(PkgIceRpc_Ice)/slice` by hand.

The README documents the shipped files and the `ItemDefinitionGroup` caveat: a `SliceCompile` item that sets `IncludeDirectories` explicitly must write `%(IncludeDirectories)` back into the value to keep the package-contributed directory.

Verified with a consumer project laid out like the installed package: `#include <Ice/Locator.ice>` compiles with no `IncludeDirectories` set anywhere, and `dotnet pack` places the props and the four `.ice` files at the expected paths in the nupkg.

## What's Changed entry

Area: icerpc+ice integration

- Referencing the IceRpc.Ice package now adds its `slice` directory to the include directories of every
  `SliceCompile` item; you no longer need to locate the packaged `.ice` files by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)