### PR TITLE
Extract toolchain archives into a staging folder and gate on the executable

### DIFF
--- a/build/ExtractTask.cs
+++ b/build/ExtractTask.cs
@@ -11,10 +11,13 @@ using Microsoft.Build.Utilities;
 /// <summary>A custom MSBuild task that extracts .zip archive files to a destination folder. This tasks uses
 /// <see cref="ZipFile.ExtractToDirectory(string, string)"/> to extract the files, which ensures that Unix permissions
 /// are correctly restored. The MSBuild Unzip task does not restore Unix permissions.</summary>
+/// <remarks>The archives are extracted into a sibling staging folder that replaces the destination folder only once
+/// all of them are extracted, so that an interrupted build does not leave a partially extracted destination folder
+/// behind.</remarks>
 public class ExtractTask : Task
 {
-    /// <summary>Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to.
-    /// </summary>
+    /// <summary>Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to. An
+    /// existing destination folder is replaced.</summary>
     [Required]
     public ITaskItem DestinationFolder { get; set; }
 
@@ -27,10 +30,32 @@ public class ExtractTask : Task
     /// <returns>Returns whether or not the execution completed successfully.</returns>
     public override bool Execute()
     {
-        foreach (ITaskItem sourceFile in SourceFiles)
+        string destinationFolder =
+            DestinationFolder.ItemSpec.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string stagingFolder = destinationFolder + ".extracting";
+
+        DeleteFolder(stagingFolder);
+        try
         {
-            ZipFile.ExtractToDirectory(sourceFile.ItemSpec, DestinationFolder.ItemSpec);
+            foreach (ITaskItem sourceFile in SourceFiles)
+            {
+                ZipFile.ExtractToDirectory(sourceFile.ItemSpec, stagingFolder);
+            }
+            DeleteFolder(destinationFolder);
+            Directory.Move(stagingFolder, destinationFolder);
+        }
+        finally
+        {
+            DeleteFolder(stagingFolder);
         }
         return true;
+    }
+
+    private static void DeleteFolder(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
     }
 }

--- a/build/ExtractTask.cs
+++ b/build/ExtractTask.cs
@@ -11,9 +11,8 @@ using Microsoft.Build.Utilities;
 /// <summary>A custom MSBuild task that extracts .zip archive files to a destination folder. This tasks uses
 /// <see cref="ZipFile.ExtractToDirectory(string, string)"/> to extract the files, which ensures that Unix permissions
 /// are correctly restored. The MSBuild Unzip task does not restore Unix permissions.</summary>
-/// <remarks>The archives are extracted into a sibling staging folder that replaces the destination folder only once
-/// all of them are extracted, so that an interrupted build does not leave a partially extracted destination folder
-/// behind.</remarks>
+/// <remarks>The destination folder is replaced only once every archive is extracted into a sibling staging folder,
+/// so it is either complete or absent.</remarks>
 public class ExtractTask : Task
 {
     /// <summary>Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to. An

--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -94,7 +94,7 @@
     <ExtractTask
       SourceFiles="$(MSBuildThisFileDirectory)obj/protoc-$(ProtobufVersion)-osx-aarch_64.zip"
       DestinationFolder="$(MSBuildThisFileDirectory)obj/protoc-$(ProtobufVersion)-osx-aarch_64"
-      Condition="!Exists('$(MSBuildThisFileDirectory)obj/protoc-$(ProtobufVersion)-osx-aarch_64')" />
+      Condition="!Exists('$(MSBuildThisFileDirectory)obj/protoc-$(ProtobufVersion)-osx-aarch_64/bin/protoc')" />
 
     <!-- Make protoc compiler writeable, otherwise Copy task fails when running inside a container -->
     <Exec

--- a/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
+++ b/src/IceRpc.Slice.Tools/IceRpc.Slice.Tools.csproj
@@ -107,7 +107,7 @@
     <ExtractTask
       SourceFiles="$(MSBuildThisFileDirectory)obj/slicec-$(SlicecVersion)-%(SlicecPlatform.Identity).zip"
       DestinationFolder="$(MSBuildThisFileDirectory)obj/slicec-$(SlicecVersion)-%(SlicecPlatform.Identity)"
-      Condition="!Exists('$(MSBuildThisFileDirectory)obj/slicec-$(SlicecVersion)-%(SlicecPlatform.Identity)')" />
+      Condition="!Exists('$(MSBuildThisFileDirectory)obj/slicec-$(SlicecVersion)-%(SlicecPlatform.Identity)/%(SlicecPlatform.Exe)')" />
 
     <!-- Copy binaries to the tools directory structure expected by the props file. -->
     <Copy


### PR DESCRIPTION
`ExtractTask` unzipped the slicec and protoc archives straight into their final `obj/` folder, and the extraction step
was skipped whenever that folder existed. A build killed mid-extraction (hard kill, disk full, power loss) therefore
left a partial folder that was never re-extracted: the following `Copy` failed with MSB3030, or copied a truncated
executable, until the developer removed `obj/` by hand.

This PR makes the extraction all-or-nothing and self-healing:

- `ExtractTask` extracts into a sibling `<folder>.extracting` staging folder and moves it into place once every archive
  is extracted. The staging folder is removed on failure and replaced on the next run.
- The slicec and protoc extraction steps are now skipped only when the extracted executable exists, so a folder left
  without its executable is re-extracted on the next build instead of failing the following `Copy`.

Verified locally on macOS: a zip with a corrupt entry no longer leaves a destination folder behind, Unix executable
permissions are still preserved, a slicec or protoc folder whose executable was deleted heals on rebuild, and the
full solution builds. The task only uses netstandard 2.0 APIs, which is what `RoslynCodeTaskFactory` compiles against.

Fixes #4800

## What's Changed entry

None — build-system change to how this repository downloads its own toolchain; no user-facing impact.
