### PR TITLE
Prune stale Protobuf outputs and tighten the protoc up-to-date check

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.props
@@ -25,6 +25,7 @@
   <Choose>
     <When Condition="$([MSBuild]::IsOSPlatform('Windows'))">
       <PropertyGroup>
+        <_ProtocExecutableExtension>.exe</_ProtocExecutableExtension>
         <_ProtocPluginScriptExtension>.bat</_ProtocPluginScriptExtension>
       </PropertyGroup>
     </When>

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -60,9 +60,94 @@
       Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
     />
   </ItemGroup>
-  <Target Name="ProtoCompile" BeforeTargets="CoreCompile" Condition="@(ProtoFile) != ''">
+  <!--
+    Computes the files that protoc produces for the current ProtoFile items, as absolute paths, and the fingerprint
+    of the configuration that produces them. ProtoCompile and the prune, manifest and clean targets share it, and
+    MSBuild runs it once per build.
+
+    It deliberately doesn't run the up-to-date check, and ProtoCompile keeps its own _ProtoFile item: Rebuild runs
+    Clean and Build in the same project instance, so an up-to-date check made before Clean would mark as current the
+    very outputs Clean is about to delete. A task <Output> also appends to an existing item, so sharing _ProtoFile
+    with ProtoCompile would leave it with two entries per ProtoFile.
+
+    The task assembly only exists in source builds once IceRpc.Protobuf.Tools has been built, which isn't the case
+    for a Clean that precedes any Build; the Exists check skips the computation in that case.
+  -->
+  <Target Name="_ComputeProtoOutputs"
+          Condition="@(ProtoFile) != '' And Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
+    <OutputFileNamesTask Sources="@(ProtoFile)">
+      <Output ItemName="_ProtoNamedFile" TaskParameter="ComputedSources" />
+    </OutputFileNamesTask>
+    <ItemGroup>
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).cs'))" />
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).IceRpc.cs'))" />
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).d'))" />
+      <!-- The xxx.BuildTelemetry.txt is generated when both IceRpcBuildTelemetry and IceRpcBuildTelemetryDebug are true -->
+      <_ProtoOutput
+        Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).BuildTelemetry.txt'))"
+        Condition="'$(IceRpcBuildTelemetry)' == 'true' And '$(IceRpcBuildTelemetryDebug)' == 'true'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!--
+        Everything that changes the generated code without touching a Proto file: the compiler and generator
+        versions, the import search path and the per-file protoc options. A change regenerates every Proto file.
+      -->
+      <_ProtocFingerprint>protoc=$(ProtocBundledPluginVersion);icerpc-csharp=$(ProtocIceRpcPluginVersion);search-path=@(ProtoSearchPath->'%(FullPath)', ',');options=@(ProtoFile->'%(Identity)=%(AdditionalOptions)', ',')</_ProtocFingerprint>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Delete generated files recorded in the previous build's manifest that the current build no longer produces.
+    Without this, a removed or renamed .proto file (or a ProtoFile whose OutputDir changed) leaves orphan .cs files
+    behind that the SDK's default Compile glob keeps picking up.
+
+    BeforeTargets covers both the ProtoFile-present case (ProtoCompile/ProtoClean) and the ProtoFile-empty case where
+    those targets are skipped by their conditions but stale files from a previous build still need pruning
+    (CoreCompile/Clean).
+  -->
+  <Target Name="_ProtoPruneStaleOutputs"
+          BeforeTargets="ProtoCompile;CoreCompile;ProtoClean;Clean"
+          DependsOnTargets="_ComputeProtoOutputs"
+          Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')">
+    <ReadLinesFromFile File="$(IntermediateOutputPath)protoc.outputs.txt">
+      <Output TaskParameter="Lines" ItemName="_PreviousProtoOutput" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_StaleProtoOutput Include="@(_PreviousProtoOutput)" Exclude="@(_ProtoOutput)" />
+      <!--
+        The SDK's default Compile glob captured these paths during item evaluation, with project-relative
+        Identities. We materialize the relative form into its own item so that <Compile Remove> can match it
+        - inlining the MakeRelative call inside an item transform pattern doesn't evaluate the property
+        function as expected.
+      -->
+      <_StaleProtoOutputRelative
+        Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_StaleProtoOutput.Identity)))"
+        Condition="'%(_StaleProtoOutput.Identity)' != ''" />
+      <!--
+        Remove now, otherwise csc still reports the stale files as inputs and fails with CS2001 once we
+        delete them on disk. We try both the absolute and relative form to cover Compile entries added by
+        either explicit ProjectReference users or the SDK glob.
+      -->
+      <Compile Remove="@(_StaleProtoOutput)" />
+      <Compile Remove="@(_StaleProtoOutputRelative)" />
+    </ItemGroup>
+    <Delete Files="@(_StaleProtoOutput)" />
+  </Target>
+
+  <Target Name="ProtoCompile" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeProtoOutputs" Condition="@(ProtoFile) != ''">
+    <ItemGroup>
+      <!-- Tools whose update must regenerate the code, in addition to the inputs recorded in the dependency files. -->
+      <_ProtocInput Include="$(IceRpcProtocPath)$(IceRpcProtocPrefix)/protoc$(_ProtocExecutableExtension)" />
+      <_ProtocInput Include="$(IceRpcProtocGenPath)IceRpc.Protobuf.Generator.dll" />
+    </ItemGroup>
+
     <MakeDir Directories="%(ProtoFile.OutputDir)" />
-    <UpToDateCheckTask OutputDir="%(ProtoFile.OutputDir)" Sources="@(ProtoFile)">
+    <UpToDateCheckTask
+      OutputDir="%(ProtoFile.OutputDir)"
+      Sources="@(ProtoFile)"
+      AdditionalInputs="@(_ProtocInput)"
+      Fingerprint="$(_ProtocFingerprint)"
+      FingerprintFile="$(IntermediateOutputPath)protoc.fingerprint.txt">
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
     </UpToDateCheckTask>
 
@@ -121,19 +206,36 @@
       />
     </ItemGroup>
   </Target>
+
   <!--
-    _ProtoCleanFile is deliberately distinct from the _ProtoFile item that ProtoCompile emits: a task <Output> appends
-    to an existing item, and Rebuild runs Clean and Build in the same project instance, so sharing the item would leave
-    ProtoCompile with two entries per ProtoFile, run protoc twice, and pass duplicate Compile items to csc.
+    Record this build's outputs and configuration so the next build can prune anything no longer produced and
+    detect a configuration change. As an AfterTargets of ProtoCompile this only runs once protoc succeeded, so a
+    failed run never records a fingerprint its outputs don't match. The fingerprint is escaped because
+    WriteLinesToFile would otherwise split it on the semicolons.
   -->
-  <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
-    <OutputFileNamesTask Sources="@(ProtoFile)">
-      <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
-    </OutputFileNamesTask>
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).d')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
+  <Target Name="_ProtoWriteOutputManifest"
+          AfterTargets="ProtoCompile"
+          DependsOnTargets="_ComputeProtoOutputs"
+          Condition="@(ProtoFile) != ''">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)protoc.outputs.txt"
+      Lines="@(_ProtoOutput)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)protoc.fingerprint.txt"
+      Lines="$([MSBuild]::Escape($(_ProtocFingerprint)))"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Target Name="ProtoClean" BeforeTargets="Clean" DependsOnTargets="_ComputeProtoOutputs">
+    <Delete Files="@(_ProtoOutput)" />
+    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt"
+            Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')" />
+    <Delete Files="$(IntermediateOutputPath)protoc.fingerprint.txt"
+            Condition="Exists('$(IntermediateOutputPath)protoc.fingerprint.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -121,14 +121,19 @@
       />
     </ItemGroup>
   </Target>
+  <!--
+    _ProtoCleanFile is deliberately distinct from the _ProtoFile item that ProtoCompile emits: a task <Output> appends
+    to an existing item, and Rebuild runs Clean and Build in the same project instance, so sharing the item would leave
+    ProtoCompile with two entries per ProtoFile, run protoc twice, and pass duplicate Compile items to csc.
+  -->
   <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
     <OutputFileNamesTask Sources="@(ProtoFile)">
-      <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
+      <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
     </OutputFileNamesTask>
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).cs')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).d')" />
-    <Delete Files="@(_ProtoFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).d')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -130,10 +130,10 @@
     <OutputFileNamesTask Sources="@(ProtoFile)">
       <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
     </OutputFileNamesTask>
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).IceRpc.cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).d')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFilename).BuildTelemetry.txt')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).IceRpc.cs')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).d')" />
+    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).BuildTelemetry.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -115,11 +115,6 @@
     </ItemGroup>
     <Delete Files="@(_StaleProtoOutput)" />
     <!--
-      With no ProtoFile left, _ProtoWriteOutputManifest do't run to replace the manifest; delete it here, or
-      every later build deletes whatever appears at the former output paths.
-    -->
-    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt" Condition="@(ProtoFile) == ''" />
-    <!--
       With no ProtoFile left, _ProtoWriteOutputManifest doesn't run to replace the manifest; delete it here, or
       every later build deletes whatever appears at the former output paths.
     -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -80,38 +80,22 @@
         Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).BuildTelemetry.txt'))"
         Condition="'$(IceRpcBuildTelemetry)' == 'true' And '$(IceRpcBuildTelemetryDebug)' == 'true'" />
     </ItemGroup>
-    <PropertyGroup>
-      <!-- Anything that changes the generated code without touching a Proto file; a change regenerates them all. -->
-      <_ProtocFingerprint>protoc=$(ProtocBundledPluginVersion);icerpc-csharp=$(ProtocIceRpcPluginVersion);search-path=@(ProtoSearchPath->'%(FullPath)', ',');options=@(ProtoFile->'%(Identity)=%(AdditionalOptions)', ',')</_ProtocFingerprint>
-    </PropertyGroup>
   </Target>
 
-  <!--
-    BeforeTargets includes CoreCompile and Clean for the case where ProtoFile is empty: ProtoCompile and ProtoClean
-    are then skipped, but the outputs of a previous build still need pruning.
-  -->
+  <!-- Runs even when ProtoFile is empty: the outputs of a previous build still need pruning. -->
   <Target Name="_ProtoPruneStaleOutputs"
-          BeforeTargets="ProtoCompile;CoreCompile;ProtoClean;Clean"
+          BeforeTargets="ProtoCompile;ProtoClean"
           DependsOnTargets="_ComputeProtoOutputs"
           Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')">
     <ReadLinesFromFile File="$(IntermediateOutputPath)protoc.outputs.txt">
       <Output TaskParameter="Lines" ItemName="_PreviousProtoOutput" />
     </ReadLinesFromFile>
     <ItemGroup>
-      <_StaleProtoOutput Include="@(_PreviousProtoOutput)" Exclude="@(_ProtoOutput)" />
-      <!--
-        The SDK's default Compile glob records project-relative identities, and <Compile Remove> matches identities
-        exactly. A MakeRelative call inlined in an item transform doesn't evaluate, hence the separate item.
-      -->
-      <_StaleProtoOutputRelative
-        Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_StaleProtoOutput.Identity)))"
-        Condition="'%(_StaleProtoOutput.Identity)' != ''" />
-      <!--
-        Remove before deleting, or csc fails with CS2001 on the missing files. The absolute form covers explicit
-        Compile items, the relative form the SDK glob.
-      -->
-      <Compile Remove="@(_StaleProtoOutput)" />
-      <Compile Remove="@(_StaleProtoOutputRelative)" />
+      <!-- _ProtoOutput is also empty when _ComputeProtoOutputs was skipped; that must not prune everything. -->
+      <_StaleProtoOutput Include="@(_PreviousProtoOutput)" Exclude="@(_ProtoOutput)"
+                         Condition="'@(_ProtoOutput)' != '' Or '@(ProtoFile)' == ''" />
+      <!-- Remove before deleting, or csc fails with CS2001 on the missing files. -->
+      <Compile Remove="@(_StaleProtoOutput)" MatchOnMetadata="FullPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
     <Delete Files="@(_StaleProtoOutput)" />
     <!--
@@ -121,32 +105,40 @@
     <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt" Condition="@(ProtoFile) == ''" />
   </Target>
 
-  <Target Name="ProtoCompile" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeProtoOutputs" Condition="@(ProtoFile) != ''">
+  <Target Name="ProtoCompile"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="_ComputeProtoOutputs"
+          Condition="@(ProtoFile) != ''">
     <ItemGroup>
-      <!-- Tools whose update must regenerate the code, in addition to the inputs recorded in the dependency files. -->
+      <!--
+        Anything that changes the generated code without touching a Proto file. Only the distinct option values: with
+        the file set in the list, adding a Proto file would regenerate them all.
+      -->
+      <_ProtocInputsCacheLine Include="protoc=$(ProtocBundledPluginVersion)" />
+      <_ProtocInputsCacheLine Include="icerpc-csharp=$(ProtocIceRpcPluginVersion)" />
+      <_ProtocInputsCacheLine Include="@(ProtoSearchPath->'search-path=%(FullPath)')" />
+      <_ProtocInputsCacheLine Include="@(ProtoFile->'options=%(AdditionalOptions)'->DistinctWithCase())" />
+    </ItemGroup>
+    <!--
+      WriteOnlyWhenDifferent moves the file's timestamp only when a value changes. As an input of every Proto file,
+      it then makes all outputs out of date, including those a failed protoc run left untouched.
+    -->
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)protoc.inputs.cache"
+      Lines="@(_ProtocInputsCacheLine)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <!-- Inputs of every Proto file, in addition to those recorded in its dependency file. -->
+      <_ProtocInput Include="$(IntermediateOutputPath)protoc.inputs.cache" />
       <_ProtocInput Include="$(IceRpcProtocPath)$(IceRpcProtocPrefix)/protoc$(_ProtocExecutableExtension)" />
       <_ProtocInput Include="$(IceRpcProtocGenPath)IceRpc.Protobuf.Generator.dll" />
     </ItemGroup>
 
     <MakeDir Directories="%(ProtoFile.OutputDir)" />
-    <UpToDateCheckTask
-      OutputDir="%(ProtoFile.OutputDir)"
-      Sources="@(ProtoFile)"
-      AdditionalInputs="@(_ProtocInput)"
-      Fingerprint="$(_ProtocFingerprint)"
-      FingerprintFile="$(IntermediateOutputPath)protoc.fingerprint.txt">
+    <UpToDateCheckTask OutputDir="%(ProtoFile.OutputDir)" Sources="@(ProtoFile)" AdditionalInputs="@(_ProtocInput)">
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
-      <Output PropertyName="_ProtocFingerprintChanged" TaskParameter="FingerprintChanged" />
     </UpToDateCheckTask>
-
-    <!--
-      When the fingerprint changed, the recorded one describes outputs protoc is about to replace. Delete it first,
-      so a run that fails part-way leaves no fingerprint for the next build to trust; _ProtoWriteOutputManifest
-      records the new one once protoc succeeds.
-    -->
-    <Delete
-      Files="$(IntermediateOutputPath)protoc.fingerprint.txt"
-      Condition="'$(_ProtocFingerprintChanged)' == 'true' And Exists('$(IntermediateOutputPath)protoc.fingerprint.txt')" />
 
     <PropertyGroup>
        <!-- Parameter for the Build Telemetry plug-in -->
@@ -204,34 +196,23 @@
     </ItemGroup>
   </Target>
 
-  <!--
-    AfterTargets keeps this after a successful protoc run, so a failed run never records a fingerprint its outputs
-    don't match (when the fingerprint changed, ProtoCompile deleted the previous one). The fingerprint is escaped
-    because WriteLinesToFile splits its Lines on semicolons.
-  -->
+  <!-- Record this build's outputs so the next build can prune anything it no longer produces. -->
   <Target Name="_ProtoWriteOutputManifest"
           AfterTargets="ProtoCompile"
           DependsOnTargets="_ComputeProtoOutputs"
           Condition="@(ProtoFile) != ''">
-    <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile
       File="$(IntermediateOutputPath)protoc.outputs.txt"
       Lines="@(_ProtoOutput)"
-      Overwrite="true"
-      WriteOnlyWhenDifferent="true" />
-    <WriteLinesToFile
-      File="$(IntermediateOutputPath)protoc.fingerprint.txt"
-      Lines="$([MSBuild]::Escape($(_ProtocFingerprint)))"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />
   </Target>
 
   <Target Name="ProtoClean" BeforeTargets="Clean" DependsOnTargets="_ComputeProtoOutputs">
     <Delete Files="@(_ProtoOutput)" />
-    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt"
-            Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')" />
-    <Delete Files="$(IntermediateOutputPath)protoc.fingerprint.txt"
-            Condition="Exists('$(IntermediateOutputPath)protoc.fingerprint.txt')" />
+    <!-- Keep the manifest when _ComputeProtoOutputs was skipped: the next build still needs it to prune. -->
+    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt;$(IntermediateOutputPath)protoc.inputs.cache"
+            Condition="'@(_ProtoOutput)' != '' Or '@(ProtoFile)' == ''" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -115,6 +115,11 @@
     </ItemGroup>
     <Delete Files="@(_StaleProtoOutput)" />
     <!--
+      With no ProtoFile left, _ProtoWriteOutputManifest do't run to replace the manifest; delete it here, or
+      every later build deletes whatever appears at the former output paths.
+    -->
+    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt" Condition="@(ProtoFile) == ''" />
+    <!--
       With no ProtoFile left, _ProtoWriteOutputManifest doesn't run to replace the manifest; delete it here, or
       every later build deletes whatever appears at the former output paths.
     -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -60,9 +60,94 @@
       Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
     />
   </ItemGroup>
-  <Target Name="ProtoCompile" BeforeTargets="CoreCompile" Condition="@(ProtoFile) != ''">
+  <!--
+    Computes the files that protoc produces for the current ProtoFile items, as absolute paths, and the fingerprint
+    of the configuration that produces them. ProtoCompile and the prune, manifest and clean targets share it, and
+    MSBuild runs it once per build.
+
+    It deliberately doesn't run the up-to-date check, and ProtoCompile keeps its own _ProtoFile item: Rebuild runs
+    Clean and Build in the same project instance, so an up-to-date check made before Clean would mark as current the
+    very outputs Clean is about to delete. A task <Output> also appends to an existing item, so sharing _ProtoFile
+    with ProtoCompile would leave it with two entries per ProtoFile.
+
+    The task assembly only exists in source builds once IceRpc.Protobuf.Tools has been built, which isn't the case
+    for a Clean that precedes any Build; the Exists check skips the computation in that case.
+  -->
+  <Target Name="_ComputeProtoOutputs"
+          Condition="@(ProtoFile) != '' And Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
+    <OutputFileNamesTask Sources="@(ProtoFile)">
+      <Output ItemName="_ProtoNamedFile" TaskParameter="ComputedSources" />
+    </OutputFileNamesTask>
+    <ItemGroup>
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).cs'))" />
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).IceRpc.cs'))" />
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).d'))" />
+      <!-- The xxx.BuildTelemetry.txt is generated when both IceRpcBuildTelemetry and IceRpcBuildTelemetryDebug are true -->
+      <_ProtoOutput
+        Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).BuildTelemetry.txt'))"
+        Condition="'$(IceRpcBuildTelemetry)' == 'true' And '$(IceRpcBuildTelemetryDebug)' == 'true'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!--
+        Everything that changes the generated code without touching a Proto file: the compiler and generator
+        versions, the import search path and the per-file protoc options. A change regenerates every Proto file.
+      -->
+      <_ProtocFingerprint>protoc=$(ProtocBundledPluginVersion);icerpc-csharp=$(ProtocIceRpcPluginVersion);search-path=@(ProtoSearchPath->'%(FullPath)', ',');options=@(ProtoFile->'%(Identity)=%(AdditionalOptions)', ',')</_ProtocFingerprint>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Delete generated files recorded in the previous build's manifest that the current build no longer produces.
+    Without this, a removed or renamed .proto file (or a ProtoFile whose OutputDir changed) leaves orphan .cs files
+    behind that the SDK's default Compile glob keeps picking up.
+
+    BeforeTargets covers both the ProtoFile-present case (ProtoCompile/ProtoClean) and the ProtoFile-empty case where
+    those targets are skipped by their conditions but stale files from a previous build still need pruning
+    (CoreCompile/Clean).
+  -->
+  <Target Name="_ProtoPruneStaleOutputs"
+          BeforeTargets="ProtoCompile;CoreCompile;ProtoClean;Clean"
+          DependsOnTargets="_ComputeProtoOutputs"
+          Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')">
+    <ReadLinesFromFile File="$(IntermediateOutputPath)protoc.outputs.txt">
+      <Output TaskParameter="Lines" ItemName="_PreviousProtoOutput" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_StaleProtoOutput Include="@(_PreviousProtoOutput)" Exclude="@(_ProtoOutput)" />
+      <!--
+        The SDK's default Compile glob captured these paths during item evaluation, with project-relative
+        Identities. We materialize the relative form into its own item so that <Compile Remove> can match it
+        - inlining the MakeRelative call inside an item transform pattern doesn't evaluate the property
+        function as expected.
+      -->
+      <_StaleProtoOutputRelative
+        Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_StaleProtoOutput.Identity)))"
+        Condition="'%(_StaleProtoOutput.Identity)' != ''" />
+      <!--
+        Remove now, otherwise csc still reports the stale files as inputs and fails with CS2001 once we
+        delete them on disk. We try both the absolute and relative form to cover Compile entries added by
+        either explicit ProjectReference users or the SDK glob.
+      -->
+      <Compile Remove="@(_StaleProtoOutput)" />
+      <Compile Remove="@(_StaleProtoOutputRelative)" />
+    </ItemGroup>
+    <Delete Files="@(_StaleProtoOutput)" />
+  </Target>
+
+  <Target Name="ProtoCompile" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeProtoOutputs" Condition="@(ProtoFile) != ''">
+    <ItemGroup>
+      <!-- Tools whose update must regenerate the code, in addition to the inputs recorded in the dependency files. -->
+      <_ProtocInput Include="$(IceRpcProtocPath)$(IceRpcProtocPrefix)/protoc$(_ProtocExecutableExtension)" />
+      <_ProtocInput Include="$(IceRpcProtocGenPath)IceRpc.Protobuf.Generator.dll" />
+    </ItemGroup>
+
     <MakeDir Directories="%(ProtoFile.OutputDir)" />
-    <UpToDateCheckTask OutputDir="%(ProtoFile.OutputDir)" Sources="@(ProtoFile)">
+    <UpToDateCheckTask
+      OutputDir="%(ProtoFile.OutputDir)"
+      Sources="@(ProtoFile)"
+      AdditionalInputs="@(_ProtocInput)"
+      Fingerprint="$(_ProtocFingerprint)"
+      FingerprintFile="$(IntermediateOutputPath)protoc.fingerprint.txt">
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
     </UpToDateCheckTask>
 
@@ -121,18 +206,36 @@
       />
     </ItemGroup>
   </Target>
+
   <!--
-    _ProtoCleanFile must stay distinct from _ProtoFile: a task <Output> appends to an existing item, and Rebuild runs
-    Clean then Build in the same project instance.
+    Record this build's outputs and configuration so the next build can prune anything no longer produced and
+    detect a configuration change. As an AfterTargets of ProtoCompile this only runs once protoc succeeded, so a
+    failed run never records a fingerprint its outputs don't match. The fingerprint is escaped because
+    WriteLinesToFile would otherwise split it on the semicolons.
   -->
-  <Target Name="ProtoClean" BeforeTargets="Clean" Condition="Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
-    <OutputFileNamesTask Sources="@(ProtoFile)">
-      <Output ItemName="_ProtoCleanFile" TaskParameter="ComputedSources" />
-    </OutputFileNamesTask>
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).IceRpc.cs')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).d')" />
-    <Delete Files="@(_ProtoCleanFile->'%(OutputDir)/%(OutputFileName).BuildTelemetry.txt')" />
+  <Target Name="_ProtoWriteOutputManifest"
+          AfterTargets="ProtoCompile"
+          DependsOnTargets="_ComputeProtoOutputs"
+          Condition="@(ProtoFile) != ''">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)protoc.outputs.txt"
+      Lines="@(_ProtoOutput)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)protoc.fingerprint.txt"
+      Lines="$([MSBuild]::Escape($(_ProtocFingerprint)))"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Target Name="ProtoClean" BeforeTargets="Clean" DependsOnTargets="_ComputeProtoOutputs">
+    <Delete Files="@(_ProtoOutput)" />
+    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt"
+            Condition="Exists('$(IntermediateOutputPath)protoc.outputs.txt')" />
+    <Delete Files="$(IntermediateOutputPath)protoc.fingerprint.txt"
+            Condition="Exists('$(IntermediateOutputPath)protoc.fingerprint.txt')" />
   </Target>
 
   <!-- Package ProtoFile items -->

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -61,17 +61,11 @@
     />
   </ItemGroup>
   <!--
-    Computes the files that protoc produces for the current ProtoFile items, as absolute paths, and the fingerprint
-    of the configuration that produces them. ProtoCompile and the prune, manifest and clean targets share it, and
-    MSBuild runs it once per build.
+    This target must not run the up-to-date check: Rebuild runs Clean then Build in the same project instance, so a
+    check made before Clean would mark as current the outputs Clean is about to delete. ProtoCompile keeps its own
+    _ProtoFile item because a task <Output> appends to an existing item.
 
-    It deliberately doesn't run the up-to-date check, and ProtoCompile keeps its own _ProtoFile item: Rebuild runs
-    Clean and Build in the same project instance, so an up-to-date check made before Clean would mark as current the
-    very outputs Clean is about to delete. A task <Output> also appends to an existing item, so sharing _ProtoFile
-    with ProtoCompile would leave it with two entries per ProtoFile.
-
-    The task assembly only exists in source builds once IceRpc.Protobuf.Tools has been built, which isn't the case
-    for a Clean that precedes any Build; the Exists check skips the computation in that case.
+    In a source build the task assembly doesn't exist until IceRpc.Protobuf.Tools is built, hence the Exists check.
   -->
   <Target Name="_ComputeProtoOutputs"
           Condition="@(ProtoFile) != '' And Exists('$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll')">
@@ -82,28 +76,19 @@
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).cs'))" />
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).IceRpc.cs'))" />
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).d'))" />
-      <!-- The xxx.BuildTelemetry.txt is generated when both IceRpcBuildTelemetry and IceRpcBuildTelemetryDebug are true -->
       <_ProtoOutput
         Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).BuildTelemetry.txt'))"
         Condition="'$(IceRpcBuildTelemetry)' == 'true' And '$(IceRpcBuildTelemetryDebug)' == 'true'" />
     </ItemGroup>
     <PropertyGroup>
-      <!--
-        Everything that changes the generated code without touching a Proto file: the compiler and generator
-        versions, the import search path and the per-file protoc options. A change regenerates every Proto file.
-      -->
+      <!-- Anything that changes the generated code without touching a Proto file; a change regenerates them all. -->
       <_ProtocFingerprint>protoc=$(ProtocBundledPluginVersion);icerpc-csharp=$(ProtocIceRpcPluginVersion);search-path=@(ProtoSearchPath->'%(FullPath)', ',');options=@(ProtoFile->'%(Identity)=%(AdditionalOptions)', ',')</_ProtocFingerprint>
     </PropertyGroup>
   </Target>
 
   <!--
-    Delete generated files recorded in the previous build's manifest that the current build no longer produces.
-    Without this, a removed or renamed .proto file (or a ProtoFile whose OutputDir changed) leaves orphan .cs files
-    behind that the SDK's default Compile glob keeps picking up.
-
-    BeforeTargets covers both the ProtoFile-present case (ProtoCompile/ProtoClean) and the ProtoFile-empty case where
-    those targets are skipped by their conditions but stale files from a previous build still need pruning
-    (CoreCompile/Clean).
+    BeforeTargets includes CoreCompile and Clean for the case where ProtoFile is empty: ProtoCompile and ProtoClean
+    are then skipped, but the outputs of a previous build still need pruning.
   -->
   <Target Name="_ProtoPruneStaleOutputs"
           BeforeTargets="ProtoCompile;CoreCompile;ProtoClean;Clean"
@@ -115,18 +100,15 @@
     <ItemGroup>
       <_StaleProtoOutput Include="@(_PreviousProtoOutput)" Exclude="@(_ProtoOutput)" />
       <!--
-        The SDK's default Compile glob captured these paths during item evaluation, with project-relative
-        Identities. We materialize the relative form into its own item so that <Compile Remove> can match it
-        - inlining the MakeRelative call inside an item transform pattern doesn't evaluate the property
-        function as expected.
+        The SDK's default Compile glob records project-relative identities, and <Compile Remove> matches identities
+        exactly. A MakeRelative call inlined in an item transform doesn't evaluate, hence the separate item.
       -->
       <_StaleProtoOutputRelative
         Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_StaleProtoOutput.Identity)))"
         Condition="'%(_StaleProtoOutput.Identity)' != ''" />
       <!--
-        Remove now, otherwise csc still reports the stale files as inputs and fails with CS2001 once we
-        delete them on disk. We try both the absolute and relative form to cover Compile entries added by
-        either explicit ProjectReference users or the SDK glob.
+        Remove before deleting, or csc fails with CS2001 on the missing files. The absolute form covers explicit
+        Compile items, the relative form the SDK glob.
       -->
       <Compile Remove="@(_StaleProtoOutput)" />
       <Compile Remove="@(_StaleProtoOutputRelative)" />
@@ -208,10 +190,8 @@
   </Target>
 
   <!--
-    Record this build's outputs and configuration so the next build can prune anything no longer produced and
-    detect a configuration change. As an AfterTargets of ProtoCompile this only runs once protoc succeeded, so a
-    failed run never records a fingerprint its outputs don't match. The fingerprint is escaped because
-    WriteLinesToFile would otherwise split it on the semicolons.
+    AfterTargets keeps this after a successful protoc run, so a failed run never records a fingerprint its outputs
+    don't match. The fingerprint is escaped because WriteLinesToFile splits its Lines on semicolons.
   -->
   <Target Name="_ProtoWriteOutputManifest"
           AfterTargets="ProtoCompile"

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -80,6 +80,7 @@
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).cs'))" />
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).IceRpc.cs'))" />
       <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).d'))" />
+      <_ProtoOutput Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).options'))" />
       <_ProtoOutput
         Include="$([MSBuild]::NormalizePath('%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).BuildTelemetry.txt'))"
         Condition="'$(IceRpcBuildTelemetry)' == 'true' And '$(IceRpcBuildTelemetryDebug)' == 'true'" />
@@ -113,13 +114,12 @@
 
     <ItemGroup>
       <!--
-        Anything that changes the generated code without touching a Proto file. Only the distinct option values: with
-        the file set in the list, adding a Proto file would regenerate them all.
+        The inputs shared by every Proto file that change the generated code without touching a Proto file. Each
+        file's AdditionalOptions get their own record below.
       -->
       <_ProtocInputsCacheLine Include="protoc=$(ProtocBundledPluginVersion)" />
       <_ProtocInputsCacheLine Include="icerpc-csharp=$(ProtocIceRpcPluginVersion)" />
       <_ProtocInputsCacheLine Include="@(ProtoSearchPath->'search-path=%(FullPath)')" />
-      <_ProtocInputsCacheLine Include="@(ProtoFile->'options=%(AdditionalOptions)'->DistinctWithCase())" />
     </ItemGroup>
 
     <!--
@@ -138,6 +138,18 @@
       <_ProtocInput Include="$(IceRpcProtocPath)$(IceRpcProtocPrefix)/protoc$(_ProtocExecutableExtension)" />
       <_ProtocInput Include="$(IceRpcProtocGenPath)IceRpc.Protobuf.Generator.dll" />
     </ItemGroup>
+
+    <!--
+      Each Proto file's own inputs cache, next to its dependency file: its AdditionalOptions, one per line, with the
+      same WriteOnlyWhenDifferent rule. A change makes that file, and only that file, out of date. The Condition skips
+      the empty batch MSBuild runs when _ComputeProtoOutputs was skipped, so the task load below fails first.
+    -->
+    <WriteLinesToFile
+      File="%(_ProtoNamedFile.OutputDir)/%(_ProtoNamedFile.OutputFileName).options"
+      Lines="%(_ProtoNamedFile.AdditionalOptions)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
+      Condition="'%(_ProtoNamedFile.Identity)' != ''" />
 
     <MakeDir Directories="%(ProtoFile.OutputDir)" />
     <UpToDateCheckTask OutputDir="%(ProtoFile.OutputDir)" Sources="@(ProtoFile)" AdditionalInputs="@(_ProtocInput)">

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -102,10 +102,7 @@
       <Compile Remove="@(_StaleProtoOutput)" MatchOnMetadata="FullPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
     <Delete Files="@(_StaleProtoOutput)" />
-    <!--
-      With no ProtoFile left, _ProtoWriteOutputManifest doesn't run to replace the manifest; delete it here, or
-      every later build deletes whatever appears at the former output paths.
-    -->
+    <!-- With no ProtoFile left, _ProtoWriteOutputManifest doesn't run to replace the manifest. -->
     <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt" Condition="@(ProtoFile) == ''" />
   </Target>
 

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -20,6 +20,7 @@
     AssemblyFile="$(IceRpcProtobufToolsTaskAssembliesPath)IceRpc.Protobuf.Tools.dll"
     Runtime="NET"
   />
+
   <!--
     Build-order-only reference: the consuming project just needs IceRpc.Protobuf.Tools (and, via its own
     ProjectReference, IceRpc.Protobuf.Generator) to be built so the protoc plug-in scripts exist on disk before we
@@ -33,10 +34,12 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)IceRpc.Protobuf.Tools.csproj"
                       ReferenceOutputAssembly="false" Private="false" Targets="Build" />
   </ItemGroup>
+
   <ItemGroup>
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)ProtoFile.ItemDefinition.xaml" />
     <AvailableItemName Include="ProtoFile" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(SetLinkMetadataAutomatically)' != 'false'">
     <ProtoFile Update="@(ProtoFile)">
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
@@ -60,6 +63,7 @@
       Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
     />
   </ItemGroup>
+
   <!--
     This target must not run the up-to-date check: Rebuild runs Clean then Build in the same project instance, so a
     check made before Clean would mark as current the outputs Clean is about to delete. ProtoCompile keeps its own
@@ -109,6 +113,7 @@
           BeforeTargets="CoreCompile"
           DependsOnTargets="_ComputeProtoOutputs"
           Condition="@(ProtoFile) != ''">
+
     <ItemGroup>
       <!--
         Anything that changes the generated code without touching a Proto file. Only the distinct option values: with
@@ -119,6 +124,7 @@
       <_ProtocInputsCacheLine Include="@(ProtoSearchPath->'search-path=%(FullPath)')" />
       <_ProtocInputsCacheLine Include="@(ProtoFile->'options=%(AdditionalOptions)'->DistinctWithCase())" />
     </ItemGroup>
+
     <!--
       WriteOnlyWhenDifferent moves the file's timestamp only when a value changes. As an input of every Proto file,
       it then makes all outputs out of date, including those a failed protoc run left untouched.
@@ -128,6 +134,7 @@
       Lines="@(_ProtocInputsCacheLine)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />
+
     <ItemGroup>
       <!-- Inputs of every Proto file, in addition to those recorded in its dependency file. -->
       <_ProtocInput Include="$(IntermediateOutputPath)protoc.inputs.cache" />

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -114,6 +114,11 @@
       <Compile Remove="@(_StaleProtoOutputRelative)" />
     </ItemGroup>
     <Delete Files="@(_StaleProtoOutput)" />
+    <!--
+      With no ProtoFile left, _ProtoWriteOutputManifest doesn't run to replace the manifest; delete it here, or
+      every later build deletes whatever appears at the former output paths.
+    -->
+    <Delete Files="$(IntermediateOutputPath)protoc.outputs.txt" Condition="@(ProtoFile) == ''" />
   </Target>
 
   <Target Name="ProtoCompile" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeProtoOutputs" Condition="@(ProtoFile) != ''">
@@ -131,7 +136,17 @@
       Fingerprint="$(_ProtocFingerprint)"
       FingerprintFile="$(IntermediateOutputPath)protoc.fingerprint.txt">
       <Output ItemName="_ProtoFile" TaskParameter="ComputedSources" />
+      <Output PropertyName="_ProtocFingerprintChanged" TaskParameter="FingerprintChanged" />
     </UpToDateCheckTask>
+
+    <!--
+      When the fingerprint changed, the recorded one describes outputs protoc is about to replace. Delete it first,
+      so a run that fails part-way leaves no fingerprint for the next build to trust; _ProtoWriteOutputManifest
+      records the new one once protoc succeeds.
+    -->
+    <Delete
+      Files="$(IntermediateOutputPath)protoc.fingerprint.txt"
+      Condition="'$(_ProtocFingerprintChanged)' == 'true' And Exists('$(IntermediateOutputPath)protoc.fingerprint.txt')" />
 
     <PropertyGroup>
        <!-- Parameter for the Build Telemetry plug-in -->
@@ -191,7 +206,8 @@
 
   <!--
     AfterTargets keeps this after a successful protoc run, so a failed run never records a fingerprint its outputs
-    don't match. The fingerprint is escaped because WriteLinesToFile splits its Lines on semicolons.
+    don't match (when the fingerprint changed, ProtoCompile deleted the previous one). The fingerprint is escaped
+    because WriteLinesToFile splits its Lines on semicolons.
   -->
   <Target Name="_ProtoWriteOutputManifest"
           AfterTargets="ProtoCompile"

--- a/src/IceRpc.Protobuf.Tools/README.md
+++ b/src/IceRpc.Protobuf.Tools/README.md
@@ -75,9 +75,15 @@ once per Proto file.
 | Pack              | `false`   | Specifies whether or not to include the items (Proto files) in the NuGet package.                                                                |
 | PackagePath       | protobuf  | Sets the target path in the NuGet package. Used only when Pack is `true`.                                                                        |
 
-> [!NOTE]
-> Changing `AdditionalOptions` does not mark previously generated code as out of date. Run `dotnet clean` and then
-> build again to regenerate the code with the new options.
+## Incremental builds
+
+`protoc` runs only for the Proto files whose generated code is missing or out of date. A Proto file is out of date
+when the Proto file itself, one of the files it imports, `protoc` or the `protoc-gen-icerpc-csharp` generator is newer
+than one of its generated files. Changing `AdditionalOptions` or `ProtoSearchPath`, or upgrading this package,
+regenerates the code of all Proto files.
+
+The generated code of a Proto file that is removed from the project, renamed, or given a different `OutputDir` is
+deleted during the next build.
 
 ## Generated code and NuGet packages
 

--- a/src/IceRpc.Protobuf.Tools/README.md
+++ b/src/IceRpc.Protobuf.Tools/README.md
@@ -79,8 +79,8 @@ once per Proto file.
 
 The build runs `protoc` only for the Proto files whose generated code is missing or out of date. A Proto file is
 out of date when the Proto file itself, one of the files it imports, `protoc` or the `protoc-gen-icerpc-csharp`
-generator is newer than one of its generated files. Changing `AdditionalOptions` or `ProtoSearchPath`, or upgrading
-this package, regenerates the code of all Proto files.
+generator is newer than one of its generated files, or when its `AdditionalOptions` differ from those used to generate
+it. Changing `ProtoSearchPath` or upgrading this package regenerates the code of all Proto files.
 
 When you remove a Proto file from the project, rename it, or change its `OutputDir`, the next build deletes the code
 previously generated for it.

--- a/src/IceRpc.Protobuf.Tools/README.md
+++ b/src/IceRpc.Protobuf.Tools/README.md
@@ -77,13 +77,13 @@ once per Proto file.
 
 ## Incremental builds
 
-`protoc` runs only for the Proto files whose generated code is missing or out of date. A Proto file is out of date
-when the Proto file itself, one of the files it imports, `protoc` or the `protoc-gen-icerpc-csharp` generator is newer
-than one of its generated files. Changing `AdditionalOptions` or `ProtoSearchPath`, or upgrading this package,
-regenerates the code of all Proto files.
+The build runs `protoc` only for the Proto files whose generated code is missing or out of date. A Proto file is
+out of date when the Proto file itself, one of the files it imports, `protoc` or the `protoc-gen-icerpc-csharp`
+generator is newer than one of its generated files. Changing `AdditionalOptions` or `ProtoSearchPath`, or upgrading
+this package, regenerates the code of all Proto files.
 
-The generated code of a Proto file that is removed from the project, renamed, or given a different `OutputDir` is
-deleted during the next build.
+When you remove a Proto file from the project, rename it, or change its `OutputDir`, the next build deletes the code
+previously generated for it.
 
 ## Generated code and NuGet packages
 

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -12,6 +12,21 @@ namespace IceRpc.Protobuf.Tools;
 /// <summary>A MSBuild task to compute what Protobuf files have to be rebuild by <c>protoc</c>.</summary>
 public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
 {
+    /// <summary>Gets or sets additional input files that every source depends on, typically the <c>protoc</c>
+    /// compiler and the code generator plug-in. A source is out of date when any of these files is missing or is
+    /// newer than one of the source's outputs.</summary>
+    public ITaskItem[] AdditionalInputs { get; set; } = [];
+
+    /// <summary>Gets or sets a string that identifies the configuration used to generate the outputs, such as the
+    /// compiler and plug-in versions and the options passed to them. When this value differs from the content of
+    /// <see cref="FingerprintFile"/>, every source is out of date.</summary>
+    public string Fingerprint { get; set; } = "";
+
+    /// <summary>Gets or sets the path of the file that holds the <see cref="Fingerprint"/> recorded by the previous
+    /// successful build. A missing file counts as a changed fingerprint. When empty, the fingerprint check is
+    /// skipped.</summary>
+    public string FingerprintFile { get; set; } = "";
+
     /// <summary>Gets or sets the output directory for the generated code.</summary>
     [Required]
     public string OutputDir { get; set; } = "";
@@ -31,42 +46,41 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
     /// item is up to date or needs to be rebuilt. The <c>OutputFileName</c> metadata contains the base file name for
     /// the generated outputs. This is the input item's file name without the extension, and converted to PascalCase.
     /// </summary>
+    /// <remarks>A source is up to date only when the <see cref="Fingerprint"/> matches the recorded one, all of its
+    /// outputs exist, every input recorded in its dependency file and every <see cref="AdditionalInputs"/> entry
+    /// exists, and the newest input is older than the oldest output.</remarks>
     /// <returns>Returns <see langword="true"/> if the task was executed successfully, <see langword="false"/>
     /// otherwise.</returns>
     public override bool Execute()
     {
-        var computedSources = new List<ITaskItem>();
+        bool fingerprintChanged = false;
+        if (FingerprintFile.Length > 0)
+        {
+            fingerprintChanged =
+                !File.Exists(FingerprintFile) || File.ReadAllText(FingerprintFile).Trim() != Fingerprint.Trim();
+            if (fingerprintChanged)
+            {
+                Log.LogMessage(
+                    MessageImportance.Normal,
+                    "The protoc configuration changed since the previous build; all Proto files are out of date.");
+            }
+        }
 
+        string[] additionalInputs = [.. AdditionalInputs.Select(item => item.GetMetadata("FullPath"))];
+
+        var computedSources = new List<ITaskItem>();
         foreach (ITaskItem source in Sources)
         {
-            bool upToDate = true;
             string fileName = source.GetMetadata("FileName").ToProtocPascalCase();
             string dependOutput = Path.Combine(OutputDir, $"{fileName}.d");
-            string csharpOutput = Path.Combine(OutputDir, $"{fileName}.cs");
-            string icerpcOutput = Path.Combine(OutputDir, $"{fileName}.IceRpc.cs");
+            string[] outputs =
+            [
+                dependOutput,
+                Path.Combine(OutputDir, $"{fileName}.cs"),
+                Path.Combine(OutputDir, $"{fileName}.IceRpc.cs"),
+            ];
 
-            if (File.Exists(dependOutput) && File.Exists(csharpOutput) && File.Exists(icerpcOutput))
-            {
-                long lastWriteTime = Math.Max(
-                    File.GetLastWriteTime(dependOutput).Ticks,
-                    File.GetLastWriteTime(csharpOutput).Ticks);
-                lastWriteTime = Math.Max(lastWriteTime, File.GetLastWriteTime(icerpcOutput).Ticks);
-                List<string> dependencies = ProcessDependencies(dependOutput);
-                foreach (string dependency in dependencies)
-                {
-                    if (File.GetLastWriteTime(dependency).Ticks >= lastWriteTime)
-                    {
-                        // If a dependency is newer than any of the outputs the source is not up to date.
-                        upToDate = false;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                // If any of the outputs is missing the file is not up to date.
-                upToDate = false;
-            }
+            bool upToDate = !fingerprintChanged && IsUpToDate(source.ItemSpec, outputs, dependOutput, additionalInputs);
 
             var computedSource = new TaskItem(source.ItemSpec);
             source.CopyMetadataTo(computedSource);
@@ -78,36 +92,71 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
 
         ComputedSources = [.. computedSources];
         return true;
+    }
 
-        static List<string> ProcessDependencies(string dependOutput)
+    private bool IsUpToDate(string source, string[] outputs, string dependOutput, string[] additionalInputs)
+    {
+        string? missingOutput = outputs.FirstOrDefault(output => !File.Exists(output));
+        if (missingOutput is not null)
         {
-            var depends = new List<string>();
-            string dependContents = File.ReadAllText(dependOutput);
+            Log.LogMessage(MessageImportance.Low, $"'{source}' is out of date: output '{missingOutput}' is missing.");
+            return false;
+        }
 
-            // Strip everything before and including "Xxx.cs:" (the output target).
-            const string outputPrefix = ".cs:";
-            int i = dependContents.IndexOf(outputPrefix, StringComparison.CurrentCultureIgnoreCase);
-            if (i == -1 || i + outputPrefix.Length >= dependContents.Length)
+        // The outputs are only up to date when all of them are newer than every input, so compare against the
+        // oldest output rather than the newest.
+        long oldestOutputTime = outputs.Min(output => File.GetLastWriteTime(output).Ticks);
+
+        foreach (string input in ProcessDependencies(dependOutput).Concat(additionalInputs))
+        {
+            if (!File.Exists(input))
             {
-                return depends;
+                // File.GetLastWriteTime returns a placeholder date for missing files, which would otherwise make a
+                // deleted import look older than the outputs.
+                Log.LogMessage(MessageImportance.Low, $"'{source}' is out of date: input '{input}' is missing.");
+                return false;
             }
 
-            dependContents = dependContents[(i + outputPrefix.Length)..];
-
-            // The Make depfile format uses '\' at end of line as a line continuation, and escapes
-            // spaces inside paths as '\ '. Windows directory separators are emitted as literal '\'
-            // (not escaped). We split on newlines, strip the trailing continuation '\' and whitespace,
-            // then unescape '\ ' -> ' ' so paths containing spaces resolve correctly.
-            foreach (string line in dependContents.Split('\n'))
+            if (File.GetLastWriteTime(input).Ticks >= oldestOutputTime)
             {
-                string filePath = line.TrimEnd().TrimEnd('\\').Trim().Replace("\\ ", " ", StringComparison.Ordinal);
-                if (!string.IsNullOrEmpty(filePath))
-                {
-                    depends.Add(Path.GetFullPath(filePath));
-                }
+                Log.LogMessage(
+                    MessageImportance.Low,
+                    $"'{source}' is out of date: input '{input}' is newer than one of its outputs.");
+                return false;
             }
+        }
 
+        return true;
+    }
+
+    private static List<string> ProcessDependencies(string dependOutput)
+    {
+        var depends = new List<string>();
+        string dependContents = File.ReadAllText(dependOutput);
+
+        // Strip everything before and including "Xxx.cs:" (the output target).
+        const string outputPrefix = ".cs:";
+        int i = dependContents.IndexOf(outputPrefix, StringComparison.CurrentCultureIgnoreCase);
+        if (i == -1 || i + outputPrefix.Length >= dependContents.Length)
+        {
             return depends;
         }
+
+        dependContents = dependContents[(i + outputPrefix.Length)..];
+
+        // The Make depfile format uses '\' at end of line as a line continuation, and escapes
+        // spaces inside paths as '\ '. Windows directory separators are emitted as literal '\'
+        // (not escaped). We split on newlines, strip the trailing continuation '\' and whitespace,
+        // then unescape '\ ' -> ' ' so paths containing spaces resolve correctly.
+        foreach (string line in dependContents.Split('\n'))
+        {
+            string filePath = line.TrimEnd().TrimEnd('\\').Trim().Replace("\\ ", " ", StringComparison.Ordinal);
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                depends.Add(Path.GetFullPath(filePath));
+            }
+        }
+
+        return depends;
     }
 }

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -87,7 +87,6 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
         {
             if (!File.Exists(input))
             {
-                // File.GetLastWriteTime returns a placeholder date for a missing file, older than any output.
                 Log.LogMessage(MessageImportance.Low, $"'{source}' is out of date: input '{input}' is missing.");
                 return false;
             }

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -37,8 +37,8 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
     /// the generated outputs. This is the input item's file name without the extension, and converted to PascalCase.
     /// </summary>
     /// <remarks>A source is up to date only when all of its outputs exist, every input recorded in its dependency
-    /// file and every <see cref="AdditionalInputs"/> entry exists, and the newest input is older than the oldest
-    /// output.</remarks>
+    /// file, its options record and every <see cref="AdditionalInputs"/> entry exists, and the newest input is older
+    /// than the oldest output.</remarks>
     /// <returns>Returns <see langword="true"/> if the task was executed successfully, <see langword="false"/>
     /// otherwise.</returns>
     public override bool Execute()
@@ -57,7 +57,11 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
                 Path.Combine(OutputDir, $"{fileName}.IceRpc.cs"),
             ];
 
-            bool upToDate = IsUpToDate(source.ItemSpec, outputs, dependOutput, additionalInputs);
+            // The options record is the source's own inputs cache: the build rewrites it only when the source's
+            // AdditionalOptions change, so it is newer than the outputs exactly then.
+            string[] inputs = [.. additionalInputs, Path.Combine(OutputDir, $"{fileName}.options")];
+
+            bool upToDate = IsUpToDate(source.ItemSpec, outputs, dependOutput, inputs);
 
             var computedSource = new TaskItem(source.ItemSpec);
             source.CopyMetadataTo(computedSource);

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -40,6 +40,11 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
     [Output]
     public ITaskItem[] ComputedSources { get; private set; } = [];
 
+    /// <summary>Gets a value indicating whether <see cref="Fingerprint"/> differs from the content of
+    /// <see cref="FingerprintFile"/>.</summary>
+    [Output]
+    public bool FingerprintChanged { get; private set; }
+
     /// <summary>Computes whether or not an output file is up to date or needs to be rebuilt. After executing this
     /// task, <see cref="ComputedSources"/> contains a task item for each item in <see cref="Sources"/> with two
     /// additional metadata entries. The <c>UpToDate</c> metadata is set to 'true' or 'false', indicating whether the
@@ -91,6 +96,7 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
         }
 
         ComputedSources = [.. computedSources];
+        FingerprintChanged = fingerprintChanged;
         return true;
     }
 

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -103,16 +103,14 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        // The outputs are only up to date when all of them are newer than every input, so compare against the
-        // oldest output rather than the newest.
+        // Every output must be newer than every input, so compare against the oldest output.
         long oldestOutputTime = outputs.Min(output => File.GetLastWriteTime(output).Ticks);
 
         foreach (string input in ProcessDependencies(dependOutput).Concat(additionalInputs))
         {
             if (!File.Exists(input))
             {
-                // File.GetLastWriteTime returns a placeholder date for missing files, which would otherwise make a
-                // deleted import look older than the outputs.
+                // File.GetLastWriteTime returns a placeholder date for a missing file, older than any output.
                 Log.LogMessage(MessageImportance.Low, $"'{source}' is out of date: input '{input}' is missing.");
                 return false;
             }

--- a/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
+++ b/src/IceRpc.Protobuf.Tools/UpToDateCheckTask.cs
@@ -17,16 +17,6 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
     /// newer than one of the source's outputs.</summary>
     public ITaskItem[] AdditionalInputs { get; set; } = [];
 
-    /// <summary>Gets or sets a string that identifies the configuration used to generate the outputs, such as the
-    /// compiler and plug-in versions and the options passed to them. When this value differs from the content of
-    /// <see cref="FingerprintFile"/>, every source is out of date.</summary>
-    public string Fingerprint { get; set; } = "";
-
-    /// <summary>Gets or sets the path of the file that holds the <see cref="Fingerprint"/> recorded by the previous
-    /// successful build. A missing file counts as a changed fingerprint. When empty, the fingerprint check is
-    /// skipped.</summary>
-    public string FingerprintFile { get; set; } = "";
-
     /// <summary>Gets or sets the output directory for the generated code.</summary>
     [Required]
     public string OutputDir { get; set; } = "";
@@ -40,37 +30,19 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
     [Output]
     public ITaskItem[] ComputedSources { get; private set; } = [];
 
-    /// <summary>Gets a value indicating whether <see cref="Fingerprint"/> differs from the content of
-    /// <see cref="FingerprintFile"/>.</summary>
-    [Output]
-    public bool FingerprintChanged { get; private set; }
-
     /// <summary>Computes whether or not an output file is up to date or needs to be rebuilt. After executing this
     /// task, <see cref="ComputedSources"/> contains a task item for each item in <see cref="Sources"/> with two
     /// additional metadata entries. The <c>UpToDate</c> metadata is set to 'true' or 'false', indicating whether the
     /// item is up to date or needs to be rebuilt. The <c>OutputFileName</c> metadata contains the base file name for
     /// the generated outputs. This is the input item's file name without the extension, and converted to PascalCase.
     /// </summary>
-    /// <remarks>A source is up to date only when the <see cref="Fingerprint"/> matches the recorded one, all of its
-    /// outputs exist, every input recorded in its dependency file and every <see cref="AdditionalInputs"/> entry
-    /// exists, and the newest input is older than the oldest output.</remarks>
+    /// <remarks>A source is up to date only when all of its outputs exist, every input recorded in its dependency
+    /// file and every <see cref="AdditionalInputs"/> entry exists, and the newest input is older than the oldest
+    /// output.</remarks>
     /// <returns>Returns <see langword="true"/> if the task was executed successfully, <see langword="false"/>
     /// otherwise.</returns>
     public override bool Execute()
     {
-        bool fingerprintChanged = false;
-        if (FingerprintFile.Length > 0)
-        {
-            fingerprintChanged =
-                !File.Exists(FingerprintFile) || File.ReadAllText(FingerprintFile).Trim() != Fingerprint.Trim();
-            if (fingerprintChanged)
-            {
-                Log.LogMessage(
-                    MessageImportance.Normal,
-                    "The protoc configuration changed since the previous build; all Proto files are out of date.");
-            }
-        }
-
         string[] additionalInputs = [.. AdditionalInputs.Select(item => item.GetMetadata("FullPath"))];
 
         var computedSources = new List<ITaskItem>();
@@ -85,7 +57,7 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
                 Path.Combine(OutputDir, $"{fileName}.IceRpc.cs"),
             ];
 
-            bool upToDate = !fingerprintChanged && IsUpToDate(source.ItemSpec, outputs, dependOutput, additionalInputs);
+            bool upToDate = IsUpToDate(source.ItemSpec, outputs, dependOutput, additionalInputs);
 
             var computedSource = new TaskItem(source.ItemSpec);
             source.CopyMetadataTo(computedSource);
@@ -96,7 +68,6 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
         }
 
         ComputedSources = [.. computedSources];
-        FingerprintChanged = fingerprintChanged;
         return true;
     }
 
@@ -109,7 +80,7 @@ public class UpToDateCheckTask : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        // Every output must be newer than every input, so compare against the oldest output.
+        // Every output must be newer than every input.
         long oldestOutputTime = outputs.Min(output => File.GetLastWriteTime(output).Ticks);
 
         foreach (string input in ProcessDependencies(dependOutput).Concat(additionalInputs))


### PR DESCRIPTION
Fixes #4817

Builds on the item rename made in #4922.

### M-17: stale outputs of removed or renamed Proto files

`ProtoClean` only ever deleted the outputs of the *current* `ProtoFile` items, so a removed or renamed `.proto` left `Hello.cs` and `Hello.IceRpc.cs` behind for the SDK's default `Compile` glob to keep compiling. The targets now mirror the Slice tooling (#4589):

- A new `_ComputeProtoOutputs` target computes the absolute paths of the files the build produces for the current items: the two C# files, the dependency file and the options record described below. `ProtoCompile`, `ProtoClean` and the two targets below depend on it. It runs only the name computation, not the up-to-date check, for the reason noted in #4922: on Rebuild it runs before Clean.
- `_ProtoWriteOutputManifest` (after `ProtoCompile`) records those paths in `$(IntermediateOutputPath)protoc.outputs.txt`.
- `_ProtoPruneStaleOutputs` (before `ProtoCompile` and `ProtoClean`) deletes anything in the previous manifest that the current build no longer produces, and removes it from `Compile` first so csc doesn't fail with CS2001. It prunes nothing when `_ComputeProtoOutputs` was skipped because the task assembly is missing. When the last Proto file is removed it also deletes the manifest, which `_ProtoWriteOutputManifest` no longer replaces; otherwise every later build would treat the former output paths as its own and delete whatever appears there.
- `ProtoClean` deletes the manifest and the inputs cache along with the generated files.

### M-18: up-to-date check accepting stale outputs

`UpToDateCheckTask` now:

- compares the newest input against the **oldest** output rather than the newest, so an old `Hello.IceRpc.cs` is no longer masked by a fresh `Hello.cs`;
- treats a **missing** dependency as out of date, instead of reading the placeholder timestamp `File.GetLastWriteTime` returns for missing files. A deleted import now surfaces as a protoc error rather than a silently stale build;
- takes `AdditionalInputs`: the `protoc` binary, `IceRpc.Protobuf.Generator.dll` and `$(IntermediateOutputPath)protoc.inputs.cache`, so a rebuilt or upgraded generator regenerates the code;
- sees a fresh `protoc.inputs.cache` when the configuration shared by all Proto files changes: `ProtoCompile` writes the compiler and generator versions and the `ProtoSearchPath` entries to it with `WriteOnlyWhenDifferent`, before the check. The file's timestamp moves only when a value changes; every Proto file is then out of date, including those a failed run left untouched;
- sees a fresh per-file record when a Proto file's `AdditionalOptions` change: `ProtoCompile` writes them, one per line, to `<OutputDir>/<Name>.options` next to the dependency file, with the same `WriteOnlyWhenDifferent` rule, and the task lists the record among that file's inputs. Only that file is then out of date, and a change reverted after a failed build is still caught, since the record is rewritten again. The record is also one of the files `_ComputeProtoOutputs` lists, so the manifest, prune and clean cover it. Adding a Proto file doesn't regenerate the others.

The README note saying that changing `AdditionalOptions` requires a `dotnet clean` is replaced by a short description of the incremental behavior.

### Verification

One-file probe importing the source-build props/targets (macOS, .NET SDK 10.0.201), protoc runs per build:

| Scenario | Before | After |
|---|---|---|
| No change | 0 | 0 |
| `Hello.IceRpc.cs` older than the `.proto`, `Hello.cs` newer | 0 (stale) | 1 |
| Imported `other.proto` deleted | 0 (stale) | protoc error for the missing import |
| `AdditionalOptions` of one of two files changed / unchanged / reverted | 0 (stale) | 1 / 0 / 1, that file only |
| A file switches to the `AdditionalOptions` value the other file uses | 0 (stale) | 1 |
| One file's options changed and `protoc` fails on the other; the failure fixed | n/a | 2, then 1 (the failed file) |
| One file's options changed and `protoc` fails on the other; the change reverted and the failure fixed | n/a | 2, then 2 (the reverted file's code no longer carries the option) |
| `ProtoSearchPath` changed | 0 (stale) | 2 |
| Task assembly missing (source build, `--no-dependencies`) | task-load error | task-load error, generated code intact |
| `third.proto` added | 1 | 1 |
| `hello.proto` renamed to `greeter.proto` | 1, `Hello.*` left behind | 1, `Hello.*` deleted, no duplicate types |
| Last `.proto` removed | 0, outputs left behind | 0, `generated/` empty |
| Generator assembly touched | 0 (stale) | 1 |
| Fresh Rebuild / second Rebuild / Clean | 1 / 1 / outputs deleted | 1 / 1 / outputs, options records, manifest and inputs cache deleted |

From the branch, `IceRpc.Protobuf.BuildTelemetry` builds clean, the `IceRpc.Protobuf.Tests` suite passes (70 tests), and a second build of that test project runs protoc zero times. Upgrading from a previous version regenerates every Proto file once, since no options record exists yet. Not exercised: Windows, where the only platform-specific addition is the `.exe` extension on the protoc input path.

## What's Changed entry

Area: Protobuf

- Removing or renaming a `.proto` file, or changing its `OutputDir`, now deletes the C# files previously generated
  for it during the next build, instead of leaving them for the compiler to pick up.
- `protoc` now regenerates a Proto file's code when any of its generated files is older than the Proto file or one of
  its imports, when an import is missing, when `protoc` or the generator is updated, when the file's
  `AdditionalOptions` change, and when `ProtoSearchPath` changes. Running `dotnet clean` after changing
  `AdditionalOptions` is no longer needed.


