### PR TITLE
Require stable publication to match the release tag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ on:
         description: "The channel to publish to (e.g., stable, nightly)"
         required: true
       run_id:
-        description: "The run ID to use for downloading artifacts"
+        description: "The build run ID (must match the publishing tag's commit for stable releases)"
         required: true
   workflow_call:
     inputs:
@@ -24,6 +24,25 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Validate stable release tag
+        if: inputs.channel == 'stable'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+            echo "::error::Stable releases must be published from a tag; selected ref is $GITHUB_REF."
+            exit 1
+          fi
+
+          build_sha=$(gh api "repos/icerpc/icerpc-csharp/actions/runs/$RUN_ID" --jq '.head_sha')
+          if [[ "$build_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::Build run $RUN_ID uses commit $build_sha, but tag $GITHUB_REF_NAME uses $GITHUB_SHA."
+            exit 1
+          fi
+
       - name: Download NuGet artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stable publication currently accepts a build run ID without checking that it contains the intended release commit. Require publication from a tag and compare the selected run's `head_sha` with the publishing tag's commit before downloading artifacts.

A candidate built from `0.6.x` can be published from `v0.6.4` when both refer to the same commit. Selecting a branch or a build of a different commit fails with an explicit error. This check also applies when the release workflow calls the publisher; it does not require the enclosing build run to have completed.

This addresses the tag/commit selection check discussed in https://github.com/icerpc/icerpc-csharp-audit/issues/49. It does not add build provenance, signing, or package-version validation.

Validation: `actionlint` (including ShellCheck) and `git diff --check` passed. Executed the workflow's validation script with a mocked GitHub API for matching and mismatched commits, a branch ref, missing SHA metadata, and API failure; all behaved as expected. Confirmed the validation precedes downloads and is conditional on the stable channel. No packages were published.

## What's Changed entry

None — release workflow validation only; no user-facing changes.
