### PR TITLE
Add code comment rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ These conventions apply to all AI coding assistants (Copilot, Claude Code, etc.)
 - Prefer `#1234` over full GitHub URLs when referencing issues or PRs in this repo
   (`icerpc/icerpc-csharp`). Use full URLs only when linking to other repositories.
 - XML doc comments use `<summary>`, `<remarks>`, `<param>`, etc. — not Markdown.
+- A comment states what the code cannot show: a why, a constraint, a contract, a non-obvious rule. It never narrates
+  the code below it; assume the reader reads the code.
+- A comment never describes the bug a change fixes or the behavior it replaces. That history belongs in the PR
+  description, not in the source.
+- Keep comments terse. Delete a comment that does not earn its keep.
 
 ## Branch conventions
 


### PR DESCRIPTION
AGENTS.md now tells coding agents what a code comment is for: a why, a constraint, a contract, a non-obvious rule. It
must not narrate the code below it, and it must not describe the bug a change fixes or the behavior it replaces; that
history belongs in the PR description.

These rules already apply to human contributors. Spelling them out here lets Copilot and Claude Code apply them when
they write or review comments.

## What's Changed entry

None — agent guidelines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
