### PR TITLE
Delete the Slice output manifest when the last Slice file is removed

### DIFF
--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -136,6 +136,11 @@
       <Compile Remove="@(_StaleSlicecOutputRelative)" />
     </ItemGroup>
     <Delete Files="@(_StaleSlicecOutput)" />
+    <!--
+      With no SliceFile left, _SlicecWriteOutputManifest doesn't run to replace the manifest; delete it here, or
+      every later build deletes whatever appears at the former output paths.
+    -->
+    <Delete Files="$(IntermediateOutputPath)slicec.outputs.txt" Condition="@(SliceFile) == ''" />
   </Target>
 
   <Target Name="Slicec" BeforeTargets="CoreCompile" DependsOnTargets="_ComputeSliceFiles" Condition="@(SliceFile) != ''">

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.targets
@@ -136,10 +136,7 @@
       <Compile Remove="@(_StaleSlicecOutputRelative)" />
     </ItemGroup>
     <Delete Files="@(_StaleSlicecOutput)" />
-    <!--
-      With no SliceFile left, _SlicecWriteOutputManifest doesn't run to replace the manifest; delete it here, or
-      every later build deletes whatever appears at the former output paths.
-    -->
+    <!-- With no SliceFile left, _SlicecWriteOutputManifest doesn't run to replace the manifest. -->
     <Delete Files="$(IntermediateOutputPath)slicec.outputs.txt" Condition="@(SliceFile) == ''" />
   </Target>
 


### PR DESCRIPTION
Follow-up to #4923, where the same gap was found in the Protobuf targets (Copilot's suppressed comment on `_ProtoPruneStaleOutputs`).

`_SlicecWriteOutputManifest` only runs when the project has `SliceFile` items. Removing the last `.slice` file therefore leaves the previous `slicec.outputs.txt` in place after `_SlicecPruneStaleOutputs` deletes its outputs, and every later build prunes the same paths again. A file created at one of those paths since, such as a hand-written replacement for the generated code, is deleted on each build.

`_SlicecPruneStaleOutputs` now deletes the manifest when there are no `SliceFile` items, after pruning the recorded outputs.

### Verification

Two-file probe importing the source-build props/targets (macOS, .NET SDK 10.0.201), slicec runs per build:

| Scenario | Before | After |
|---|---|---|
| Remove both `.slice` files, build | outputs pruned, manifest kept | outputs pruned, manifest deleted |
| Then create `generated/a.cs` by hand, build | `a.cs` deleted | `a.cs` kept |
| Add the `.slice` files back, build | 1 | 1, manifest recorded again |
| Rename `a.slice` to `alpha.slice` | `a.cs` pruned | `a.cs` pruned |
| Unchanged build / Rebuild / Clean | 1 / 1 / outputs and manifest deleted | 1 / 1 / outputs and manifest deleted |
| Remove both `.slice` files, Clean | outputs and manifest deleted | outputs and manifest deleted |

`src/IceRpc` (which imports these targets) builds clean from this branch.

## What's Changed entry

None — only affects a hand-written file placed at a former generated-code path after the last Slice file is removed, which no project does in practice.

