### PR TITLE
Use an absolute Cargo path in the devcontainer PATH

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Set environment variables
 ENV DOTNET_ROOT=/root/.dotnet
-ENV PATH=$DOTNET_ROOT:$DOTNET_ROOT/tools:~/.cargo/bin:$PATH
+ENV PATH=$DOTNET_ROOT:$DOTNET_ROOT/tools:/root/.cargo/bin:$PATH
 
 RUN ln -s "$DOTNET_ROOT/dotnet" /usr/bin/dotnet


### PR DESCRIPTION
The devcontainer Dockerfile put a literal `~/.cargo/bin` in `ENV PATH`. Executable lookup does not expand a tilde inside a PATH entry, so non-login processes in the container could not find `cargo`. Use `/root/.cargo/bin`, where rustup installs it for the root user the image runs as.

Addresses L-30 in #4833, split out of #4946.

## What's Changed entry

None — devcontainer change only.
