### PR TITLE
Fix the generated code for a verbatim cs::identifier on a parameter

### DIFF
--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -155,7 +155,8 @@ internal static class OperationExtensions
             }
 
             var items = op.ReturnType
-                .Select(r => (r.Name, Overview: DocCommentFormatter.FormatOverview(r.Comment, currentNamespace)))
+                .Select(r =>
+                    (Name: r.Name.TrimStart('@'), Overview: DocCommentFormatter.FormatOverview(r.Comment, currentNamespace)))
                 .Where(item => item.Overview is not null)
                 .Select(item => $"<item><term>{item.Name}</term><description>{item.Overview}</description></item>")
                 .ToList();

--- a/src/IceRpc.Slice.Generator/OperationExtensions.cs
+++ b/src/IceRpc.Slice.Generator/OperationExtensions.cs
@@ -264,16 +264,16 @@ internal static class OperationExtensions
             foreach (Field field in sortedFields)
             {
                 string decodeExpr = field.GetFieldDecodeExpression(currentNamespace, useIncomingType: true);
-                body.WriteLine($"var sliceP_{field.ParameterName} = {decodeExpr};");
+                body.WriteLine($"var {field.DecodedVariableName} = {decodeExpr};");
             }
 
             if (fields.Count == 1)
             {
-                body.WriteLine($"return sliceP_{sortedFields[0].ParameterName};");
+                body.WriteLine($"return {sortedFields[0].DecodedVariableName};");
             }
             else
             {
-                body.WriteLine($"return ({string.Join(", ", fields.Select(f => $"sliceP_{f.ParameterName}"))});");
+                body.WriteLine($"return ({string.Join(", ", fields.Select(f => f.DecodedVariableName))});");
             }
 
             return $$"""

--- a/src/IceRpc.Slice.Generator/ProxyGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ProxyGenerator.cs
@@ -348,8 +348,8 @@ internal static class ProxyGenerator
                 {
                     string decodeLambda = nonStreamedReturns.GenerateDecodeLambda(currentNamespace);
                     string varName = nonStreamedReturns.Count == 1
-                        ? $"sliceP_{nonStreamedReturns[0].ParameterName}"
-                        : $"({string.Join(", ", nonStreamedReturns.Select(r => $"sliceP_{r.ParameterName}"))})";
+                        ? nonStreamedReturns[0].DecodedVariableName
+                        : $"({string.Join(", ", nonStreamedReturns.Select(r => r.DecodedVariableName))})";
                     body.WriteLine($$"""
                         var {{varName}} = await response.DecodeReturnValueAsync(
                             request,
@@ -401,7 +401,7 @@ internal static class ProxyGenerator
                 }
                 else
                 {
-                    var returnParts = nonStreamedReturns.Select(r => $"sliceP_{r.ParameterName}").ToList();
+                    var returnParts = nonStreamedReturns.Select(r => r.DecodedVariableName).ToList();
                     returnParts.Add("sliceP_returnValue");
                     body.WriteLine($"return ({string.Join(", ", returnParts)});");
                 }

--- a/src/IceRpc.Slice.Generator/ServiceGenerator.cs
+++ b/src/IceRpc.Slice.Generator/ServiceGenerator.cs
@@ -133,8 +133,8 @@ internal static class ServiceGenerator
                 {
                     string decodeLambda = nonStreamedParams.GenerateDecodeLambda(currentNamespace);
                     string varName = nonStreamedParams.Count == 1 ?
-                        $"sliceP_{nonStreamedParams[0].ParameterName}" :
-                        $"({string.Join(", ", nonStreamedParams.Select(p => $"sliceP_{p.ParameterName}"))})";
+                        nonStreamedParams[0].DecodedVariableName :
+                        $"({string.Join(", ", nonStreamedParams.Select(p => p.DecodedVariableName))})";
                     body.WriteLine($$"""
                         var {{varName}} = await request.DecodeArgsAsync(
                             {{decodeLambda}},
@@ -182,7 +182,7 @@ internal static class ServiceGenerator
                 }
                 else
                 {
-                    var returnParts = nonStreamedParams.Select(p => $"sliceP_{p.ParameterName}").ToList();
+                    var returnParts = nonStreamedParams.Select(p => p.DecodedVariableName).ToList();
                     returnParts.Add("sliceP_stream");
                     body.WriteLine($"return ({string.Join(", ", returnParts)});");
                 }

--- a/src/ZeroC.CodeBuilder/ContainerBuilder.cs
+++ b/src/ZeroC.CodeBuilder/ContainerBuilder.cs
@@ -89,7 +89,7 @@ public sealed class ContainerBuilder : IBuilder, IAttributeBuilder<ContainerBuil
     {
         if (docComment is not null)
         {
-            AddComment("param", "name", paramName, docComment);
+            AddComment("param", "name", paramName.TrimStart('@'), docComment);
         }
         _parameters.Add($"{paramType} {paramName}");
         return this;

--- a/src/ZeroC.CodeBuilder/FunctionBuilder.cs
+++ b/src/ZeroC.CodeBuilder/FunctionBuilder.cs
@@ -83,7 +83,7 @@ public sealed class FunctionBuilder : IBuilder, IAttributeBuilder<FunctionBuilde
 
         if (docComment is not null)
         {
-            AddComment("param", "name", paramName, docComment);
+            AddComment("param", "name", paramName.TrimStart('@'), docComment);
         }
 
         return this;

--- a/src/ZeroC.Slice.Generator/EntityExtensions.cs
+++ b/src/ZeroC.Slice.Generator/EntityExtensions.cs
@@ -32,10 +32,6 @@ internal static class EntityExtensions
         internal string ParameterName => entity.Attributes.FindAttribute(CSAttributes.CSIdentifier) is Attribute attr ?
             attr.Args[0] : entity.Identifier.ToCamelCase();
 
-        /// <summary>Gets the name of the local variable that holds the decoded value of this parameter or return
-        /// field.</summary>
-        internal string DecodedVariableName => $"sliceP_{entity.ParameterName.TrimStart('@')}";
-
         /// <summary>Gets the name of the encoder or decoder extensions class. The returned name is fully qualified when
         /// the entity is in a different namespace.</summary>
         internal string ExtensionsClass(string currentNamespace, bool decoder)

--- a/src/ZeroC.Slice.Generator/EntityExtensions.cs
+++ b/src/ZeroC.Slice.Generator/EntityExtensions.cs
@@ -32,6 +32,10 @@ internal static class EntityExtensions
         internal string ParameterName => entity.Attributes.FindAttribute(CSAttributes.CSIdentifier) is Attribute attr ?
             attr.Args[0] : entity.Identifier.ToCamelCase();
 
+        /// <summary>Gets the name of the local variable that holds the decoded value of this parameter or return
+        /// field.</summary>
+        internal string DecodedVariableName => $"sliceP_{entity.ParameterName.TrimStart('@')}";
+
         /// <summary>Gets the name of the encoder or decoder extensions class. The returned name is fully qualified when
         /// the entity is in a different namespace.</summary>
         internal string ExtensionsClass(string currentNamespace, bool decoder)

--- a/src/ZeroC.Slice.Generator/FieldExtensions.cs
+++ b/src/ZeroC.Slice.Generator/FieldExtensions.cs
@@ -246,6 +246,10 @@ internal static class FieldExtensions
 
     extension(Field value)
     {
+        /// <summary>Gets the name of the local variable that holds the decoded value of this parameter or return
+        /// field.</summary>
+        internal string DecodedVariableName => $"sliceP_{value.ParameterName.TrimStart('@')}";
+
         /// <summary>Returns true if the streamed field is a raw byte stream (non-optional uint8).</summary>
         internal bool IsByteStream =>
             value.DataType.Type is Builtin b && b.Kind == BuiltinKind.UInt8 && !value.DataTypeIsOptional;

--- a/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
+++ b/tests/IceRpc.Slice.Generator.Tests/DocumentationTests.slice
@@ -52,6 +52,11 @@ interface MySessionManager {
 
     /// Retrieves the {@link UserList} containing the names of the active users.
     getActiveUsers() -> UserList
+
+    /// Subscribes the given user to an event.
+    /// @param user: The user.
+    /// @param event: The event name.
+    subscribe(user: string, [cs::identifier("@event")] event: string)
 }
 
 /// This summary comment includes special XML characters like < > & ' ", which should be properly escaped by

--- a/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.slice
+++ b/tests/ZeroC.Slice.Generator.Tests/VariantEnumTests.slice
@@ -30,6 +30,13 @@ unchecked enum Shape {
     Triangle(side1: uint32, side2: uint32, side3: uint32)
 }
 
+/// A subscription change.
+unchecked enum SubscriptionChange {
+    /// A subscription was created.
+    /// @param event: The event name.
+    Created([cs::identifier("@event")] event: string)
+}
+
 unchecked enum RevisedShape {
     Circle(radius: uint32),
     Rectangle(width: uint32, height: uint32)


### PR DESCRIPTION
Fixes #4928.

A parameter or variant field mapped with `cs::identifier("@event")` and documented with `@param` generated
`<param name="@event">`, which the C# compiler rejects with CS1572. `FunctionBuilder.AddParameter` and
`ContainerBuilder.AddPrimaryConstructorParameter` now strip the leading `@` from the name in the `param` tag.

The test definitions exposed a second bug with the same trigger: the generators name the local variables that hold
decoded parameters and return values by prefixing the parameter name, which turned `@event` into `sliceP_@event`, a
syntax error. An operation with a verbatim parameter identifier did not compile at all. A new `DecodedVariableName`
property on `Entity` builds that name without the `@`, and the nine sites in the proxy, service, and operation
generators use it.

The test Slice files gain an operation with a documented `@event` parameter and a variant enum with a documented
`@event` field. Warnings are errors in the test builds, so these definitions fail to compile without the fix. Generated
output with it:

```csharp
/// <param name="event">The event name.</param>
...
var sliceP_event = decoder.DecodeString();
return (sliceP_user, sliceP_event);

/// <param name="event">The event name.</param>
partial record class Created(string @event) : SubscriptionChange
```

## What's Changed

Area: Slice codec

- Fixed the code generated for an operation parameter or variant field mapped to a verbatim C# identifier with
  `cs::identifier`. The generated doc comment and decoding code did not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
