### PR TITLE
Generate variant field and return value doc comments

### DIFF
--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -144,6 +144,27 @@ internal static class OperationExtensions
             return fn.Build();
         }
 
+        /// <summary>Returns the <c>&lt;returns&gt;</c> doc comment for the operation: the doc comment of its single
+        /// return field, or a list with one item per documented field of a tuple return. Returns null when no return
+        /// field is documented.</summary>
+        internal string? GetReturnsDocComment(string currentNamespace)
+        {
+            if (op.ReturnType.Count == 1)
+            {
+                return DocCommentFormatter.FormatOverview(op.ReturnType[0].Comment, currentNamespace);
+            }
+
+            var items = op.ReturnType
+                .Select(r => (r.Name, Overview: DocCommentFormatter.FormatOverview(r.Comment, currentNamespace)))
+                .Where(item => item.Overview is not null)
+                .Select(item => $"<item><term>{item.Name}</term><description>{item.Overview}</description></item>")
+                .ToList();
+
+            return items.Count > 0
+                ? $"A tuple containing:\n<list type=\"bullet\">\n{string.Join("\n", items)}\n</list>"
+                : null;
+        }
+
         /// <summary>Returns the C# return type for an operation (<c>Task</c>, <c>Task&lt;T&gt;</c>, or
         /// <c>Task&lt;tuple&gt;</c>). Stream returns are included in the tuple with their stream type.</summary>
         internal string GetClientReturnType(string currentNamespace) =>

--- a/src/IceRpc.Slice.Generator/ProxyGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ProxyGenerator.cs
@@ -99,9 +99,13 @@ internal static class ProxyGenerator
             "default",
             "A cancellation token that receives the cancellation requests.");
 
-        if (op.NonStreamedReturns.Count == 0 && !op.HasStreamedReturn)
+        if (op.ReturnType.Count == 0)
         {
             builder.AddComment("returns", "A task that completes when the response is received.");
+        }
+        else if (op.GetReturnsDocComment(currentNamespace) is string returns)
+        {
+            builder.AddComment("returns", returns);
         }
 
         builder.AddDocCommentSeeAlso(op.Comment, currentNamespace);

--- a/src/IceRpc.Slice.Generator/ServiceGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ServiceGenerator.cs
@@ -310,9 +310,14 @@ internal static class ServiceGenerator
             op.CancellationTokenParamName,
             docComment: "A cancellation token that receives the cancellation requests.");
 
-        if (op.NonStreamedReturns.Count == 0 && !op.HasStreamedReturn)
+        if (op.ReturnType.Count == 0)
         {
             operationBuilder.AddComment("returns", "A value task that completes when this implementation completes.");
+        }
+        else if (!op.Attributes.HasAttribute(CSAttributes.CSEncodedReturn) &&
+            op.GetReturnsDocComment(currentNamespace) is string returns)
+        {
+            operationBuilder.AddComment("returns", returns);
         }
 
         // Build SliceOperation attribute with optional named parameters

--- a/src/ZeroC.CodeBuilder/ContainerBuilder.cs
+++ b/src/ZeroC.CodeBuilder/ContainerBuilder.cs
@@ -10,7 +10,7 @@ public sealed class ContainerBuilder : IBuilder, IAttributeBuilder<ContainerBuil
     private readonly List<CommentTag> _comments = [];
     private readonly string _containerType;
     private readonly List<CodeBlock> _contents = [];
-    private readonly List<string> _fields = [];
+    private readonly List<string> _parameters = [];
     private readonly string _name;
 
     /// <summary>Initializes a new instance of the <see cref="ContainerBuilder"/> class.</summary>
@@ -77,18 +77,21 @@ public sealed class ContainerBuilder : IBuilder, IAttributeBuilder<ContainerBuil
         return this;
     }
 
-    /// <summary>Adds a primary constructor field to the container.</summary>
-    /// <param name="fieldName">The name of the field.</param>
-    /// <param name="fieldType">The type of the field.</param>
-    /// <param name="docComment">An optional documentation comment for the field.</param>
+    /// <summary>Adds a parameter to the primary constructor of the container.</summary>
+    /// <param name="paramType">The parameter type, including any attributes.</param>
+    /// <param name="paramName">The parameter name.</param>
+    /// <param name="docComment">An optional documentation comment.</param>
     /// <returns>This builder instance for method chaining.</returns>
-    public ContainerBuilder AddField(string fieldName, string fieldType, string? docComment = null)
+    public ContainerBuilder AddPrimaryConstructorParameter(
+        string paramType,
+        string paramName,
+        string? docComment = null)
     {
         if (docComment is not null)
         {
-            AddComment("param", "name", fieldName, docComment);
+            AddComment("param", "name", paramName, docComment);
         }
-        _fields.Add($"{fieldType} {fieldName}");
+        _parameters.Add($"{paramType} {paramName}");
         return this;
     }
 
@@ -111,11 +114,11 @@ public sealed class ContainerBuilder : IBuilder, IAttributeBuilder<ContainerBuil
             ? $" : {string.Join(", ", _bases)}"
             : string.Empty;
 
-        string fieldsClause = _fields.Count > 0
-            ? $"({string.Join(", ", _fields)})"
+        string parametersClause = _parameters.Count > 0
+            ? $"({string.Join(", ", _parameters)})"
             : string.Empty;
 
-        code.WriteLine($"{_containerType} {_name}{fieldsClause}{basesClause}");
+        code.WriteLine($"{_containerType} {_name}{parametersClause}{basesClause}");
 
         var bodyContent = CodeBlock.FromBlocks(_contents);
 

--- a/src/ZeroC.Slice.Generator/BuilderExtensions.cs
+++ b/src/ZeroC.Slice.Generator/BuilderExtensions.cs
@@ -21,6 +21,20 @@ internal static class BuilderExtensions
         return builder;
     }
 
+    /// <summary>Adds a <c>&lt;param&gt;</c> tag for each field that has a doc comment.</summary>
+    internal static T AddDocCommentParams<T>(this T builder, IEnumerable<Field> fields, string currentNamespace)
+        where T : ICommentBuilder<T>
+    {
+        foreach (Field field in fields)
+        {
+            if (DocCommentFormatter.FormatOverview(field.Comment, currentNamespace) is string overview)
+            {
+                builder.AddComment("param", "name", field.Name, overview);
+            }
+        }
+        return builder;
+    }
+
     /// <summary>Adds the <c>&lt;seealso&gt;</c> tags from a <see cref="Comment"/> to a builder.</summary>
     internal static T AddDocCommentSeeAlso<T>(this T builder, Comment? comment, string currentNamespace)
         where T : ICommentBuilder<T>

--- a/src/ZeroC.Slice.Generator/BuilderExtensions.cs
+++ b/src/ZeroC.Slice.Generator/BuilderExtensions.cs
@@ -21,20 +21,6 @@ internal static class BuilderExtensions
         return builder;
     }
 
-    /// <summary>Adds a <c>&lt;param&gt;</c> tag for each field that has a doc comment.</summary>
-    internal static T AddDocCommentParams<T>(this T builder, IEnumerable<Field> fields, string currentNamespace)
-        where T : ICommentBuilder<T>
-    {
-        foreach (Field field in fields)
-        {
-            if (DocCommentFormatter.FormatOverview(field.Comment, currentNamespace) is string overview)
-            {
-                builder.AddComment("param", "name", field.Name, overview);
-            }
-        }
-        return builder;
-    }
-
     /// <summary>Adds the <c>&lt;seealso&gt;</c> tags from a <see cref="Comment"/> to a builder.</summary>
     internal static T AddDocCommentSeeAlso<T>(this T builder, Comment? comment, string currentNamespace)
         where T : ICommentBuilder<T>

--- a/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
+++ b/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
@@ -142,6 +142,7 @@ internal static class VariantEnumGenerator
 
         return new ContainerBuilder("partial record class", nameWithParams)
             .AddDocCommentSummary(variant.Comment, currentNamespace)
+            .AddDocCommentParams(variant.Fields, currentNamespace)
             .AddDocCommentSeeAlso(variant.Comment, currentNamespace)
             .AddDeprecatedAttribute(variant.Attributes)
             .AddBase(parentIdentifier)

--- a/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
+++ b/src/ZeroC.Slice.Generator/VariantEnumGenerator.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-using System.Collections.Immutable;
 using ZeroC.CodeBuilder;
 using ZeroC.Slice.Symbols;
 
@@ -130,19 +129,21 @@ internal static class VariantEnumGenerator
         string currentNamespace,
         int discriminant)
     {
-        string variantName = variant.Name;
+        ContainerBuilder builder = new ContainerBuilder("partial record class", variant.Name)
+            .AddDocCommentSummary(variant.Comment, currentNamespace);
 
         // Inside the union record, the case record names can shadow type names from the enclosing namespace. We set
-        // currentNamespace to "" to generate fully qualified type names for the parameter list and the encode method.
+        // currentNamespace to "" to generate fully qualified type names for the parameters and the encode method.
+        foreach (Field field in variant.Fields)
+        {
+            string type = field.DataType.FieldTypeString(field.DataTypeIsOptional, currentNamespace: "");
+            builder.AddPrimaryConstructorParameter(
+                PropertyAttributes(field) + type,
+                field.Name,
+                DocCommentFormatter.FormatOverview(field.Comment, currentNamespace));
+        }
 
-        // Build parameter list for the record constructor.
-        string nameWithParams = variant.Fields.Count > 0
-            ? $"{variantName}({BuildParameterList(variant.Fields, currentNamespace: "")})"
-            : variantName;
-
-        return new ContainerBuilder("partial record class", nameWithParams)
-            .AddDocCommentSummary(variant.Comment, currentNamespace)
-            .AddDocCommentParams(variant.Fields, currentNamespace)
+        return builder
             .AddDocCommentSeeAlso(variant.Comment, currentNamespace)
             .AddDeprecatedAttribute(variant.Attributes)
             .AddBase(parentIdentifier)
@@ -328,25 +329,18 @@ internal static class VariantEnumGenerator
         return code;
     }
 
-    /// <summary>Builds the positional parameter list of a variant's record declaration: one parameter per field, with
-    /// the field's <c>cs::attribute</c> and <c>deprecated</c> attributes emitted on the property that the record
-    /// generates for the parameter.</summary>
-    private static string BuildParameterList(ImmutableList<Field> fields, string currentNamespace)
+    /// <summary>Returns the <c>cs::attribute</c> and <c>deprecated</c> attributes of a variant field, with the
+    /// <c>property:</c> target that applies them to the property the record generates for the parameter.</summary>
+    private static string PropertyAttributes(Field field)
     {
-        return string.Join(", ", fields.Select(f =>
+        string attributes = string.Concat(
+            field.Attributes.CSAttributes().Select(attr => $"[property: {attr.Args[0]}] "));
+        if (field.Attributes.IsDeprecated)
         {
-            string attributes = string.Concat(
-                f.Attributes.CSAttributes().Select(attr => $"[property: {attr.Args[0]}] "));
-            if (f.Attributes.IsDeprecated)
-            {
-                attributes += f.Attributes.DeprecatedMessage is string message ?
-                    $"[property: global::System.Obsolete(\"{message}\")] " :
-                    "[property: global::System.Obsolete] ";
-            }
-
-            string typeString = f.DataType.FieldTypeString(f.DataTypeIsOptional, currentNamespace);
-            string paramName = f.Name;
-            return $"{attributes}{typeString} {paramName}";
-        }));
+            attributes += field.Attributes.DeprecatedMessage is string message ?
+                $"[property: global::System.Obsolete(\"{message}\")] " :
+                "[property: global::System.Obsolete] ";
+        }
+        return attributes;
     }
 }

--- a/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.cs
+++ b/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ZeroC, Inc.
+
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace IceRpc.Slice.Generator.Tests;
+
+[Parallelizable(scope: ParallelScope.All)]
+public class DocumentationTests
+{
+    private const string MemberPrefix = "M:IceRpc.Slice.Generator.Tests.";
+
+    private const string TrailingParams = "IceRpc.Features.IFeatureCollection,System.Threading.CancellationToken)";
+
+    [TestCase("IMySessionManager")]
+    [TestCase("IMySessionManagerService")]
+    public void Single_return_gets_returns_doc_comment(string interfaceName)
+    {
+        // Arrange / Act
+        XElement member = GetMember(
+            $"{MemberPrefix}{interfaceName}.CreateSessionAsync(IceRpc.Slice.Generator.Tests.MyAuthToken,{TrailingParams}");
+
+        // Assert
+        Assert.That(member.Element("returns")?.Value, Is.EqualTo("The new session."));
+    }
+
+    [TestCase("IMySessionManager")]
+    [TestCase("IMySessionManagerService")]
+    public void Tuple_return_gets_returns_doc_comment_with_one_item_per_field(string interfaceName)
+    {
+        // Arrange / Act
+        XElement member = GetMember($"{MemberPrefix}{interfaceName}.GetStatusAsync(System.String,{TrailingParams}");
+        var items = member.Element("returns")!.Element("list")!.Elements("item")
+            .ToDictionary(item => item.Element("term")!.Value, item => item.Element("description")!.Value);
+
+        // Assert
+        Assert.That(member.Element("returns")!.Value.Trim(), Does.StartWith("A tuple containing:"));
+        Assert.That(items["Status"], Is.EqualTo("The status."));
+        Assert.That(items["LastSeen"], Is.EqualTo("The time at what the user was last seen."));
+    }
+
+    private static XElement GetMember(string name) =>
+        XDocument.Load(Path.ChangeExtension(typeof(DocumentationTests).Assembly.Location, ".xml"))
+            .Descendants("member")
+            .Single(m => m.Attribute("name")!.Value == name);
+}

--- a/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
@@ -41,6 +41,7 @@ interface MySessionManager {
     /// Creates a session. The {@link MySession::status} is always {@link MyStatus::Idle} after creation. To retrieve the
     /// status of a user call {@link getStatus}.
     /// @param authToken: The authentication token.
+    /// @returns: The new session.
     createSession(authToken: MyAuthToken) -> MySession
 
     /// Retrieve the status of the given user.

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.cs
@@ -3,6 +3,9 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using ZeroC.Slice.Codec;
 using ZeroC.Tests.Common;
 
@@ -271,6 +274,28 @@ public class VariantEnumTests
         Assert.That(decoded, Is.InstanceOf<VariantFieldKinds.StringDictionary>());
         Assert.That(((VariantFieldKinds.StringDictionary)decoded).Entries, Is.EqualTo(value.Entries));
         Assert.That(decoder.Consumed, Is.EqualTo(encoder.EncodedByteCount));
+    }
+
+    [Test]
+    public void Variant_fields_get_param_doc_comments()
+    {
+        // Arrange
+        var xmlDoc = XDocument.Load(Path.ChangeExtension(typeof(Shape).Assembly.Location, ".xml"));
+
+        // Act
+        XElement member = xmlDoc.Descendants("member")
+            .Single(m => m.Attribute("name")!.Value == "T:ZeroC.Slice.Generator.Tests.Shape.Rectangle");
+        var parameters = member.Elements("param").ToDictionary(p => p.Attribute("name")!.Value, p => p.Value);
+
+        // Assert
+        Assert.That(
+            parameters,
+            Is.EqualTo(
+                new Dictionary<string, string>
+                {
+                    ["Width"] = "The width of the rectangle.",
+                    ["Height"] = "The height of the rectangle."
+                }));
     }
 
     [Test]


### PR DESCRIPTION
Closes #4832 by fixing the two remaining findings, the `@param` half of L-11 and L-12. Both depend on the doc comments
that slicec 0.5 now forwards for variant fields and return fields (icerpc/slicec#809).

- `VariantEnumGenerator` emits a `<param>` tag on the variant's record for each field documented with `@param` on the
  variant.
- `ProxyGenerator` and `ServiceGenerator` emit a `<returns>` tag from the operation's `@returns` tags: the description
  of a single return value, or a bulleted list with one item per documented element of a tuple return. Operations with
  `cs::encodedReturn` keep no `<returns>` tag on the service side, since their return value is a `PipeReader` the Slice
  doc comment doesn't describe.

The new tests read the generated members from the test assembly's XML documentation file.

## What's Changed entry

Area: Slice codec

- The Slice compiler now generates a `<param>` doc comment for each field of a variant enum documented with `@param`.
- The Slice compiler now generates a `<returns>` doc comment for operations documented with `@returns`. For an
  operation that returns a tuple, the comment lists each documented return value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
