### PR TITLE
Remove the Exportable key storage flag from the ice server templates

### DIFF
--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-DI-Server/Program.cs
@@ -27,8 +27,7 @@ services.AddSingleton<X509Certificate2>(_ =>
         Path.Combine(
             hostBuilder.Environment.ContentRootPath,
             hostBuilder.Configuration.GetValue<string>("Certificate:File")!),
-        password: null,
-        keyStorageFlags: X509KeyStorageFlags.Exportable));
+        password: null));
 
 // Bind the server options to the "appsettings.json" configuration "Server" section, and add a Configure
 // callback to configure its authentication options.

--- a/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/Program.cs
+++ b/src/IceRpc.Templates/Templates/IceRpc-Ice-Server/Program.cs
@@ -19,8 +19,7 @@ Router router = new Router()
 
 using X509Certificate2 serverCertificate = X509CertificateLoader.LoadPkcs12FromFile(
     "certs/server.p12",
-    password: null,
-    keyStorageFlags: X509KeyStorageFlags.Exportable);
+    password: null);
 
 // Create a server that uses the ice protocol for compatibility with ZeroC Ice, and logs messages to a
 // logger with category `IceRpc.Server`. The default port for the ice protocol is 4061.


### PR DESCRIPTION
The two ice server templates load the server certificate with `X509KeyStorageFlags.Exportable`. That flag is only
needed for QUIC on macOS, where .NET hands the certificate to MsQuic as a PKCS#12 blob exported from the loaded
certificate. The ice protocol runs over TCP, and TLS over TCP signs with the key in place without exporting it.

Verified on macOS with .NET 10: the test server certificate loads with the default key set, a TLS handshake over TCP
succeeds with the non-exportable key, and both templates build with warnings as errors and start.

The four icerpc server templates keep the flag, since their default transport is QUIC.

## What's Changed

None — project template code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
