### PR TITLE
Pack the IceRpc.Protobuf.Tools task assembly from bin instead of obj

### DIFF
--- a/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
+++ b/src/IceRpc.Protobuf.Tools/IceRpc.Protobuf.Tools.csproj
@@ -54,7 +54,7 @@
       <Pack>true</Pack>
       <PackagePath />
     </None>
-    <None Include="$(IntermediateOutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="tasks/" Visible="false" />
+    <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="tasks/" Visible="false" />
     <!--
       Pack everything from the protoc plug-in (IceRpc.Protobuf.Generator) and the build-telemetry plug-in
       (IceRpc.Protobuf.BuildTelemetry) bin folders, excluding files in the BuildTelemetry bin that have the


### PR DESCRIPTION
Fixes #4814

The release workflow signs the assemblies matching `src/<Project>/bin/Release/net*/<Project>.dll` and then runs `dotnet pack --no-build`. `IceRpc.Protobuf.Tools` packed its MSBuild task assembly from `$(IntermediateOutputPath)`, so `tasks/IceRpc.Protobuf.Tools.dll` in the published package was the unsigned obj copy. This packs it from `$(OutputPath)` instead, as `IceRpc.Slice.Tools` already does.

Verified locally: after a Release build, appending bytes to the bin copy (to stand in for signing) and running `dotnet pack --no-build` produced a package whose `tasks/` dll matched the obj copy before this change and the bin copy after it.

The unsigned first-party dependency copies in the Tools packages' `tools/` folder are tracked in #4949.

## What's Changed entry

None — packaging fix, the task assembly is now signed like the other assemblies in the package.
