### PR TITLE
Name MaxIceFrameSize in the oversized ice frame error message

### DIFF
--- a/src/IceRpc/Internal/IceProtocolConnection.cs
+++ b/src/IceRpc/Internal/IceProtocolConnection.cs
@@ -1209,7 +1209,7 @@ internal sealed class IceProtocolConnection : IProtocolConnection
                 if (prologue.FrameSize > _maxFrameSize)
                 {
                     throw new InvalidDataException(
-                        $"Received frame with size ({prologue.FrameSize}) greater than max frame size.");
+                        $"Received frame with size ({prologue.FrameSize}) greater than {nameof(ConnectionOptions.MaxIceFrameSize)} ({_maxFrameSize}).");
                 }
                 if (prologue.FrameSize < IceDefinitions.PrologueSize)
                 {


### PR DESCRIPTION
When an incoming ice frame exceeds the connection's maximum frame size, the error message now names
`ConnectionOptions.MaxIceFrameSize` and includes its current value, so the operator knows which property to raise.

This message is local only: the connection aborts and nothing is sent to the peer.

## What's Changed

None — error message wording only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)