### PR TITLE
Extract helpers for optional encoding in the Slice generators

### DIFF
--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -125,7 +125,7 @@ internal static class OperationExtensions
                 bool useSegments;
                 if (streamField.DataTypeIsOptional)
                 {
-                    encodeLambda = GetStreamOfOptionalEncodeLambda(streamField, currentNamespace);
+                    encodeLambda = streamField.DataType.GetEncodeLambdaWithNullMarker(currentNamespace);
                     useSegments = true;
                 }
                 else
@@ -366,28 +366,6 @@ internal static class OperationExtensions
         }
 
         return count == 1 ? $"{taskType}<{parts[0]}>" : $"{taskType}<({string.Join(", ", parts)})>";
-    }
-
-    /// <summary>Returns an encode lambda for an optional stream element with a one bit bit-sequence.</summary>
-    internal static string GetStreamOfOptionalEncodeLambda(Field streamField, string currentNamespace)
-    {
-        IType elemType = streamField.DataType.Type;
-        string csType = streamField.DataType.FieldTypeString(true, currentNamespace);
-        // CustomType → (value ?? default!), value types → value!.Value, reference types → value!
-        string valueExpr = elemType is CustomType
-            ? "(value ?? default!)"
-            : streamField.DataType.IsValueType ? "value!.Value" : "value!";
-        string encodeExpr = elemType.EncodeExpression(currentNamespace, valueExpr);
-        return $$"""
-            (ref SliceEncoder encoder, {{csType}} value) =>
-            {
-                encoder.EncodeBool(value is not null);
-                if (value is not null)
-                {
-                    {{encodeExpr}};
-                }
-            }
-            """;
     }
 
     /// <summary>Returns a decode lambda for an optional stream element with a one bit bit-sequence.</summary>

--- a/src/ZeroC.Slice.Generator/FieldExtensions.cs
+++ b/src/ZeroC.Slice.Generator/FieldExtensions.cs
@@ -209,10 +209,10 @@ internal static class FieldExtensions
                 }
                 else
                 {
-                    string valueParam = field.DataType.Type is CustomType
-                        ? $"({param} ?? default!)"
-                        : field.DataType.IsValueType ? $"{param}.Value" : param;
-                    CodeBlock encodeExpr = field.DataType.EncodeExpression(currentNamespace, valueParam, encoderName);
+                    CodeBlock encodeExpr = field.DataType.EncodeExpression(
+                        currentNamespace,
+                        field.DataType.UnwrapNonNullOptional(param),
+                        encoderName);
                     body.WriteLine($$"""
                         bitSequenceWriter.Write({{param}} != null);
                         if ({{param}} != null)

--- a/src/ZeroC.Slice.Generator/ITypeExtensions.cs
+++ b/src/ZeroC.Slice.Generator/ITypeExtensions.cs
@@ -191,70 +191,25 @@ internal static class ITypeExtensions
             string param,
             string encoderName)
         {
-            IType elemType = seq.ElementType.Type;
-            if (seq.ElementTypeIsOptional)
-            {
-                string csOptType = seq.ElementType.FieldTypeString(true, currentNamespace);
-                string lambda = EncodeOptionalValueLambda(elemType, csOptType, currentNamespace);
-                return $$"""
-                    {{encoderName}}.EncodeSequenceOfOptionals(
-                        {{param}},
-                        {{lambda}})
-                    """;
-            }
-
             // Fixed-size primitives use the optimized EncodeSequence<T> overload (no lambda).
-            if (!seq.ElementTypeIsOptional && elemType is Builtin builtin && builtin.IsFixedSize)
+            if (!seq.ElementTypeIsOptional && seq.ElementType.Type is Builtin { IsFixedSize: true })
             {
                 return $"{encoderName}.EncodeSequence({param})";
             }
 
             CodeBlock elementEncodeLambda = seq.ElementType.GetEncodeLambda(seq.ElementTypeIsOptional, currentNamespace);
+            string method = seq.ElementTypeIsOptional ? "EncodeSequenceOfOptionals" : "EncodeSequence";
             return $$"""
-                {{encoderName}}.EncodeSequence(
+                {{encoderName}}.{{method}}(
                     {{param}},
                     {{elementEncodeLambda.Indent()}})
                 """;
-
-            static string EncodeOptionalValueLambda(IType elemType, string csOptType, string currentNamespace)
-            {
-                // CustomType → (value ?? default!), value types → value!.Value, reference types → value!
-                string valueExpr = elemType is CustomType
-                    ? "(value ?? default!)"
-                    : elemType is Struct or BasicEnum or Builtin { IsValueType: true } ? "value!.Value" : "value!";
-                string encodeExpr = elemType.EncodeExpression(currentNamespace, valueExpr);
-                return $"(ref SliceEncoder encoder, {csOptType} value) => {encodeExpr}";
-            }
         }
 
-        // Returns an encode lambda for a result success/failure type, handling optional inner types with a
-        // one bit bit-sequence.
-        static string ResultEncodeLambda(TypeRef typeRef, bool isOptional, string currentNamespace)
-        {
-            IType type = typeRef.Type;
-
-            if (!isOptional)
-            {
-                return typeRef.GetEncodeLambda(isOptional: false, currentNamespace);
-            }
-            string csType = typeRef.FieldTypeString(true, currentNamespace);
-
-            // CustomType → (value ?? default!), value types → value!.Value, reference types → value!
-            string valueParam = type is CustomType
-                ? "(value ?? default!)"
-                : typeRef.IsValueType ? "value!.Value" : "value!";
-            CodeBlock encodeBody = type.EncodeExpression(currentNamespace, valueParam);
-            return $$"""
-                (ref SliceEncoder encoder, {{csType}} value) =>
-                {
-                    encoder.EncodeBool(value is not null);
-                    if (value is not null)
-                    {
-                        {{encodeBody.Indent().Indent()}};
-                    }
-                }
-                """;
-        }
+        static string ResultEncodeLambda(TypeRef typeRef, bool isOptional, string currentNamespace) =>
+            isOptional
+                ? typeRef.GetEncodeLambdaWithNullMarker(currentNamespace)
+                : typeRef.GetEncodeLambda(isOptional: false, currentNamespace);
     }
 
     /// <summary>Returns a decode lambda for a type. When <paramref name="withCast"/> is true, a cast to the field

--- a/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
+++ b/src/ZeroC.Slice.Generator/TypeRefExtensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+using ZeroC.CodeBuilder;
 using ZeroC.Slice.Symbols;
 
 namespace ZeroC.Slice.Generator;
@@ -7,7 +8,6 @@ namespace ZeroC.Slice.Generator;
 /// <summary>C#-specific extension methods for <see cref="TypeRef"/>.</summary>
 internal static class TypeRefExtensions
 {
-
     /// <summary>Generates decode expression for a type reference. When the TypeRef has a cs::type attribute,
     /// it is passed through as the concrete type for dictionary/sequence factory construction.</summary>
     internal static string DecodeExpression(this TypeRef typeRef, string currentNamespace)
@@ -45,11 +45,26 @@ internal static class TypeRefExtensions
         }
 
         string csType = typeRef.Type.ToTypeString(currentNamespace) + "?";
-        string param = typeRef.Type is CustomType
-            ? "(value ?? default!)"
-            : typeRef.IsValueType ? "value!.Value" : "value!";
-        string encodeExpr = typeRef.Type.EncodeExpression(currentNamespace, param);
+        string encodeExpr = typeRef.Type.EncodeExpression(currentNamespace, typeRef.UnwrapNonNullOptional("value"));
         return $"(ref SliceEncoder encoder, {csType} value) => {encodeExpr}";
+    }
+
+    /// <summary>Returns an encode lambda for an optional type reference that writes a bool null marker before the
+    /// value, for use where the caller has no bit sequence.</summary>
+    internal static string GetEncodeLambdaWithNullMarker(this TypeRef typeRef, string currentNamespace)
+    {
+        string csType = typeRef.FieldTypeString(true, currentNamespace);
+        CodeBlock encodeBody = typeRef.EncodeExpression(currentNamespace, typeRef.UnwrapNonNullOptional("value"));
+        return $$"""
+            (ref SliceEncoder encoder, {{csType}} value) =>
+            {
+                encoder.EncodeBool(value is not null);
+                if (value is not null)
+                {
+                    {{encodeBody.Indent().Indent()}};
+                }
+            }
+            """;
     }
 
     /// <summary>Returns the C# type string for an incoming parameter (decode target). Sequences map to arrays,
@@ -108,6 +123,11 @@ internal static class TypeRefExtensions
 
         return (isOptional && !ignoreOptional) ? $"{baseType}?" : baseType;
     }
+
+    /// <summary>Returns the expression that unwraps a non-null optional value for encoding. A custom type can map to
+    /// either a C# value type or a reference type, so it uses <c>??</c> instead of <c>!</c>.</summary>
+    internal static string UnwrapNonNullOptional(this TypeRef typeRef, string param) =>
+        typeRef.Type is CustomType ? $"({param} ?? default!)" : typeRef.IsValueType ? $"{param}!.Value" : $"{param}!";
 
     extension(TypeRef value)
     {


### PR DESCRIPTION
Fixes #4870.

The choice between `(value ?? default!)`, `value!.Value`, and `value!` when encoding an optional was written out at
five encode sites. This PR adds `TypeRef.UnwrapNonNullOptional(param)` and uses it everywhere.

Two further collapses fell out of it:

- The sequence-of-optionals site had its own lambda builder that, once it used `TypeRef.IsValueType` instead of a
  hand-rolled value-type test, was identical to `GetEncodeLambda`. `EncodeSequence` now mirrors `EncodeDictionary`:
  one lambda call plus a method-name switch.
- The `Result` success/failure lambda and the stream-of-optionals lambda were the same bool-prefixed lambda in two
  projects. Both now use the new `TypeRef.GetEncodeLambdaWithNullMarker`.

Generated code is unchanged except that the optional field/parameter site now emits `x!.Value` and `x!` inside its
null check, like the other sites, and multi-line encode bodies in a stream-of-optionals lambda are now indented.

## What's Changed

None — generator internals only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
