### PR TITLE
Send the deferred Slic StreamReadsClosed frame when the peer closes writes first

### DIFF
--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -55,7 +55,7 @@ internal class SlicStream : IMultiplexedStream
     private readonly SlicConnection _connection;
     private ulong _id = ulong.MaxValue;
     private readonly SlicPipeReader? _inputPipeReader;
-    // This mutex protects _writesClosePending, _closeReadsOnWritesClosure and _wroteLastStreamFrame.
+    // This mutex protects _writesClosePending, _closeReadsOnWritesClosure.
     private readonly Lock _mutex = new();
     private readonly SlicPipeWriter? _outputPipeWriter;
     // FlagEnumExtensions operations are used to update the state. These operations are atomic and don't require mutex
@@ -63,9 +63,6 @@ internal class SlicStream : IMultiplexedStream
     private int _state;
     private readonly TaskCompletionSource _writesClosedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private bool _writesClosePending;
-    // Set once the StreamLast frame is queued on the connection. Unlike WritesClosed, it is not set when the peer
-    // closes writes.
-    private bool _wroteLastStreamFrame;
 
     internal SlicStream(SlicConnection connection, bool isBidirectional, bool isRemote)
     {
@@ -133,7 +130,6 @@ internal class SlicStream : IMultiplexedStream
     internal void CloseReads(bool graceful)
     {
         bool writeReadsClosedFrame = false;
-        bool deferReadsClosedFrame = false;
 
         lock (_mutex)
         {
@@ -143,39 +139,25 @@ internal class SlicStream : IMultiplexedStream
                 // writes are closed, we don't send the StreamReadsClosed frame just yet. Instead, when writes are
                 // closed, CloseWrites will bundle the sending of the StreamReadsClosed with the sending of the
                 // StreamLast or StreamWritesClosed frame. This allows to send both frames with a single write on the
-                // duplex connection.
+                // duplex connection. If the peer closes its reads first, ReceivedReadsClosedFrame sends the frame on
+                // its own.
                 if (graceful &&
                     IsBidirectional &&
                     IsRemote &&
                     !_state.HasFlag(State.WritesClosed) &&
                     !_writesClosePending)
                 {
-                    deferReadsClosedFrame = true;
+                    // Reads are closed before the deferral is published, both under the mutex, so that the stream
+                    // count is decreased before the StreamReadsClosed frame can be sent and ReceivedReadsClosedFrame
+                    // can't close writes in between.
+                    TrySetReadsClosed();
+                    _closeReadsOnWritesClosure = true;
                 }
                 else if (!graceful || IsRemote)
                 {
                     // If forcefully closed because the input was completed before the data was fully read or if writes
                     // are already closed and the stream is a remote stream, we send the StreamReadsClosed frame to
                     // notify the peer that reads are closed.
-                    writeReadsClosedFrame = true;
-                }
-            }
-        }
-
-        if (deferReadsClosedFrame)
-        {
-            // Reads must be closed before the StreamReadsClosed frame can be sent, by CloseWrites or by a concurrent
-            // StreamLast write, so that the connection's stream count is decreased before the peer receives the frame.
-            TrySetReadsClosed();
-
-            lock (_mutex)
-            {
-                if (!_state.HasFlag(State.WritesClosed) && !_writesClosePending)
-                {
-                    _closeReadsOnWritesClosure = true;
-                }
-                else
-                {
                     writeReadsClosedFrame = true;
                 }
             }
@@ -228,7 +210,9 @@ internal class SlicStream : IMultiplexedStream
         {
             if (IsStarted && !_state.HasFlag(State.WritesClosed) && !_writesClosePending)
             {
+                // The frame sent below can't be canceled, so the deferred StreamReadsClosed frame is claimed here.
                 writeReadsClosedFrame = _closeReadsOnWritesClosure;
+                _closeReadsOnWritesClosure = false;
                 _writesClosePending = true;
                 writeWritesClosedFrame = true;
 
@@ -238,16 +222,10 @@ internal class SlicStream : IMultiplexedStream
                     // frame to ensure _connection._bidirectionalStreamCount or _connection._unidirectionalStreamCount
                     // is decreased before the peer receives the frame. This is necessary to prevent a race condition
                     // where the peer could release the connection's bidirectional or unidirectional stream semaphore
-                    // before this connection's stream count is actually decreased. Doing so while holding the mutex
-                    // ensures CloseReads observes _writesClosePending only once the stream count is decreased.
+                    // before this connection's stream count is actually decreased. This is done under the mutex so
+                    // that ReceivedReadsClosedFrame can't send the deferred StreamReadsClosed frame in between.
                     TrySetWritesClosed();
                 }
-            }
-            else if (_closeReadsOnWritesClosure && !_wroteLastStreamFrame)
-            {
-                // The peer closed its reads before StreamLast could carry our deferred StreamReadsClosed frame.
-                // Send the deferred frame on its own so the peer can release its stream.
-                writeReadsClosedFrame = true;
             }
         }
 
@@ -291,18 +269,6 @@ internal class SlicStream : IMultiplexedStream
         }
         else
         {
-            if (writeReadsClosedFrame)
-            {
-                try
-                {
-                    WriteStreamFrame(FrameType.StreamReadsClosed, encode: null, writeReadsClosedFrame: false);
-                }
-                catch (IceRpcException)
-                {
-                    // Ignore connection failures.
-                }
-            }
-
             TrySetWritesClosed();
         }
     }
@@ -350,8 +316,31 @@ internal class SlicStream : IMultiplexedStream
     /// <summary>Notifies the stream of the reception of a <see cref="FrameType.StreamReadsClosed" /> frame.</summary>
     internal void ReceivedReadsClosedFrame()
     {
-        TrySetWritesClosed();
+        bool writeReadsClosedFrame;
+        lock (_mutex)
+        {
+            // Writes are closed under the mutex so that CloseReads can't defer the StreamReadsClosed frame afterwards.
+            TrySetWritesClosed();
+
+            // A pending StreamLast write may no longer carry the deferred StreamReadsClosed frame, so it's sent on its
+            // own.
+            writeReadsClosedFrame = _closeReadsOnWritesClosure;
+            _closeReadsOnWritesClosure = false;
+        }
+
         _outputPipeWriter?.CompleteWrites(exception: null);
+
+        if (writeReadsClosedFrame)
+        {
+            try
+            {
+                WriteStreamFrame(FrameType.StreamReadsClosed, encode: null, writeReadsClosedFrame: false);
+            }
+            catch (IceRpcException)
+            {
+                // Ignore connection failures.
+            }
+        }
     }
 
     /// <summary>Notifies the stream of the reception of a <see cref="FrameType.StreamWindowUpdate" /> frame.</summary>
@@ -449,16 +438,15 @@ internal class SlicStream : IMultiplexedStream
                     writeReadsClosedFrame,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch
+            catch when (!_writesClosedTcs.Task.IsCompleted)
             {
+                // The write failed before the StreamLast frame was queued on the connection (WroteLastStreamFrame
+                // completes _writesClosedTcs when the frame is queued), so roll back _writesClosePending so that
+                // completing the stream output can still close writes and notify the peer with a StreamWritesClosed
+                // frame. The bundled reads closure isn't lost either since _closeReadsOnWritesClosure wasn't cleared.
                 lock (_mutex)
                 {
-                    if (!_wroteLastStreamFrame)
-                    {
-                        // The StreamLast frame wasn't queued, so completing the stream output must still be able to
-                        // close writes and notify the peer.
-                        _writesClosePending = false;
-                    }
+                    _writesClosePending = false;
                 }
                 throw;
             }
@@ -469,11 +457,6 @@ internal class SlicStream : IMultiplexedStream
     /// connection.</summary>
     internal void WroteLastStreamFrame()
     {
-        lock (_mutex)
-        {
-            _wroteLastStreamFrame = true;
-        }
-
         if (IsRemote)
         {
             TrySetWritesClosed();

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -55,7 +55,7 @@ internal class SlicStream : IMultiplexedStream
     private readonly SlicConnection _connection;
     private ulong _id = ulong.MaxValue;
     private readonly SlicPipeReader? _inputPipeReader;
-    // This mutex protects _writesClosePending, _closeReadsOnWritesClosure.
+    // This mutex protects _writesClosePending, _closeReadsOnWritesClosure and _wroteLastStreamFrame.
     private readonly Lock _mutex = new();
     private readonly SlicPipeWriter? _outputPipeWriter;
     // FlagEnumExtensions operations are used to update the state. These operations are atomic and don't require mutex
@@ -63,6 +63,9 @@ internal class SlicStream : IMultiplexedStream
     private int _state;
     private readonly TaskCompletionSource _writesClosedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private bool _writesClosePending;
+    // Set once the StreamLast frame is queued on the connection. Unlike WritesClosed, it is not set when the peer
+    // closes writes.
+    private bool _wroteLastStreamFrame;
 
     internal SlicStream(SlicConnection connection, bool isBidirectional, bool isRemote)
     {
@@ -130,6 +133,7 @@ internal class SlicStream : IMultiplexedStream
     internal void CloseReads(bool graceful)
     {
         bool writeReadsClosedFrame = false;
+        bool deferReadsClosedFrame = false;
 
         lock (_mutex)
         {
@@ -146,13 +150,32 @@ internal class SlicStream : IMultiplexedStream
                     !_state.HasFlag(State.WritesClosed) &&
                     !_writesClosePending)
                 {
-                    _closeReadsOnWritesClosure = true;
+                    deferReadsClosedFrame = true;
                 }
                 else if (!graceful || IsRemote)
                 {
                     // If forcefully closed because the input was completed before the data was fully read or if writes
                     // are already closed and the stream is a remote stream, we send the StreamReadsClosed frame to
                     // notify the peer that reads are closed.
+                    writeReadsClosedFrame = true;
+                }
+            }
+        }
+
+        if (deferReadsClosedFrame)
+        {
+            // Reads must be closed before the StreamReadsClosed frame can be sent, by CloseWrites or by a concurrent
+            // StreamLast write, so that the connection's stream count is decreased before the peer receives the frame.
+            TrySetReadsClosed();
+
+            lock (_mutex)
+            {
+                if (!_state.HasFlag(State.WritesClosed) && !_writesClosePending)
+                {
+                    _closeReadsOnWritesClosure = true;
+                }
+                else
+                {
                     writeReadsClosedFrame = true;
                 }
             }
@@ -208,21 +231,28 @@ internal class SlicStream : IMultiplexedStream
                 writeReadsClosedFrame = _closeReadsOnWritesClosure;
                 _writesClosePending = true;
                 writeWritesClosedFrame = true;
+
+                if (IsRemote)
+                {
+                    // If it's a remote stream, we close writes before sending the StreamLast or StreamWritesClosed
+                    // frame to ensure _connection._bidirectionalStreamCount or _connection._unidirectionalStreamCount
+                    // is decreased before the peer receives the frame. This is necessary to prevent a race condition
+                    // where the peer could release the connection's bidirectional or unidirectional stream semaphore
+                    // before this connection's stream count is actually decreased. Doing so while holding the mutex
+                    // ensures CloseReads observes _writesClosePending only once the stream count is decreased.
+                    TrySetWritesClosed();
+                }
+            }
+            else if (_closeReadsOnWritesClosure && !_wroteLastStreamFrame)
+            {
+                // The peer closed writes before the StreamLast frame could bundle the deferred StreamReadsClosed frame.
+                // The peer still needs this frame to close its stream, so it's sent on its own.
+                writeReadsClosedFrame = true;
             }
         }
 
         if (writeWritesClosedFrame)
         {
-            if (IsRemote)
-            {
-                // If it's a remote stream, we close writes before sending the StreamLast or StreamWritesClosed
-                // frame to ensure _connection._bidirectionalStreamCount or _connection._unidirectionalStreamCount
-                // is decreased before the peer receives the frame. This is necessary to prevent a race condition
-                // where the peer could release the connection's bidirectional or unidirectional stream semaphore
-                // before this connection's stream count is actually decreased.
-                TrySetWritesClosed();
-            }
-
             if (graceful)
             {
                 try
@@ -261,6 +291,18 @@ internal class SlicStream : IMultiplexedStream
         }
         else
         {
+            if (writeReadsClosedFrame)
+            {
+                try
+                {
+                    WriteStreamFrame(FrameType.StreamReadsClosed, encode: null, writeReadsClosedFrame: false);
+                }
+                catch (IceRpcException)
+                {
+                    // Ignore connection failures.
+                }
+            }
+
             TrySetWritesClosed();
         }
     }
@@ -407,15 +449,16 @@ internal class SlicStream : IMultiplexedStream
                     writeReadsClosedFrame,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch when (!_writesClosedTcs.Task.IsCompleted)
+            catch
             {
-                // The write failed before the StreamLast frame was queued on the connection (WroteLastStreamFrame
-                // completes _writesClosedTcs when the frame is queued), so roll back _writesClosePending so that
-                // completing the stream output can still close writes and notify the peer with a StreamWritesClosed
-                // frame. The bundled reads closure isn't lost either since _closeReadsOnWritesClosure wasn't cleared.
                 lock (_mutex)
                 {
-                    _writesClosePending = false;
+                    if (!_wroteLastStreamFrame)
+                    {
+                        // The StreamLast frame wasn't queued, so completing the stream output must still be able to
+                        // close writes and notify the peer.
+                        _writesClosePending = false;
+                    }
                 }
                 throw;
             }
@@ -426,6 +469,11 @@ internal class SlicStream : IMultiplexedStream
     /// connection.</summary>
     internal void WroteLastStreamFrame()
     {
+        lock (_mutex)
+        {
+            _wroteLastStreamFrame = true;
+        }
+
         if (IsRemote)
         {
             TrySetWritesClosed();

--- a/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
+++ b/src/IceRpc/Transports/Slic/Internal/SlicStream.cs
@@ -245,8 +245,8 @@ internal class SlicStream : IMultiplexedStream
             }
             else if (_closeReadsOnWritesClosure && !_wroteLastStreamFrame)
             {
-                // The peer closed writes before the StreamLast frame could bundle the deferred StreamReadsClosed frame.
-                // The peer still needs this frame to close its stream, so it's sent on its own.
+                // The peer closed its reads before StreamLast could carry our deferred StreamReadsClosed frame.
+                // Send the deferred frame on its own so the peer can release its stream.
                 writeReadsClosedFrame = true;
             }
         }

--- a/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
+++ b/tests/IceRpc.Tests/Transports/Slic/SlicTransportTests.cs
@@ -2109,6 +2109,91 @@ public class SlicTransportTests
         Assert.That(totalRead, Is.EqualTo(payload.Length));
     }
 
+    /// <summary>Verifies that the StreamReadsClosed frame deferred by the graceful closure of reads on a remote
+    /// bidirectional stream is still sent when the peer closes its reads before the StreamLast frame is written, so
+    /// that the peer's stream permit is released.</summary>
+    /// <param name="peerClosesReads">When the peer closes its reads: while the endStream write is parked on the
+    /// exhausted peer window, before the endStream write is attempted, or before the output is completed without an
+    /// endStream write.</param>
+    [Test]
+    public async Task Deferred_reads_closed_frame_is_sent_when_peer_closes_reads_before_last_stream_frame(
+        [Values("during-write", "before-write", "without-write")] string peerClosesReads)
+    {
+        // Arrange: the peer allows a single bidirectional stream and has a small window so it's easy to exhaust.
+        IServiceCollection services = new ServiceCollection().AddSlicTest();
+        services.AddOptions<MultiplexedConnectionOptions>().Configure(options => options.MaxBidirectionalStreams = 1);
+        services.AddOptions<SlicTransportOptions>("client").Configure(
+            options => options.InitialStreamWindowSize = 4 * 1024);
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        var sut = provider.GetRequiredService<ClientServerMultiplexedConnection>();
+        await sut.AcceptAndConnectAsync();
+
+        // With the StreamLast frame sent by the output completion, the client stream closes its writes only once the
+        // server's StreamReadsClosed frame is received.
+        IMultiplexedStream clientStream = await sut.Client.CreateStreamAsync(bidirectional: true, default);
+        _ = await clientStream.Output.WriteAsync(new byte[1], default);
+        clientStream.Output.Complete();
+
+        // The server consumes the request: reads are gracefully closed and the StreamReadsClosed frame is deferred
+        // until the closure of writes.
+        IMultiplexedStream serverStream = await sut.Server.AcceptStreamAsync(default);
+        ReadResult readResult;
+        do
+        {
+            readResult = await serverStream.Input.ReadAsync(default);
+            serverStream.Input.AdvanceTo(readResult.Buffer.End);
+        }
+        while (!readResult.IsCompleted);
+
+        // Exhaust the client's window without the client reading.
+        byte[] payload = new byte[4 * 1024];
+        _ = await serverStream.Output.WriteAsync(payload, default);
+
+        if (peerClosesReads == "during-write")
+        {
+            // The endStream write parks on AcquireSendCreditAsync because the peer window is exhausted; the client
+            // closes its reads while the write is parked, which cancels the write.
+            ValueTask<FlushResult> writeTask = ((ReadOnlySequencePipeWriter)serverStream.Output).WriteAsync(
+                new ReadOnlySequence<byte>(payload),
+                endStream: true,
+                default);
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+            Assert.That(writeTask.IsCompleted, Is.False);
+            clientStream.Input.Complete(new OperationCanceledException());
+            FlushResult flushResult = await writeTask;
+            Assert.That(flushResult.IsCompleted, Is.True);
+        }
+        else
+        {
+            clientStream.Input.Complete(new OperationCanceledException());
+            await serverStream.WritesClosed;
+
+            if (peerClosesReads == "before-write")
+            {
+                FlushResult flushResult = await ((ReadOnlySequencePipeWriter)serverStream.Output).WriteAsync(
+                    new ReadOnlySequence<byte>(payload),
+                    endStream: true,
+                    default);
+                Assert.That(flushResult.IsCompleted, Is.True);
+            }
+        }
+
+        // Act: complete the server output, like a dispatch does.
+        serverStream.Output.Complete();
+
+        // Assert: the client stream is released and a new stream can be created; if the deferred StreamReadsClosed
+        // frame was lost this would wait forever. The WaitAsync margin exceeds CI's --blame-hang-timeout (60 s) so
+        // that a hang is detected and dumped by the hang detection first; the timeout is only a fallback that fails
+        // this test instead of hanging the test run when hang detection is not enabled.
+        IMultiplexedStream nextStream = await sut.Client.CreateStreamAsync(bidirectional: true, default)
+            .AsTask().WaitAsync(TimeSpan.FromMinutes(2));
+
+        // Cleanup
+        serverStream.Input.Complete();
+        nextStream.Output.Complete();
+        nextStream.Input.Complete();
+    }
+
     /// <summary>Verifies that a write blocked on the connection-level pipe pause (PauseWriterThreshold reached)
     /// can be canceled.</summary>
     [Test]


### PR DESCRIPTION
A client that cancels an invocation while the server is still sending the response can leak a bidirectional stream slot on its connection. Each such cancellation leaves one stream that never closes, and once the connection's bidirectional stream limit is reached, every new invocation on it blocks until the connection is closed.

The cause is on the server side of the stream. When the server has consumed the whole request, it defers its `StreamReadsClosed` frame so that it can be bundled with the response's `StreamLast` frame in a single write. When the client's own `StreamReadsClosed` frame (sent when it stops reading the response) closes the server's writes first, the `StreamLast` frame is never written and the deferred `StreamReadsClosed` frame was never sent: the client stream is left waiting for it and is never released.

This happens in three timings, each covered by a new test:

- the response's endStream write is parked (exhausted peer window or connection write semaphore) and is canceled by the client's frame;
- the client's frame arrives before the endStream write is attempted, so the write fails right away;
- no endStream write is attempted at all (`CopyFromAsync` returns as soon as writes are closed and the dispatch completes the output).

The rollback added in #4765 doesn't cover these cases because `_writesClosedTcs`, which it keys on, is also completed when the peer closes writes.

The leak shows up when the client's `StreamLast` frame is sent by the output completion rather than by an endStream write: raw `IMultiplexedStream` usage, or a plain `PipeWriter` payload decorator such as the compressor. After an endStream write, `CloseWrites` currently closes the local stream's writes as soon as the output is completed instead of waiting for the peer's `StreamReadsClosed` frame (#4788), which hides the leak for that shape; the tests therefore send the client's `StreamLast` frame through `Output.Complete()`.

### Fix

`ReceivedReadsClosedFrame` now sends the deferred `StreamReadsClosed` frame on its own when the peer closes writes while the frame is still owed, and clears the deferral. If a `StreamLast` write is already past cancellation and bundles the frame too, the peer receives it twice, which is harmless: a released stream is dropped by the connection and a live one handles it idempotently.

Two ordering details keep this race-free, without closing reads or writes under the stream mutex:

- `ReceivedReadsClosedFrame` closes writes before it captures the deferral under the mutex: a `CloseReads` that ran before left the deferral for the handler, and one that runs after sees writes closed and sends the frame itself.
- `CloseWrites` clears the deferral when it claims it, so `ReceivedReadsClosedFrame` can't send the frame before the stream is released; the bundled frame follows the closure of writes on the same thread.

### Tests

`Deferred_reads_closed_frame_is_sent_when_peer_closes_reads_during_end_stream_write`, `..._before_end_stream_write` and `..._without_end_stream_write` cover the three timings: with `MaxBidirectionalStreams = 1`, the client sends its request and completes the output, the server consumes the request and exhausts the client's window, the client closes its reads at the given point, and the test asserts that the client can create a new stream once the server output is completed. Without the fix, all three fail when their `[CancelAfter]` token is canceled (2 min, above CI's `--blame-hang-timeout`).

Full `IceRpc.Tests` suite passes (1051 passed / 0 failed), `dotnet format` clean.

## What's Changed entry

Area: Slic

- Fixed a stream leak that could eventually block all new invocations on a connection when invocations were canceled while the server was still sending their response.
