### PR TITLE
Add ConnectionCacheOptions.MaxConnections

### DIFF
--- a/src/IceRpc/ConnectionCache.cs
+++ b/src/IceRpc/ConnectionCache.cs
@@ -13,7 +13,9 @@ namespace IceRpc;
 /// <summary>Represents an invoker that routes outgoing requests to connections it manages.</summary>
 /// <remarks><para>The connection cache routes requests based on the request's <see cref="IServerAddressFeature" />
 /// feature or the server addresses of the request's target service.</para>
-/// <para>The connection cache keeps at most one active connection per server address.</para></remarks>
+/// <para>The connection cache keeps at most one active connection per server address.
+/// <see cref="ConnectionCacheOptions.MaxConnections" /> bounds the total number of connections it manages.</para>
+/// </remarks>
 public sealed class ConnectionCache : IInvoker, IAsyncDisposable
 {
     // Connected connections.
@@ -36,6 +38,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     private readonly CancellationTokenSource _disposedCts = new();
 
     private Task? _disposeTask;
+
+    private readonly int _maxConnections;
 
     private readonly Lock _mutex = new();
 
@@ -72,6 +76,7 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
             logger);
 
         _connectTimeout = options.ConnectTimeout;
+        _maxConnections = options.MaxConnections;
         _shutdownTimeout = options.ShutdownTimeout;
 
         _preferExistingConnection = options.PreferExistingConnection;
@@ -141,8 +146,10 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// <exception cref="InvalidOperationException">Thrown when no <see cref="IServerAddressFeature" /> feature is set
     /// and the request's service address has no server addresses.</exception>
     /// <exception cref="IceRpcException">Thrown with <see cref="IceRpcError.InvocationRefused" /> when the connection
-    /// cache is shut down, or with <see cref="IceRpcError.NoConnection" /> when the request's
-    /// <see cref="IServerAddressFeature" /> feature has no server addresses.</exception>
+    /// cache is shut down, with <see cref="IceRpcError.NoConnection" /> when the request's
+    /// <see cref="IServerAddressFeature" /> feature has no server addresses, or with
+    /// <see cref="IceRpcError.LimitExceeded" /> when the request requires a new connection and the connection cache
+    /// has reached <see cref="ConnectionCacheOptions.MaxConnections" />.</exception>
     /// <exception cref="ObjectDisposedException">Thrown when this connection cache is disposed.</exception>
     /// <remarks><para>If the request <see cref="IServerAddressFeature" /> feature is not set, the cache sets it from
     /// the server addresses of the target service.</para>
@@ -150,7 +157,8 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
     /// property influences how the cache selects this active connection. If no active connection can be found, the
     /// cache creates a new connection to one of the server addresses from the <see cref="IServerAddressFeature" />
     /// feature.</para>
-    /// <para>If the connection establishment to <see cref="IServerAddressFeature.ServerAddress" /> fails, <see
+    /// <para>If the connection establishment to <see cref="IServerAddressFeature.ServerAddress" /> fails, or is not
+    /// attempted because the connection cache has reached <see cref="ConnectionCacheOptions.MaxConnections" />, <see
     /// cref="IServerAddressFeature.ServerAddress" /> is appended at the end of <see
     /// cref="IServerAddressFeature.AltServerAddresses" /> and the first address from <see
     /// cref="IServerAddressFeature.AltServerAddresses" /> replaces <see cref="IServerAddressFeature.ServerAddress" />.
@@ -477,6 +485,20 @@ public sealed class ConnectionCache : IInvoker, IAsyncDisposable
 
                     if (!_pendingConnections.TryGetValue(serverAddress, out pendingConnectionValue))
                     {
+                        Debug.Assert(
+                            _maxConnections == 0 ||
+                            _activeConnections.Count + _detachedConnectionCount <= _maxConnections);
+
+                        if (_maxConnections > 0 &&
+                            _activeConnections.Count + _detachedConnectionCount == _maxConnections)
+                        {
+                            // Another server address may have an active or pending connection.
+                            connectionException = new IceRpcException(
+                                IceRpcError.LimitExceeded,
+                                $"The connection cache has reached its maximum number of connections ({_maxConnections}).");
+                            continue;
+                        }
+
                         connection = _connectionFactory.CreateConnection(serverAddress);
                         _detachedConnectionCount++;
                         pendingConnectionValue = (connection, CreateConnectTask(connection, serverAddress));

--- a/src/IceRpc/ConnectionCacheOptions.cs
+++ b/src/IceRpc/ConnectionCacheOptions.cs
@@ -27,6 +27,21 @@ public record class ConnectionCacheOptions
             throw new ArgumentException($"0 is not a valid value for {nameof(ConnectTimeout)}", nameof(value));
     }
 
+    /// <summary>Gets or sets the maximum number of connections managed by the connection cache. This count includes
+    /// active connections and connections being established, shut down or disposed. Once the maximum number of
+    /// connections has been reached, an invocation that requires a new connection fails with <see
+    /// cref="IceRpcError.LimitExceeded" />.</summary>
+    /// <value>The maximum number of connections. Defaults to <c>0</c>, meaning unlimited.</value>
+    public int MaxConnections
+    {
+        get => _maxConnections;
+        set => _maxConnections = value >= 0 ? value :
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                $"{nameof(MaxConnections)} must be greater than or equal to 0 (where 0 means unlimited).");
+    }
+
     /// <summary>Gets or sets a value indicating whether or not the connection cache prefers an active connection over
     /// creating a new one.</summary>
     /// <value>When <see langword="true" />, the connection cache first checks the server addresses of the target
@@ -46,5 +61,6 @@ public record class ConnectionCacheOptions
     }
 
     private TimeSpan _connectTimeout = TimeSpan.FromSeconds(10);
+    private int _maxConnections;
     private TimeSpan _shutdownTimeout = TimeSpan.FromSeconds(10);
 }

--- a/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
+++ b/tests/IceRpc.Retry.Tests/RetryInterceptorTests.cs
@@ -22,6 +22,7 @@ public sealed class RetryInterceptorTests
             yield return new IceRpcException(IceRpcError.NoConnection);
             yield return new ArgumentException();
             yield return new IceRpcException(IceRpcError.IceRpcError);
+            yield return new IceRpcException(IceRpcError.LimitExceeded);
         }
     }
 

--- a/tests/IceRpc.Tests/ConnectionCacheOptionsTests.cs
+++ b/tests/IceRpc.Tests/ConnectionCacheOptionsTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ZeroC, Inc.
+
+using NUnit.Framework;
+
+namespace IceRpc.Tests;
+
+public class ConnectionCacheOptionsTests
+{
+    [TestCase(-1)]
+    [TestCase(int.MinValue)]
+    public void MaxConnections_rejects_negative_values(int value)
+    {
+        ArgumentOutOfRangeException? exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => _ = new ConnectionCacheOptions { MaxConnections = value });
+        Assert.That(exception!.ActualValue, Is.EqualTo(value));
+    }
+}

--- a/tests/IceRpc.Tests/ConnectionCacheTests.cs
+++ b/tests/IceRpc.Tests/ConnectionCacheTests.cs
@@ -367,6 +367,158 @@ public sealed class ConnectionCacheTests
         await cache.ShutdownAsync();
     }
 
+    /// <summary>Verifies that an invocation that requires a new connection fails once the connection cache reached
+    /// <see cref="ConnectionCacheOptions.MaxConnections" />, while invocations over an active connection still succeed.
+    /// </summary>
+    [Test]
+    public async Task Invocation_fails_when_max_connections_is_reached()
+    {
+        // Arrange
+        using var dispatcher = new TestDispatcher();
+        var colocTransport = new ColocTransport();
+        await using var server1 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        server1.Listen();
+
+        await using var server2 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://bar"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        server2.Listen();
+
+        await using var cache = new ConnectionCache(
+            new ConnectionCacheOptions { MaxConnections = 1 },
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport));
+
+        await SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://foo")));
+
+        // Act/Assert
+        Assert.That(
+            () => SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://bar"))),
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.LimitExceeded));
+        Assert.That(
+            () => SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://foo"))),
+            Throws.Nothing);
+
+        // Cleanup
+        await server1.ShutdownAsync();
+        await server2.ShutdownAsync();
+        await cache.ShutdownAsync();
+    }
+
+    /// <summary>Verifies that a connection being established counts toward
+    /// <see cref="ConnectionCacheOptions.MaxConnections" />.</summary>
+    [Test]
+    public async Task Pending_connection_counts_toward_max_connections()
+    {
+        // Arrange
+        using var dispatcher = new TestDispatcher();
+        var colocTransport = new ColocTransport();
+        var multiplexedClientTransport = new TestMultiplexedClientTransportDecorator(
+            new SlicClientTransport(colocTransport.ClientTransport),
+            operationsOptions: new() { Hold = MultiplexedTransportOperations.Connect });
+
+        await using var server1 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        server1.Listen();
+
+        await using var server2 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://bar"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        server2.Listen();
+
+        await using var cache = new ConnectionCache(
+            new ConnectionCacheOptions { MaxConnections = 1 },
+            multiplexedClientTransport: multiplexedClientTransport);
+
+        Task pendingInvokeTask = SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://foo")));
+
+        // Act/Assert
+        Assert.That(
+            () => SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://bar"))),
+            Throws.InstanceOf<IceRpcException>().With.Property("IceRpcError").EqualTo(IceRpcError.LimitExceeded));
+
+        multiplexedClientTransport.LastCreatedConnection.Operations.Hold = MultiplexedTransportOperations.None;
+        Assert.That(async () => await pendingInvokeTask, Throws.Nothing);
+
+        // Cleanup
+        await server1.ShutdownAsync();
+        await server2.ShutdownAsync();
+        await cache.ShutdownAsync();
+    }
+
+    /// <summary>Verifies that once the connection cache reached <see cref="ConnectionCacheOptions.MaxConnections" />,
+    /// it still uses an active connection to an alt server address, even when it does not prefer existing connections.
+    /// </summary>
+    [Test]
+    public async Task Use_active_connection_to_alt_server_when_max_connections_is_reached()
+    {
+        // Arrange
+        using var dispatcher = new TestDispatcher();
+        var colocTransport = new ColocTransport();
+        await using var server1 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://foo"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        server1.Listen();
+
+        await using var server2 = new Server(
+            new ServerOptions
+            {
+                ConnectionOptions = new ConnectionOptions { Dispatcher = dispatcher },
+                ServerAddress = new ServerAddress(new Uri("icerpc://bar"))
+            },
+            multiplexedServerTransport: new SlicServerTransport(colocTransport.ServerTransport));
+        ServerAddress server2Address = server2.Listen();
+
+        await using var cache = new ConnectionCache(
+            new ConnectionCacheOptions { MaxConnections = 1, PreferExistingConnection = false },
+            multiplexedClientTransport: new SlicClientTransport(colocTransport.ClientTransport));
+
+        ServerAddress? serverAddress = null;
+        Pipeline pipeline = new Pipeline()
+            .Use(next => new InlineInvoker(async (request, cancellationToken) =>
+                {
+                    IncomingResponse response = await next.InvokeAsync(request, cancellationToken);
+                    serverAddress = request.Features.Get<IServerAddressFeature>()?.ServerAddress;
+                    return response;
+                }))
+            .Into(cache);
+
+        await SendEmptyRequestAsync(cache, new ServiceAddress(new Uri("icerpc://bar")));
+
+        // Act
+        await SendEmptyRequestAsync(pipeline, new ServiceAddress(new Uri("icerpc://foo/?alt-server=bar")));
+
+        // Assert
+        Assert.That(serverAddress?.Host, Is.EqualTo(server2Address.Host));
+
+        // Cleanup
+        await server1.ShutdownAsync();
+        await server2.ShutdownAsync();
+        await cache.ShutdownAsync();
+    }
+
     private static async Task SendEmptyRequestAsync(IInvoker invoker, ServiceAddress serviceAddress)
     {
         using var request = new OutgoingRequest(serviceAddress)


### PR DESCRIPTION
`ConnectionCache` created a new connection for every server address it had not connected to yet, with no bound on the total number of connections it manages. An application that routes invocations through a cache over a large or externally supplied address set (a long alt-server list, a locator result) could therefore open an unbounded number of outbound connections.

`ConnectionCacheOptions` now has a `MaxConnections` property that mirrors `ServerOptions.MaxConnections` (validated `>= 0`, defaults to `0` meaning unlimited). The cache counts what the server counts: active connections plus connections being established, shut down or disposed. Once the limit is reached, an invocation that requires a new connection fails with `IceRpcException(IceRpcError.LimitExceeded)`. Before failing, the cache still walks the request's server addresses and uses an active or pending connection to any of them, so the limit never prevents reuse. `LimitExceeded` is not retried by the retry interceptor.

### Tests

- `Invocation_fails_when_max_connections_is_reached`: with `MaxConnections = 1` and one active connection, an invocation to a second server fails with `LimitExceeded` while an invocation to the first server still succeeds.
- `Pending_connection_counts_toward_max_connections`: a connection whose transport connect is held counts toward the limit; an invocation to a second server fails with `LimitExceeded` and the held invocation completes once released.
- `Use_active_connection_to_alt_server_when_max_connections_is_reached`: with `PreferExistingConnection = false` and the limit reached, an invocation whose main address has no connection is sent over the active connection to its alt server instead of failing.
- `ConnectionCacheOptionsTests.MaxConnections_rejects_negative_values`, and `LimitExceeded` added to the retry interceptor's non-retryable exceptions.

All three cache tests fail without the `ConnectionCache` change (no exception thrown, connect timeout, and the request going to the main server respectively).

## What's Changed entry

Area: Core

- Added `ConnectionCacheOptions.MaxConnections`, the maximum number of connections a `ConnectionCache` manages (defaults to 0, meaning unlimited). Once the limit is reached, an invocation that requires a new connection fails with `IceRpcError.LimitExceeded`.
