### PR TITLE
Add locked Prettier and XML plugin dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ NuGet.config
 # CSharp Dev Kit
 .mono
 *.csproj.lscache
+
+# Formatting dependencies
+node_modules/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,6 +2,7 @@
 
 - [Prerequisites](#prerequisites)
 - [Building IceRPC](#building-icerpc)
+- [Formatting XML files](#formatting-xml-files)
 - [Running the tests](#running-the-tests)
 - [Generating the code coverage reports](#generating-the-code-coverage-reports)
 - [Generating the API reference](#generating-the-api-reference)
@@ -35,6 +36,15 @@ dotnet build
 ```
 
 This command builds all the tools, sources and tests with the default configuration (debug).
+
+## Formatting XML files
+
+To use the repository's Prettier configuration, install Node.js and run `npm ci` from the repository root. This installs
+Prettier and its XML plugin for the VS Code Prettier extension and the command line:
+
+```shell
+npx prettier --write path/to/project.csproj
+```
 
 ## Running the tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "icerpc-csharp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "icerpc-csharp",
+      "devDependencies": {
+        "@prettier/plugin-xml": "3.4.2",
+        "prettier": "3.9.6"
+      }
+    },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz",
+      "integrity": "sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==",
+      "dev": true,
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "dependencies": {
+        "chevrotain": "7.1.1"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "icerpc-csharp",
+  "private": true,
+  "devDependencies": {
+    "@prettier/plugin-xml": "3.4.2",
+    "prettier": "3.9.6"
+  }
+}


### PR DESCRIPTION
`.prettierrc` requires `@prettier/plugin-xml`, but no package manifest or lockfile provisioned it, so the VS Code Prettier extension and `npx prettier` could not load the configuration. Add `package.json` and `package-lock.json` with pinned versions of Prettier and the plugin, ignore `node_modules`, and document the `npm ci` setup in BUILDING.md.

Addresses L-29 in #4833, split out of #4946.

## What's Changed entry

None — developer tooling only.
