### PR TITLE
Use a distinct item name in ProtoClean so Rebuild runs protoc once

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -121,14 +121,19 @@
       />
     </ItemGroup>
   </Target>
+  <!--
+    _ProtoCleanFile is deliberately distinct from the _ProtoFile item that ProtoCompile emits: a task <Output> appends
+    to an existing item, and Rebuild runs Clean and Build in the same project instance, so sharing the item would leave
+    ProtoCompile with two entries per ProtoFile, run protoc twice, and pass duplicate Compile items to csc.
+  -->
   <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
     <OutputFileNamesTask Sources="@(ProtoFile)">
-      <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
+      <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
     </OutputFileNamesTask>
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).cs')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).d')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).d')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -130,10 +130,10 @@
     <OutputFileNamesTask Sources="@(ProtoFile)">
       <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
     </OutputFileNamesTask>
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).d')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).IceRpc.cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).d')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).BuildTelemetry.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -122,9 +122,8 @@
     </ItemGroup>
   </Target>
   <!--
-    _ProtoCleanFile is deliberately distinct from the _ProtoFile item that ProtoCompile emits: a task <Output> appends
-    to an existing item, and Rebuild runs Clean and Build in the same project instance, so sharing the item would leave
-    ProtoCompile with two entries per ProtoFile, run protoc twice, and pass duplicate Compile items to csc.
+    _ProtoCleanFile must stay distinct from _ProtoFile: a task <Output> appends to an existing item, and Rebuild runs
+    Clean then Build in the same project instance.
   -->
   <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
     <OutputFileNamesTask Sources="@(ProtoFile)">


### PR DESCRIPTION
Fixes #4790

`ProtoClean` and `ProtoCompile` both wrote their task output to `_ProtoFile`. A task `<Output>` appends to an existing item, and Rebuild runs Clean and Build in the same project instance, so after a Rebuild `_ProtoFile` held two entries per `.proto` that differed only in the `UpToDate` metadata. `ProtoCompile` then batched protoc over both entries and emitted duplicate `Compile` items, which csc reported as CS2002.

- `ProtoClean` now writes to `_ProtoCleanFile`, with a comment explaining why the item must stay distinct from `_ProtoFile`.
- I chose the rename over a shared `_ComputeProtoFiles` target. A shared target would run before `Clean` on Rebuild, and if it ran `UpToDateCheckTask` at that point the outputs would still exist, every file would be marked up to date, and `ProtoCompile` would skip protoc after `ProtoClean` had deleted the generated files.

Verified with a one-file probe project importing the source-build props/targets (macOS, .NET SDK 10.0.201):

| Scenario | Before | After |
|---|---|---|
| Fresh `dotnet build` | 1 protoc run | 1 protoc run |
| Fresh Rebuild | 2 protoc runs, 2 `_ProtoFile` entries, CS2002 x2 | 1 protoc run, 1 entry, no warning |
| Second Rebuild | 2 protoc runs | 1 protoc run |
| `Clean` | generated files deleted | generated files deleted |

## What's Changed entry

Area: Protobuf

- Rebuilding a project that uses IceRpc.Protobuf.Tools (`dotnet build --no-incremental`, or Rebuild in the IDE) no
  longer runs `protoc` twice per `.proto` file or reports warning CS2002 for the generated C# files.
