### PR TITLE
Pin the whitespace action to a commit

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run whitespace validation
-        uses: zeroc-ice/github-actions@main
+        uses: zeroc-ice/github-actions@333b1fd88d8edc678e008c9a3b63b40f3e2a2ae3
         with:
           whitespace_patterns: "'*'"


### PR DESCRIPTION
`whitespace.yml` used the mutable `zeroc-ice/github-actions@main` while every other external action in the workflows is pinned to a commit. Pin it to the current head of `main`; the repository has no tags.

Addresses L-28 in #4833, split out of #4946.

## What's Changed entry

None — CI workflow change only.
