### PR TITLE
Return the TLS write buffer when TCP client connection socket setup fails

### DIFF
--- a/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
+++ b/src/IceRpc/Transports/Tcp/Internal/TcpConnection.cs
@@ -337,12 +337,12 @@ internal class TcpClientConnection : TcpConnection
         }
         catch (SocketException exception)
         {
-            Socket.Dispose();
+            Dispose();
             throw exception.ToIceRpcException();
         }
         catch
         {
-            Socket.Dispose();
+            Dispose();
             throw;
         }
     }


### PR DESCRIPTION
When the `TcpClientConnection` constructor failed to bind or configure its socket (for example a `LocalNetworkAddress`
the socket cannot bind), its two catch blocks disposed the socket but never returned the TLS write buffer rented in the
base-constructor initializer. Since the constructor throws, no instance escapes and `Dispose()`, which returns the
buffer, was never called.

The catch blocks now call `Dispose()` instead of `Socket.Dispose()`. At that point the SSL stream is still null and the
socket is not connected, so `Dispose()` closes the socket and returns the write buffer to the pool.

Fixes #4828

## What's Changed entry

None — the default pool doesn't leak, and a client socket setup failure means every connection attempt fails.
