### PR TITLE
Wait for pending connection establishment in the Server listen task

### DIFF
--- a/src/IceRpc/Server.cs
+++ b/src/IceRpc/Server.cs
@@ -364,12 +364,18 @@ public sealed class Server : IAsyncDisposable
         {
             await Task.Yield(); // exit mutex lock
 
+            // The semaphore is disposed once the accept loop has exited and all the connect tasks have completed.
+            using var pendingConnectionSemaphore = new SemaphoreSlim(
+                _maxPendingConnections,
+                _maxPendingConnections);
+
+            // The connect tasks of the accepted connections. A connect task completes after it disposes its connector
+            // and releases its pending connection semaphore permit. The completed tasks are removed from this list
+            // before adding a new task, so the list holds about _maxPendingConnections tasks at most.
+            var connectTasks = new List<Task>();
+
             try
             {
-                using var pendingConnectionSemaphore = new SemaphoreSlim(
-                    _maxPendingConnections,
-                    _maxPendingConnections);
-
                 while (!_shutdownCts.IsCancellationRequested)
                 {
                     await pendingConnectionSemaphore.WaitAsync(_shutdownCts.Token).ConfigureAwait(false);
@@ -394,7 +400,8 @@ public sealed class Server : IAsyncDisposable
                     // connection initialization as we wouldn't be able to accept new connections in the meantime. The
                     // call will eventually timeout if the ConnectTimeout expires.
                     CancellationToken cancellationToken = _disposedCts.Token;
-                    _ = Task.Run(
+                    connectTasks.RemoveAll(task => task.IsCompleted);
+                    connectTasks.Add(Task.Run(
                         async () =>
                         {
                             try
@@ -412,18 +419,11 @@ public sealed class Server : IAsyncDisposable
                                 // adopted by the protocol connection.
                                 await connector.DisposeAsync().ConfigureAwait(false);
 
-                                // The pending connection semaphore is disposed by the listen task completion once
-                                // shutdown / dispose is initiated.
-                                lock (_mutex)
-                                {
-                                    if (_shutdownTask is null)
-                                    {
-                                        pendingConnectionSemaphore.Release();
-                                    }
-                                }
+                                // The semaphore is not disposed until this connect task completes.
+                                pendingConnectionSemaphore.Release();
                             }
                         },
-                        CancellationToken.None); // the task must run to dispose the connector.
+                        CancellationToken.None)); // the task must run to dispose the connector.
                 }
             }
             catch
@@ -433,6 +433,10 @@ public sealed class Server : IAsyncDisposable
             finally
             {
                 await listener.DisposeAsync().ConfigureAwait(false);
+
+                // Wait for the connect tasks of the accepted connections to complete. ShutdownAsync (within its
+                // shutdown timeout) and DisposeAsync wait for the completion of this listen task.
+                await Task.WhenAll(connectTasks).ConfigureAwait(false);
             }
 
             async Task ConnectAsync(IConnector connector, CancellationToken cancellationToken)
@@ -441,7 +445,7 @@ public sealed class Server : IAsyncDisposable
                 connectCts.CancelAfter(_connectTimeout);
 
                 // Connect the transport connection first. This connection establishment can be interrupted by the
-                // connect timeout or the server ShutdownAsync/DisposeAsync.
+                // connect timeout or the server DisposeAsync.
                 TransportConnectionInformation transportConnectionInformation =
                     await connector.ConnectTransportConnectionAsync(connectCts.Token).ConfigureAwait(false);
 

--- a/tests/IceRpc.Tests/ServerTests.cs
+++ b/tests/IceRpc.Tests/ServerTests.cs
@@ -380,6 +380,132 @@ public class ServerTests
             Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionRefused));
     }
 
+    /// <summary>Verifies that the server shutdown waits for the establishment of an accepted transport connection to
+    /// complete. The connection is refused and its transport connection disposed before the shutdown completes.
+    /// </summary>
+    [Test]
+    public async Task Shutdown_waits_for_pending_connection_establishment()
+    {
+        // Arrange
+        var colocTransport = new ColocTransport();
+        var multiplexedServerTransport = new TestMultiplexedServerTransportDecorator(
+            new SlicServerTransport(colocTransport.ServerTransport));
+        var multiplexedClientTransport = new SlicClientTransport(colocTransport.ClientTransport);
+
+        await using var server = new Server(
+            dispatcher: NotFoundDispatcher.Instance,
+            serverAddress: new ServerAddress(new Uri("icerpc://foo")),
+            multiplexedServerTransport: multiplexedServerTransport);
+
+        // Hold the connection establishment of the accepted transport connections.
+        multiplexedServerTransport.ConnectionOperationsOptions = new()
+        {
+            Hold = MultiplexedTransportOperations.Connect
+        };
+
+        // The accept operation is reported as called when it starts and again when it completes.
+        Task acceptStartedTask = multiplexedServerTransport.ListenerOperations.GetCalledTask(
+            MultiplexedTransportOperations.Accept);
+        ServerAddress serverAddress = server.Listen();
+        await acceptStartedTask;
+        Task acceptCompletedTask = multiplexedServerTransport.ListenerOperations.GetCalledTask(
+            MultiplexedTransportOperations.Accept);
+
+        await using var clientConnection = new ClientConnection(
+            serverAddress,
+            multiplexedClientTransport: multiplexedClientTransport);
+        Task<TransportConnectionInformation> connectTask = clientConnection.ConnectAsync();
+        await acceptCompletedTask;
+
+        TestMultiplexedConnectionDecorator serverConnection = multiplexedServerTransport.LastAcceptedConnection;
+        Task disposeCalledTask = serverConnection.Operations.GetCalledTask(MultiplexedTransportOperations.Dispose);
+
+        // Act
+        Task shutdownTask = server.ShutdownAsync();
+
+        // Assert
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        Assert.That(() => shutdownTask.WaitAsync(cts.Token), Throws.InstanceOf<OperationCanceledException>());
+
+        serverConnection.Operations.Hold = MultiplexedTransportOperations.None; // Release connect
+        await shutdownTask;
+
+        Assert.That(disposeCalledTask.IsCompleted, Is.True);
+        Assert.That(
+            async () => await connectTask,
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionRefused));
+    }
+
+    /// <summary>Verifies that the server shutdown waits for the establishment of an accepted transport connection to
+    /// complete when the server stopped accepting connections because of a fatal accept exception.</summary>
+    [Test]
+    public async Task Shutdown_waits_for_pending_connection_establishment_after_fatal_accept_exception()
+    {
+        // Arrange
+        var colocTransport = new ColocTransport();
+        var multiplexedServerTransport = new TestMultiplexedServerTransportDecorator(
+            new SlicServerTransport(colocTransport.ServerTransport),
+            operationsOptions: new() { FailureException = new Exception() });
+        var multiplexedClientTransport = new SlicClientTransport(colocTransport.ClientTransport);
+
+        await using var server = new Server(
+            dispatcher: NotFoundDispatcher.Instance,
+            serverAddress: new ServerAddress(new Uri("icerpc://foo")),
+            multiplexedServerTransport: multiplexedServerTransport);
+
+        // Hold the connection establishment of the accepted transport connections.
+        multiplexedServerTransport.ConnectionOperationsOptions = new()
+        {
+            Hold = MultiplexedTransportOperations.Connect
+        };
+
+        // The accept operation is reported as called when it starts and again when it completes.
+        Task acceptStartedTask = multiplexedServerTransport.ListenerOperations.GetCalledTask(
+            MultiplexedTransportOperations.Accept);
+        ServerAddress serverAddress = server.Listen();
+        await acceptStartedTask;
+        Task acceptCompletedTask = multiplexedServerTransport.ListenerOperations.GetCalledTask(
+            MultiplexedTransportOperations.Accept);
+
+        await using var clientConnection1 = new ClientConnection(
+            serverAddress,
+            multiplexedClientTransport: multiplexedClientTransport);
+        Task<TransportConnectionInformation> connectTask1 = clientConnection1.ConnectAsync();
+        await acceptCompletedTask;
+
+        TestMultiplexedConnectionDecorator serverConnection = multiplexedServerTransport.LastAcceptedConnection;
+        Task disposeCalledTask = serverConnection.Operations.GetCalledTask(MultiplexedTransportOperations.Dispose);
+
+        // Make the next accept fail with a fatal exception. The server stops accepting connections and disposes the
+        // listener while the first connection is still connecting.
+        Task listenerDisposeCalledTask = multiplexedServerTransport.ListenerOperations.GetCalledTask(
+            MultiplexedTransportOperations.Dispose);
+        multiplexedServerTransport.ListenerOperations.Fail = MultiplexedTransportOperations.Accept;
+
+        // The failure is raised either before the next accept starts or once it accepts this second connection. In
+        // both cases the second connection establishment fails and the server stops accepting connections.
+        await using var clientConnection2 = new ClientConnection(
+            serverAddress,
+            multiplexedClientTransport: multiplexedClientTransport);
+        Assert.That(() => clientConnection2.ConnectAsync(), Throws.InstanceOf<IceRpcException>());
+        await listenerDisposeCalledTask;
+
+        // Act
+        Task shutdownTask = server.ShutdownAsync();
+
+        // Assert
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        Assert.That(() => shutdownTask.WaitAsync(cts.Token), Throws.InstanceOf<OperationCanceledException>());
+
+        serverConnection.Operations.Hold = MultiplexedTransportOperations.None; // Release connect
+        await shutdownTask;
+
+        Assert.That(disposeCalledTask.IsCompleted, Is.True);
+        Assert.That(
+            async () => await connectTask1,
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.ConnectionRefused));
+    }
+
     /// <summary>Verifies that the Server's ConnectTimeout is transmitted to the multiplexed transport as
     /// HandshakeTimeout.</summary>
     [Test]


### PR DESCRIPTION
The `Server` accept loop disposed the pending-connection semaphore as soon as the loop exited, while the connect tasks of the already accepted transport connections could still release it. When the loop exited because of a non-retryable accept exception, `_shutdownTask` was still null, so the `Release()` guard did not apply and the connect task faulted with `ObjectDisposedException` as an unobserved task exception. These connect tasks were also not awaited by `ShutdownAsync` or `DisposeAsync`, which could complete while an accepted transport connection was still connecting or being disposed (the second consequence noted in the issue comments).

The listen task now keeps the connect tasks of the accepted connections and waits for their completion after disposing the listener, before the semaphore is disposed. Since `ShutdownAsync` and `DisposeAsync` wait for the listen task, they now also wait for the accepted connections to be established and refused, or disposed. This is a small behavior change for `ShutdownAsync`: it waits for in-flight transport connection establishment, bounded by the remaining `ConnectTimeout` and capped by `ShutdownTimeout`. The transport connect is still only canceled by `DisposeAsync` (as decided in #2441).

Two new tests, `Shutdown_waits_for_pending_connection_establishment` and `Shutdown_waits_for_pending_connection_establishment_after_fatal_accept_exception`, fail on `main` (shutdown completes immediately) and pass with this change. The full `IceRpc.Tests` assembly passes with no unobserved task exceptions; the only local failures are the known QUIC `QUIC_STATUS_TLS_ERROR` ones from #4906.

Fixes #4749

## What's Changed entry

Area: Core

- Fixed server shutdown and disposal to wait for accepted connections that are still being established or cleaned up.
