### PR TITLE
Use the slicec 0.5 nightly on main

### DIFF
--- a/build/IceRpc.Version.props
+++ b/build/IceRpc.Version.props
@@ -3,7 +3,7 @@
     <!-- The version of all assembly files built in this repository -->
     <Version Condition="'$(Version)' == ''">0.7.0-preview.1</Version>
     <!-- The slicec compiler version -->
-    <SlicecVersion Condition="'$(SlicecVersion)' == ''">0.4.0</SlicecVersion>
-    <SlicecBaseUrl Condition="'$(SlicecBaseUrl)' == ''">https://download.zeroc.com/icerpc/slicec/0.4</SlicecBaseUrl>
+    <SlicecVersion Condition="'$(SlicecVersion)' == ''">0.5.0</SlicecVersion>
+    <SlicecBaseUrl Condition="'$(SlicecBaseUrl)' == ''">https://download.zeroc.com/icerpc/slicec/nightly/0.5</SlicecBaseUrl>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
`main` builds with the stable slicec 0.4.0 release, so fixes merged on slicec's `main` never reach this branch until a
new stable release ships. This PR points `SlicecBaseUrl` at the `nightly/0.5` path and bumps `SlicecVersion` to 0.5.0,
the version published there by the daily slicec build.

The Compiler Slice definitions under `slice/Compiler` are identical on slicec `main`, so the checked-in
`ZeroC.Slice.Symbols` sources need no regeneration.

Verified locally with a clean download of the four nightly zips: the full solution builds, and the generator, Ice
generator, ServiceGenerator, IceRpc.Slice and IceRpc test projects pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
