### PR TITLE
Fail the tools pack when a bundled plug-in has not been built

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -21,9 +21,9 @@
                       ReferenceOutputAssembly="false" Private="false" Targets="Build" />
     <!--
       IceRpc.Protobuf.BuildTelemetry imports this project's props/targets (to compile its
-      protobuf_build_telemetry.proto), so a ProjectReference from here back to it would create a cycle. Release
-      packaging expects a prior `dotnet build` on the solution so its outputs exist in
-      ../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/ when the None Include glob below is evaluated.
+      protobuf_build_telemetry.proto), so a ProjectReference from here back to it would create a cycle. Packaging
+      expects a prior `dotnet build` on the solution so its outputs exist in
+      ../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/; IncludeProtocPluginsInPackage fails the pack otherwise.
     -->
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -55,19 +55,6 @@
       <PackagePath />
     </None>
     <None Include="$(IntermediateOutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="tasks/" Visible="false" />
-    <!--
-      Pack everything from the protoc plug-in (IceRpc.Protobuf.Generator) and the build-telemetry plug-in
-      (IceRpc.Protobuf.BuildTelemetry) bin folders, excluding files in the BuildTelemetry bin that have the
-      same name as a file already coming from the Generator bin (e.g. Google.Protobuf.dll). The bins are
-      otherwise clean - neither contains transitive tooling outputs because we use Targets="Build" on the
-      generator ProjectReferences (see IceRpc.Protobuf.Tools.targets).
-    -->
-    <_ProtobufGeneratorBinFile Include="../IceRpc.Protobuf.Generator/bin/$(Configuration)/net10.0/*" />
-    <_ProtobufBuildTelemetryBinFile
-      Include="../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/*"
-      Exclude="@(_ProtobufGeneratorBinFile -> '../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
-    <None Include="@(_ProtobufGeneratorBinFile);@(_ProtobufBuildTelemetryBinFile)"
-          Pack="true" PackagePath="tools/" Visible="false" />
   </ItemGroup>
   <Target Name="CopyGoogleProtobufTools" BeforeTargets="CoreCompile">
     <ItemGroup>
@@ -120,6 +107,35 @@
         <PackagePath>tools/</PackagePath>
         <Pack>true</Pack>
       </None>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Pack everything from the protoc plug-in (IceRpc.Protobuf.Generator) and the build-telemetry plug-in
+    (IceRpc.Protobuf.BuildTelemetry) bin folders, excluding files in the BuildTelemetry bin that have the
+    same name as a file already coming from the Generator bin (e.g. Google.Protobuf.dll). The bins are
+    otherwise clean - neither contains transitive tooling outputs because we use Targets="Build" on the
+    generator ProjectReferences (see IceRpc.Protobuf.Tools.targets).
+
+    The globs run in a target rather than at evaluation time so that packing this project on its own picks up
+    the Generator outputs that its ProjectReference has just built. The build-telemetry plug-in can't be
+    referenced (see above), so the pack fails when a plug-in hasn't been built instead of silently producing a
+    package without it.
+  -->
+  <Target Name="IncludeProtocPluginsInPackage" BeforeTargets="_GetPackageFiles">
+    <Error
+      Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Protobuf.Generator/bin/$(Configuration)/net10.0/IceRpc.Protobuf.Generator.dll')"
+      Text="IceRpc.Protobuf.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Protobuf.Tools." />
+    <Error
+      Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/IceRpc.Protobuf.BuildTelemetry.dll')"
+      Text="IceRpc.Protobuf.BuildTelemetry has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Protobuf.Tools." />
+    <ItemGroup>
+      <_ProtobufGeneratorBinFile Include="../IceRpc.Protobuf.Generator/bin/$(Configuration)/net10.0/*" />
+      <_ProtobufBuildTelemetryBinFile
+        Include="../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/*"
+        Exclude="@(_ProtobufGeneratorBinFile -> '../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
+      <None Include="@(_ProtobufGeneratorBinFile);@(_ProtobufBuildTelemetryBinFile)"
+            Pack="true" PackagePath="tools/" Visible="false" />
     </ItemGroup>
   </Target>
 

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -20,10 +20,9 @@
     <ProjectReference Include="../IceRpc.Protobuf.Generator/IceRpc.Protobuf.Generator.csproj"
                       ReferenceOutputAssembly="false" Private="false" Targets="Build" />
     <!--
-      IceRpc.Protobuf.BuildTelemetry imports this project's props/targets (to compile its
-      protobuf_build_telemetry.proto), so a ProjectReference from here back to it would create a cycle. Packaging
-      expects a prior `dotnet build` on the solution so its outputs exist in
-      ../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/; IncludeProtocPluginsInPackage fails the pack otherwise.
+      IceRpc.Protobuf.BuildTelemetry imports this project's props/targets to compile its .proto file, so a
+      ProjectReference to it would be a cycle. IncludeProtocPluginsInPackage expects its outputs to exist already: build
+      the solution before packing.
     -->
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -111,16 +110,9 @@
   </Target>
 
   <!--
-    Pack everything from the protoc plug-in (IceRpc.Protobuf.Generator) and the build-telemetry plug-in
-    (IceRpc.Protobuf.BuildTelemetry) bin folders, excluding files in the BuildTelemetry bin that have the
-    same name as a file already coming from the Generator bin (e.g. Google.Protobuf.dll). The bins are
-    otherwise clean - neither contains transitive tooling outputs because we use Targets="Build" on the
-    generator ProjectReferences (see IceRpc.Protobuf.Tools.targets).
-
-    The globs run in a target rather than at evaluation time so that packing this project on its own picks up
-    the Generator outputs that its ProjectReference has just built. The build-telemetry plug-in can't be
-    referenced (see above), so the pack fails when a plug-in hasn't been built instead of silently producing a
-    package without it.
+    Collected after Build so the globs see the Generator ProjectReference's outputs. The bins contain no transitive
+    tooling outputs (build-only ProjectReferences, see IceRpc.Protobuf.Tools.targets); dependencies present in both
+    bins, such as Google.Protobuf.dll, are packed once.
   -->
   <Target Name="IncludeProtocPluginsInPackage" BeforeTargets="_GetPackageFiles">
     <Error

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -117,10 +117,10 @@
   <Target Name="IncludeProtocPluginsInPackage" BeforeTargets="_GetPackageFiles">
     <Error
       Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Protobuf.Generator/bin/$(Configuration)/net10.0/IceRpc.Protobuf.Generator.dll')"
-      Text="IceRpc.Protobuf.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Protobuf.Tools." />
+      Text="IceRpc.Protobuf.Generator has not been built in the $(Configuration) configuration. Run 'dotnet build -c $(Configuration)' from the repository root before packing IceRpc.Protobuf.Tools." />
     <Error
       Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Protobuf.BuildTelemetry/bin/$(Configuration)/net10.0/IceRpc.Protobuf.BuildTelemetry.dll')"
-      Text="IceRpc.Protobuf.BuildTelemetry has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Protobuf.Tools." />
+      Text="IceRpc.Protobuf.BuildTelemetry has not been built in the $(Configuration) configuration. Run 'dotnet build -c $(Configuration)' from the repository root before packing IceRpc.Protobuf.Tools." />
     <ItemGroup>
       <_ProtobufGeneratorBinFile Include="../IceRpc.Protobuf.Generator/bin/$(Configuration)/net10.0/*" />
       <_ProtobufBuildTelemetryBinFile

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.targets
@@ -25,9 +25,8 @@
     ProjectReference, IceRpc.Protobuf.Generator) to be built so the protoc plug-in scripts exist on disk before we
     invoke them. We don't want the Tools project's assemblies or CopyToOutputDirectory items (e.g. the
     protoc-gen-icerpc-csharp scripts, *.runtimeconfig.json) to flow into the consumer's bin. The metadata below
-    switches the reference to "build-only" mode: ReferenceOutputAssembly=false skips the assembly reference,
-    Private=false suppresses Copy Local, and Targets=Build restricts the cross-project call to the Build target so
-    GetCopyToOutputDirectoryItems is never invoked on the referenced project.
+    switches the reference to "build-only" mode: ReferenceOutputAssembly=false skips the assembly reference and
+    Private=false suppresses Copy Local, including the GetCopyToOutputDirectoryItems call on the referenced project.
   -->
   <ItemGroup Condition="'$(IceRpcProtobufToolsSourceBuild)' == 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)IceRpc.Protobuf.Tools.csproj"

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -29,9 +29,9 @@
                       ReferenceOutputAssembly="false" Private="false" Targets="Build" />
     <!--
       IceRpc.Slice.BuildTelemetry imports this project's props/targets (to compile its BuildTelemetry.slice), so a
-      ProjectReference from here back to it would create a cycle. Release packaging expects a prior
-      `dotnet build` on the solution so its outputs exist in ../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/
-      when the None Include glob below is evaluated.
+      ProjectReference from here back to it would create a cycle. Packaging expects a prior `dotnet build` on the
+      solution so its outputs exist in ../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/;
+      IncludeSliceGeneratorsInPackage fails the pack otherwise.
     -->
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -70,23 +70,6 @@
       <PackagePath>/</PackagePath>
     </None>
     <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="tasks/" Visible="false" />
-    <!--
-      Pack everything from the two slicec generator plug-ins (ZeroC.Slice.Generator and
-      IceRpc.Slice.Generator) and the build-telemetry plug-in (IceRpc.Slice.BuildTelemetry), excluding
-      files that have the same name as a file already coming from an earlier bin. The bins are otherwise
-      clean - none of them contain transitive tooling outputs because we use Targets="Build" on the
-      generator ProjectReferences (see IceRpc.Slice.Tools.targets).
-    -->
-    <_ZeroCSliceGeneratorBinFile Include="../ZeroC.Slice.Generator/bin/$(Configuration)/net10.0/*" />
-    <_IceRpcSliceGeneratorBinFile
-      Include="../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/*"
-      Exclude="@(_ZeroCSliceGeneratorBinFile -> '../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
-    <_SliceBuildTelemetryBinFile
-      Include="../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/*"
-      Exclude="@(_ZeroCSliceGeneratorBinFile -> '../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)');
-               @(_IceRpcSliceGeneratorBinFile -> '../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
-    <None Include="@(_ZeroCSliceGeneratorBinFile);@(_IceRpcSliceGeneratorBinFile);@(_SliceBuildTelemetryBinFile)"
-          Pack="true" PackagePath="tools/" Visible="false" />
   </ItemGroup>
   <Target Name="DownloadSlicec" BeforeTargets="CoreCompile">
     <ItemGroup>
@@ -124,6 +107,42 @@
         <PackagePath>tools/</PackagePath>
         <Pack>true</Pack>
       </Content>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Pack everything from the two slicec generator plug-ins (ZeroC.Slice.Generator and
+    IceRpc.Slice.Generator) and the build-telemetry plug-in (IceRpc.Slice.BuildTelemetry), excluding
+    files that have the same name as a file already coming from an earlier bin. The bins are otherwise
+    clean - none of them contain transitive tooling outputs because we use Targets="Build" on the
+    generator ProjectReferences (see IceRpc.Slice.Tools.targets).
+
+    The globs run in a target rather than at evaluation time so that packing this project on its own picks up
+    the generator outputs that its ProjectReferences have just built. The build-telemetry plug-in can't be
+    referenced (see above), so the pack fails when a plug-in hasn't been built instead of silently producing a
+    package without it.
+  -->
+  <Target Name="IncludeSliceGeneratorsInPackage" BeforeTargets="_GetPackageFiles">
+    <Error
+      Condition="!Exists('$(MSBuildThisFileDirectory)../ZeroC.Slice.Generator/bin/$(Configuration)/net10.0/ZeroC.Slice.Generator.dll')"
+      Text="ZeroC.Slice.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+    <Error
+      Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/IceRpc.Slice.Generator.dll')"
+      Text="IceRpc.Slice.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+    <Error
+      Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/IceRpc.Slice.BuildTelemetry.dll')"
+      Text="IceRpc.Slice.BuildTelemetry has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+    <ItemGroup>
+      <_ZeroCSliceGeneratorBinFile Include="../ZeroC.Slice.Generator/bin/$(Configuration)/net10.0/*" />
+      <_IceRpcSliceGeneratorBinFile
+        Include="../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/*"
+        Exclude="@(_ZeroCSliceGeneratorBinFile -> '../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
+      <_SliceBuildTelemetryBinFile
+        Include="../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/*"
+        Exclude="@(_ZeroCSliceGeneratorBinFile -> '../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)');
+                 @(_IceRpcSliceGeneratorBinFile -> '../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/%(Filename)%(Extension)')" />
+      <None Include="@(_ZeroCSliceGeneratorBinFile);@(_IceRpcSliceGeneratorBinFile);@(_SliceBuildTelemetryBinFile)"
+            Pack="true" PackagePath="tools/" Visible="false" />
     </ItemGroup>
   </Target>
 

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -117,13 +117,13 @@
   <Target Name="IncludeSliceGeneratorsInPackage" BeforeTargets="_GetPackageFiles">
     <Error
       Condition="!Exists('$(MSBuildThisFileDirectory)../ZeroC.Slice.Generator/bin/$(Configuration)/net10.0/ZeroC.Slice.Generator.dll')"
-      Text="ZeroC.Slice.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+      Text="ZeroC.Slice.Generator has not been built in the $(Configuration) configuration. Run 'dotnet build -c $(Configuration)' from the repository root before packing IceRpc.Slice.Tools." />
     <Error
       Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Slice.Generator/bin/$(Configuration)/net10.0/IceRpc.Slice.Generator.dll')"
-      Text="IceRpc.Slice.Generator has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+      Text="IceRpc.Slice.Generator has not been built in the $(Configuration) configuration. Run 'dotnet build -c $(Configuration)' from the repository root before packing IceRpc.Slice.Tools." />
     <Error
       Condition="!Exists('$(MSBuildThisFileDirectory)../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/net10.0/IceRpc.Slice.BuildTelemetry.dll')"
-      Text="IceRpc.Slice.BuildTelemetry has not been built in the $(Configuration) configuration. Build the solution before packing IceRpc.Slice.Tools." />
+      Text="IceRpc.Slice.BuildTelemetry has not been built in the $(Configuration) configuration. Run 'dotnet build -c $(Configuration)' from the repository root before packing IceRpc.Slice.Tools." />
     <ItemGroup>
       <_ZeroCSliceGeneratorBinFile Include="../ZeroC.Slice.Generator/bin/$(Configuration)/net10.0/*" />
       <_IceRpcSliceGeneratorBinFile

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -28,10 +28,9 @@
     <ProjectReference Include="../IceRpc.Slice.Generator/IceRpc.Slice.Generator.csproj"
                       ReferenceOutputAssembly="false" Private="false" Targets="Build" />
     <!--
-      IceRpc.Slice.BuildTelemetry imports this project's props/targets (to compile its BuildTelemetry.slice), so a
-      ProjectReference from here back to it would create a cycle. Packaging expects a prior `dotnet build` on the
-      solution so its outputs exist in ../IceRpc.Slice.BuildTelemetry/bin/$(Configuration)/;
-      IncludeSliceGeneratorsInPackage fails the pack otherwise.
+      IceRpc.Slice.BuildTelemetry imports this project's props/targets to compile its .slice file, so a ProjectReference
+      to it would be a cycle. IncludeSliceGeneratorsInPackage expects its outputs to exist already: build the solution
+      before packing.
     -->
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -111,16 +110,9 @@
   </Target>
 
   <!--
-    Pack everything from the two slicec generator plug-ins (ZeroC.Slice.Generator and
-    IceRpc.Slice.Generator) and the build-telemetry plug-in (IceRpc.Slice.BuildTelemetry), excluding
-    files that have the same name as a file already coming from an earlier bin. The bins are otherwise
-    clean - none of them contain transitive tooling outputs because we use Targets="Build" on the
-    generator ProjectReferences (see IceRpc.Slice.Tools.targets).
-
-    The globs run in a target rather than at evaluation time so that packing this project on its own picks up
-    the generator outputs that its ProjectReferences have just built. The build-telemetry plug-in can't be
-    referenced (see above), so the pack fails when a plug-in hasn't been built instead of silently producing a
-    package without it.
+    Collected after Build so the globs see the generator ProjectReferences' outputs. The bins contain no transitive
+    tooling outputs (build-only ProjectReferences, see IceRpc.Slice.Tools.targets); dependencies present in several
+    bins are packed once.
   -->
   <Target Name="IncludeSliceGeneratorsInPackage" BeforeTargets="_GetPackageFiles">
     <Error

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -13,8 +13,8 @@
     slicec compiler exist on disk before we invoke them. We don't want the referenced projects' assemblies or
     CopyToOutputDirectory items (e.g. the slicec-*-generator scripts, *.runtimeconfig.json) to flow into the
     consumer's bin. The metadata below switches each reference to "build-only" mode: ReferenceOutputAssembly=false
-    skips the assembly reference, Private=false suppresses Copy Local, and Targets=Build restricts the cross-project
-    call to the Build target so GetCopyToOutputDirectoryItems is never invoked on the referenced project.
+    skips the assembly reference and Private=false suppresses Copy Local, including the GetCopyToOutputDirectoryItems
+    call on the referenced project.
   -->
   <ItemGroup Condition="'$(_IceRpcSliceToolsSourceBuild)' == 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)IceRpc.Slice.Tools.csproj"


### PR DESCRIPTION
Fixes #4824

`IceRpc.Protobuf.Tools` and `IceRpc.Slice.Tools` bundle their generator and build-telemetry plug-ins with globs over the plug-ins' `bin/$(Configuration)/net10.0` folders. The globs were evaluated before the generator project references built anything, so packing a tools project on its own on a clean checkout produced a package with no plug-in and reported success. The release workflow and `build/publish-local-packages.sh` are unaffected: both build the solution before `dotnet pack --no-build`.

- The globs now run in a pack-time target, as the protoc and slicec binaries already do, so an isolated pack picks up the outputs its project references just built.
- The target fails the pack when a bundled plug-in has not been built, naming the project, the configuration and the build command to run. The build-telemetry plug-ins can't be project references (they import the tools' targets to compile their own `.proto`/`.slice` file), so packing still needs a prior solution build.
- The build-order-only reference comments in both `.targets` files credited `Targets=Build` for keeping `CopyToOutputDirectory` items out of the consumer's bin; `Private=false` is what does that, and the comments now say so.

## What's Changed entry

None — build-system change to how this repository packs its own tools packages; no user-facing impact.
