### PR TITLE
Clarify the IIceFeature, ISliceFeature and IProtobufFeature docs

### DIFF
--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -16,9 +16,9 @@ public interface IIceFeature
 
     /// <summary>Gets the base proxy used when decoding a service address into a proxy.</summary>
     /// <value>The base proxy. A decoded proxy inherits the invoker and encode options of the base proxy. When
-    /// <see langword="null" />, a proxy decoded from an incoming request receives
-    /// <see cref="InvalidInvoker.Instance" /> as its invoker, and a proxy decoded from an incoming response inherits
-    /// the invoker and encode options of the proxy that sent the request.</value>
+    /// <see langword="null" />, the proxy that sent the request serves as the base proxy for a proxy decoded from an
+    /// incoming response, while a proxy decoded from an incoming request receives
+    /// <see cref="InvalidInvoker.Instance" /> as its invoker.</value>
     IIceProxy? BaseProxy { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>
@@ -44,15 +44,11 @@ public interface IIceFeature
     /// encoded arguments of an operation, the encoded return values of an operation, or the encoded Ice exception
     /// carried by a response with status code <see cref="StatusCode.ApplicationError" />.</summary>
     /// <value>The maximum size of an Ice-encoded payload, in bytes.</value>
-    /// <remarks><para>This limit applies only when decoding the payload of an incoming request or response: the
-    /// decoding throws <see cref="InvalidDataException" /> when the payload size carried by the request or response
-    /// exceeds this maximum, before decoding any byte of the payload. It does not restrict the size of the payloads
-    /// encoded by the application. The payload size does not include the size of any header for this payload, such
-    /// as the encapsulation header with the ice protocol. Implementations must return a value greater than or equal
-    /// to <c>0</c> and less than <see cref="int.MaxValue" />.</para>
-    /// <para>This property is the counterpart of the Ice property
-    /// <see href="https://docs.zeroc.com/ice/3.8/cpp/ice#Ice.MessageSizeMax">Ice.MessageSizeMax</see>, with two
-    /// differences: the maximum payload size is in bytes rather than kilobytes, and it excludes the protocol header
-    /// that Ice.MessageSizeMax includes.</para></remarks>
+    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: the decoding
+    /// throws <see cref="InvalidDataException" /> when the payload size carried by the request or response exceeds
+    /// this maximum, before decoding any byte of the payload. It does not restrict the size of the payloads encoded by
+    /// the application. The payload size does not include the size of any header for this payload, such as the
+    /// encapsulation header with the ice protocol. Implementations must return a value greater than or equal to
+    /// <c>0</c> and less than <see cref="int.MaxValue" />.</remarks>
     int MaxPayloadSize { get; }
 }

--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -15,7 +15,10 @@ public interface IIceFeature
     IActivator? Activator { get; }
 
     /// <summary>Gets the base proxy used when decoding a service address into a proxy.</summary>
-    /// <value>The base proxy.</value>
+    /// <value>The base proxy. A decoded proxy inherits the invoker and encode options of the base proxy. When
+    /// <see langword="null" />, a proxy decoded from an incoming request receives
+    /// <see cref="InvalidInvoker.Instance" /> as its invoker, and a proxy decoded from an incoming response inherits
+    /// the invoker and encode options of the proxy that sent the request.</value>
     IIceProxy? BaseProxy { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>
@@ -25,7 +28,10 @@ public interface IIceFeature
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
     /// <value>The maximum collection allocation.</value>
-    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
+    /// <remarks>This value is a cumulative budget for the decoding of one payload, not a limit on the size of each
+    /// collection: the decoder adds the estimated memory size of every string, sequence, and dictionary it decodes,
+    /// and throws <see cref="InvalidDataException" /> once this total exceeds the maximum collection allocation.
+    /// Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum depth when decoding a class recursively.</summary>
@@ -34,10 +40,14 @@ public interface IIceFeature
     int MaxDepth { get; }
 
     /// <summary>Gets the maximum size of an Ice-encoded payload, in bytes. An Ice-encoded payload corresponds to the
-    /// encoded arguments of an operation, or the encoded return values of an operation.</summary>
+    /// encoded arguments of an operation, the encoded return values of an operation, or the encoded Ice exception
+    /// carried by a response with status code <see cref="StatusCode.ApplicationError" />.</summary>
     /// <value>The maximum size of an Ice-encoded payload, in bytes.</value>
-    /// <remarks>The payload size does not include the size of any header for this payload, such as the encapsulation
-    /// header with the ice protocol. Implementations must return a value greater than or equal to <c>0</c> and less
-    /// than <see cref="int.MaxValue" />.</remarks>
+    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: the payload is
+    /// read in full into memory before it is decoded, and this read throws <see cref="InvalidDataException" /> when
+    /// the payload exceeds this size. It does not restrict the size of the payloads encoded by the application. The
+    /// payload size does not include the size of any header for this payload, such as the encapsulation header with
+    /// the ice protocol. Implementations must return a value greater than or equal to <c>0</c> and less than
+    /// <see cref="int.MaxValue" />.</remarks>
     int MaxPayloadSize { get; }
 }

--- a/src/IceRpc.Ice/Features/IIceFeature.cs
+++ b/src/IceRpc.Ice/Features/IIceFeature.cs
@@ -29,9 +29,10 @@ public interface IIceFeature
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
     /// <value>The maximum collection allocation.</value>
     /// <remarks>This value is a cumulative budget for the decoding of one payload, not a limit on the size of each
-    /// collection: the decoder adds the estimated memory size of every string, sequence, and dictionary it decodes,
-    /// and throws <see cref="InvalidDataException" /> once this total exceeds the maximum collection allocation.
-    /// Implementations must return a value greater than or equal to <c>0</c>.</remarks>
+    /// collection: the decoder charges the estimated memory size of each string, sequence, and dictionary against
+    /// this budget before decoding it, based on the size or element count found in the encoded data, and throws
+    /// <see cref="InvalidDataException" /> when the charge exceeds the remaining budget. Implementations must return
+    /// a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum depth when decoding a class recursively.</summary>
@@ -43,11 +44,15 @@ public interface IIceFeature
     /// encoded arguments of an operation, the encoded return values of an operation, or the encoded Ice exception
     /// carried by a response with status code <see cref="StatusCode.ApplicationError" />.</summary>
     /// <value>The maximum size of an Ice-encoded payload, in bytes.</value>
-    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: the payload is
-    /// read in full into memory before it is decoded, and this read throws <see cref="InvalidDataException" /> when
-    /// the payload exceeds this size. It does not restrict the size of the payloads encoded by the application. The
-    /// payload size does not include the size of any header for this payload, such as the encapsulation header with
-    /// the ice protocol. Implementations must return a value greater than or equal to <c>0</c> and less than
-    /// <see cref="int.MaxValue" />.</remarks>
+    /// <remarks><para>This limit applies only when decoding the payload of an incoming request or response: the
+    /// decoding throws <see cref="InvalidDataException" /> when the payload size carried by the request or response
+    /// exceeds this maximum, before decoding any byte of the payload. It does not restrict the size of the payloads
+    /// encoded by the application. The payload size does not include the size of any header for this payload, such
+    /// as the encapsulation header with the ice protocol. Implementations must return a value greater than or equal
+    /// to <c>0</c> and less than <see cref="int.MaxValue" />.</para>
+    /// <para>This property is the counterpart of the Ice property
+    /// <see href="https://docs.zeroc.com/ice/3.8/cpp/ice#Ice.MessageSizeMax">Ice.MessageSizeMax</see>, with two
+    /// differences: the maximum payload size is in bytes rather than kilobytes, and it excludes the protocol header
+    /// that Ice.MessageSizeMax includes.</para></remarks>
     int MaxPayloadSize { get; }
 }

--- a/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
+++ b/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
@@ -10,7 +10,12 @@ public interface IProtobufFeature
 {
     /// <summary>Gets the maximum length of an encoded Protobuf message, in bytes.</summary>
     /// <value>The maximum length of a Protobuf message, in bytes.</value>
-    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
+    /// <remarks>This limit applies only when decoding the payload of an incoming request or response, whether this
+    /// payload holds a single message or a stream of messages: each message is read in full into memory before it is
+    /// parsed, and this read throws <see cref="InvalidDataException" /> when the message exceeds this length. It does
+    /// not restrict the length of the messages encoded by the application. The message length does not include the
+    /// 5-byte prefix that precedes each message. Implementations must return a value greater than or equal to
+    /// <c>0</c>.</remarks>
     int MaxMessageLength { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>

--- a/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
+++ b/src/IceRpc.Protobuf/Features/IProtobufFeature.cs
@@ -11,11 +11,11 @@ public interface IProtobufFeature
     /// <summary>Gets the maximum length of an encoded Protobuf message, in bytes.</summary>
     /// <value>The maximum length of a Protobuf message, in bytes.</value>
     /// <remarks>This limit applies only when decoding the payload of an incoming request or response, whether this
-    /// payload holds a single message or a stream of messages: each message is read in full into memory before it is
-    /// parsed, and this read throws <see cref="InvalidDataException" /> when the message exceeds this length. It does
-    /// not restrict the length of the messages encoded by the application. The message length does not include the
-    /// 5-byte prefix that precedes each message. Implementations must return a value greater than or equal to
-    /// <c>0</c>.</remarks>
+    /// payload holds a single message or a stream of messages: the decoding throws
+    /// <see cref="InvalidDataException" /> when the length encoded in the 5-byte prefix of a message exceeds this
+    /// maximum, before parsing any byte of the message. It does not restrict the length of the messages encoded by the
+    /// application. The message length does not include this prefix. Implementations must return a value greater than
+    /// or equal to <c>0</c>.</remarks>
     int MaxMessageLength { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>

--- a/src/IceRpc.Slice/Features/ISliceFeature.cs
+++ b/src/IceRpc.Slice/Features/ISliceFeature.cs
@@ -11,10 +11,9 @@ public interface ISliceFeature
     /// <summary>Gets the base proxy used when decoding a service address into a proxy.</summary>
     /// <value>The base proxy. A decoded proxy inherits the invoker and encode options of the base proxy, and a decoded
     /// relative service address is resolved against the service address of the base proxy. When
-    /// <see langword="null" />, a proxy decoded from an incoming request receives
-    /// <see cref="InvalidInvoker.Instance" /> as its invoker and keeps its relative service address as is, and a proxy
-    /// decoded from an incoming response inherits the invoker and encode options of the proxy that sent the request.
-    /// </value>
+    /// <see langword="null" />, the proxy that sent the request serves as the base proxy for a proxy decoded from an
+    /// incoming response, while a proxy decoded from an incoming request receives
+    /// <see cref="InvalidInvoker.Instance" /> as its invoker and keeps its relative service address as is.</value>
     ISliceProxy? BaseProxy { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>

--- a/src/IceRpc.Slice/Features/ISliceFeature.cs
+++ b/src/IceRpc.Slice/Features/ISliceFeature.cs
@@ -9,7 +9,12 @@ namespace IceRpc.Features;
 public interface ISliceFeature
 {
     /// <summary>Gets the base proxy used when decoding a service address into a proxy.</summary>
-    /// <value>The base proxy.</value>
+    /// <value>The base proxy. A decoded proxy inherits the invoker and encode options of the base proxy, and a decoded
+    /// relative service address is resolved against the service address of the base proxy. When
+    /// <see langword="null" />, a proxy decoded from an incoming request receives
+    /// <see cref="InvalidInvoker.Instance" /> as its invoker and keeps its relative service address as is, and a proxy
+    /// decoded from an incoming response inherits the invoker and encode options of the proxy that sent the request.
+    /// </value>
     ISliceProxy? BaseProxy { get; }
 
     /// <summary>Gets the options to use when encoding the payload of an outgoing response.</summary>
@@ -19,13 +24,20 @@ public interface ISliceFeature
 
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
     /// <value>The maximum collection allocation.</value>
-    /// <remarks>Implementations must return a value greater than or equal to <c>0</c>.</remarks>
+    /// <remarks>This value is a cumulative budget for the decoding of one Slice payload segment, not a limit on the
+    /// size of each collection: the decoder adds the estimated memory size of every string, sequence, and dictionary
+    /// it decodes, and throws <see cref="InvalidDataException" /> once this total exceeds the maximum collection
+    /// allocation. Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum size of a Slice payload segment, in bytes. A Slice payload segment corresponds to the
     /// encoded arguments of an operation, the encoded return values of an operation, or a portion of a stream of
     /// variable-size elements.</summary>
     /// <value>The maximum size of a Slice payload segment, in bytes.</value>
-    /// <remarks>Implementations must return a value greater than <c>0</c>.</remarks>
+    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: each segment is
+    /// read in full into memory before it is decoded, and this read throws <see cref="InvalidDataException" /> when
+    /// the segment exceeds this size. It does not restrict the size of the segments encoded by the application. The
+    /// segment size does not include the size of its size prefix. Implementations must return a value greater than
+    /// <c>0</c>.</remarks>
     int MaxSegmentSize { get; }
 }

--- a/src/IceRpc.Slice/Features/ISliceFeature.cs
+++ b/src/IceRpc.Slice/Features/ISliceFeature.cs
@@ -25,19 +25,20 @@ public interface ISliceFeature
     /// <summary>Gets the maximum collection allocation when decoding a payload, in bytes.</summary>
     /// <value>The maximum collection allocation.</value>
     /// <remarks>This value is a cumulative budget for the decoding of one Slice payload segment, not a limit on the
-    /// size of each collection: the decoder adds the estimated memory size of every string, sequence, and dictionary
-    /// it decodes, and throws <see cref="InvalidDataException" /> once this total exceeds the maximum collection
-    /// allocation. Implementations must return a value greater than or equal to <c>0</c>.</remarks>
+    /// size of each collection: the decoder charges the estimated memory size of each string, sequence, and
+    /// dictionary against this budget before decoding it, based on the size or element count found in the encoded
+    /// data, and throws <see cref="InvalidDataException" /> when the charge exceeds the remaining budget.
+    /// Implementations must return a value greater than or equal to <c>0</c>.</remarks>
     int MaxCollectionAllocation { get; }
 
     /// <summary>Gets the maximum size of a Slice payload segment, in bytes. A Slice payload segment corresponds to the
     /// encoded arguments of an operation, the encoded return values of an operation, or a portion of a stream of
     /// variable-size elements.</summary>
     /// <value>The maximum size of a Slice payload segment, in bytes.</value>
-    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: each segment is
-    /// read in full into memory before it is decoded, and this read throws <see cref="InvalidDataException" /> when
-    /// the segment exceeds this size. It does not restrict the size of the segments encoded by the application. The
-    /// segment size does not include the size of its size prefix. Implementations must return a value greater than
-    /// <c>0</c>.</remarks>
+    /// <remarks>This limit applies only when decoding the payload of an incoming request or response: the decoding
+    /// throws <see cref="InvalidDataException" /> when the size encoded in the size prefix of a segment exceeds this
+    /// maximum, before decoding any byte of the segment. It does not restrict the size of the segments encoded by the
+    /// application. The segment size does not include the size of its size prefix. Implementations must return a value
+    /// greater than <c>0</c>.</remarks>
     int MaxSegmentSize { get; }
 }

--- a/src/IceRpc/ConnectionOptions.cs
+++ b/src/IceRpc/ConnectionOptions.cs
@@ -69,6 +69,11 @@ public record class ConnectionOptions
     /// <summary>Gets or sets the maximum size of a frame received over the ice protocol.</summary>
     /// <value>The maximum size of an incoming frame, in bytes. This value must be at least <c>256</c>. Defaults to
     /// <c>1</c> MB.</value>
+    /// <remarks>This property is the counterpart of the Ice property
+    /// <see href="https://docs.zeroc.com/ice/3.8/cpp/ice#Ice.MessageSizeMax">Ice.MessageSizeMax</see>: both limit
+    /// the size of a whole frame, header included, and both close the connection when the size of an incoming frame
+    /// exceeds this limit. Unlike Ice.MessageSizeMax, this property is expressed in bytes rather than kilobytes and
+    /// cannot be set to <c>0</c> to disable the limit.</remarks>
     public int MaxIceFrameSize
     {
         get => _maxIceFrameSize;


### PR DESCRIPTION
Fixes #4905

Documentation-only change to the three feature interfaces:

- **BaseProxy** (Ice, Slice): a decoded proxy inherits the invoker and encode options of the base proxy. When null, a proxy decoded from a request gets `InvalidInvoker.Instance`, while a proxy decoded from a response inherits from the proxy that sent the request. For Slice, also documents that relative service addresses are resolved against the base proxy's service address.
- **MaxPayloadSize** / **MaxSegmentSize** / **MaxMessageLength**: these limits apply only when decoding incoming payloads. The full payload, segment, or message is read into memory before decoding, and the read throws `InvalidDataException` when the limit is exceeded. The size excludes the encapsulation header, segment size prefix, or 5-byte message prefix respectively. `MaxPayloadSize` now also lists Ice exception payloads.
- **MaxCollectionAllocation** (Ice, Slice): a cumulative budget across every string, sequence, and dictionary decoded from one payload (Ice) or one segment (Slice), not a per-collection limit.

- **ConnectionOptions.MaxIceFrameSize**: documents that this property, not `MaxPayloadSize`, is the counterpart of the Ice property `Ice.MessageSizeMax`, and how the two differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)