### PR TITLE
Check for unflushed bytes in CompressorPipeWriter.Complete

### DIFF
--- a/src/IceRpc.Compressor/CompressorPipeWriter.cs
+++ b/src/IceRpc.Compressor/CompressorPipeWriter.cs
@@ -29,13 +29,19 @@ internal class CompressorPipeWriter : PipeWriter
     {
         if (!_isCompleted)
         {
+            if (exception is null && _compressedDataWriter.UnflushedBytes > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Completing a {nameof(CompressorPipeWriter)} without an exception is not allowed when this pipe writer has unflushed bytes.");
+            }
+
             _isCompleted = true;
 
             if (exception is null)
             {
                 try
                 {
-                    // Flushes the buffered data and the compression trailer into the decoratee.
+                    // Writes the compression trailer into the decoratee.
                     _compressedDataWriter.Complete();
                 }
                 catch (Exception completeException)


### PR DESCRIPTION
`SlicPipeWriter.Complete` and `QuicPipeWriter.Complete` throw `InvalidOperationException` when called without an exception while the writer holds unflushed bytes. This PR adds the same check to `CompressorPipeWriter`, per the synchronous `Complete` convention (#4908): a graceful `Complete` must have no payload data left to flush — for the compressor, the only bytes `Complete` writes are the compression trailer. The trailer comment is reworded accordingly.

See #4911 for a related flow-control concern with the trailer write.

## What's Changed entry

None — enforces an existing convention; no behavior change for conforming payload writers.
